### PR TITLE
Document MCP directory rollout queue

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,7 @@ Live steering only. **Budget 4 KB / 60 lines.** Concerns/Work = one line each; l
 - [filed:2026-04-28] Claude card matcher cleanup conflicts with `tests/test_claude_chat_inline_dismiss.py` legacy-connector fallback contract.
 - **[P1 filed:2026-04-30]** Castles II live branch run `28479d8ddfb44488` failed `provider_exhausted` at `candidate_discovery`; blocks branch-run proof (see BUG-038).
 - [filed:2026-04-30 verified:2026-05-01] Scorched exact: live reset-loop fixed @981eb8f; AROS still not playable; exact needs rights-cleared Kickstart.
+- **[P0 filed:2026-05-01 verified:2026-05-01 monitoring]** Directory-safe `/mcp-directory` is live/protocol-green; rollout incomplete until MCP Registry publish + Claude/ChatGPT directory acceptance + first-user evidence.
 
 ## Approved Specs
 
@@ -35,6 +36,7 @@ Path: #18 retarget sweep (live) → Arc B phase 2 → Arc C → Phase 6 db renam
 | Task | Files | Depends | Status |
 |------|-------|---------|--------|
 | Scorched exact-original proof — live mount guard green; acceptance still requires rights-cleared Kickstart path plus input, sound, and tank hit. | WebSite/site/static/play/scorched-tanks/licensed/kickstart-a500-1.3.rom (deployment-only; do not commit ROM) | rights-cleared Kickstart entitlement/source | host-action |
+| External directory acceptance — publish MCP Registry package, submit Claude/ChatGPT directory packets, tee website/no-login host tasks, then capture no-dev-mode proof + first-user evidence. | packaging/registry/server.json, docs/ops/mcp-directory-submission-packet.md, docs/ops/mcp-directory-rollout-action-queue.md, docs/ops/mcp-host-proof-registry.md, docs/exec-plans/active/2026-05-01-host-discoverability-and-onboarding-rollout.md, chatgpt-app-submission.json | PRs #123-#126 live; needs host/admin publisher + directory submissions | host-action |
 | **#18 retarget sweep + Arc A/E shim deletion** — IN FLIGHT (dev Step 7/10, fail-fast iteration; first failure landed). Target ~940 LOC residual (ROI §5.2 floor). Lock: workflow/universe_server.py, workflow/api/{evaluation,market,runs,status,helpers}.py, plugin mirror, ~53 test files, workflow/storage/__init__.py. | workflow/universe_server.py, workflow/api/evaluation.py, workflow/api/market.py, workflow/api/runs.py, workflow/api/status.py, workflow/api/helpers.py, packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/, tests/ | - | claimed:dev |
 | **#24 Arc C** — Phase 1 entrypoint env migration landed; remaining fixture migration + resolver deletion. | workflow/storage/__init__.py, workflow/api/helpers.py, packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/, tests/, AGENTS.md, deploy/README.md | #18 | dev-ready |
 | **Phase 6** (nav 2026-04-28): `.workflow.db`, `db_path()` fn, Option A migration, 30s restart, plugin minor-bump. ~2-3h dev + 1h host. | workflow/storage/__init__.py, packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/storage/__init__.py, tests/ | #24 | dev-ready |
@@ -61,8 +63,10 @@ Path: #18 retarget sweep (live) → Arc B phase 2 → Arc C → Phase 6 db renam
 
 ## Next
 
