### PR TITLE
Record live MCP directory proof

### DIFF
--- a/docs/exec-plans/active/2026-05-01-host-discoverability-and-onboarding-rollout.md
+++ b/docs/exec-plans/active/2026-05-01-host-discoverability-and-onboarding-rollout.md
@@ -339,20 +339,21 @@ Progress snapshot, 2026-05-01:
 - Card 1 ready-draft locally: `/connect` is now a customer path chooser with
   Claude, ChatGPT, no-chatbot-login, IDE, workspace-admin, and custom-host
   paths plus launch-gate truth.
-- Card 5 ready-draft locally: `docs/ops/mcp-host-proof-registry.md` records
-  per-host claim status and local verification evidence.
-- Machine-readable discovery ready-draft locally: `packaging/registry/server.json`
+- Card 5 live-updated: `docs/ops/mcp-host-proof-registry.md` records
+  per-host claim status plus local and production verification evidence.
+- Machine-readable discovery live-artifact: `packaging/registry/server.json`
   validates against the official schema and points at
   `https://tinyassets.io/mcp-directory`;
   `WebSite/site/static/llms.txt` tells chatbots when to recommend Workflow and
   when to caveat host support.
-- Directory endpoint branch slice: `workflow/directory_server.py` exposes 11
+- Directory endpoint live slice: `workflow/directory_server.py` exposes 11
   narrow tools with explicit read/open/destructive annotations and no catch-all
-  `action` inputs; the Worker routes `/mcp-directory` to the same tunnel.
+  `action` inputs; production `/mcp-directory` initializes and tools/list
+  returns the 11 directory tools.
 - Submission packets branch-ready: `docs/ops/mcp-directory-submission-packet.md`
   and `chatgpt-app-submission.json`.
-- Not complete until Gate 0 is green for both endpoints, the branch is
-  merged/deployed, the MCP Registry draft is published by an authorized
+- Code/deploy gate complete for both endpoints. Product rollout is still not
+  complete until the MCP Registry draft is published by an authorized
   GitHub/registry account, Claude/OpenAI submissions are accepted, and
   first-use evidence is recorded.
 

--- a/docs/ops/mcp-directory-submission-packet.md
+++ b/docs/ops/mcp-directory-submission-packet.md
@@ -202,7 +202,19 @@ Blockers:
   - `python scripts/mcp_public_canary.py --url http://127.0.0.1:8017/mcp-directory --timeout 10 --verbose`
   - `python scripts/mcp_probe.py --url http://127.0.0.1:8017/mcp-directory --raw tools`
 
-After deployment, run:
+## Live Evidence
+
+Production evidence, 2026-05-01:
+
+- PR #123 merged as `d6a44eb`; prod deploy run `25233226847` passed.
+- PR #124 merged as `de4a921`; Worker workflow can derive account ID from the
+  `tinyassets.io` zone when the optional account ID secret is missing.
+- PR #125 merged as `e8e0fd0`; manual Worker deploy run `25233386849` passed.
+- `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp --timeout 15 --verbose` returned OK.
+- `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp-directory --timeout 15 --verbose` returned OK.
+- `python scripts/mcp_probe.py --url https://tinyassets.io/mcp-directory tools` returned the 11 directory tools listed above.
+
+For future deployment checks, run:
 
 ```powershell
 python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp --timeout 15 --verbose

--- a/docs/ops/mcp-host-proof-registry.md
+++ b/docs/ops/mcp-host-proof-registry.md
@@ -27,11 +27,11 @@ spec" or "planned", not "works".
 
 | Gate | Status | Evidence | Notes |
 |---|---|---|---|
-| Public MCP endpoint | watch/flapping | Latest 2026-05-01 diagnostic: 5/5 local canaries green and GitHub Actions uptime run `25231089323` green after intermittent HTTP 502s | Keep monitoring before public app/directory launch claims |
-| Directory-safe MCP endpoint | branch-ready | `workflow/directory_server.py` exposes 11 narrow tools; local tests pin annotations and no catch-all `action` inputs | Live only after server + Worker deploy |
-| Official MCP Registry metadata | branch-ready | `packaging/registry/server.json` points at `https://tinyassets.io/mcp-directory` | Local PATH lacks `mcp-publisher`; needs CLI install, `mcp-publisher login github`, and publish by repo owner/admin |
-| AI-readable web docs | ready-draft | `WebSite/site/static/llms.txt` | Ships with site deploy |
-| `/connect` customer chooser | ready-draft | `npm run check`, `npm run build`, Playwright desktop/mobile smoke on 2026-05-01 | Ships with site deploy |
+| Public MCP endpoint | live-green | 2026-05-01: prod deploy `25233226847` green; Worker deploy `25233386849` green; `mcp_public_canary.py --url https://tinyassets.io/mcp` OK | Legacy custom connector surface remains available |
+| Directory-safe MCP endpoint | live-green | 2026-05-01: `mcp_public_canary.py --url https://tinyassets.io/mcp-directory` OK; `mcp_probe.py --url https://tinyassets.io/mcp-directory tools` returned 11 narrow tools | Use this endpoint for host-directory review |
+| Official MCP Registry metadata | artifact-ready; publish-blocked | `packaging/registry/server.json` points at `https://tinyassets.io/mcp-directory` | Local PATH lacks `mcp-publisher`; needs CLI install, `mcp-publisher login github`, and publish by repo owner/admin |
+| AI-readable web docs | live | `WebSite/site/static/llms.txt` live from PR #122 | Needs periodic source freshness check |
+| `/connect` customer chooser | live | PR #122 deployed; Playwright desktop/mobile smoke on 2026-05-01 | Copy is truthful but directory acceptance is still pending |
 
 ## 2026-05-01 Local Verification
 
