### PR TITLE
chore: add check_primitive_exists.py pre-design cohit guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ If it's about what's happening right now → STATUS.md.
      non-architectural code changes.
 3. If the idea inbox is non-empty, scan `ideas/PIPELINE.md` and `ideas/INBOX.md`.
 4. If your approach conflicts with a PLAN.md principle, do NOT implement it. Add the conflict to STATUS.md Concerns. PLAN.md changes require user approval.
+5. **Cohit-prevention check before drafting:** before drafting a design note that proposes a new MCP action, citing an unfixed `BUG-NNN`, or pinning a sha in frontmatter / memory, run `python scripts/check_primitive_exists.py {action <verb>|bug <BUG-NNN>|sha <sha>}` from origin/main. Exits 0 (clean), 1 (warning — may be false positive), 2 (collision — investigate before drafting). Catches the "primitive already exists / already-landed work" class — see `.claude/agent-memory/dev-2/2026-05-02-check-primitive-exists-script.md` for the four 2026-05-02 cohit incidents this script is calibrated against.
 
 ### Updating the Three Files
 

--- a/scripts/check_primitive_exists.py
+++ b/scripts/check_primitive_exists.py
@@ -1,0 +1,361 @@
+"""Pre-design cohit-prevention helper.
+
+Run BEFORE drafting any design note proposing a new MCP action, citing an
+unfixed BUG-NNN, or pinning a sha. Catches the "primitive already exists"
+class of session waste — see
+`.claude/agent-memory/dev-2/2026-05-02-check-primitive-exists-script.md`
+for the four 2026-05-02 cohit incidents this script is calibrated against.
+
+Usage
+-----
+    # Has someone already wired this MCP action verb?
+    python scripts/check_primitive_exists.py action validate_branch
+
+    # Is BUG-037 already fixed somewhere?
+    python scripts/check_primitive_exists.py bug BUG-037
+
+    # Is this sha actually on origin/main, or only on a feature branch?
+    python scripts/check_primitive_exists.py sha a288444
+
+Exit codes (each subcommand)
+----------------------------
+    0  CLEAN     — nothing landed; safe to proceed with new work.
+    1  WARNING   — something matched but it may be a false positive
+                   (e.g. the verb appears as a docstring; the BUG keyword
+                   matches an unrelated commit). Investigate before assuming.
+    2  COLLISION — definite hit. Stop and re-scope before drafting.
+
+Each check is shallow — read-only grep + git log against `refs/remotes/origin/main`.
+No network calls beyond the local git ref. Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Force UTF-8 stdout for Windows consoles (matches scripts/claim_check.py).
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+    except (AttributeError, ValueError, OSError):
+        pass
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MAIN_REF = "refs/remotes/origin/main"
+
+# Exit codes are also constants for the test suite.
+EXIT_CLEAN = 0
+EXIT_WARNING = 1
+EXIT_COLLISION = 2
+
+
+def _git(*args: str, repo_root: Path | None = None) -> str:
+    """Run a git command and return stdout. Empty string on failure."""
+    root = repo_root or REPO_ROOT
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), *args],
+            check=False, capture_output=True, text=True, encoding="utf-8",
+        )
+    except (FileNotFoundError, OSError):
+        return ""
+    if out.returncode != 0:
+        return ""
+    return out.stdout
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Subcommand: action <verb>
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+# Action-map files we expect to find dispatch tables / handler functions in.
+# Hardcoded list — narrower than `workflow/api/*.py` because not every module
+# defines actions, and broader-than-needed glob inflates false-positive rate.
+_ACTION_MAP_FILES = (
+    "workflow/api/branches.py",
+    "workflow/api/runs.py",
+    "workflow/api/extensions.py",
+    "workflow/api/wiki.py",
+    "workflow/api/goals.py",
+    "workflow/api/universe.py",
+    "workflow/api/status.py",
+    "workflow/api/evaluation.py",
+    "workflow/api/market.py",
+    "workflow/api/prompts.py",
+)
+
+
+def check_action(verb: str, repo_root: Path | None = None) -> int:
+    """Detect collisions for a proposed MCP action verb.
+
+    Looks for three shapes on origin/main:
+    1. `_ext_<verb>` handler function name
+    2. `"<verb>": _ext_*` dispatch-table mapping
+    3. `def <verb>(` standalone function (weaker signal)
+
+    Returns EXIT_CLEAN / WARNING / COLLISION.
+    """
+    root = repo_root or REPO_ROOT
+
+    if not re.match(r"^[a-z_][a-z0-9_]*$", verb):
+        print(
+            f"[ERROR] action verb '{verb}' is not a valid identifier "
+            "(lowercase + underscores only).",
+            file=sys.stderr,
+        )
+        return EXIT_COLLISION
+
+    handler_pattern = f"_ext_{verb}\\b"
+    map_pattern = f'["\']{verb}["\']\\s*:\\s*_ext_'
+    def_pattern = f"^def {verb}\\b"
+
+    hits: list[tuple[str, str, str]] = []  # (kind, file, line)
+    for relpath in _ACTION_MAP_FILES:
+        # Use git show to read the file at origin/main (not the working tree —
+        # that may have unstaged drafts).
+        raw = _git("show", f"{MAIN_REF}:{relpath}", repo_root=root)
+        if not raw:
+            continue
+        for lineno, line in enumerate(raw.splitlines(), 1):
+            if re.search(handler_pattern, line):
+                hits.append(("handler", f"{relpath}:{lineno}", line.strip()))
+            if re.search(map_pattern, line):
+                hits.append(("map_entry", f"{relpath}:{lineno}", line.strip()))
+            if re.search(def_pattern, line):
+                hits.append(("def", f"{relpath}:{lineno}", line.strip()))
+
+    if not hits:
+        print(f"CLEAN — no '{verb}' action handler/map-entry on {MAIN_REF}.")
+        return EXIT_CLEAN
+
+    has_definite = any(kind in {"handler", "map_entry"} for kind, _, _ in hits)
+    severity = EXIT_COLLISION if has_definite else EXIT_WARNING
+    label = "COLLISION" if has_definite else "WARNING"
+
+    print(f"{label} — found {len(hits)} hit(s) for action verb '{verb}':")
+    for kind, loc, line in hits:
+        print(f"  [{kind}] {loc}: {line[:120]}")
+    print()
+    if has_definite:
+        print(
+            f"This action appears to already be wired on {MAIN_REF}. "
+            "Read the handler before proposing a new one."
+        )
+    else:
+        print(
+            f"Symbol '{verb}' appears in source but not as an MCP action "
+            "handler/map-entry. Spot-check before assuming collision."
+        )
+    return severity
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Subcommand: bug <BUG-NNN>
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+_BUG_ID_RE = re.compile(r"^BUG-(\d{1,4})$", re.IGNORECASE)
+
+
+def check_bug(bug_id: str, repo_root: Path | None = None) -> int:
+    """Detect whether a BUG-NNN identifier already has a fix landed on main.
+
+    Three signals:
+    1. `git log --grep="BUG-NNN"` on origin/main → any matching commit.
+    2. `git log --grep="<keyword>"` on origin/main → keyword-mode commits
+       (looser; warning-tier if the bug-id grep is empty but keyword hits).
+    3. local file mentions of BUG-NNN — warning-tier signal.
+    """
+    root = repo_root or REPO_ROOT
+
+    m = _BUG_ID_RE.match(bug_id)
+    if not m:
+        print(
+            f"[ERROR] '{bug_id}' is not a valid BUG-NNN identifier "
+            "(expected e.g. 'BUG-037').",
+            file=sys.stderr,
+        )
+        return EXIT_COLLISION
+    canonical_id = f"BUG-{m.group(1).zfill(3)}"
+
+    direct_hits_raw = _git(
+        "log", MAIN_REF, "--grep", canonical_id, "--oneline",
+        "-i", "-n", "20",
+        repo_root=root,
+    )
+    direct_hits = [ln for ln in direct_hits_raw.splitlines() if ln.strip()]
+
+    if direct_hits:
+        print(
+            f"COLLISION — found {len(direct_hits)} commit(s) on {MAIN_REF} "
+            f"mentioning {canonical_id}:"
+        )
+        for ln in direct_hits[:10]:
+            print(f"  {ln}")
+        if len(direct_hits) > 10:
+            print(f"  ... + {len(direct_hits) - 10} more")
+        print()
+        print(
+            f"This bug may already be fixed. Check `git log --grep "
+            f"{canonical_id} -p` for the patch before proposing a new fix."
+        )
+        return EXIT_COLLISION
+
+    # No direct-id hit. Try a few weaker signals.
+    weak_hits: list[str] = []
+
+    # Signal: BUG-NNN mentioned anywhere in the working tree (docs, specs).
+    grep_raw = _git(
+        "grep", "--no-color", "-l", canonical_id,
+        repo_root=root,
+    )
+    if grep_raw.strip():
+        for ln in grep_raw.splitlines():
+            ln = ln.strip()
+            if ln:
+                weak_hits.append(f"file mentions {canonical_id}: {ln}")
+
+    if weak_hits:
+        print(
+            f"WARNING — no commit on {MAIN_REF} grep-matches '{canonical_id}', "
+            f"but {len(weak_hits)} working-tree file(s) mention it:"
+        )
+        for ln in weak_hits[:10]:
+            print(f"  {ln}")
+        print()
+        print(
+            "The bug may be filed but unfixed, or fixed without naming the ID "
+            "in the commit message (BUG-037 was an example: fix sha a288444 "
+            "did not include the ID in its subject). Read the file mentions "
+            "and recent commits in the same component before drafting a new fix."
+        )
+        return EXIT_WARNING
+
+    print(f"CLEAN — no commit or file reference to {canonical_id} on {MAIN_REF}.")
+    return EXIT_CLEAN
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Subcommand: sha <sha>
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+_SHA_RE = re.compile(r"^[0-9a-f]{4,40}$", re.IGNORECASE)
+
+
+def check_sha(sha: str, repo_root: Path | None = None) -> int:
+    """Verify a sha is actually on origin/main.
+
+    Catches the "pinned to feature branch, not main" failure mode (e.g. a
+    design-note frontmatter or memory file cites a sha that hasn't landed).
+    Uses `git merge-base --is-ancestor`.
+    """
+    root = repo_root or REPO_ROOT
+
+    if not _SHA_RE.match(sha):
+        print(
+            f"[ERROR] '{sha}' does not look like a git sha "
+            "(expected 4-40 hex chars).",
+            file=sys.stderr,
+        )
+        return EXIT_COLLISION
+
+    # Resolve the sha first to a full identifier — catches typos.
+    resolved = _git("rev-parse", "--verify", f"{sha}^{{commit}}", repo_root=root).strip()
+    if not resolved:
+        print(
+            f"COLLISION — sha '{sha}' does not resolve to any commit in this "
+            "checkout. Either it's a typo, or the commit lives in a remote "
+            "you haven't fetched."
+        )
+        return EXIT_COLLISION
+
+    # is-ancestor exits 0 if YES, 1 if NO. We bypass _git() because we need
+    # the exit code, not stdout.
+    rc = subprocess.run(
+        ["git", "-C", str(root), "merge-base", "--is-ancestor", resolved, MAIN_REF],
+        check=False, capture_output=True, text=True,
+    ).returncode
+
+    if rc == 0:
+        # On main — find a friendly subject line for the report.
+        subject = _git(
+            "log", "-1", "--format=%h %s", resolved, repo_root=root,
+        ).strip()
+        print(
+            f"CLEAN — sha {sha} is on {MAIN_REF}.\n"
+            f"  {subject}"
+        )
+        return EXIT_CLEAN
+
+    # Not on main. Report which branches DO have it (best-effort hint).
+    branches_raw = _git(
+        "branch", "-a", "--contains", resolved, repo_root=root,
+    )
+    branches = [b.strip().lstrip("* ") for b in branches_raw.splitlines() if b.strip()]
+    print(
+        f"COLLISION — sha {sha} is NOT on {MAIN_REF}. "
+        "Citing it in a frontmatter / memory / design note will silently "
+        "rot the moment readers expect it to be merged."
+    )
+    if branches:
+        print(f"  Found on {len(branches)} branch(es):")
+        for b in branches[:10]:
+            print(f"    {b}")
+        if len(branches) > 10:
+            print(f"    ... + {len(branches) - 10} more")
+    return EXIT_COLLISION
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="check_primitive_exists",
+        description=(
+            "Verify a proposed primitive (action / bug / sha) doesn't already "
+            "exist on origin/main before drafting work. Run BEFORE design "
+            "notes / new MCP actions / sha-citing frontmatter."
+        ),
+    )
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    sp_action = sub.add_parser(
+        "action",
+        help="Check whether an MCP action verb is already wired.",
+    )
+    sp_action.add_argument("verb", help="Lowercase action verb, e.g. 'validate_branch'.")
+
+    sp_bug = sub.add_parser(
+        "bug",
+        help="Check whether a BUG-NNN identifier has a landed fix.",
+    )
+    sp_bug.add_argument("bug_id", help="Canonical id, e.g. 'BUG-037'.")
+
+    sp_sha = sub.add_parser(
+        "sha",
+        help="Verify a sha is on origin/main (not a feature branch).",
+    )
+    sp_sha.add_argument("sha", help="Short or long git sha.")
+
+    args = ap.parse_args(argv)
+
+    if args.cmd == "action":
+        return check_action(args.verb)
+    if args.cmd == "bug":
+        return check_bug(args.bug_id)
+    if args.cmd == "sha":
+        return check_sha(args.sha)
+    return EXIT_COLLISION
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_check_primitive_exists.py
+++ b/tests/test_check_primitive_exists.py
@@ -1,0 +1,258 @@
+"""Tests for scripts/check_primitive_exists.py — pre-design cohit guard.
+
+Each subcommand (action / bug / sha) is exercised against a temp git repo
+that simulates origin/main. The repo holds a tiny api file with a known
+action verb and a few seed commits so we can assert CLEAN / WARNING /
+COLLISION outcomes without depending on the real workflow tree.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import check_primitive_exists as cpe  # noqa: E402
+
+# ── Fixture: a fake repo with origin/main ────────────────────────────────────
+
+
+def _git(repo: Path, *args: str, env_extra: dict | None = None) -> None:
+    env = {
+        "GIT_AUTHOR_NAME": "Test", "GIT_AUTHOR_EMAIL": "t@example.com",
+        "GIT_COMMITTER_NAME": "Test", "GIT_COMMITTER_EMAIL": "t@example.com",
+    }
+    if env_extra:
+        env.update(env_extra)
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True, capture_output=True, text=True, env=env,
+    )
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    """Fresh git repo with a `refs/remotes/origin/main` ref pointing at HEAD.
+
+    Layout:
+      workflow/api/branches.py       — fake action-map file containing a
+                                       `validate_branch` map entry to
+                                       simulate the dev-cohit-#2 case.
+      docs/notes/bug042-mention.md   — file mentions BUG-042 by id.
+
+    Commit history:
+      [BUG-038 cited]  fix: handle BUG-038 cooldown drift
+      [BUG-040 keyword] fix: tighten branch validation        (no BUG- in subject)
+      [seed]           initial layout
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+
+    api_dir = repo / "workflow" / "api"
+    api_dir.mkdir(parents=True)
+    (api_dir / "branches.py").write_text(
+        '"""fake api file."""\n'
+        "_ACTIONS = {\n"
+        '    "validate_branch": _ext_branch_validate,\n'
+        '    "build_branch": _ext_branch_build,\n'
+        "}\n"
+        "def _ext_branch_validate(): pass\n",
+        encoding="utf-8",
+    )
+    notes = repo / "docs" / "notes"
+    notes.mkdir(parents=True)
+    (notes / "bug042-mention.md").write_text(
+        "Note about BUG-042 — filed but no fix yet.\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "initial layout")
+
+    # Add a commit referencing BUG-038 in subject (direct-id hit case).
+    (repo / "workflow" / "api" / "branches.py").write_text(
+        '"""fake api file v2."""\n'
+        "_ACTIONS = {\n"
+        '    "validate_branch": _ext_branch_validate,\n'
+        '    "build_branch": _ext_branch_build,\n'
+        "}\n"
+        "def _ext_branch_validate(): pass\n"
+        "# tweak\n",
+        encoding="utf-8",
+    )
+    _git(repo, "commit", "-aq", "-m", "fix: handle BUG-038 cooldown drift")
+
+    # Add a commit that fixes a bug WITHOUT naming the id in subject —
+    # simulates the BUG-037 case (a288444 didn't say "BUG-037" in subject).
+    (repo / "workflow" / "api" / "branches.py").write_text(
+        '"""fake api file v3."""\n'
+        "_ACTIONS = {\n"
+        '    "validate_branch": _ext_branch_validate,\n'
+        '    "build_branch": _ext_branch_build,\n'
+        "}\n"
+        "def _ext_branch_validate(): pass\n"
+        "# tweak v3\n",
+        encoding="utf-8",
+    )
+    _git(repo, "commit", "-aq", "-m", "fix: tighten branch validation")
+
+    # Set up the origin/main ref the script expects.
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    return repo
+
+
+# ── action subcommand ────────────────────────────────────────────────────────
+
+
+def test_action_collision_on_known_verb(fake_repo: Path, capsys):
+    rc = cpe.check_action("validate_branch", repo_root=fake_repo)
+    out = capsys.readouterr().out
+    assert rc == cpe.EXIT_COLLISION, out
+    assert "COLLISION" in out
+    assert "validate_branch" in out
+    # Both shapes (handler + map_entry) get reported.
+    assert "map_entry" in out
+    assert "handler" in out
+
+
+def test_action_clean_on_unknown_verb(fake_repo: Path, capsys):
+    rc = cpe.check_action("zzznopenope", repo_root=fake_repo)
+    out = capsys.readouterr().out
+    assert rc == cpe.EXIT_CLEAN, out
+    assert "CLEAN" in out
+
+
+def test_action_rejects_bad_identifier(fake_repo: Path, capsys):
+    rc = cpe.check_action("Has-Hyphens-And-Caps", repo_root=fake_repo)
+    err = capsys.readouterr().err
+    assert rc == cpe.EXIT_COLLISION, err
+    assert "not a valid identifier" in err
+
+
+# ── bug subcommand ───────────────────────────────────────────────────────────
+
+
+def test_bug_collision_when_id_in_commit_subject(fake_repo: Path, capsys):
+    """BUG-038 IS named in a commit subject — direct hit."""
+    rc = cpe.check_bug("BUG-038", repo_root=fake_repo)
+    out = capsys.readouterr().out
+    assert rc == cpe.EXIT_COLLISION, out
+    assert "COLLISION" in out
+    assert "BUG-038" in out
+    assert "cooldown drift" in out
+
+
+def test_bug_warning_when_only_file_mentions_match(fake_repo: Path, capsys):
+    """BUG-042 is mentioned in a doc file but no commit subject — warning tier
+    matches the BUG-037 real-world case (fix sha a288444 didn't say BUG-037
+    in its subject)."""
+    rc = cpe.check_bug("BUG-042", repo_root=fake_repo)
+    out = capsys.readouterr().out
+    assert rc == cpe.EXIT_WARNING, out
+    assert "WARNING" in out
+    assert "BUG-042" in out
+    assert "bug042-mention.md" in out
+
+
+def test_bug_clean_on_unknown_id(fake_repo: Path, capsys):
+    rc = cpe.check_bug("BUG-9999", repo_root=fake_repo)
+    out = capsys.readouterr().out
+    assert rc == cpe.EXIT_CLEAN, out
+    assert "CLEAN" in out
+
+
+def test_bug_rejects_malformed_id(fake_repo: Path, capsys):
+    rc = cpe.check_bug("not-a-bug", repo_root=fake_repo)
+    err = capsys.readouterr().err
+    assert rc == cpe.EXIT_COLLISION, err
+    assert "valid BUG-NNN" in err
+
+
+def test_bug_id_normalized_with_zero_pad(fake_repo: Path, capsys):
+    """`BUG-38` should normalize to `BUG-038` when matching commit subjects."""
+    # Our fixture has 'fix: handle BUG-038 cooldown drift'. A query for BUG-38
+    # (no zero pad) should still hit because we canonicalize before the grep.
+    rc = cpe.check_bug("BUG-38", repo_root=fake_repo)
+    out = capsys.readouterr().out
+    # Direct grep is case-insensitive substring; "BUG-38" is a substring of
+    # "BUG-038" so the grep WILL match — collision is the right verdict.
+    assert rc == cpe.EXIT_COLLISION, out
+
+
+# ── sha subcommand ───────────────────────────────────────────────────────────
+
+
+def test_sha_clean_on_main_ancestor(fake_repo: Path, capsys):
+    head = subprocess.run(
+        ["git", "-C", str(fake_repo), "rev-parse", "HEAD"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    rc = cpe.check_sha(head[:8], repo_root=fake_repo)
+    out = capsys.readouterr().out
+    assert rc == cpe.EXIT_CLEAN, out
+    assert "CLEAN" in out
+    assert "tighten branch validation" in out
+
+
+def test_sha_collision_when_unresolvable(fake_repo: Path, capsys):
+    rc = cpe.check_sha("deadbeef", repo_root=fake_repo)
+    out = capsys.readouterr().out
+    assert rc == cpe.EXIT_COLLISION, out
+    assert "does not resolve" in out
+
+
+def test_sha_collision_when_off_main(fake_repo: Path, capsys):
+    """A commit on a feature branch that's NOT an ancestor of origin/main
+    must report COLLISION — the daemon_registry doc-frontmatter cohit case."""
+    # Make a feature branch, commit something there, do NOT merge it into main,
+    # do NOT update origin/main ref.
+    _git(fake_repo, "checkout", "-q", "-b", "feature/off-main")
+    (fake_repo / "feature.txt").write_text("only on feature\n", encoding="utf-8")
+    _git(fake_repo, "add", "feature.txt")
+    _git(fake_repo, "commit", "-q", "-m", "feat: orphan commit")
+    feature_sha = subprocess.run(
+        ["git", "-C", str(fake_repo), "rev-parse", "HEAD"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    _git(fake_repo, "checkout", "-q", "main")
+
+    rc = cpe.check_sha(feature_sha[:10], repo_root=fake_repo)
+    out = capsys.readouterr().out
+    assert rc == cpe.EXIT_COLLISION, out
+    assert "NOT on" in out
+    assert "feature/off-main" in out
+
+
+def test_sha_rejects_non_hex(fake_repo: Path, capsys):
+    rc = cpe.check_sha("zzznotahex!", repo_root=fake_repo)
+    err = capsys.readouterr().err
+    assert rc == cpe.EXIT_COLLISION, err
+    assert "does not look like a git sha" in err
+
+
+# ── CLI entry point smoke ────────────────────────────────────────────────────
+
+
+def test_cli_main_dispatches_action(monkeypatch, fake_repo: Path, capsys):
+    monkeypatch.setattr(cpe, "REPO_ROOT", fake_repo)
+    rc = cpe.main(["action", "zzznopenope"])
+    assert rc == cpe.EXIT_CLEAN
+    assert "CLEAN" in capsys.readouterr().out
+
+
+def test_cli_main_dispatches_bug(monkeypatch, fake_repo: Path, capsys):
+    monkeypatch.setattr(cpe, "REPO_ROOT", fake_repo)
+    rc = cpe.main(["bug", "BUG-038"])
+    assert rc == cpe.EXIT_COLLISION
+    assert "COLLISION" in capsys.readouterr().out
+
+
+def test_cli_main_requires_subcommand(capsys):
+    with pytest.raises(SystemExit):
+        cpe.main([])


### PR DESCRIPTION
## Summary

Layer-2 of the 3-layer cohit-prevention chain (memory → script → hook). Earned a script after four primitive-already-exists incidents in 24h on 2026-05-02 (per AGENTS.md auto-iterate: recurrence ≥4 → ratchet).

Three subcommands grep-based against `refs/remotes/origin/main`:

- `action <verb>` — handler / map-entry collision. Catches dev's `validate_branch` cohit (already wired at `workflow/api/branches.py:2590`).
- `bug <BUG-NNN>` — commit-subject grep + working-tree file mention. Direct hit → COLLISION (exit 2); file-only → WARNING (exit 1); both empty → CLEAN. The warning case cites BUG-037 explicitly (fix `a288444` didn't name the id in its subject).
- `sha <sha>` — `merge-base --is-ancestor` against origin/main. Catches design-note frontmatter sha pins that point at feature branches.

Exit codes: 0 CLEAN / 1 WARNING / 2 COLLISION. Stdlib-only, ~270 LOC, matches `scripts/claim_check.py` style.

15 tests against a fixture repo that simulates origin/main with the four real cohit shapes encoded as test cases. AGENTS.md §Orient gains a 5th item pointing at the script.

## Test plan

- [x] `pytest tests/test_check_primitive_exists.py -p no:cacheprovider -q` → 15 passed in 4.41s.
- [x] `ruff check scripts/check_primitive_exists.py tests/test_check_primitive_exists.py` clean.
- [x] Smoke against the real Workflow tree: `action validate_branch` → COLLISION (matches dev's cohit), `action zzznopenope` → CLEAN, `bug BUG-037` → WARNING (matches the unnamed-in-subject case), `sha a288444` → CLEAN, `sha deadbeef` → COLLISION.
- [x] Pre-commit hooks pass (cross-provider-drift, skills-valid, mojibake, mirror-parity-N/A).
- [ ] Verifier full pytest sweep with `-p no:cacheprovider` and isolated `WORKFLOW_DATA_DIR`.