### PR TITLE
api/branches: preserve invoke_branch authoring specs

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -1283,6 +1283,22 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
     out_keys, err = _coerce_node_keys(raw.get("output_keys"), "output_keys")
     if err:
         return err
+    # BUG-045: thread the three sub-branch / sibling-run spec fields. The
+    # compiler reads them (workflow/graph_compiler.py:_build_invoke_branch /
+    # invoke_branch_version / await_run callables) and NodeDefinition
+    # declares them (workflow/branches.py:267/285/294), but this authoring
+    # plumbing was silently dropping the keys — callers got a node that
+    # validated fine but ran as a no-op prompt-template. Mutual exclusivity
+    # is enforced in BranchDefinition.validate(); we accept whatever the
+    # caller provided and let validate() catch invalid combinations.
+    invoke_branch = raw.get("invoke_branch_spec")
+    invoke_branch_version = raw.get("invoke_branch_version_spec")
+    await_run = raw.get("await_run_spec")
+    invoke_branch_arg = invoke_branch if isinstance(invoke_branch, dict) else None
+    invoke_branch_version_arg = (
+        invoke_branch_version if isinstance(invoke_branch_version, dict) else None
+    )
+    await_run_arg = await_run if isinstance(await_run, dict) else None
     try:
         node = NodeDefinition(
             node_id=nid,
@@ -1295,6 +1311,9 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
             prompt_template=prompt_template,
             author=raw.get("author") or _current_actor(),
             approved=bool(raw.get("approved", False)),
+            invoke_branch_spec=invoke_branch_arg,
+            invoke_branch_version_spec=invoke_branch_version_arg,
+            await_run_spec=await_run_arg,
         )
     except ValueError as exc:
         return str(exc)
@@ -2005,6 +2024,36 @@ def _ext_branch_update_node(kwargs: dict[str, Any]) -> str:
             updates["input_keys"] = kwargs["input_keys"]
         if kwargs.get("output_keys"):
             updates["output_keys"] = kwargs["output_keys"]
