### PR TITLE
[auto-change] BUG-020: No long-poll / synchronous-wait mode

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
@@ -596,7 +596,7 @@ def _extensions_impl(
             "validate_branch", "describe_branch",
             "get_branch", "list_branches", "delete_branch",
             "run_branch", "get_run", "list_runs",
-            "stream_run", "cancel_run", "get_run_output",
+            "stream_run", "wait_for_run", "cancel_run", "get_run_output",
             "resume_run", "estimate_run_cost", "query_runs",
             "judge_run", "list_judgments", "compare_runs",
             "suggest_node_edit", "get_node_output",

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
@@ -34,7 +34,10 @@ agentic work producing substantive output. Do NOT tell users this is
    web-search, populate wiki pages, or narrate imagined output. Creating
    state (registering a node, building a branch) requires an explicit
    user ask; route "what do i have", "show me", "list my" to `list` or
-   `list_branches`. When intent is ambiguous, ask.
+   `list_branches`. After starting a run, prefer
+   `extensions action=wait_for_run` over repeated `get_run` or
+   `stream_run` polling so one tool call can cover the wait window.
+   When intent is ambiguous, ask.
 6. Prefer NAMES, not IDs, when referring to workflows, runs, Goals, or
    nodes in conversation. Users read replies on phones; raw UUIDs like
    `run_id=54dac140d2b7460c` or `branch_def_id=4f9e...` are noise. Say

--- a/tests/test_wait_for_run.py
+++ b/tests/test_wait_for_run.py
@@ -242,6 +242,12 @@ def test_wait_for_run_rejects_unknown_run(us_env):
     assert "not found" in result["error"].lower()
 
 
+def test_wait_for_run_is_advertised_in_available_actions(us_env):
+    us, _ = us_env
+    result = json.loads(us.extensions(action="not-a-real-action"))
+    assert "wait_for_run" in result["available_actions"]
+
+
 def test_wait_for_run_caps_max_wait_at_120s(us_env):
     """A client asking for a 10-minute wait should be capped at 120s
     so the server thread isn't tied up forever."""

--- a/workflow/api/extensions.py
+++ b/workflow/api/extensions.py
@@ -596,7 +596,7 @@ def _extensions_impl(
             "validate_branch", "describe_branch",
             "get_branch", "list_branches", "delete_branch",
             "run_branch", "get_run", "list_runs",
-            "stream_run", "cancel_run", "get_run_output",
+            "stream_run", "wait_for_run", "cancel_run", "get_run_output",
             "resume_run", "estimate_run_cost", "query_runs",
             "judge_run", "list_judgments", "compare_runs",
             "suggest_node_edit", "get_node_output",

--- a/workflow/api/prompts.py
+++ b/workflow/api/prompts.py
@@ -34,7 +34,10 @@ agentic work producing substantive output. Do NOT tell users this is
    web-search, populate wiki pages, or narrate imagined output. Creating
    state (registering a node, building a branch) requires an explicit
    user ask; route "what do i have", "show me", "list my" to `list` or
-   `list_branches`. When intent is ambiguous, ask.
+   `list_branches`. After starting a run, prefer
+   `extensions action=wait_for_run` over repeated `get_run` or
+   `stream_run` polling so one tool call can cover the wait window.
+   When intent is ambiguous, ask.
 6. Prefer NAMES, not IDs, when referring to workflows, runs, Goals, or
    nodes in conversation. Users read replies on phones; raw UUIDs like
    `run_id=54dac140d2b7460c` or `branch_def_id=4f9e...` are noise. Say


### PR DESCRIPTION
Fixes #47

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane in run 25199686073.

Scope note: this touches `workflow/api/extensions.py`, `workflow/api/prompts.py`, the plugin mirror, and tests. It needs cross-family review before landing.