### PR TITLE
[auto-change] BUG-044: change_loop_v1 compile fails because node id collides with state key

### DIFF
--- a/tests/test_api_runs.py
+++ b/tests/test_api_runs.py
@@ -193,6 +193,54 @@ def test_action_run_branch_returns_str():
     assert isinstance(out, str)
 
 
+def test_action_run_branch_rejects_node_state_key_collision(tmp_path, monkeypatch):
+    from workflow.branches import (
+        BranchDefinition,
+        EdgeDefinition,
+        GraphNodeRef,
+        NodeDefinition,
+    )
+    from workflow.daemon_server import initialize_author_server, save_branch_definition
+
+    monkeypatch.setattr(runs_mod, "_base_path", lambda: tmp_path)
+    initialize_author_server(tmp_path)
+
+    branch = BranchDefinition(
+        name="change_loop_v1 repro",
+        entry_point="investigation_gate",
+    )
+    branch.node_defs = [
+        NodeDefinition(
+            node_id="investigation_gate",
+            display_name="Investigation Gate",
+            prompt_template="decide next step",
+        )
+    ]
+    branch.graph_nodes = [
+        GraphNodeRef(
+            id="investigation_gate",
+            node_def_id="investigation_gate",
+            position=0,
+        )
+    ]
+    branch.edges = [
+        EdgeDefinition(from_node="START", to_node="investigation_gate"),
+        EdgeDefinition(from_node="investigation_gate", to_node="END"),
+    ]
+    branch.state_schema = [{"name": "investigation_gate", "type": "str"}]
+    saved = save_branch_definition(tmp_path, branch_def=branch.to_dict())
+
+    out = json.loads(_action_run_branch({"branch_def_id": saved["branch_def_id"]}))
+
+    assert "run_id" not in out
+    assert out["error"] == "Branch is not valid. Fix these before running:"
+    assert out["validation_errors"] == [
+        "Node ID 'investigation_gate' conflicts with state field name "
+        "'investigation_gate'. Rename either the node or the state field "
+        "before running."
+    ]
+
+
 # Arc A re-export shims removed in Task #18 retarget sweep — the
 # `test_universe_server_reexports_run_actions` + parametrized identity tests
 # are gone alongside the shim block.

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -518,6 +518,16 @@ class TestBranchDefinition:
         errors = b.validate()
         assert any("Duplicate state field" in e for e in errors)
 
+    def test_validate_node_id_state_field_collision(self):
+        b = _make_sample_branch()
+        b.state_schema.append({"name": "orient-def", "type": "str"})
+        errors = b.validate()
+        assert any(
+            "Node ID 'orient-def' conflicts with state field name 'orient-def'"
+            in e
+            for e in errors
+        )
+
     def test_fork(self):
         b = _make_sample_branch()
         b.stats["run_count"] = 42

--- a/workflow/branches.py
+++ b/workflow/branches.py
@@ -989,6 +989,13 @@ class BranchDefinition:
                     errors.append(f"Duplicate state field name: '{name}'.")
                 field_names.add(name)
 
+        colliding_ids = seen_defs & field_names
+        for name in sorted(colliding_ids):
+            errors.append(
+                f"Node ID '{name}' conflicts with state field name '{name}'. "
+                "Rename either the node or the state field before running."
+            )
+
         # Build-time placeholder validation: every ``{ident}`` in a
         # node's prompt_template must resolve via the node's
         # input_keys OR the branch-level state_schema. Runtime


### PR DESCRIPTION
Fixes #89

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.

Live evidence: GitHub Actions run 25194444920 produced branch auto-change/issue-89-codex-25194444920 with subscription-backed Codex auth, committed c660ac7, and passed its focused tests before GitHub Actions PR creation was blocked by repository Actions policy. This PR is opened through the GitHub connector so the branch can enter review while the workflow permission fallback is patched.