### PR TITLE
Derive Cloudflare account ID for Worker deploy

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -64,18 +64,32 @@ jobs:
 
       - name: Verify secrets present
         if: github.event_name != 'pull_request'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID_SECRET: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          if [ -z "${{ secrets.CLOUDFLARE_API_TOKEN }}" ]; then
+          if [ -z "${CLOUDFLARE_API_TOKEN}" ]; then
             echo "::error::CLOUDFLARE_API_TOKEN secret is not set."
             echo "::error::Required scope: Account:Workers Scripts:Edit + Zone:Workers Routes:Edit + Zone:Zone:Read"
             echo "::error::Mint at: dash.cloudflare.com/profile/api-tokens → Custom Token"
             exit 1
           fi
-          if [ -z "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" ]; then
-            echo "::error::CLOUDFLARE_ACCOUNT_ID secret is not set."
-            echo "::error::Find it at: dash.cloudflare.com → right-side Account ID widget"
+
+          account_id="${CLOUDFLARE_ACCOUNT_ID_SECRET}"
+          if [ -z "${account_id}" ]; then
+            echo "CLOUDFLARE_ACCOUNT_ID secret is not set; resolving from tinyassets.io zone."
+            response="$(curl -fsS \
+              -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+              -H "Content-Type: application/json" \
+              "https://api.cloudflare.com/client/v4/zones?name=tinyassets.io")"
+            account_id="$(python -c 'import json,sys; data=json.load(sys.stdin); result=data.get("result") or []; print(((result[0].get("account") or {}).get("id") or "") if result else "")' <<< "${response}")"
+          fi
+
+          if [ -z "${account_id}" ]; then
+            echo "::error::Could not resolve Cloudflare account ID for tinyassets.io."
             exit 1
           fi
+          echo "CLOUDFLARE_ACCOUNT_ID=${account_id}" >> "${GITHUB_ENV}"
 
       - name: Run Worker unit tests
         working-directory: deploy/cloudflare-worker
@@ -88,7 +102,6 @@ jobs:
         working-directory: deploy/cloudflare-worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           echo "=== dry-run — validating wrangler config + worker bundle ==="
           if [ -z "${CLOUDFLARE_API_TOKEN}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID}" ]; then

--- a/tests/test_deploy_worker_workflow.py
+++ b/tests/test_deploy_worker_workflow.py
@@ -192,6 +192,13 @@ def test_pull_requests_do_not_require_cloudflare_secrets():
     assert "skipping Wrangler dry-run" in dry_run.get("run", "")
 
 
+def test_live_deploy_resolves_account_id_from_zone_when_secret_missing():
+    """The API token has Zone:Read, so the workflow can derive account ID."""
+    text = _workflow_text()
+    assert "zones?name=tinyassets.io" in text
+    assert "CLOUDFLARE_ACCOUNT_ID=${account_id}" in text
+
+
 # ---------------------------------------------------------------------------
 # (e) Required secrets referenced
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- derive `CLOUDFLARE_ACCOUNT_ID` from the `tinyassets.io` zone when the optional secret is missing
- keep PR Worker checks independent from deploy credentials
- keep live deploy fail-fast if the token is missing or account resolution fails

## Verification
- `python -m ruff check tests/test_deploy_worker_workflow.py`
- `python -m pytest tests/test_deploy_worker_workflow.py -q`
- `git diff --check`

Local note: `actionlint` is not installed in this environment; CI remains the authoritative actionlint gate.