### PR TITLE
[auto-change] BUG-027: No startup file-probe for required data files — retry

### DIFF
--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -47,6 +47,28 @@ if [[ "${_any_set}" -eq 0 ]]; then
     exit 1
 fi
 
+# ---------------------------------------------------------------------
+# Required static data-file probe
+# ---------------------------------------------------------------------
+# Keep this shell-native: the container command provides the Python
+# executable contract, and host-side verification may not have a
+# `python` alias on PATH.
+_package_root="${WORKFLOW_PACKAGE_ROOT:-/app}"
+if command -v cygpath >/dev/null 2>&1 && [[ "${_package_root}" == [A-Za-z]:* ]]; then
+    _package_root="$(cygpath -u "${_package_root}")"
+fi
+
+_required_data_files=(
+    data/world_rules.lp
+)
+for _rel_path in "${_required_data_files[@]}"; do
+    _full_path="${_package_root}/${_rel_path}"
+    if [[ ! -f "${_full_path}" ]]; then
+        echo "DATA-FILE-MISSING: ${_rel_path} (expected at ${_full_path})" >&2
+        exit 1
+    fi
+done
+
 _truthy() {
     case "${1:-}" in
         1|true|TRUE|True|yes|YES|Yes|on|ON|On) return 0 ;;

--- a/tests/test_dockerfile_shape.py
+++ b/tests/test_dockerfile_shape.py
@@ -219,6 +219,16 @@ def test_entrypoint_replaces_auth_bundle_atomically():
     )
 
 
+def test_entrypoint_probes_required_data_files_without_python_alias():
+    text = ENTRYPOINT.read_text(encoding="utf-8")
+    assert "DATA-FILE-MISSING" in text
+    assert "data/world_rules.lp" in text
+    assert "startup_file_probe" not in text, (
+        "entrypoint data-file probe must not invoke the Python startup_file_probe; "
+        "host-side bash verification may not have a python alias on PATH"
+    )
+
+
 def test_entrypoint_execs_cmd():
     text = ENTRYPOINT.read_text(encoding="utf-8")
     assert 'exec "$@"' in text, (

--- a/tests/test_env_unreadable_marker.py
+++ b/tests/test_env_unreadable_marker.py
@@ -57,6 +57,7 @@ def _run_entrypoint_via_stdin(
     preamble_lines = [
         # Clear sentinels first so ambient-shell values don't leak through.
         "unset CLOUDFLARE_TUNNEL_TOKEN SUPABASE_DB_URL WORKFLOW_IMAGE",
+        f"export WORKFLOW_PACKAGE_ROOT={str(_REPO)!r}",
     ]
     for key, value in (extra_env or {}).items():
         preamble_lines.append(f"export {key}={value!r}")
@@ -108,6 +109,46 @@ def test_entrypoint_passes_through_when_one_sentinel_set():
     assert CANONICAL_MARKER not in result.stderr, (
         "marker should NOT fire when a sentinel is set"
     )
+    assert "would-exec" in result.stdout
+
+
+@pytest.mark.skipif(not _have_bash(), reason="bash not on PATH")
+def test_entrypoint_fails_loudly_when_required_data_file_missing(tmp_path: Path):
+    """Missing required static data files fail before daemon startup."""
+    result = _run_entrypoint_via_stdin(
+        exec_replacement='echo "[harness] would-exec: $@"',
+        extra_env={
+            "WORKFLOW_IMAGE": "ghcr.io/jonnyton/workflow-daemon:abc123",
+            "WORKFLOW_PACKAGE_ROOT": str(tmp_path),
+        },
+    )
+    assert result.returncode == 1, (
+        f"expected missing-data exit 1; got {result.returncode}. "
+        f"stderr={result.stderr!r} stdout={result.stdout!r}"
+    )
+    assert "DATA-FILE-MISSING: data/world_rules.lp" in result.stderr
+    assert "startup data-file probe crashed" not in result.stderr
+    assert "would-exec" not in result.stdout
+
+
+@pytest.mark.skipif(not _have_bash(), reason="bash not on PATH")
+def test_entrypoint_data_file_probe_does_not_require_python_alias(tmp_path: Path):
+    """The data-file probe must not depend on host PATH containing python."""
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "world_rules.lp").write_text("% ok\n", encoding="utf-8")
+    result = _run_entrypoint_via_stdin(
+        exec_replacement='echo "[harness] would-exec: $@"',
+        extra_env={
+            "PATH": "/usr/bin:/bin",
+            "WORKFLOW_IMAGE": "ghcr.io/jonnyton/workflow-daemon:abc123",
+            "WORKFLOW_PACKAGE_ROOT": str(tmp_path),
+        },
+    )
+    assert result.returncode == 0, (
+        f"expected happy-path exit 0; got {result.returncode}. "
+        f"stderr={result.stderr!r} stdout={result.stdout!r}"
+    )
+    assert "DATA-FILE-MISSING" not in result.stderr
     assert "would-exec" in result.stdout
 
 


### PR DESCRIPTION
Fixes #57

Writer family: Codex
Required checker family: Claude

Automated community-loop retry produced by subscription-backed Codex in GitHub Actions run 25200607048 after review feedback on PR #105.

Live evidence:
- Issue #57 was requeued through the public loop with the failing focused-test evidence.
- Codex writer used subscription auth; API-key lanes were ignored.
- Post-generation verification passed before branch push: `python -m ruff check tests/test_env_unreadable_marker.py tests/test_dockerfile_shape.py` and `python -m pytest tests/test_env_unreadable_marker.py tests/test_dockerfile_shape.py -q` -> 31 passed.
- GitHub Actions still blocked PR creation from GITHUB_TOKEN (`github_actions_pr_creation_disabled`), so this PR is opened through the connector fallback.

Supersedes failed PR #105, whose focused tests failed because the previous entrypoint probe depended on a host `python` alias.