### PR TITLE
[codex] Refresh self-hosted MCP connection copy

### DIFF
--- a/WebSite/site/src/routes/connect/+page.svelte
+++ b/WebSite/site/src/routes/connect/+page.svelte
@@ -80,10 +80,10 @@
     },
     {
       title: 'Open WebUI / LibreChat / OpenClaw',
-      status: 'Self-hosted path',
+      status: 'Verified self-hosted path',
       account: 'Use this if you run your own chat UI, local model shell, or channel gateway and do not want a Claude or ChatGPT login.',
-      setup: `Add ${url} as a Streamable HTTP / remote MCP server. Use a bridge only when that host requires one.`,
-      proof: 'Open WebUI is the first no-login verification target. LibreChat, OpenClaw, and peers stay compatible-by-spec until smoke traces land.',
+      setup: `For Open WebUI or LibreChat, add ${directoryUrl} as a Streamable HTTP / remote MCP server. Use ${url} only when a host needs the full custom connector surface.`,
+      proof: 'Open WebUI local Docker 0.9.2 and LibreChat local Docker v0.8.5 are verified. LM Studio, Jan, OpenClaw/channel gateways, and IDE hosts stay planned until proof traces land.',
       anchor: '#proof-state'
     },
     {
@@ -123,9 +123,9 @@
       body: 'Claude custom connector setup is the clearest hosted-chat path today. Directory listing remains separate.'
     },
     {
-      label: 'Open WebUI and self-hosted chat',
-      status: 'Verification target',
-      body: 'No-login use starts with Open WebUI proof, then expands to LibreChat, LM Studio, Jan, OpenClaw, and compatible hosts.'
+      label: 'Open WebUI and LibreChat',
+      status: 'Verified self-hosted path',
+      body: `No-login local Docker proof exists for Open WebUI and LibreChat via ${directoryUrl}. LM Studio, Jan, OpenClaw, and IDE hosts stay planned until registry proof lands.`
     },
     {
       label: 'Directories and app stores',

--- a/WebSite/site/static/llms.txt
+++ b/WebSite/site/static/llms.txt
@@ -42,9 +42,11 @@ surface a chatbot uses when the user's work needs to survive the current chat.
   self-hosted path instead.
 - ChatGPT app/custom MCP support depends on logged-in plan, workspace settings,
   developer mode, region, and admin approval.
-- Local/self-hosted users should use Open WebUI, LibreChat, LM Studio, Jan,
-  OpenClaw/channel gateways, or a custom MCP host only when that host's MCP path
-  is verified in the proof registry.
+- Open WebUI and LibreChat are verified local Docker/self-hosted paths when
+  configured against https://tinyassets.io/mcp-directory.
+- LM Studio, Jan, OpenClaw/channel gateways, IDE hosts, and custom MCP hosts
+  remain planned or compatible-by-spec until the proof registry verifies that
+  host's MCP path.
 - If a host has not been verified, say "compatible by spec, not verified yet."
 
 ## First Prompts


### PR DESCRIPTION
﻿## Summary

- Refresh `/connect` so Open WebUI and LibreChat are described as verified local Docker/self-hosted paths.
- Point the verified self-hosted setup copy at `https://tinyassets.io/mcp-directory`, while keeping `https://tinyassets.io/mcp` as the full custom connector URL for hosts that need the full surface.
- Update `/llms.txt` with the same truth boundary: LM Studio, Jan, OpenClaw/channel gateways, IDE hosts, and custom MCP hosts remain planned or compatible-by-spec until registry proof lands.

## Verification

- `npm run check` in `WebSite/site` (0 errors, 0 warnings)
- `npm run build` in `WebSite/site` (`build/connect.html` and `build/llms.txt` emitted)
- Playwright local preview smoke: `/connect` desktop 1440x1000, `/connect` mobile 390x900, and `/llms.txt` all passed with no console/page errors and no horizontal overflow
- `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp --timeout 15 --verbose` -> OK
- `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp-directory --timeout 15 --verbose` -> OK