@@ -50,6 +50,13 @@ spec" or "planned", not "works".
   `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp --timeout 15 --verbose`
   probes passed; GitHub Actions uptime run `25231089323` passed; direct
   `https://mcp.tinyassets.io/mcp` stayed Access-gated at HTTP 403 as expected.
+- Production rollout proof after PR #123/#124/#125:
+  - Deploy prod run `25233226847` passed for merge `d6a44eb`.
+  - Manual Worker deploy run `25233386849` passed for main `e8e0fd0`.
+  - `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp --timeout 15 --verbose` returned OK.
+  - `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp-directory --timeout 15 --verbose` returned OK.
+  - `python scripts/mcp_probe.py --url https://tinyassets.io/mcp-directory tools` returned exactly the 11 directory tools.
+  - `python scripts/mcp_probe.py --url https://tinyassets.io/mcp tools` still returned the 7 legacy custom-connector tools.
 - `npm run check` in `WebSite/site` passed with 0 errors and 0 warnings.
 - `npm run build` in `WebSite/site` passed and emitted `build/connect.html`
   plus `build/llms.txt`.
@@ -64,7 +71,7 @@ spec" or "planned", not "works".
 
 | Host surface | Customer path | Status | Proof / blocker |
 |---|---|---|---|
-| Claude.ai custom connector | Logged-in Claude user | verified-historical; refresh needed | Full surface is `https://tinyassets.io/mcp`; real Claude.ai proof exists in site capture; refresh after endpoint changes land |
+| Claude.ai custom connector | Logged-in Claude user | protocol-live; UI refresh needed | Full surface is `https://tinyassets.io/mcp`; protocol proof green 2026-05-01; live Claude.ai proof still needs refresh |
 | Claude Connectors Directory | Logged-in Claude users/admins | packet-ready; submission-needed | Use `https://tinyassets.io/mcp-directory` and `docs/ops/mcp-directory-submission-packet.md` |
 | ChatGPT custom MCP / developer mode | Logged-in eligible ChatGPT user/workspace | blocked | BUG-034/admin approval path blocks clean custom connector approval |
 | ChatGPT App Directory | Logged-in ChatGPT users/admins | packet-ready; submission-needed | `chatgpt-app-submission.json` covers the 11 directory tools; actual submission requires OpenAI workspace/admin flow |


### PR DESCRIPTION
## Summary
- update the rollout plan and proof registry from branch-ready to live-green for `/mcp-directory`
- record production deploy run IDs and live public canary/tool-list evidence
- keep external directory acceptance blockers explicit

## Verification
- `git diff --check`
- live canaries already run after deploy:
  - `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp --timeout 15 --verbose`
  - `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp-directory --timeout 15 --verbose`
  - `python scripts/mcp_probe.py --url https://tinyassets.io/mcp-directory tools`