### PR TITLE
[auto-change] BUG-029: Failed workflow run error says empty LLM response but gives no clear next action

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/runs.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/runs.py
@@ -586,10 +586,17 @@ def _compose_run_snapshot(
     # so it doesn't have to guess (Mara's failure mode 2026-04-24).
     if run_record["status"] == "failed":
         error_annotation = _classify_run_outcome_error(run_record.get("error", ""))
+        failure_lines = ["", f"Error: {run_record.get('error', '')}"]
         if error_annotation:
             snapshot["failure_class"] = error_annotation[0]
             snapshot["suggested_action"] = error_annotation[1]
-            snapshot["actionable_by"] = _actionable_by(error_annotation[0])
+            actionable_by = _actionable_by(error_annotation[0])
+            snapshot["actionable_by"] = actionable_by
+            failure_lines.append(
+                f"Next action ({actionable_by}): {error_annotation[1]}",
+            )
+        snapshot["text"] = "\n".join([summary, *failure_lines])
+        snapshot["summary"] = snapshot["text"]
     return snapshot
 
 

--- a/tests/test_run_branch_failure_taxonomy.py
+++ b/tests/test_run_branch_failure_taxonomy.py
@@ -591,6 +591,9 @@ class TestActionableByOnGetRunSnapshot:
         assert snapshot["failure_class"] == "empty_llm_response"
         assert snapshot["actionable_by"] == "host"
         assert snapshot["suggested_action"]
+        assert "Error: Empty LLM response" in snapshot["text"]
+        assert "Next action (host):" in snapshot["text"]
+        assert snapshot["suggested_action"] in snapshot["text"]
 
     def test_completed_omits_actionable_by(self):
         snapshot = self._make_snapshot("completed", "")
@@ -600,6 +603,11 @@ class TestActionableByOnGetRunSnapshot:
         # Symmetric with failure_class/suggested_action — opaque means no enrichment.
         snapshot = self._make_snapshot("failed", "some opaque crash nobody knows")
         assert "actionable_by" not in snapshot
+
+    def test_failed_unknown_still_surfaces_error_in_text(self):
+        snapshot = self._make_snapshot("failed", "some opaque crash nobody knows")
+        assert "Error: some opaque crash nobody knows" in snapshot["text"]
+        assert "Next action" not in snapshot["text"]
 
 
 class TestActionableByOnListRecentRuns:

--- a/workflow/api/runs.py
+++ b/workflow/api/runs.py
@@ -586,10 +586,17 @@ def _compose_run_snapshot(
     # so it doesn't have to guess (Mara's failure mode 2026-04-24).
     if run_record["status"] == "failed":
         error_annotation = _classify_run_outcome_error(run_record.get("error", ""))
+        failure_lines = ["", f"Error: {run_record.get('error', '')}"]
         if error_annotation:
             snapshot["failure_class"] = error_annotation[0]
             snapshot["suggested_action"] = error_annotation[1]
-            snapshot["actionable_by"] = _actionable_by(error_annotation[0])
+            actionable_by = _actionable_by(error_annotation[0])
+            snapshot["actionable_by"] = actionable_by
+            failure_lines.append(
+                f"Next action ({actionable_by}): {error_annotation[1]}",
+            )
+        snapshot["text"] = "\n".join([summary, *failure_lines])
+        snapshot["summary"] = snapshot["text"]
     return snapshot
 
 


### PR DESCRIPTION
Fixes #64

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane in run 25198856127.

Scope note: this touches `workflow/api/runs.py`, its plugin mirror, and `tests/test_run_branch_failure_taxonomy.py`. That overlaps the active STATUS.md #18 retarget sweep write area, so it should wait for cross-family review and merge coordination before landing.