### PR TITLE
Run Worker deploy with Node 22

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install Wrangler
         run: npm install -g wrangler@latest
@@ -119,7 +119,6 @@ jobs:
         working-directory: deploy/cloudflare-worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           echo "=== deploying Worker tinyassets-mcp-proxy ==="
           wrangler deploy

--- a/tests/test_deploy_worker_workflow.py
+++ b/tests/test_deploy_worker_workflow.py
@@ -108,6 +108,14 @@ def test_workflow_job_runs_on_ubuntu():
     assert "ubuntu" in job.get("runs-on", "")
 
 
+def test_workflow_uses_wrangler_supported_node_version():
+    wf = _load_workflow()
+    steps = wf["jobs"]["deploy-worker"]["steps"]
+    setup = _get_step(steps, "Set up Node")
+    assert setup is not None
+    assert setup.get("with", {}).get("node-version") == "22"
+
+
 # ---------------------------------------------------------------------------
 # (c) wrangler.toml name matches actual Worker
 # ---------------------------------------------------------------------------
@@ -197,6 +205,7 @@ def test_live_deploy_resolves_account_id_from_zone_when_secret_missing():
     text = _workflow_text()
     assert "zones?name=tinyassets.io" in text
     assert "CLOUDFLARE_ACCOUNT_ID=${account_id}" in text
+    assert "CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" not in text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- update Worker deploy workflow to Node 22 for current Wrangler
- stop overriding the resolved Cloudflare account ID with an empty optional secret
- add workflow structure coverage for both constraints

## Verification
- `python -m ruff check tests/test_deploy_worker_workflow.py`
- `python -m pytest tests/test_deploy_worker_workflow.py -q`
- `git diff --check`

Local note: `actionlint` is not installed here; CI is the authoritative actionlint gate.