### PR TITLE
Add MCP host customer matrix

### DIFF
--- a/docs/design-notes/2026-05-01-mcp-host-customer-matrix.md
+++ b/docs/design-notes/2026-05-01-mcp-host-customer-matrix.md
@@ -1,0 +1,90 @@
+# MCP Host Customer Matrix
+
+Status: distribution planning artifact; not a support-claim source.
+Date: 2026-05-01
+Last checked: 2026-05-01 against selected public vendor docs.
+
+This matrix keeps Workflow customer planning broader than Claude and OpenAI.
+A Workflow customer is anyone operating an MCP-capable host: a hosted chatbot,
+IDE agent, local model shell, enterprise agent builder, self-hosted chat UI, or
+custom app that can connect to a Workflow MCP server.
+
+The proof source for public claims remains
+`docs/ops/mcp-host-proof-registry.md`. If a host is not verified there, website
+copy should say "planned" or "compatible by spec, not verified."
+
+## Host vs Client Language
+
+MCP distinguishes the user-facing host from the protocol client. The host is
+the app the user interacts with, such as Claude, ChatGPT, VS Code, Cursor, or a
+self-hosted chat UI. The MCP client is the protocol component that connects
+that host to one server. Product planning should use "host" for the user-facing
+surface and "client" only for protocol behavior.
+
+## Priority Tiers
+
+| Tier | Meaning | Examples |
+|---|---|---|
+| P0 launch gates | Highest reach, hardest discoverability path, public promise blockers | Claude directory, ChatGPT App Directory, official MCP Registry |
+| P1 coverage targets | Important for builders, contributors, no-chatbot-login users, and teams | Open WebUI, LibreChat, VS Code/Copilot, Cursor, Gemini CLI, Codex |
+| P2 ecosystem/watch | Useful surfaces that need direct proof before public support claims | LM Studio, Jan, Goose, Zed, 5ire, OpenClaw, custom hosts |
+
+## Current Matrix
+
+| Host surface | User shape | Likely Workflow path | Discovery/install path | Status | Minimum proof |
+|---|---|---|---|---|---|
+| Official MCP Registry | Any registry-aware MCP host | `https://tinyassets.io/mcp-directory` | Published `server.json` | artifact-ready; publish-blocked | Registry listing fetched publicly |
+| Claude Connectors Directory | Logged-in Claude users/admins | `https://tinyassets.io/mcp-directory` | Anthropic directory review | packet-ready; submission-needed | Directory install plus live Claude tool call |
+| Claude custom connector | Logged-in Claude users | `https://tinyassets.io/mcp` | Custom connector settings | protocol-live; UI proof refresh needed | Claude.ai trace with visible result |
+| ChatGPT App Directory | Eligible logged-in ChatGPT users/admins | `https://tinyassets.io/mcp-directory` plus app metadata/widget if required | OpenAI app submission | packet-ready; submission-needed | App Directory install without Developer Mode |
+| ChatGPT guest | Logged-out browser user | None through ChatGPT apps/MCP | Not available | unsupported by ChatGPT path | Route to no-login local/self-hosted path |
+| ChatGPT custom MCP/developer mode | Eligible logged-in user/workspace | `https://tinyassets.io/mcp-directory` or full `/mcp` for dev testing | Developer Mode/workspace approval | blocked by BUG-034 | Approval plus read-only tool call |
+| OpenAI API/Agents | Developer/API agent | Remote MCP tool | API configuration | planned | Responses/Agents smoke list + read call |
+| Codex CLI/IDE | Local developer agent | MCP config | Codex config | planned | Codex tool list + read call |
+| Gemini CLI | Local developer agent | MCP server config | Gemini CLI settings | planned | Gemini CLI tool list + read call |
+| VS Code/GitHub Copilot | Local IDE user | `.vscode/mcp.json` or user MCP config | MCP gallery/config/command palette | planned | Copilot Agent mode calls Workflow |
+| Cursor | Local IDE user | Cursor MCP config | Cursor settings/add path | planned | Cursor lists and calls Workflow |
+| Cline/Roo/Continue/Windsurf | Local IDE agent user | MCP config or marketplace | Host-specific settings | planned | Tool list plus safe read call |
+| Replit Agent | Cloud developer agent | Replit MCP integration | Replit MCP path | planned | Replit Agent invokes Workflow |
+| Open WebUI | Self-hosted/no-hosted-chat-login user | Native Streamable HTTP to `/mcp-directory` or `/mcp` | Admin Settings -> External Tools | first no-login target | Open WebUI chat invokes read-only tool |
+| LibreChat | Self-hosted/no-hosted-chat-login user | `streamable-http` MCP server config | `librechat.yaml` or UI-created server | planned | Chat/agent invokes read-only tool |
+| LM Studio | Local model user | Local or remote MCP in `mcp.json` | LM Studio Program tab or add button | planned | Local model invokes read-only tool |
+| Jan | Local model user | MCP support/path to verify | App settings or bridge | watch | Do not claim until direct proof |
+| OpenClaw/channel gateway | Channel user | Direct MCP support/path to verify | TBD | watch | Do not claim until direct proof |
+| Microsoft Copilot Studio | Enterprise maker/admin | Remote MCP server or OpenAPI fallback | Tenant/admin tool setup | planned | Agent invokes Workflow under tenant policy |
+| Custom customer host | Enterprise/custom builder | Host's supported MCP transport | Integration guide | compatible by spec | Contract test plus real user flow |
+
+## Product Rules
+
+1. Claude/OpenAI are acceptance gates, not the definition of the customer.
+2. Directory acceptance is stronger than custom URL support. Keep the distinction
+   visible in website copy and proof records.
+3. Browser-only users need a hosted-chatbot path or a no-login local/self-hosted
+   fallback; do not imply ChatGPT guest users can install apps/MCP.
+4. Local and self-hosted users get a first-class no-chatbot-login path.
+5. A support claim is scoped to the host and date in the proof registry.
+6. Long-tail hosts get spec-compatible setup notes only after a tool-list/read
+   proof, not from rumor or marketplace presence.
+
+## Website Implications
+
+The `/connect` page should present a chooser by customer situation:
+
+- "Find Workflow in your app/connector directory" for accepted hosts.
+- "Use custom connector URL today" for hosts that support remote MCP by URL.
+- "Use a no-login local/self-hosted host" for Open WebUI, LibreChat, LM Studio,
+  Jan, OpenClaw, or a custom host after proof.
+- "Use an IDE/developer host" for VS Code, Cursor, Codex, Gemini CLI, and
+  similar tools after config proof.
+
+Each path should show whether it is live, pending submission, planned, or
+verified in `docs/ops/mcp-host-proof-registry.md`.
+
+## Sources Checked
+
+- MCP host/client distinction: <https://modelcontextprotocol.io/docs/learn/client-concepts>
+- Open WebUI MCP: <https://docs.openwebui.com/features/mcp/>
+- LibreChat MCP: <https://www.librechat.ai/docs/features/mcp>
+- LM Studio MCP: <https://lmstudio.ai/docs/app/mcp>
+- VS Code/GitHub Copilot MCP: <https://code.visualstudio.com/docs/copilot/customization/mcp-servers>
+- Existing submission packet sources: `docs/ops/mcp-directory-submission-packet.md`


### PR DESCRIPTION
## Summary
- add the host/customer matrix referenced by the discoverability rollout plan
- scope it as a planning artifact, with proof claims delegated to the proof registry
- include no-login/local hosts and the ChatGPT guest caveat for website handoff

## Verification
- git diff --cached --check
- pre-commit text checks during commit
- checked selected current primary docs: MCP client concepts, Open WebUI MCP, LibreChat MCP, LM Studio MCP, VS Code MCP