-1. **Active session 2026-04-27c**: dev resuming #18 (171 files unstaged, 972 LOC); dev-2 = #2 Layer-2 smoke DONE (exit 10 — module fix confirmed; heuristic loosen filed Task #7) → #3 methods-prose reframe → #4 Q6.3 platform impl; navigator = wiki sweep clean + Option C scoping rules → PLAN.md; verifier standby.
-2. **Five Scoping Rules now in PLAN.md** (2026-04-28): minimal-primitives / community-build-over-platform / privacy-via-community-composition / commons-first-architecture / user-capability-axis. Cross-provider source. Depth in lead memory.
-3. **Decision pile awaiting host (large):** primitive-set proposal §7 (10 asks) + engine substrate §7 (4 asks) + Tomás persona approval + A.1 fantasy_daemon unpack §7 (7 asks) + Phase 6 db rename (6 asks) + parked Q D (file-reading split). Plus Task #29 commons-first audit deliverables when navigator lands them next session.
-4. **No-shims-ever rule active** + **platform responsibility model** + **public-surface probes after DNS/tunnel/Worker/connector changes** (canonical: https://tinyassets.io/mcp).
-5. **BUG-028 reframe (nav 2026-04-27 evidence)**: alias-resolution at `wiki.py:409-423` is live in prod (6/8 writes succeeded 2026-04-28). 2 misroutes are CODE GAPS (BUG-003 `path.exists` wins; BUG-018 `.strip("-")` breaks trailing-hyphen) — dev-2 patching now. Not a redeploy gate.
+1. **Today 2026-05-01:** `/mcp-directory` is live/protocol-green; completion now means MCP Registry publish + Claude/ChatGPT directory acceptance + no-dev-mode proof + first-user evidence.
+
+2. **Active session 2026-04-27c**: dev resuming #18 (171 files unstaged, 972 LOC); dev-2 = #2 Layer-2 smoke DONE (exit 10 — module fix confirmed; heuristic loosen filed Task #7) → #3 methods-prose reframe → #4 Q6.3 platform impl; navigator = wiki sweep clean + Option C scoping rules → PLAN.md; verifier standby.
+3. **Five Scoping Rules now in PLAN.md** (2026-04-28): minimal-primitives / community-build-over-platform / privacy-via-community-composition / commons-first-architecture / user-capability-axis. Cross-provider source. Depth in lead memory.
+4. **Decision pile awaiting host (large):** primitive-set proposal §7 (10 asks) + engine substrate §7 (4 asks) + Tomás persona approval + A.1 fantasy_daemon unpack §7 (7 asks) + Phase 6 db rename (6 asks) + parked Q D (file-reading split). Plus Task #29 commons-first audit deliverables when navigator lands them next session.
+5. **No-shims-ever rule active** + **platform responsibility model** + **public-surface probes after DNS/tunnel/Worker/connector changes** (canonical: https://tinyassets.io/mcp).
+6. **BUG-028 reframe (nav 2026-04-27 evidence)**: alias-resolution at `wiki.py:409-423` is live in prod (6/8 writes succeeded 2026-04-28). 2 misroutes are CODE GAPS (BUG-003 `path.exists` wins; BUG-018 `.strip("-")` breaks trailing-hyphen) — dev-2 patching now. Not a redeploy gate.

--- a/docs/exec-plans/active/2026-05-01-host-discoverability-and-onboarding-rollout.md
+++ b/docs/exec-plans/active/2026-05-01-host-discoverability-and-onboarding-rollout.md
@@ -53,6 +53,8 @@ native discovery where the host supports it:
 - `scripts/mcp_public_canary.py`, `scripts/mcp_tool_canary.py`,
   `scripts/uptime_canary.py`, and `.github/workflows/uptime-canary.yml` cover
   public endpoint proof.
+- `docs/ops/mcp-directory-rollout-action-queue.md` is the current execution
+  queue after `/mcp-directory` shipped live.
 
 ## Design Decisions
 

--- a/docs/ops/mcp-directory-rollout-action-queue.md
+++ b/docs/ops/mcp-directory-rollout-action-queue.md
@@ -1,0 +1,191 @@
+# MCP Directory Rollout Action Queue
+
+Date: 2026-05-01
+Status: active queue after `/mcp-directory` live proof
+Owner: lead + available providers
+
+This queue starts after the implementation slice shipped. The live state is:
+
+- Full custom-connector endpoint: `https://tinyassets.io/mcp`
+- Directory/review endpoint: `https://tinyassets.io/mcp-directory`
+- Public canary: green for both endpoints on 2026-05-01
+- Directory tool-list: 11 narrow tools from `/mcp-directory`
+
+The rollout is not complete until Workflow is accepted into host-native
+directories or registries, normal eligible users can find/add it without
+Developer Mode or custom URL friction, and first-use evidence is recorded.
+
+## Completion Definition
+
+Done means all of these are true:
+
+- MCP Registry lists Workflow and points clients at `https://tinyassets.io/mcp-directory`.
+- Claude lists Workflow in the Connectors Directory, not only as a custom MCP URL.
+- ChatGPT lists Workflow in the App Directory for eligible logged-in users, not
+  only in Developer Mode.
+- The public site tells each customer which path fits them: directory listing,
+  custom URL fallback, no-chatbot-login local/self-hosted path, or planned host.
+- The proof registry has a normal-user trace for each listed host.
+
+## Host/Admin Actions
+
+These require account, workspace, or directory submission authority. Do not mark
+them complete from code-only evidence.
+
+### MCP Registry Publish
+
+Artifact: `packaging/registry/server.json`
+
+Steps:
+
+1. Install the official `mcp-publisher` CLI in an environment controlled by the
+   repository/namespace owner.
+2. Run `mcp-publisher login github`.
+3. Run `mcp-publisher publish packaging/registry/server.json`.
+4. Verify Workflow appears through the public registry/search path.
+5. Update `docs/ops/mcp-host-proof-registry.md` with registry URL, date, and
+   verification command/output.
+
+Blocker from 2026-05-01: `mcp-publisher --help` was not available in the Codex
+Windows PATH.
+
+### Claude Connectors Directory Submission
+
+Artifact: `docs/ops/mcp-directory-submission-packet.md`
+
+Submit:
+
+- Name: Workflow
+- Endpoint: `https://tinyassets.io/mcp-directory`
+- Website: `https://tinyassets.io/connect`
+- Support: `ops@tinyassets.io`
+- Security: `security@tinyassets.io`
+
+Acceptance proof:
+
+- Workflow appears in the Claude Connectors Directory.
+- A normal logged-in Claude user adds Workflow without pasting a custom URL.
+- Claude invokes `get_workflow_status` or `list_workflow_goals`.
+- Trace goes to `output/claude_chat_trace.md` and summary to
+  `output/user_sim_session.md`.
+
+### ChatGPT App Directory Submission
+
+Artifact: `chatgpt-app-submission.json`
+
+Submit through an OpenAI workspace that has app write/read permissions and org
+verification complete.
+
+Known blockers:
+
+- BUG-034 tracks the current ChatGPT connector approval/post-approval stall.
+- If the App Directory dashboard requires an embedded app resource, a widget/CSP
+  slice must land before pressing Submit.
+- Screenshots and privacy/safety fields must be captured from the verified live
+  deployment.
+
+Acceptance proof:
+
+- Workflow appears in the ChatGPT App Directory for eligible logged-in users.
+- A normal eligible user invokes Workflow without Developer Mode.
+- At least one read-only tool call succeeds and is logged in the proof registry.
+
+## Website Editor Handoff
+
+Do not edit these files from this queue while the website row is claimed. Hand
+this section to the website-editing session that already owns `WebSite/site/*`.
+
+Observed on the live site/source, 2026-05-01:
+
+- `/` and `/connect` still lead with the custom URL path: `tinyassets.io/mcp`.
+- `/connect` mentions Claude and ChatGPT as gates, but it does not yet make the
+  new `/mcp-directory` route visible as the review/listing endpoint.
+- `llms.txt` correctly warns that ChatGPT guest users cannot connect apps/MCP,
+  but it still names only the full custom connector as the canonical MCP server.
+
+Website task:
+
+1. Add a customer path chooser to `/connect`:
+   - "Find Workflow in your app/connector directory" once a host is accepted.
+   - "Use custom connector URL today" with `https://tinyassets.io/mcp`.
+   - "No hosted chatbot login" with Open WebUI/LibreChat/LM Studio/Jan/OpenClaw
+     status, marked verified only after proof.
+   - "Developer/IDE" with MCP Registry/config snippets.
+2. Add an honest status band:
+   - `mcp` full custom connector: live.
+   - `mcp-directory` directory/review endpoint: live, pending host acceptance.
+   - Claude directory: submission pending.
+   - ChatGPT App Directory: submission pending.
+3. Update AI-readable docs:
+   - Keep `https://tinyassets.io/mcp` as full custom connector.
+   - Add `https://tinyassets.io/mcp-directory` as the reviewed directory endpoint.
+   - Keep the ChatGPT guest/no-app caveat.
+   - Avoid claiming any host directory acceptance until proof lands.
+4. After edits, run the website skill's full check/build/browser-preview loop
+   and attach screenshots to the proof registry.
+
+Acceptance criteria:
+
+- A non-technical user can tell whether they should use an app directory, paste
+  a URL, use a local/no-login host, or wait.
+- No page says Workflow is in a host directory before acceptance.
+- Mobile `/connect` shows the chooser without horizontal overflow.
+
+## Dev Verification Queue
+
+These can be picked up by any non-website dev with a narrow worktree.
+
+### No-Chatbot-Login Pack
+
+First target: Open WebUI.
+
+Deliverables:
+
+- Host version and transport notes.
+- Minimal config for `https://tinyassets.io/mcp-directory`.
+- Tool-list proof and one visible read-only user result.
+- Proof registry row.
+
+Then repeat for LibreChat, LM Studio/Jan, OpenClaw/channel gateway, and any
+custom host that claims MCP support. If a host needs a bridge, document the
+bridge truthfully instead of saying it works natively.
+
+### IDE/Developer Pack
+
+Targets:
+
+- VS Code / Copilot MCP config
+- Cursor MCP config/add-button path
+- Gemini CLI config
+- Cline/Roo/Continue/Windsurf where practical
+
+Acceptance proof per host:
+
+- Config snippet committed or documented.
+- Tool list succeeds.
+- One safe read-only tool call succeeds.
+- Proof registry updated with date, version, and command/UI trace.
+
+### Partner Packet
+
+Create a compact package for host/platform maintainers:
+
+- One-paragraph category: "live collaborative workflow/node daemon for AI agents"
+- Endpoint and transport matrix
+- Tool surface summary
+- Privacy/safety/support links
+- Uptime/proof registry links
+- Negative invocation cases
+
+This should reuse `docs/ops/mcp-directory-submission-packet.md` rather than
+forking a second source of truth.
+
+## Status Update Rules
+
+When a host moves forward:
+
+1. Update `docs/ops/mcp-host-proof-registry.md`.
+2. Update `docs/ops/mcp-directory-submission-packet.md` if reviewer-facing facts
+   changed.
+3. Update `STATUS.md` only if there is still an active blocker or next action.
+4. Do not mark completion until normal-user discovery and first-use proof exist.

--- a/docs/ops/mcp-directory-submission-packet.md
+++ b/docs/ops/mcp-directory-submission-packet.md
@@ -1,7 +1,7 @@
 # MCP Directory Submission Packet
 
 Date: 2026-05-01
-Status: branch-ready packet, not yet externally submitted
+Status: live endpoint packet, not yet externally submitted
 Owner: lead + codex-gpt5-desktop
 
 This packet is for app-directory and registry reviewers. It separates the full
@@ -13,6 +13,9 @@ custom connector endpoint from the narrower review/listing endpoint:
 - Support: `ops@tinyassets.io`
 - Security: `security@tinyassets.io`
 - Legal/privacy: `https://tinyassets.io/legal`
+
+Execution queue for remaining host/admin, website, and verification work:
+`docs/ops/mcp-directory-rollout-action-queue.md`.
 
 ## Completion Definition
 

--- a/docs/ops/mcp-host-proof-registry.md
+++ b/docs/ops/mcp-host-proof-registry.md
@@ -99,6 +99,8 @@ Use host-specific wording, but each host should prove at least one of these:
 
 ## Open Follow-Ups
 
+Detailed execution queue: `docs/ops/mcp-directory-rollout-action-queue.md`.
+
 - Publish `packaging/registry/server.json` to the official MCP Registry after
   the public directory endpoint is deployed and green.
 - Submit the Claude directory packet through Anthropic's review flow.


### PR DESCRIPTION
## Summary
- add an MCP directory rollout action queue for host/admin submissions, website handoff, no-login host verification, and proof capture
- update the submission packet/proof registry to point at the queue
- add a STATUS row preserving the corrected completion definition after /mcp-directory went live

## Verification
- git diff --cached --check
- pre-commit text checks during commit