### PR TITLE
Add directory-safe MCP surface

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -63,6 +63,7 @@ jobs:
         run: npm install -g wrangler@latest
 
       - name: Verify secrets present
+        if: github.event_name != 'pull_request'
         run: |
           if [ -z "${{ secrets.CLOUDFLARE_API_TOKEN }}" ]; then
             echo "::error::CLOUDFLARE_API_TOKEN secret is not set."
@@ -90,6 +91,10 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           echo "=== dry-run — validating wrangler config + worker bundle ==="
+          if [ -z "${CLOUDFLARE_API_TOKEN}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID}" ]; then
+            echo "Cloudflare deploy credentials are unavailable on this PR; unit tests already ran, skipping Wrangler dry-run."
+            exit 0
+          fi
           wrangler deploy --dry-run --outdir /tmp/wrangler-out
           echo "=== dry-run passed ==="
           ls -lh /tmp/wrangler-out/

--- a/chatgpt-app-submission.json
+++ b/chatgpt-app-submission.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "https://developers.openai.com/apps-sdk/schemas/chatgpt-app-submission.v1.json",
+  "schema_version": 1,
+  "app_info": {
+    "display_name": "Workflow",
+    "subtitle": "Build durable workflows",
+    "description": "Workflow helps ChatGPT users inspect durable AI workflow state, browse shared goals and wiki knowledge, and submit bounded requests into a long-running Workflow daemon.",
+    "category": "PRODUCTIVITY"
+  },
+  "tools": {
+    "get_workflow_status": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves daemon status, routing evidence, and caveats without changing Workflow state.",
+        "open_world_justification": "Does not publish content or modify public internet state.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "list_workflow_universes": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Lists available Workflow universes without creating or updating records.",
+        "open_world_justification": "Only reads Workflow-managed state and does not write to external systems.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "inspect_workflow_universe": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Inspects one Workflow universe and summarizes existing state without mutating it.",
+        "open_world_justification": "Does not publish content or affect third-party systems.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "list_workflow_goals": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Lists shared Workflow goals matching optional filters without changing them.",
+        "open_world_justification": "Only returns Workflow goal metadata and does not publish or modify external systems.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "search_workflow_goals": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Searches existing Workflow goal metadata without creating or updating records.",
+        "open_world_justification": "Does not write to public internet state or third-party systems.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "get_workflow_goal": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Returns one existing Workflow goal and its bound branches without changing state.",
+        "open_world_justification": "Does not publish content or affect third-party systems.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "search_workflow_wiki": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Searches existing Workflow wiki pages and returns matching snippets without modifying the wiki.",
+        "open_world_justification": "Does not publish content or write to external systems.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "read_workflow_wiki_page": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Reads one existing Workflow wiki page without changing it.",
+        "open_world_justification": "Does not publish content or affect third-party systems.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "list_workflow_runs": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Lists recent Workflow branch runs without starting, stopping, or editing runs.",
+        "open_world_justification": "Only reads Workflow run metadata and does not write to external systems.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "propose_workflow_goal": {
+      "annotations": {
+        "readOnlyHint": false,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Creates a shared Workflow goal proposal, so it changes Workflow state.",
+        "open_world_justification": "The created goal can be visible in shared Workflow goal discovery.",
+        "destructive_justification": "Creates a new proposal and does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "submit_workflow_request": {
+      "annotations": {
+        "readOnlyHint": false,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Queues a bounded request in Workflow, so it changes Workflow state.",
+        "open_world_justification": "Writes only to the Workflow request queue and does not publish content or modify third-party systems.",
+        "destructive_justification": "Queues a request and does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    }
+  },
+  "test_cases": [
+    {
+      "description": "Check whether Workflow is connected and safe to use.",
+      "user_prompt": "Use Workflow to check the current daemon status and tell me any caveats before I start.",
+      "file_attachment_urls": null,
+      "tools_triggered": "get_workflow_status",
+      "expected_output": "Returns a factual daemon status summary with routing evidence and caveats.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Find existing durable goals for a user's work category.",
+      "user_prompt": "Use Workflow to search for goals related to onboarding and show the best matches.",
+      "file_attachment_urls": null,
+      "tools_triggered": "search_workflow_goals",
+      "expected_output": "Returns matching Workflow goals with enough context for the user to choose one.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Browse available universes before choosing where to work.",
+      "user_prompt": "Use Workflow to list available universes, then inspect the active one.",
+      "file_attachment_urls": null,
+      "tools_triggered": "list_workflow_universes, inspect_workflow_universe",
+      "expected_output": "Shows available universes and summarizes the selected universe's durable state.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Read project knowledge from the Workflow wiki.",
+      "user_prompt": "Use Workflow to search the wiki for current launch risks, then read the most relevant page.",
+      "file_attachment_urls": null,
+      "tools_triggered": "search_workflow_wiki, read_workflow_wiki_page",
+      "expected_output": "Returns relevant wiki search results and a grounded summary of the chosen page.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Create a new shared goal proposal after user intent is clear.",
+      "user_prompt": "Use Workflow to propose a public goal named 'Onboard new MCP hosts' with tags discovery,onboarding.",
+      "file_attachment_urls": null,
+      "tools_triggered": "propose_workflow_goal",
+      "expected_output": "Confirms that a new Workflow goal proposal was created and reports its identifier or next step.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Queue a bounded request into an existing Workflow universe.",
+      "user_prompt": "Use Workflow to submit a request asking the daemon to summarize today's discoverability blockers.",
+      "file_attachment_urls": null,
+      "tools_triggered": "submit_workflow_request",
+      "expected_output": "Confirms the request was queued in Workflow and states what will happen next.",
+      "expected_output_url": null
+    }
+  ],
+  "negative_test_cases": [
+    {
+      "description": "Do not invoke Workflow for unrelated weather requests.",
+      "user_prompt": "What is the weather in San Francisco tomorrow?",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not be invoked because the request is unrelated to Workflow.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Do not use Workflow to send messages through unrelated third-party systems.",
+      "user_prompt": "Use Workflow to send an email to my team about the launch.",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not be invoked because Workflow does not send email.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Do not perform destructive admin operations.",
+      "user_prompt": "Use Workflow to delete every universe and wipe all stored data.",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not call any Workflow tool because the directory surface exposes no destructive delete operation.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Do not request or store account credentials.",
+      "user_prompt": "Use Workflow to save my API key and password for later.",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not be invoked because Workflow's directory tools do not collect credentials.",
+      "expected_output_url": null
+    }
+  ]
+}

--- a/deploy/cloudflare-worker/worker.js
+++ b/deploy/cloudflare-worker/worker.js
@@ -9,11 +9,13 @@
 //     404 handler → "Session terminated" in Claude.ai (the 2026-04-19 P0).
 //
 // Fix:
-//   This Worker runs on route `tinyassets.io/mcp*`. Any request whose
-//   path begins with `/mcp` is forwarded to the internal tunnel origin at
-//   `mcp.tinyassets.io` (same path), authenticated via Cloudflare Access
-//   service-token headers. All other paths are left untouched by this
-//   Worker — they hit the GoDaddy origin as before.
+//   This Worker runs on route `tinyassets.io/mcp*`. Requests to `/mcp`
+//   use the full custom-connector surface. Requests to `/mcp-directory`
+//   use the narrow review-ready surface for host directories. Both are
+//   forwarded to the internal tunnel origin at `mcp.tinyassets.io`
+//   (same path), authenticated via Cloudflare Access service-token
+//   headers. All other paths are left untouched by this Worker — they hit
+//   the GoDaddy origin as before.
 //
 // Security model (host directive 2026-04-20):
 //   - `tinyassets.io/mcp` is the ONLY public user-facing URL.
@@ -37,6 +39,7 @@
 //   - Pure proxy: no response-body rewriting.
 //
 // Canonical URL: https://tinyassets.io/mcp  (apex + path, user-facing).
+// Directory URL: https://tinyassets.io/mcp-directory  (review/listing surface).
 // Tunnel origin: https://mcp.tinyassets.io  (Access-gated, internal only).
 
 const TUNNEL_ORIGIN = 'https://mcp.tinyassets.io';
@@ -197,10 +200,17 @@ async function proxyToTunnel(request, env) {
  * themselves); this is purely the method-allow check.
  */
 function shouldProxy(pathname) {
-    // Anything under `/mcp` belongs to the tunnel. The Cloudflare route
+    // Anything under `/mcp` or `/mcp-directory` belongs to the tunnel. The Cloudflare route
     // `tinyassets.io/mcp*` should only invoke this Worker for matching
     // paths, but double-check to defend against route-misconfiguration.
-    return pathname === '/mcp' || pathname.startsWith('/mcp/') || pathname.startsWith('/mcp?');
+    return (
+        pathname === '/mcp' ||
+        pathname.startsWith('/mcp/') ||
+        pathname.startsWith('/mcp?') ||
+        pathname === '/mcp-directory' ||
+        pathname.startsWith('/mcp-directory/') ||
+        pathname.startsWith('/mcp-directory?')
+    );
 }
 
 export default {

--- a/deploy/cloudflare-worker/worker.test.js
+++ b/deploy/cloudflare-worker/worker.test.js
@@ -65,12 +65,24 @@ describe('shouldProxy', () => {
         assert.equal(shouldProxy('/mcp/foo'), true);
     });
 
+    it('accepts /mcp-directory', () => {
+        assert.equal(shouldProxy('/mcp-directory'), true);
+    });
+
+    it('accepts /mcp-directory/foo', () => {
+        assert.equal(shouldProxy('/mcp-directory/foo'), true);
+    });
+
     it('rejects /', () => {
         assert.equal(shouldProxy('/'), false);
     });
 
     it('rejects /mcpx (no slash, not /mcp)', () => {
         assert.equal(shouldProxy('/mcpx'), false);
+    });
+
+    it('rejects /mcp-directory-old', () => {
+        assert.equal(shouldProxy('/mcp-directory-old'), false);
     });
 
     it('rejects paths outside /mcp', () => {

--- a/docs/exec-plans/active/2026-05-01-host-discoverability-and-onboarding-rollout.md
+++ b/docs/exec-plans/active/2026-05-01-host-discoverability-and-onboarding-rollout.md
@@ -18,7 +18,8 @@ A Workflow customer is anyone using a chatbot, local model shell, IDE agent,
 enterprise agent builder, self-hosted chat UI, channel gateway, or custom app
 that can connect to a Workflow MCP server.
 
-The rollout must make three paths explicit:
+The rollout must make three paths explicit and carry them all the way to
+native discovery where the host supports it:
 
 1. Logged-in chatbot users: Claude, ChatGPT, Mistral Le Chat, Perplexity, Grok,
    Copilot Studio, and similar hosted chat products.
@@ -70,6 +71,10 @@ The rollout must make three paths explicit:
    logging into Claude/ChatGPT/Gemini/etc.
 7. Every claimed host gets an acceptance proof. Otherwise the copy must say
    "compatible by spec, not verified yet."
+8. A host-directory rollout is not complete at "docs live" or "custom URL
+   works." Completion means the host listing is accepted, a normal user can
+   add/use Workflow without Developer Mode or custom URL friction, and at
+   least one real or user-sim first-use trace exists.
 
 ## Ecosystem Default Strategy
 
@@ -154,7 +159,10 @@ automatically, maintain these machine-readable artifacts:
 - MCP `server.json` for the official registry.
 - Host-specific manifests for ChatGPT Apps and any Claude/Mistral directory
   submission requirements.
-- A stable public endpoint: `https://tinyassets.io/mcp`.
+- Stable public endpoints:
+  - `https://tinyassets.io/mcp` for the full custom-connector surface.
+  - `https://tinyassets.io/mcp-directory` for reviewed host directories and
+    registry metadata.
 - `/.well-known` metadata where supported by host requirements.
 - `llms.txt` and concise AI-readable docs for "when to use Workflow."
 - Host-specific config snippets for `.mcp.json`, `.vscode/mcp.json`, Cursor,
@@ -179,11 +187,14 @@ The rollout should create a compounding loop:
 ### Gate 0: Public MCP Green
 
 Do not ship discoverability copy, directory listings, or app submissions while
-`https://tinyassets.io/mcp` is red.
+the relevant public MCP endpoint is red.
 
 Acceptance:
 
 - `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp`
+  exits 0.
+- After the directory endpoint lands:
+  `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp-directory`
   exits 0.
 - Latest `.github/workflows/uptime-canary.yml` run is green.
 - If a 502 appears, update `STATUS.md` immediately and pause rollout work until
@@ -232,6 +243,8 @@ browser chat surfaces.
 Claude:
 
 - Finish connector metadata and directory-readiness package.
+- Submit the directory endpoint `https://tinyassets.io/mcp-directory`, not the
+  legacy catch-all `/mcp` surface.
 - Keep custom connector path working for Free/Pro/Max/Team/Enterprise.
 - Verify with live Claude.ai `ui-test` and post-fix clean-use evidence.
 
@@ -240,15 +253,19 @@ ChatGPT:
 - Treat Apps SDK/custom MCP as the ChatGPT distribution path.
 - Resolve the workspace-admin registration issue before claiming public
   ChatGPT parity.
+- Submit `chatgpt-app-submission.json` through the OpenAI app submission flow.
 - Build a minimal ChatGPT App/widget plan around browse, inspect, approve, and
   run controls.
 - Keep backend state authoritative and widget state ephemeral.
 
 Acceptance:
 
-- Claude setup works from published copy, not insider instructions.
+- Claude setup works from the Connectors Directory listing, not insider
+  instructions or a custom URL.
 - ChatGPT setup states exactly which plans/roles support read/fetch vs
   write/modify MCP actions.
+- ChatGPT App Directory use works for a normal eligible logged-in user without
+  Developer Mode.
 - ChatGPT guest mode is explicitly marked unsupported for MCP controls.
 
 ### Phase 3: No-Chatbot-Login Path
@@ -325,11 +342,19 @@ Progress snapshot, 2026-05-01:
 - Card 5 ready-draft locally: `docs/ops/mcp-host-proof-registry.md` records
   per-host claim status and local verification evidence.
 - Machine-readable discovery ready-draft locally: `packaging/registry/server.json`
-  validates against the official schema and points at `https://tinyassets.io/mcp`;
+  validates against the official schema and points at
+  `https://tinyassets.io/mcp-directory`;
   `WebSite/site/static/llms.txt` tells chatbots when to recommend Workflow and
   when to caveat host support.
-- Not live until Gate 0 is green, the website branch is merged/deployed, and
-  the MCP Registry draft is published by an authorized GitHub/registry account.
+- Directory endpoint branch slice: `workflow/directory_server.py` exposes 11
+  narrow tools with explicit read/open/destructive annotations and no catch-all
+  `action` inputs; the Worker routes `/mcp-directory` to the same tunnel.
+- Submission packets branch-ready: `docs/ops/mcp-directory-submission-packet.md`
+  and `chatgpt-app-submission.json`.
+- Not complete until Gate 0 is green for both endpoints, the branch is
+  merged/deployed, the MCP Registry draft is published by an authorized
+  GitHub/registry account, Claude/OpenAI submissions are accepted, and
+  first-use evidence is recorded.
 
 ### Card 1: Publish Host Chooser Copy
 
@@ -359,6 +384,9 @@ Acceptance:
 
 - Directory-facing name, description, scopes, examples, and safety copy are
   ready.
+- Claude submission uses `https://tinyassets.io/mcp-directory`.
+- The accepted listing appears in Claude's Connectors Directory.
+- A normal Claude user can add Workflow from the directory without a custom URL.
 - Live Claude.ai proof is refreshed after the copy lands.
 
 Dependency: Gate 0 green.
@@ -373,10 +401,14 @@ Files:
 
 Acceptance:
 
-- Defines the first ChatGPT App tools, widget panels, and state split.
+- `chatgpt-app-submission.json` covers the first directory-safe tools and test
+  cases.
+- Defines the first ChatGPT widget panels, CSP, screenshots, and state split
+  before pressing Submit if OpenAI's dashboard requires embedded app resources.
 - Explicitly records that ChatGPT guest mode cannot use Workflow MCP controls
   until OpenAI supports Apps for logged-out users.
-- Blocks public parity on workspace-admin registration and live ChatGPT proof.
+- Blocks public parity on OpenAI submission acceptance, workspace-admin
+  registration where required, and live ChatGPT proof.
 
 Dependency: host/admin action for ChatGPT workspace setup.
 
@@ -441,9 +473,18 @@ Fresh source snapshot, checked 2026-05-01:
 - OpenAI says developers can submit apps for review/publication in ChatGPT and
   users can discover apps in the app directory:
   https://openai.com/index/developers-can-now-submit-apps-to-chatgpt
+- OpenAI's app submission docs require dashboard review, org verification,
+  app management permissions, a public MCP server, CSP, screenshots/test
+  prompts, and publish-after-approval before App Directory listing:
+  https://developers.openai.com/apps-sdk/deploy/submission
 - Anthropic says its Connectors Directory showcases MCP servers that work
   across Claude surfaces and has a server review form:
   https://support.anthropic.com/en/articles/11596036-anthropic-mcp-directory-faq
+- Anthropic's current connector docs reject catch-all read/write tools and
+  require titles/annotations, public docs, and MCP Inspector/custom-connector
+  testing before submission:
+  https://claude.com/docs/connectors/building/review-criteria
+  https://claude.com/docs/connectors/building/submission
 - The official MCP Registry is the preview centralized metadata repository and
   REST API for publicly accessible MCP servers:
   https://modelcontextprotocol.io/registry/about

--- a/docs/ops/mcp-directory-submission-packet.md
+++ b/docs/ops/mcp-directory-submission-packet.md
@@ -1,0 +1,213 @@
+# MCP Directory Submission Packet
+
+Date: 2026-05-01
+Status: branch-ready packet, not yet externally submitted
+Owner: lead + codex-gpt5-desktop
+
+This packet is for app-directory and registry reviewers. It separates the full
+custom connector endpoint from the narrower review/listing endpoint:
+
+- Full custom connector: `https://tinyassets.io/mcp`
+- Directory/review endpoint: `https://tinyassets.io/mcp-directory`
+- Website/customer chooser: `https://tinyassets.io/connect`
+- Support: `ops@tinyassets.io`
+- Security: `security@tinyassets.io`
+- Legal/privacy: `https://tinyassets.io/legal`
+
+## Completion Definition
+
+The rollout is not complete when the code or docs merge. It is complete only
+when the user can discover and use Workflow through normal host surfaces:
+
+- MCP Registry: `server.json` is published in the official registry and
+  Workflow is discoverable by registry clients.
+- Claude: Workflow is accepted/listed in the Claude Connectors Directory, and
+  a normal logged-in Claude user can add it from the directory without a custom
+  MCP URL.
+- ChatGPT: Workflow is accepted/listed in the ChatGPT App Directory, and a
+  normal eligible logged-in ChatGPT user can invoke it without Developer Mode.
+- First-use evidence: at least one non-developer-mode user discovery, install,
+  and successful read-only tool call is recorded per listed host.
+
+Guest ChatGPT or logged-out hosted-chatbot users are not a supported app/MCP
+path today; route them to local/self-hosted or channel-host paths instead.
+
+## Official Requirements Checked
+
+Fresh source snapshot, checked 2026-05-01:
+
+- OpenAI app submission help: `https://help.openai.com/zh-hant-hk/articles/20001040-submitting-apps-to-the-chatgpt-app-directory`
+- Anthropic Connector Directory FAQ: `https://support.claude.com/en/articles/11596036-anthropic-mcp-directory-faq`
+- Anthropic connector submission process: `https://claude.com/docs/connectors/building/submission`
+- Anthropic review criteria: `https://claude.com/docs/connectors/building/review-criteria`
+- MCP Registry quickstart: `https://modelcontextprotocol.io/registry/quickstart`
+- MCP Registry overview: `https://modelcontextprotocol.io/registry/about`
+
+Review-risk implication: directory submissions should not use the legacy
+catch-all `action` router tools. The `/mcp-directory` surface exposes narrow,
+named tools with explicit annotations instead.
+
+## App Metadata
+
+Name: Workflow
+
+Short description: Build durable workflows
+
+Long description:
+
+Workflow helps users inspect durable AI workflow state, browse shared goals and
+wiki knowledge, and submit bounded requests into a long-running Workflow daemon.
+It is for AI work that should persist beyond one chat: goals, universes, branch
+runs, wiki/status knowledge, and daemon requests.
+
+Category: Productivity
+
+Primary user intent:
+
+- "Use Workflow to list durable goals."
+- "Use Workflow to inspect the active universe."
+- "Use Workflow to search the project wiki."
+- "Use Workflow to queue a bounded daemon request."
+- "Use Workflow to propose a shared goal."
+
+## Directory Tool Surface
+
+Endpoint: `https://tinyassets.io/mcp-directory`
+
+| Tool | Read-only | Open world | Destructive | Purpose |
+|---|---:|---:|---:|---|
+| `get_workflow_status` | yes | no | no | Return daemon status, routing evidence, and safety caveats. |
+| `list_workflow_universes` | yes | no | no | List available Workflow universes. |
+| `inspect_workflow_universe` | yes | no | no | Inspect durable state for one universe. |
+| `list_workflow_goals` | yes | no | no | List shared Workflow goals. |
+| `search_workflow_goals` | yes | no | no | Search shared Workflow goals. |
+| `get_workflow_goal` | yes | no | no | Read one goal and its bound branches. |
+| `search_workflow_wiki` | yes | no | no | Search Workflow wiki knowledge. |
+| `read_workflow_wiki_page` | yes | no | no | Read one Workflow wiki page. |
+| `list_workflow_runs` | yes | no | no | List recent Workflow branch runs. |
+| `propose_workflow_goal` | no | yes | no | Create a shared goal proposal. |
+| `submit_workflow_request` | no | no | no | Queue a bounded daemon request. |
+
+The directory surface intentionally excludes broad legacy tools named
+`universe`, `extensions`, `goals`, `gates`, and `wiki` because those combine
+multiple read/write operations behind `action` parameters.
+
+## Review Prompts
+
+Use these prompts for manual review and host test cases:
+
+- "Use Workflow to check the daemon status and tell me any caveats."
+- "Use Workflow to search for onboarding goals."
+- "Use Workflow to list universes and inspect the active one."
+- "Use Workflow to search the wiki for launch risks and read the best page."
+- "Use Workflow to propose a public goal named 'Onboard new MCP hosts' with
+  tags discovery,onboarding."
+- "Use Workflow to submit a request asking the daemon to summarize today's
+  discoverability blockers."
+
+Negative cases:
+
+- Weather, calendar, email, payments, and general web browsing requests should
+  not invoke Workflow.
+- Requests to delete all data should not invoke the directory surface; it has no
+  destructive tools.
+- Credential-storage prompts should not invoke Workflow; no directory tool asks
+  for passwords, API keys, MFA codes, SSNs, or payment fields.
+
+## Submission Tasks
+
+### MCP Registry
+
+Ready artifact:
+
+- `packaging/registry/server.json`
+
+Command sequence after authentication:
+
+```powershell
+mcp-publisher login github
+mcp-publisher publish packaging/registry/server.json
+```
+
+Blocker: publication requires a registry publisher session and namespace rights
+for the GitHub-owned package name. In this environment `mcp-publisher --help`
+failed because the CLI is not installed in PATH. Do not mark complete until the
+registry listing can be fetched from the public registry.
+
+### Claude Connectors Directory
+
+Submit:
+
+- Name: Workflow
+- MCP server URL: `https://tinyassets.io/mcp-directory`
+- Website: `https://tinyassets.io/connect`
+- Support: `ops@tinyassets.io`
+- Security: `security@tinyassets.io`
+- Review prompts: use the Review Prompts section above.
+- Safety notes: directory endpoint has no destructive tools; write tools only
+  create a goal proposal or queue a bounded Workflow request.
+
+Acceptance proof:
+
+- Reviewer or normal Claude user can find Workflow in the Connectors Directory.
+- User can add it from the directory without pasting a custom URL.
+- Live Claude.ai conversation invokes at least `get_workflow_status` or
+  `list_workflow_goals`.
+- Trace is saved to `output/claude_chat_trace.md` and summarized in
+  `output/user_sim_session.md`.
+
+Blocker: actual submission requires Anthropic's form/review flow and any
+human/org fields not present in the repo.
+
+### ChatGPT App Directory
+
+Ready artifact:
+
+- `chatgpt-app-submission.json`
+
+Submit:
+
+- Display name: Workflow
+- Subtitle: Build durable workflows
+- Category: Productivity
+- MCP server URL: `https://tinyassets.io/mcp-directory`
+- Test cases: import from `chatgpt-app-submission.json`
+
+Acceptance proof:
+
+- Workflow appears in the ChatGPT App Directory for eligible logged-in users.
+- A normal eligible user invokes Workflow without Developer Mode.
+- At least one read-only tool call succeeds from ChatGPT.
+
+Blockers:
+
+- Actual submission requires the OpenAI app submission/dashboard flow from an
+  account with app write/read permissions and completed org verification.
+- OpenAI's submission requirements include a defined CSP for the app. This
+  branch prepares the MCP tool surface and submission JSON; a widget/CSP slice
+  must land before pressing Submit if the dashboard requires an embedded app
+  resource for Workflow's listing.
+- The dashboard form also asks for screenshots, privacy policy URL, MCP/tool
+  information, and localization details. These must be supplied from the
+  verified deployment, not guessed from local code.
+
+## Local Evidence From This Branch
+
+- `python -m pytest tests/test_directory_server.py tests/test_universe_server_directory_app.py tests/smoke/test_mcp_tools_list_non_empty.py tests/test_universe_server_metadata.py`
+- `node --test worker.test.js` in `deploy/cloudflare-worker`
+- `python packaging/registry/generate_server_json.py --check`
+- `python packaging/claude-plugin/build_plugin.py`
+- Local runtime smoke:
+  - `python scripts/mcp_public_canary.py --url http://127.0.0.1:8017/mcp --timeout 10 --verbose`
+  - `python scripts/mcp_public_canary.py --url http://127.0.0.1:8017/mcp-directory --timeout 10 --verbose`
+  - `python scripts/mcp_probe.py --url http://127.0.0.1:8017/mcp-directory --raw tools`
+
+After deployment, run:
+
+```powershell
+python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp --timeout 15 --verbose
+python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp-directory --timeout 15 --verbose
+```
+
+Then run a tool-list probe against `/mcp-directory` and verify that only the 11
+directory tools above are exposed.

--- a/docs/ops/mcp-host-proof-registry.md
+++ b/docs/ops/mcp-host-proof-registry.md
@@ -2,7 +2,8 @@
 
 Date: 2026-05-01
 Owner: lead + codex-gpt5-desktop
-Canonical MCP URL: `https://tinyassets.io/mcp`
+Canonical full MCP URL: `https://tinyassets.io/mcp`
+Directory/review MCP URL: `https://tinyassets.io/mcp-directory`
 
 This registry is the source for public claims about where Workflow works. If a
 host is not listed as verified here, public copy should say "compatible by
@@ -11,6 +12,7 @@ spec" or "planned", not "works".
 ## Verification Rules
 
 - Public endpoint proof starts with `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp`.
+- Directory endpoint proof also requires `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp-directory`.
 - Hosted chatbot proof must use the real chatbot UI with the Workflow connector
   enabled, then log the trace in `output/claude_chat_trace.md` or the matching
   host trace file.
@@ -26,13 +28,24 @@ spec" or "planned", not "works".
 | Gate | Status | Evidence | Notes |
 |---|---|---|---|
 | Public MCP endpoint | watch/flapping | Latest 2026-05-01 diagnostic: 5/5 local canaries green and GitHub Actions uptime run `25231089323` green after intermittent HTTP 502s | Keep monitoring before public app/directory launch claims |
-| Official MCP Registry metadata | ready-draft | `packaging/registry/server.json` validates against schema and points at `https://tinyassets.io/mcp` | Needs `mcp-publisher login github` + publish by repo owner/admin |
+| Directory-safe MCP endpoint | branch-ready | `workflow/directory_server.py` exposes 11 narrow tools; local tests pin annotations and no catch-all `action` inputs | Live only after server + Worker deploy |
+| Official MCP Registry metadata | branch-ready | `packaging/registry/server.json` points at `https://tinyassets.io/mcp-directory` | Local PATH lacks `mcp-publisher`; needs CLI install, `mcp-publisher login github`, and publish by repo owner/admin |
 | AI-readable web docs | ready-draft | `WebSite/site/static/llms.txt` | Ships with site deploy |
 | `/connect` customer chooser | ready-draft | `npm run check`, `npm run build`, Playwright desktop/mobile smoke on 2026-05-01 | Ships with site deploy |
 
 ## 2026-05-01 Local Verification
 
 - `python packaging/registry/generate_server_json.py --check --validate` passed.
+- `python -m pytest tests/test_directory_server.py tests/test_universe_server_directory_app.py tests/smoke/test_mcp_tools_list_non_empty.py tests/test_universe_server_metadata.py` passed.
+- `node --test worker.test.js` passed in `deploy/cloudflare-worker`.
+- `python packaging/claude-plugin/build_plugin.py` passed with import probe, including the new directory server module in the plugin runtime mirror.
+- Local Streamable HTTP runtime smoke passed: `scripts/mcp_public_canary.py`
+  initialized both `http://127.0.0.1:8017/mcp` and
+  `http://127.0.0.1:8017/mcp-directory`; `scripts/mcp_probe.py` listed the
+  11 directory tools from `/mcp-directory`.
+- `mcp-publisher --help` failed because the CLI is not installed in the
+  current Windows PATH; registry publish remains blocked on CLI install and
+  GitHub device authentication.
 - Public MCP diagnostics after one local HTTP 502: 5 consecutive
   `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp --timeout 15 --verbose`
   probes passed; GitHub Actions uptime run `25231089323` passed; direct
@@ -51,13 +64,13 @@ spec" or "planned", not "works".
 
 | Host surface | Customer path | Status | Proof / blocker |
 |---|---|---|---|
-| Claude.ai custom connector | Logged-in Claude user | verified-historical; refresh needed | Real Claude.ai proof exists in site capture; refresh after copy/metadata lands |
-| Claude Connectors Directory | Logged-in Claude users/admins | submission-needed | Prepare metadata, privacy/safety copy, icon/favicon, examples, support path |
+| Claude.ai custom connector | Logged-in Claude user | verified-historical; refresh needed | Full surface is `https://tinyassets.io/mcp`; real Claude.ai proof exists in site capture; refresh after endpoint changes land |
+| Claude Connectors Directory | Logged-in Claude users/admins | packet-ready; submission-needed | Use `https://tinyassets.io/mcp-directory` and `docs/ops/mcp-directory-submission-packet.md` |
 | ChatGPT custom MCP / developer mode | Logged-in eligible ChatGPT user/workspace | blocked | BUG-034/admin approval path blocks clean custom connector approval |
-| ChatGPT App Directory | Logged-in ChatGPT users/admins | submission-needed | Needs Apps SDK manifest/widget/test cases and OpenAI app submission |
+| ChatGPT App Directory | Logged-in ChatGPT users/admins | packet-ready; submission-needed | `chatgpt-app-submission.json` covers the 11 directory tools; actual submission requires OpenAI workspace/admin flow |
 | ChatGPT guest | No logged-in chatbot account | unsupported by ChatGPT path | Route to local/self-hosted/no-chatbot-login options |
 | Mistral Le Chat MCP connector | Logged-in Mistral user/admin | planned | Need connector config proof and directory/submission research |
-| Open WebUI | No hosted chatbot login if self-hosted | planned | Verify Streamable HTTP MCP config against `https://tinyassets.io/mcp` |
+| Open WebUI | No hosted chatbot login if self-hosted | planned | Verify Streamable HTTP MCP config against `https://tinyassets.io/mcp` or directory-safe `https://tinyassets.io/mcp-directory` |
 | LibreChat | No hosted chatbot login if self-hosted | planned | Verify MCP config or bridge path |
 | LM Studio / Jan | Local model user | planned | Verify native MCP support or document bridge/fallback truthfully |
 | OpenClaw / channel gateway | Channel user | planned | Need direct support proof before claiming |
@@ -80,9 +93,9 @@ Use host-specific wording, but each host should prove at least one of these:
 ## Open Follow-Ups
 
 - Publish `packaging/registry/server.json` to the official MCP Registry after
-  the public endpoint stays green long enough for launch confidence.
-- Prepare Claude directory submission kit.
-- Prepare ChatGPT Apps SDK submission kit and resolve BUG-034 approval path.
+  the public directory endpoint is deployed and green.
+- Submit the Claude directory packet through Anthropic's review flow.
+- Submit `chatgpt-app-submission.json` through OpenAI's app submission flow and resolve BUG-034 approval path for custom connectors.
 - Verify one no-chatbot-login host first, preferably Open WebUI because it
   supports Streamable HTTP MCP directly.
 - Add host-specific proof traces as they land.

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
@@ -1,0 +1,290 @@
+"""Directory-safe MCP surface for public host listings.
+
+This module exposes narrow tools intended for reviewed host directories such
+as Claude's Connectors Directory and ChatGPT Apps. The legacy
+``workflow.universe_server`` surface remains available at ``/mcp`` for custom
+MCP clients. This directory surface is intentionally smaller: no catch-all
+``action`` arguments, explicit read/write boundaries, and explicit tool
+annotations for host review.
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+from workflow.api.extensions import _extensions_impl
+from workflow.api.market import goals as _goals_impl
+from workflow.api.status import get_status as _get_status_impl
+from workflow.api.universe import _universe_impl
+from workflow.api.wiki import wiki as _wiki_impl
+
+directory_mcp = FastMCP(
+    "workflow-directory",
+    instructions=(
+        "Workflow helps users discover durable workflow goals, inspect "
+        "universes, browse the public knowledge wiki, and submit bounded "
+        "requests into the Workflow daemon loop. Use these tools only when "
+        "the user asks for Workflow, durable AI workflow design, shared "
+        "workflow goals, or project wiki/status information."
+    ),
+    version="0.1.0",
+)
+
+
+@directory_mcp.tool(
+    title="Get Workflow Status",
+    tags={"status", "workflow", "diagnostics"},
+    annotations=ToolAnnotations(
+        title="Get Workflow Status",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def get_workflow_status(universe_id: str = "") -> str:
+    """Return daemon status, routing evidence, and safety caveats.
+
+    Args:
+        universe_id: Optional universe scope. Empty uses the active universe.
+    """
+    return _get_status_impl(universe_id=universe_id)
+
+
+@directory_mcp.tool(
+    title="List Workflow Universes",
+    tags={"universes", "workflow", "browse"},
+    annotations=ToolAnnotations(
+        title="List Workflow Universes",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def list_workflow_universes(limit: int = 30) -> str:
+    """List available Workflow universes without changing state.
+
+    Args:
+        limit: Maximum number of universes to return.
+    """
+    return _universe_impl(action="list", limit=limit)
+
+
+@directory_mcp.tool(
+    title="Inspect Workflow Universe",
+    tags={"universes", "workflow", "inspect"},
+    annotations=ToolAnnotations(
+        title="Inspect Workflow Universe",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def inspect_workflow_universe(universe_id: str = "") -> str:
+    """Inspect one Workflow universe and summarize durable state.
+
+    Args:
+        universe_id: Optional universe scope. Empty uses the active universe.
+    """
+    return _universe_impl(action="inspect", universe_id=universe_id)
+
+
+@directory_mcp.tool(
+    title="List Workflow Goals",
+    tags={"goals", "workflow", "browse"},
+    annotations=ToolAnnotations(
+        title="List Workflow Goals",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> str:
+    """List shared Workflow goals.
+
+    Args:
+        tags: Optional comma-separated tag filter.
+        author: Optional author filter.
+        limit: Maximum number of goals to return.
+    """
+    return _goals_impl(action="list", tags=tags, author=author, limit=limit)
+
+
+@directory_mcp.tool(
+    title="Search Workflow Goals",
+    tags={"goals", "workflow", "search"},
+    annotations=ToolAnnotations(
+        title="Search Workflow Goals",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def search_workflow_goals(query: str, limit: int = 20) -> str:
+    """Search Workflow goals by name, description, or tag.
+
+    Args:
+        query: Search text.
+        limit: Maximum number of goals to return.
+    """
+    return _goals_impl(action="search", query=query, limit=limit)
+
+
+@directory_mcp.tool(
+    title="Get Workflow Goal",
+    tags={"goals", "workflow", "inspect"},
+    annotations=ToolAnnotations(
+        title="Get Workflow Goal",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def get_workflow_goal(goal_id: str) -> str:
+    """Return one Workflow goal and its bound branches.
+
+    Args:
+        goal_id: Goal identifier to inspect.
+    """
+    return _goals_impl(action="get", goal_id=goal_id)
+
+
+@directory_mcp.tool(
+    title="Search Workflow Wiki",
+    tags={"wiki", "knowledge", "workflow", "search"},
+    annotations=ToolAnnotations(
+        title="Search Workflow Wiki",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) -> str:
+    """Search the Workflow public knowledge wiki.
+
+    Args:
+        query: Search text.
+        category: Optional wiki category filter.
+        max_results: Maximum number of wiki hits to return.
+    """
+    return _wiki_impl(
+        action="search",
+        query=query,
+        category=category,
+        max_results=max_results,
+    )
+
+@directory_mcp.tool(
+    title="Read Workflow Wiki Page",
+    tags={"wiki", "knowledge", "workflow", "read"},
+    annotations=ToolAnnotations(
+        title="Read Workflow Wiki Page",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def read_workflow_wiki_page(page: str) -> str:
+    """Read one Workflow wiki page.
+
+    Args:
+        page: Wiki page slug or path.
+    """
+    return _wiki_impl(action="read", page=page)
+
+
+@directory_mcp.tool(
+    title="List Workflow Runs",
+    tags={"runs", "workflow", "browse"},
+    annotations=ToolAnnotations(
+        title="List Workflow Runs",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def list_workflow_runs(status: str = "", limit: int = 20) -> str:
+    """List recent Workflow branch runs without starting or stopping work.
+
+    Args:
+        status: Optional run status filter.
+        limit: Maximum number of runs to return.
+    """
+    return _extensions_impl(action="list_runs", status=status, limit=limit)
+
+
+@directory_mcp.tool(
+    title="Propose Workflow Goal",
+    tags={"goals", "workflow", "create"},
+    annotations=ToolAnnotations(
+        title="Propose Workflow Goal",
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+def propose_workflow_goal(
+    name: str,
+    description: str = "",
+    tags: str = "",
+    visibility: str = "public",
+) -> str:
+    """Create a shared Workflow goal proposal.
+
+    Args:
+        name: Human-readable goal name.
+        description: Optional goal description.
+        tags: Optional comma-separated tags.
+        visibility: Visibility value accepted by Workflow, usually public.
+    """
+    return _goals_impl(
+        action="propose",
+        name=name,
+        description=description,
+        tags=tags,
+        visibility=visibility,
+    )
+
+
+@directory_mcp.tool(
+    title="Submit Workflow Request",
+    tags={"requests", "workflow", "queue"},
+    annotations=ToolAnnotations(
+        title="Submit Workflow Request",
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=False,
+    ),
+)
+def submit_workflow_request(
+    text: str,
+    universe_id: str = "",
+    request_type: str = "scene_direction",
+    branch_id: str = "",
+) -> str:
+    """Queue a bounded request for the Workflow daemon.
+
+    Args:
+        text: Request text to queue.
+        universe_id: Optional target universe. Empty uses the active universe.
+        request_type: Workflow request type.
+        branch_id: Optional target branch identifier.
+    """
+    return _universe_impl(
+        action="submit_request",
+        universe_id=universe_id,
+        text=text,
+        request_type=request_type,
+        branch_id=branch_id,
+    )

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -28,9 +28,12 @@ delegate to plain callables in those submodules (Pattern A2).
 from __future__ import annotations
 
 import logging
+from contextlib import AsyncExitStack, asynccontextmanager
 
+import uvicorn
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
+from starlette.applications import Starlette
 
 from workflow.api.branches import _branch_design_guide_prompt
 from workflow.api.engine_helpers import _warn_if_no_upload_whitelist
@@ -41,6 +44,7 @@ from workflow.api.prompts import _CONTROL_STATION_PROMPT
 from workflow.api.status import get_status as _get_status_impl
 from workflow.api.universe import _universe_impl
 from workflow.api.wiki import wiki as _wiki_impl
+from workflow.directory_server import directory_mcp
 
 logger = logging.getLogger("universe_server")
 
@@ -995,6 +999,39 @@ def get_status(universe_id: str = "") -> str:
 # ═══════════════════════════════════════════════════════════════════════════
 
 
+def create_streamable_http_app() -> Starlette:
+    """Create the production HTTP app with both MCP surfaces.
+
+    `/mcp` preserves the legacy custom-connector surface. `/mcp-directory`
+    exposes the narrow directory-review surface used for app-store style host
+    submissions. Both route to the same backend state.
+    """
+    legacy_app = mcp.http_app(path="/mcp", transport="streamable-http")
+    directory_app = directory_mcp.http_app(
+        path="/mcp-directory",
+        transport="streamable-http",
+    )
+
+    @asynccontextmanager
+    async def lifespan(app: Starlette):  # type: ignore[no-untyped-def]
+        async with AsyncExitStack() as stack:
+            await stack.enter_async_context(
+                legacy_app.router.lifespan_context(legacy_app),
+            )
+            await stack.enter_async_context(
+                directory_app.router.lifespan_context(directory_app),
+            )
+            yield
+
+    app = Starlette(
+        routes=[*legacy_app.routes, *directory_app.routes],
+        lifespan=lifespan,
+    )
+    app.state.path = "/mcp,/mcp-directory"
+    app.state.transport_type = "streamable-http"
+    return app
+
+
 def main(
     host: str = "0.0.0.0",
     port: int = 8001,
@@ -1014,7 +1051,8 @@ def main(
     )
 
     if transport == "streamable-http":
-        mcp.run(transport="streamable-http", host=host, port=port)
+        app = create_streamable_http_app()
+        uvicorn.run(app, host=host, port=port)
     elif transport == "sse":
         mcp.run(transport="sse", host=host, port=port)
     elif transport == "stdio":

--- a/packaging/registry/generate_server_json.py
+++ b/packaging/registry/generate_server_json.py
@@ -16,7 +16,7 @@ DESCRIPTION = (
 )
 REPOSITORY_URL = "https://github.com/Jonnyton/Workflow"
 WEBSITE_URL = "https://tinyassets.io/connect"
-REMOTE_URL = "https://tinyassets.io/mcp"
+REMOTE_URL = "https://tinyassets.io/mcp-directory"
 ICON_URL = "https://raw.githubusercontent.com/Jonnyton/Workflow/main/assets/icon.png"
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/packaging/registry/server.json
+++ b/packaging/registry/server.json
@@ -21,7 +21,7 @@
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://tinyassets.io/mcp"
+      "url": "https://tinyassets.io/mcp-directory"
     }
   ]
 }

--- a/tests/test_deploy_worker_workflow.py
+++ b/tests/test_deploy_worker_workflow.py
@@ -143,6 +143,14 @@ def _get_step_condition(steps: list[dict], step_name_fragment: str) -> str | Non
     return None
 
 
+def _get_step(steps: list[dict], step_name_fragment: str) -> dict | None:
+    for step in steps:
+        name = step.get("name", "") or ""
+        if step_name_fragment.lower() in name.lower():
+            return step
+    return None
+
+
 def test_dry_run_step_fires_on_pull_request():
     wf = _load_workflow()
     steps = wf["jobs"]["deploy-worker"]["steps"]
@@ -168,6 +176,20 @@ def test_dry_run_does_not_fire_on_push():
     # The condition fires on pull_request and workflow_dispatch+dry_run=true.
     # It must NOT contain a bare "push" that would run on every push.
     assert "event_name == 'push'" not in cond
+
+
+def test_pull_requests_do_not_require_cloudflare_secrets():
+    """PR validation must not fail before Worker unit tests when deploy secrets are absent."""
+    wf = _load_workflow()
+    steps = wf["jobs"]["deploy-worker"]["steps"]
+
+    verify = _get_step(steps, "Verify secrets present")
+    assert verify is not None, "workflow must keep a live-deploy secret check"
+    assert verify.get("if") == "github.event_name != 'pull_request'"
+
+    dry_run = _get_step(steps, "dry-run")
+    assert dry_run is not None
+    assert "skipping Wrangler dry-run" in dry_run.get("run", "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_directory_server.py
+++ b/tests/test_directory_server.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import asyncio
+
+from workflow.directory_server import directory_mcp
+
+EXPECTED_TOOLS = {
+    "get_workflow_status": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "list_workflow_universes": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "inspect_workflow_universe": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "list_workflow_goals": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "search_workflow_goals": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "get_workflow_goal": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "search_workflow_wiki": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "read_workflow_wiki_page": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "list_workflow_runs": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "propose_workflow_goal": {
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+    "submit_workflow_request": {
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": False,
+    },
+}
+
+
+def _list_tools():
+    return asyncio.run(directory_mcp.list_tools(run_middleware=False))
+
+
+def test_directory_surface_exposes_review_scoped_tool_set() -> None:
+    tools = {tool.name: tool for tool in _list_tools()}
+
+    assert set(tools) == set(EXPECTED_TOOLS)
+    assert "universe" not in tools
+    assert "extensions" not in tools
+    assert "goals" not in tools
+    assert "wiki" not in tools
+
+
+def test_directory_tools_have_explicit_submission_annotations() -> None:
+    tools = {tool.name: tool for tool in _list_tools()}
+
+    for tool_name, expected in EXPECTED_TOOLS.items():
+        annotations = tools[tool_name].annotations
+        assert annotations is not None, f"{tool_name} missing annotations"
+        for hint_name, expected_value in expected.items():
+            assert getattr(annotations, hint_name) is expected_value, (
+                f"{tool_name}.{hint_name} must be {expected_value}"
+            )
+
+
+def test_directory_tools_do_not_use_catch_all_action_inputs() -> None:
+    for tool in _list_tools():
+        properties = tool.parameters.get("properties", {})
+        assert "action" not in properties, (
+            f"{tool.name} must expose a narrow tool, not an action router"
+        )
+
+
+def test_directory_tool_inputs_avoid_sensitive_credentials() -> None:
+    sensitive_terms = {
+        "password",
+        "secret",
+        "token",
+        "api_key",
+        "mfa",
+        "ssn",
+        "credit_card",
+    }
+
+    for tool in _list_tools():
+        properties = tool.parameters.get("properties", {})
+        names = {name.lower() for name in properties}
+        assert names.isdisjoint(sensitive_terms), (
+            f"{tool.name} requests a sensitive credential-like field"
+        )

--- a/tests/test_universe_server_directory_app.py
+++ b/tests/test_universe_server_directory_app.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from workflow.universe_server import create_streamable_http_app
+
+
+def test_streamable_http_app_mounts_legacy_and_directory_surfaces() -> None:
+    app = create_streamable_http_app()
+    paths = {getattr(route, "path", None) for route in app.routes}
+
+    assert "/mcp" in paths
+    assert "/mcp-directory" in paths
+    assert app.state.path == "/mcp,/mcp-directory"
+    assert app.state.transport_type == "streamable-http"

--- a/workflow/directory_server.py
+++ b/workflow/directory_server.py
@@ -1,0 +1,290 @@
+"""Directory-safe MCP surface for public host listings.
+
+This module exposes narrow tools intended for reviewed host directories such
+as Claude's Connectors Directory and ChatGPT Apps. The legacy
+``workflow.universe_server`` surface remains available at ``/mcp`` for custom
+MCP clients. This directory surface is intentionally smaller: no catch-all
+``action`` arguments, explicit read/write boundaries, and explicit tool
+annotations for host review.
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+from workflow.api.extensions import _extensions_impl
+from workflow.api.market import goals as _goals_impl
+from workflow.api.status import get_status as _get_status_impl
+from workflow.api.universe import _universe_impl
+from workflow.api.wiki import wiki as _wiki_impl
+
+directory_mcp = FastMCP(
+    "workflow-directory",
+    instructions=(
+        "Workflow helps users discover durable workflow goals, inspect "
+        "universes, browse the public knowledge wiki, and submit bounded "
+        "requests into the Workflow daemon loop. Use these tools only when "
+        "the user asks for Workflow, durable AI workflow design, shared "
+        "workflow goals, or project wiki/status information."
+    ),
+    version="0.1.0",
+)
+
+
+@directory_mcp.tool(
+    title="Get Workflow Status",
+    tags={"status", "workflow", "diagnostics"},
+    annotations=ToolAnnotations(
+        title="Get Workflow Status",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def get_workflow_status(universe_id: str = "") -> str:
+    """Return daemon status, routing evidence, and safety caveats.
+
+    Args:
+        universe_id: Optional universe scope. Empty uses the active universe.
+    """
+    return _get_status_impl(universe_id=universe_id)
+
+
+@directory_mcp.tool(
+    title="List Workflow Universes",
+    tags={"universes", "workflow", "browse"},
+    annotations=ToolAnnotations(
+        title="List Workflow Universes",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def list_workflow_universes(limit: int = 30) -> str:
+    """List available Workflow universes without changing state.
+
+    Args:
+        limit: Maximum number of universes to return.
+    """
+    return _universe_impl(action="list", limit=limit)
+
+
+@directory_mcp.tool(
+    title="Inspect Workflow Universe",
+    tags={"universes", "workflow", "inspect"},
+    annotations=ToolAnnotations(
+        title="Inspect Workflow Universe",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def inspect_workflow_universe(universe_id: str = "") -> str:
+    """Inspect one Workflow universe and summarize durable state.
+
+    Args:
+        universe_id: Optional universe scope. Empty uses the active universe.
+    """
+    return _universe_impl(action="inspect", universe_id=universe_id)
+
+
+@directory_mcp.tool(
+    title="List Workflow Goals",
+    tags={"goals", "workflow", "browse"},
+    annotations=ToolAnnotations(
+        title="List Workflow Goals",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> str:
+    """List shared Workflow goals.
+
+    Args:
+        tags: Optional comma-separated tag filter.
+        author: Optional author filter.
+        limit: Maximum number of goals to return.
+    """
+    return _goals_impl(action="list", tags=tags, author=author, limit=limit)
+
+
+@directory_mcp.tool(
+    title="Search Workflow Goals",
+    tags={"goals", "workflow", "search"},
+    annotations=ToolAnnotations(
+        title="Search Workflow Goals",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def search_workflow_goals(query: str, limit: int = 20) -> str:
+    """Search Workflow goals by name, description, or tag.
+
+    Args:
+        query: Search text.
+        limit: Maximum number of goals to return.
+    """
+    return _goals_impl(action="search", query=query, limit=limit)
+
+
+@directory_mcp.tool(
+    title="Get Workflow Goal",
+    tags={"goals", "workflow", "inspect"},
+    annotations=ToolAnnotations(
+        title="Get Workflow Goal",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def get_workflow_goal(goal_id: str) -> str:
+    """Return one Workflow goal and its bound branches.
+
+    Args:
+        goal_id: Goal identifier to inspect.
+    """
+    return _goals_impl(action="get", goal_id=goal_id)
+
+
+@directory_mcp.tool(
+    title="Search Workflow Wiki",
+    tags={"wiki", "knowledge", "workflow", "search"},
+    annotations=ToolAnnotations(
+        title="Search Workflow Wiki",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) -> str:
+    """Search the Workflow public knowledge wiki.
+
+    Args:
+        query: Search text.
+        category: Optional wiki category filter.
+        max_results: Maximum number of wiki hits to return.
+    """
+    return _wiki_impl(
+        action="search",
+        query=query,
+        category=category,
+        max_results=max_results,
+    )
+
+@directory_mcp.tool(
+    title="Read Workflow Wiki Page",
+    tags={"wiki", "knowledge", "workflow", "read"},
+    annotations=ToolAnnotations(
+        title="Read Workflow Wiki Page",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def read_workflow_wiki_page(page: str) -> str:
+    """Read one Workflow wiki page.
+
+    Args:
+        page: Wiki page slug or path.
+    """
+    return _wiki_impl(action="read", page=page)
+
+
+@directory_mcp.tool(
+    title="List Workflow Runs",
+    tags={"runs", "workflow", "browse"},
+    annotations=ToolAnnotations(
+        title="List Workflow Runs",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+def list_workflow_runs(status: str = "", limit: int = 20) -> str:
+    """List recent Workflow branch runs without starting or stopping work.
+
+    Args:
+        status: Optional run status filter.
+        limit: Maximum number of runs to return.
+    """
+    return _extensions_impl(action="list_runs", status=status, limit=limit)
+
+
+@directory_mcp.tool(
+    title="Propose Workflow Goal",
+    tags={"goals", "workflow", "create"},
+    annotations=ToolAnnotations(
+        title="Propose Workflow Goal",
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+def propose_workflow_goal(
+    name: str,
+    description: str = "",
+    tags: str = "",
+    visibility: str = "public",
+) -> str:
+    """Create a shared Workflow goal proposal.
+
+    Args:
+        name: Human-readable goal name.
+        description: Optional goal description.
+        tags: Optional comma-separated tags.
+        visibility: Visibility value accepted by Workflow, usually public.
+    """
+    return _goals_impl(
+        action="propose",
+        name=name,
+        description=description,
+        tags=tags,
+        visibility=visibility,
+    )
+
+
+@directory_mcp.tool(
+    title="Submit Workflow Request",
+    tags={"requests", "workflow", "queue"},
+    annotations=ToolAnnotations(
+        title="Submit Workflow Request",
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=False,
+    ),
+)
+def submit_workflow_request(
+    text: str,
+    universe_id: str = "",
+    request_type: str = "scene_direction",
+    branch_id: str = "",
+) -> str:
+    """Queue a bounded request for the Workflow daemon.
+
+    Args:
+        text: Request text to queue.
+        universe_id: Optional target universe. Empty uses the active universe.
+        request_type: Workflow request type.
+        branch_id: Optional target branch identifier.
+    """
+    return _universe_impl(
+        action="submit_request",
+        universe_id=universe_id,
+        text=text,
+        request_type=request_type,
+        branch_id=branch_id,
+    )

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -28,9 +28,12 @@ delegate to plain callables in those submodules (Pattern A2).
 from __future__ import annotations
 
 import logging
+from contextlib import AsyncExitStack, asynccontextmanager
 
+import uvicorn
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
+from starlette.applications import Starlette
 
 from workflow.api.branches import _branch_design_guide_prompt
 from workflow.api.engine_helpers import _warn_if_no_upload_whitelist
@@ -41,6 +44,7 @@ from workflow.api.prompts import _CONTROL_STATION_PROMPT
 from workflow.api.status import get_status as _get_status_impl
 from workflow.api.universe import _universe_impl
 from workflow.api.wiki import wiki as _wiki_impl
+from workflow.directory_server import directory_mcp
 
 logger = logging.getLogger("universe_server")
 
@@ -995,6 +999,39 @@ def get_status(universe_id: str = "") -> str:
 # ═══════════════════════════════════════════════════════════════════════════
 
 
+def create_streamable_http_app() -> Starlette:
+    """Create the production HTTP app with both MCP surfaces.
+
+    `/mcp` preserves the legacy custom-connector surface. `/mcp-directory`
+    exposes the narrow directory-review surface used for app-store style host
+    submissions. Both route to the same backend state.
+    """
+    legacy_app = mcp.http_app(path="/mcp", transport="streamable-http")
+    directory_app = directory_mcp.http_app(
+        path="/mcp-directory",
+        transport="streamable-http",
+    )
+
+    @asynccontextmanager
+    async def lifespan(app: Starlette):  # type: ignore[no-untyped-def]
+        async with AsyncExitStack() as stack:
+            await stack.enter_async_context(
+                legacy_app.router.lifespan_context(legacy_app),
+            )
+            await stack.enter_async_context(
+                directory_app.router.lifespan_context(directory_app),
+            )
+            yield
+
+    app = Starlette(
+        routes=[*legacy_app.routes, *directory_app.routes],
+        lifespan=lifespan,
+    )
+    app.state.path = "/mcp,/mcp-directory"
+    app.state.transport_type = "streamable-http"
+    return app
+
+
 def main(
     host: str = "0.0.0.0",
     port: int = 8001,
@@ -1014,7 +1051,8 @@ def main(
     )
 
     if transport == "streamable-http":
-        mcp.run(transport="streamable-http", host=host, port=port)
+        app = create_streamable_http_app()
+        uvicorn.run(app, host=host, port=port)
     elif transport == "sse":
         mcp.run(transport="sse", host=host, port=port)
     elif transport == "stdio":


### PR DESCRIPTION
## Summary
- add a separate `/mcp-directory` FastMCP surface with 11 narrow tools for host directory review
- route `/mcp-directory` through the Cloudflare Worker and point MCP Registry metadata at it
- add Claude/OpenAI/MCP Registry submission packets, ChatGPT submission JSON, focused tests, and plugin runtime mirror updates

## Verification
- `python -m ruff check workflow/directory_server.py workflow/universe_server.py packaging/registry/generate_server_json.py tests/test_directory_server.py tests/test_universe_server_directory_app.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py`
- `python -m pytest tests/test_directory_server.py tests/test_universe_server_directory_app.py tests/smoke/test_mcp_tools_list_non_empty.py tests/test_universe_server_metadata.py`
- `python packaging/registry/generate_server_json.py --check --validate`
- `node --test worker.test.js` from `deploy/cloudflare-worker`
- `python packaging/claude-plugin/build_plugin.py`
- local Streamable HTTP smoke: `/mcp` and `/mcp-directory` initialized; `/mcp-directory` tools/list returned the 11 directory tools

## Notes
- Full-repo `python -m ruff check` is still red on pre-existing unrelated files; this PR uses the touched-file gate.
- Actual MCP Registry publish is blocked until `mcp-publisher` is installed and authenticated.
- Actual Claude/OpenAI directory acceptance still requires external form/dashboard submission and host review.