+        # BUG-045: same plumbing fix as _apply_node_spec for the
+        # update_node write path. update_node has its own kwargs-merge
+        # logic and writes through save_branch_definition without
+        # routing through _apply_node_spec. Each spec-bearing field can
+        # arrive as a JSON-encoded string (kwargs-only callers can't
+        # send raw dicts) or as a dict (changes_json path).
+        for field in (
+            "invoke_branch_spec",
+            "invoke_branch_version_spec",
+            "await_run_spec",
+        ):
+            raw_val = kwargs.get(field)
+            if not raw_val:
+                continue
+            if isinstance(raw_val, dict):
+                updates[field] = raw_val
+            elif isinstance(raw_val, str):
+                try:
+                    decoded = json.loads(raw_val)
+                except json.JSONDecodeError as exc:
+                    return json.dumps({
+                        "status": "rejected",
+                        "error": f"{field} is not valid JSON: {exc}",
+                    })
+                if not isinstance(decoded, dict):
+                    return json.dumps({
+                        "status": "rejected",
+                        "error": f"{field} must decode to an object.",
+                    })
+                updates[field] = decoded
 
     if not updates:
         return json.dumps({
@@ -2088,6 +2137,22 @@ def _ext_branch_update_node(kwargs: dict[str, Any]) -> str:
             if err:
                 return json.dumps({"status": "rejected", "error": err})
             target_node.output_keys = keys
+        # BUG-045: thread the three spec fields onto target_node. Mutual
+        # exclusivity vs prompt_template / source_code is enforced by
+        # BranchDefinition.validate() at compile time; we accept what
+        # the caller asked for and let validate() catch invalid combos.
+        for spec_field in (
+            "invoke_branch_spec",
+            "invoke_branch_version_spec",
+            "await_run_spec",
+        ):
+            if spec_field in updates:
+                val = updates[spec_field]
+                setattr(
+                    target_node,
+                    spec_field,
+                    val if isinstance(val, dict) else None,
+                )
     except Exception as exc:
         return json.dumps({
             "status": "rejected",

--- a/tests/test_invoke_branch_authoring.py
+++ b/tests/test_invoke_branch_authoring.py
@@ -1,0 +1,302 @@
+"""BUG-045 — invoke_branch / invoke_branch_version / await_run authoring plumbing.
+
+The compiler reads three NodeDefinition fields:
+- ``invoke_branch_spec`` — fork a sub-branch run inline.
+- ``invoke_branch_version_spec`` — same shape against a pinned branch_version.
+- ``await_run_spec`` — block on a sibling run_id from state.
+
+`workflow/branches.py` declares them; `workflow/graph_compiler.py` consumes
+them. But two distinct authoring write paths in `workflow/api/branches.py`
+silently dropped the keys — callers got nodes that validated and even compiled
+but ran as no-op stubs:
+
+1. `_apply_node_spec` — shared by `add_node` / `build_branch` /
+   `patch_branch` (add_node op).
+2. `_ext_branch_update_node` (~L1880) — its own kwargs-merge logic, writes
+   through `save_branch_definition` directly. NOT an alias of
+   `_apply_node_spec`; bug surface is duplicated here.
+
+This regression suite pins both write paths per navigator's
+`2026-05-02-bug045-test-surface.md` 8-test target:
+
+- 6 round-trip tests: 3 fields × 2 call sites (add_node, update_node).
+- 1 signature-regression test: confirm both call sites accept the new
+  kwargs / changes_json keys; future drift fails loudly.
+- 1 mutual-exclusion test: spec field + prompt_template on the same node
+  is rejected by BranchDefinition.validate() — the fix must not bypass.
+
+Runtime semantics for invoke_branch / await_run are pinned in
+`tests/test_sub_branch_invocation.py`; this file is authoring-surface only.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def ext_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    base = tmp_path / "output"
+    base.mkdir()
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(base))
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "tester")
+    from workflow import universe_server as us
+
+    importlib.reload(us)
+    yield us, base
+    importlib.reload(us)
+
+
+def _call(us, tool: str, action: str, **kwargs):
+    fn = getattr(us, tool)
+    return json.loads(fn(action=action, **kwargs))
+
+
+def _load(us, base: Path, bid: str) -> dict:
+    from workflow.daemon_server import get_branch_definition
+
+    return get_branch_definition(base, branch_def_id=bid)
+
+
+def _node(branch: dict, nid: str) -> dict:
+    for n in branch["node_defs"]:
+        if n["node_id"] == nid:
+            return n
+    raise AssertionError(f"node '{nid}' not on branch")
+
+
+# Sample specs — `wait_mode` valid values are ("blocking", "async") per
+# BranchDefinition.validate(). Spec-bearing nodes must NOT carry
+# prompt_template / source_code (mutual exclusion).
+_INVOKE_BRANCH = {
+    "branch_def_id": "child-bid-abc",
+    "wait_mode": "blocking",
+    "inputs": {"seed": "x"},
+}
+_INVOKE_VERSION = {
+    "branch_version_id": "ver-abc",
+    "wait_mode": "async",
+    "on_child_fail": "propagate",
+    "inputs": {"seed": "y"},
+}
+_AWAIT_RUN = {
+    "run_id_field": "spawned_run_id",
+    "timeout_seconds": 30,
+}
+
+
+def _scaffold_with_target(spec_extra: dict | None = None) -> dict:
+    """Two-node branch: a regular prompt-template seed + a spec-bearing target.
+    Spec fields are mutually exclusive with prompt_template, so the target node
+    must NOT carry a prompt_template if it carries a spec field."""
+    seed: dict = {
+        "node_id": "seed",
+        "display_name": "Seed",
+        "prompt_template": "do: {x}",
+        "input_keys": ["x"],
+        "output_keys": ["out"],
+    }
+    target: dict = {
+        "node_id": "target",
+        "display_name": "Target",
+        "input_keys": ["out"],
+        "output_keys": ["final"],
+    }
+    if spec_extra:
+        target.update(spec_extra)
+    return {
+        "name": "b",
+        "entry_point": "seed",
+        "node_defs": [seed, target],
+        "edges": [
+            {"from": "START", "to": "seed"},
+            {"from": "seed", "to": "target"},
+            {"from": "target", "to": "END"},
+        ],
+        "state_schema": [
+            {"name": "x", "type": "str"},
+            {"name": "out", "type": "str"},
+            {"name": "final", "type": "str"},
+        ],
+    }
+
+
+def _build_with(us, *, spec_extra: dict | None = None) -> str:
+    """Build a branch where `target` carries the given spec_extra. Returns
+    branch_def_id."""
+    res = _call(
+        us, "extensions", "build_branch",
+        spec_json=json.dumps(_scaffold_with_target(spec_extra)),
+    )
+    assert res["status"] == "built", res
+    return res["branch_def_id"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6 round-trip tests: 3 fields × 2 call sites (add_node via build_branch,
+# update_node via patch_branch update_node).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+# --- Site 1: add_node / build_branch (shares _apply_node_spec) ---
+
+
+def test_add_node_threads_invoke_branch_spec(ext_env):
+    us, base = ext_env
+    bid = _build_with(us, spec_extra={"invoke_branch_spec": _INVOKE_BRANCH})
+    branch = _load(us, base, bid)
+    assert _node(branch, "target")["invoke_branch_spec"] == _INVOKE_BRANCH
+
+
+def test_add_node_threads_invoke_branch_version_spec(ext_env):
+    us, base = ext_env
+    bid = _build_with(us, spec_extra={"invoke_branch_version_spec": _INVOKE_VERSION})
+    branch = _load(us, base, bid)
+    assert _node(branch, "target")["invoke_branch_version_spec"] == _INVOKE_VERSION
+
+
+def test_add_node_threads_await_run_spec(ext_env):
+    us, base = ext_env
+    bid = _build_with(us, spec_extra={"await_run_spec": _AWAIT_RUN})
+    branch = _load(us, base, bid)
+    assert _node(branch, "target")["await_run_spec"] == _AWAIT_RUN
+
+
+# --- Site 2: update_node (its own write path, NOT _apply_node_spec) ---
+
+
+def _update_target(us, bid: str, *, changes: dict) -> dict:
+    """Issue extensions update_node via changes_json — the path that exercises
+    _ext_branch_update_node's kwargs-merge logic for spec-bearing keys."""
+    return _call(
+        us, "extensions", "update_node",
+        branch_def_id=bid,
+        node_id="target",
+        changes_json=json.dumps(changes),
+    )
+
+
+def test_update_node_threads_invoke_branch_spec(ext_env):
+    us, base = ext_env
+    # Bare scaffold: target has no spec yet.
+    bid = _build_with(us)
+    res = _update_target(us, bid, changes={"invoke_branch_spec": _INVOKE_BRANCH})
+    assert res.get("status") not in ("rejected",), res
+    new_bid = res.get("branch_def_id", bid)
+    branch = _load(us, base, new_bid)
+    assert _node(branch, "target")["invoke_branch_spec"] == _INVOKE_BRANCH
+
+
+def test_update_node_threads_invoke_branch_version_spec(ext_env):
+    us, base = ext_env
+    bid = _build_with(us)
+    res = _update_target(
+        us, bid, changes={"invoke_branch_version_spec": _INVOKE_VERSION},
+    )
+    assert res.get("status") not in ("rejected",), res
+    new_bid = res.get("branch_def_id", bid)
+    branch = _load(us, base, new_bid)
+    assert _node(branch, "target")["invoke_branch_version_spec"] == _INVOKE_VERSION
+
+
+def test_update_node_threads_await_run_spec(ext_env):
+    us, base = ext_env
+    bid = _build_with(us)
+    res = _update_target(us, bid, changes={"await_run_spec": _AWAIT_RUN})
+    assert res.get("status") not in ("rejected",), res
+    new_bid = res.get("branch_def_id", bid)
+    branch = _load(us, base, new_bid)
+    assert _node(branch, "target")["await_run_spec"] == _AWAIT_RUN
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Signature regression — both NodeDefinition fields and the authoring API
+# entry points must continue to accept the three keys. Catches future drift
+# (someone refactors _apply_node_spec or _ext_branch_update_node and forgets
+# the spec keys; this test fails loudly instead of users seeing silent drops).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_signature_regression_node_definition_and_authoring_paths():
+    from workflow.api.branches import _apply_node_spec, _ext_branch_update_node
+    from workflow.branches import NodeDefinition
+
+    # NodeDefinition declares all three fields.
+    nd_fields = {f.name for f in NodeDefinition.__dataclass_fields__.values()}
+    for spec_field in (
+        "invoke_branch_spec",
+        "invoke_branch_version_spec",
+        "await_run_spec",
+    ):
+        assert spec_field in nd_fields, (
+            f"NodeDefinition lost field '{spec_field}' — runtime invocation "
+            f"semantics will break."
+        )
+
+    # _apply_node_spec is a (branch, raw) function — no per-field kwargs to
+    # check at the signature level. Instead we verify that the function
+    # source contains the read-from-raw idiom for each spec key. This is a
+    # weaker invariant than a typed signature but stronger than no check.
+    src = inspect.getsource(_apply_node_spec)
+    for spec_field in (
+        "invoke_branch_spec",
+        "invoke_branch_version_spec",
+        "await_run_spec",
+    ):
+        assert spec_field in src, (
+            f"_apply_node_spec source no longer references '{spec_field}' "
+            f"— silent-drop regression risk."
+        )
+
+    # _ext_branch_update_node (kwargs-merge path) must also reference each
+    # field — its plumbing is independent of _apply_node_spec.
+    update_src = inspect.getsource(_ext_branch_update_node)
+    for spec_field in (
+        "invoke_branch_spec",
+        "invoke_branch_version_spec",
+        "await_run_spec",
+    ):
+        assert spec_field in update_src, (
+            f"_ext_branch_update_node source no longer references "
+            f"'{spec_field}' — second-site silent-drop regression risk."
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Mutual-exclusion contract — spec field + prompt_template/source_code on the
+# same node is rejected by BranchDefinition.validate(). Authoring-surface fix
+# must not bypass the check by silently coercing or stripping one side.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_mutual_exclusion_invoke_branch_spec_and_prompt_template_rejected(ext_env):
+    us, _ = ext_env
+    # Build a 2-node branch where `target` carries BOTH a prompt_template
+    # AND an invoke_branch_spec. validate() must reject — the authoring
+    # plumbing fix must not bypass this check.
+    spec = _scaffold_with_target({
+        "prompt_template": "should be exclusive: {out}",
+        "invoke_branch_spec": _INVOKE_BRANCH,
+    })
+    res = _call(us, "extensions", "build_branch", spec_json=json.dumps(spec))
+    # Either the build is rejected outright, or it surfaces an error string
+    # mentioning the mutual exclusion. The wrong shape is silent acceptance.
+    if res.get("status") == "built":
+        pytest.fail(
+            f"build_branch silently accepted prompt_template + "
+            f"invoke_branch_spec on the same node: {res!r}"
+        )
+    err_str = json.dumps(res).lower()
+    assert (
+        "mutually exclusive" in err_str
+        or "exclusive" in err_str
+        or "invoke_branch_spec" in err_str
+        or "prompt_template" in err_str
+    ), (
+        f"rejection reason should cite the mutual-exclusion contract: {res!r}"
+    )

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -1283,6 +1283,22 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
     out_keys, err = _coerce_node_keys(raw.get("output_keys"), "output_keys")
     if err:
         return err
+    # BUG-045: thread the three sub-branch / sibling-run spec fields. The
+    # compiler reads them (workflow/graph_compiler.py:_build_invoke_branch /
+    # invoke_branch_version / await_run callables) and NodeDefinition
+    # declares them (workflow/branches.py:267/285/294), but this authoring
+    # plumbing was silently dropping the keys — callers got a node that
+    # validated fine but ran as a no-op prompt-template. Mutual exclusivity
+    # is enforced in BranchDefinition.validate(); we accept whatever the
+    # caller provided and let validate() catch invalid combinations.
+    invoke_branch = raw.get("invoke_branch_spec")
+    invoke_branch_version = raw.get("invoke_branch_version_spec")
+    await_run = raw.get("await_run_spec")
+    invoke_branch_arg = invoke_branch if isinstance(invoke_branch, dict) else None
+    invoke_branch_version_arg = (
+        invoke_branch_version if isinstance(invoke_branch_version, dict) else None
+    )
+    await_run_arg = await_run if isinstance(await_run, dict) else None
     try:
         node = NodeDefinition(
             node_id=nid,
@@ -1295,6 +1311,9 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
             prompt_template=prompt_template,
             author=raw.get("author") or _current_actor(),
             approved=bool(raw.get("approved", False)),
+            invoke_branch_spec=invoke_branch_arg,
+            invoke_branch_version_spec=invoke_branch_version_arg,
+            await_run_spec=await_run_arg,
         )
     except ValueError as exc:
         return str(exc)
@@ -2005,6 +2024,36 @@ def _ext_branch_update_node(kwargs: dict[str, Any]) -> str:
             updates["input_keys"] = kwargs["input_keys"]
         if kwargs.get("output_keys"):
             updates["output_keys"] = kwargs["output_keys"]
+        # BUG-045: same plumbing fix as _apply_node_spec for the
+        # update_node write path. update_node has its own kwargs-merge
+        # logic and writes through save_branch_definition without
+        # routing through _apply_node_spec. Each spec-bearing field can
+        # arrive as a JSON-encoded string (kwargs-only callers can't
+        # send raw dicts) or as a dict (changes_json path).
+        for field in (
+            "invoke_branch_spec",
+            "invoke_branch_version_spec",
+            "await_run_spec",
+        ):
+            raw_val = kwargs.get(field)
+            if not raw_val:
+                continue
+            if isinstance(raw_val, dict):
+                updates[field] = raw_val
+            elif isinstance(raw_val, str):
+                try:
+                    decoded = json.loads(raw_val)
+                except json.JSONDecodeError as exc:
+                    return json.dumps({
+                        "status": "rejected",
+                        "error": f"{field} is not valid JSON: {exc}",
+                    })
+                if not isinstance(decoded, dict):
+                    return json.dumps({
+                        "status": "rejected",
+                        "error": f"{field} must decode to an object.",
+                    })
+                updates[field] = decoded
 
     if not updates:
         return json.dumps({
@@ -2088,6 +2137,22 @@ def _ext_branch_update_node(kwargs: dict[str, Any]) -> str:
             if err:
                 return json.dumps({"status": "rejected", "error": err})
             target_node.output_keys = keys
+        # BUG-045: thread the three spec fields onto target_node. Mutual
+        # exclusivity vs prompt_template / source_code is enforced by
+        # BranchDefinition.validate() at compile time; we accept what
+        # the caller asked for and let validate() catch invalid combos.
+        for spec_field in (
+            "invoke_branch_spec",
+            "invoke_branch_version_spec",
+            "await_run_spec",
+        ):
+            if spec_field in updates:
+                val = updates[spec_field]
+                setattr(
+                    target_node,
+                    spec_field,
+                    val if isinstance(val, dict) else None,
+                )
     except Exception as exc:
         return json.dumps({
             "status": "rejected",


### PR DESCRIPTION
## Summary
- preserves invoke_branch_spec, invoke_branch_version_spec, and await_run_spec through build_branch / patch_branch add_node plumbing
- preserves the same spec fields through update_node
- adds authoring regression tests for both write paths

## Live evidence
- 2026-05-02 direct public MCP proof: built branch 45232dd2c548 via https://tinyassets.io/mcp with invoke_child.invoke_branch_spec supplied.
- Readback showed invoke_child.invoke_branch_spec = null, so BUG-045 is still live until this patch lands/deploys.
- P1a attach_existing_child_run is already live via PR #136; this PR targets the remaining true child-invoke authoring gap.

## Existing branch verification
From commit ccad42e:
- targeted test_invoke_branch_authoring.py passed
- wider branch-authoring/sub-branch invocation sweep passed
- ruff passed
- plugin build probe passed

Closes #130