### PR TITLE
docs: record OpenAI write-path proof gap

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -9,7 +9,7 @@ Live steering only. **Budget 4 KB / 60 lines.** Concerns/Work = one line each; l
 - [filed:2026-04-20 verified:2026-04-27] `test_node_eval` roundtrip flake: Fix B landed 16d4823; watch ≥30d.
 - [filed:2026-04-18 verified:2026-04-28] `add_canon_from_path` sensitivity: host Qs reframed by commons-first audit F3.
 - [filed:2026-04-24] Task #9 host Qs: GH Actions GROQ/GEMINI/XAI secrets + rotation e2e after deploy step.
-- **[P1 filed:2026-04-25 verified:2026-05-01]** BUG-034 ChatGPT approval stall; direct MCP needed to repair live branches.
+- **[P1 filed:2026-04-25 verified:2026-05-02]** BUG-034 ChatGPT goal-propose approval stalls; dev chat still calls legacy Goals router.
 - [filed:2026-04-28] Claude card matcher cleanup conflicts with legacy connector fallback test.
 - **[P1 filed:2026-04-30]** Castles II run `28479d8ddfb44488` failed `provider_exhausted` at discovery; blocks branch-run proof (BUG-038).
 
@@ -22,7 +22,7 @@ Run `python scripts/claim_check.py --provider <name>` before claiming. Claim by 
 | Task | Files | Depends | Status |
 |------|-------|---------|--------|
 | Scorched exact-original proof - mount guard green; needs rights-cleared Kickstart + input/sound/tank-hit acceptance. | WebSite/site/static/play/scorched-tanks/licensed/kickstart-a500-1.3.rom (deployment-only; do not commit ROM) | rights-cleared Kickstart | host-action |
-| Directory submissions + first-use evidence - OpenAI app draft at Submit; read paths green; write-path hit `/mcp-directory` goal import regression, fix in flight. Final blocked on legal fields, mobile, submit approval. | chatgpt-app-submission.json, docs/ops/mcp-*.md, docs/ops/openai-app-submission-prep-2026-05-02.md, workflow/api/{market,evaluation}.py, packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/{market,evaluation}.py, tests/test_directory_server.py | action-time compliance/final-submit approval | claimed:codex-gpt5-desktop ACTIVE 2026-05-02 |
+| Directory submissions + first-use evidence - #149 deployed; direct goal write + ChatGPT search/request green. Final blocked on BUG-034 propose-card stall, mobile, legal fields, submit approval. | chatgpt-app-submission.json, docs/ops/mcp-*.md, docs/ops/openai-app-submission-prep-2026-05-02.md | action-time compliance/final-submit approval | host-action |
 | Community change loop - watch/canary green 2026-05-02 05:36Z; P1a + invoke provider path live; actual proof parent `2ff26ffa401a4829`, child `ce6678fc08dd4a83` completed REVIEW_READY; next: incentive-directed pickup + stress. | docs/exec-plans/active/2026-04-30-live-community-reiteration-loop.md, docs/ops/auto-fix-runbook.md | API/tests claim | monitoring |
 | Daemon memory action discoverability - route chatbots to capture/search/review/promote/status from `control_station`. | workflow/api/prompts.py, tests/test_universe_server_framing.py, packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py, docs/design-notes/2026-05-02-daemon-mini-openbrain.md | daemon_memory actions live | claimed:codex-gpt5-desktop ACTIVE 2026-05-02 |
 | Daemon soul followups - flagship core routing + host review/editor + memory evals. | workflow/daemon_{registry,wiki,memory}.py, workflow/dispatcher.py, workflow/api/universe.py, fantasy_daemon/api.py, tests/ | - | dev-ready |

--- a/docs/ops/openai-app-submission-prep-2026-05-02.md
+++ b/docs/ops/openai-app-submission-prep-2026-05-02.md
@@ -139,9 +139,10 @@ Required before final submit:
 - Optional proof uploads if we choose to provide them: logo, screenshots, and
   demo recording URL. The dashboard says screenshots are optional for non-UI
   apps, but submission docs still list screenshots among form information.
-- Retry the real ChatGPT write-path test for `propose_workflow_goal` and
-  `submit_workflow_request` after the `/mcp-directory` goal-tool import fix is
-  live. This mutates Workflow state, so run only with action-time host approval.
+- Resolve the ChatGPT approval-card stall for `propose_workflow_goal`.
+  Direct `/mcp-directory` and `/mcp` goal writes are fixed and deployed, and
+  ChatGPT can read goals and submit requests, but goal-proposal approval cards
+  still stall after approval (BUG-034).
 - Mobile evidence for the main flows, because the OpenAI testing docs say to
   invoke the connector in ChatGPT iOS or Android apps.
 - Keep expected outputs clear and free of personal identifiers or irrelevant
@@ -200,12 +201,30 @@ Write-path attempt:
   `/mcp-directory` probe reproduced `cannot import name '_ensure_author_server_db'
   from 'workflow.api.branches'`; final write-path proof is blocked until the
   directory goal-tool fix is deployed and retested.
+- Follow-up after PR #149 deployment (`2a1651f`, deploy run 25245035290):
+  - Direct `/mcp-directory` `propose_workflow_goal` succeeded and created goal
+    `35f70887461e` (`Onboard new MCP hosts`).
+  - Direct `/mcp` `goals action=propose` also succeeded, creating
+    `975e8fbdead0` (`Workflow legacy propose probe 2026-05-02`).
+  - ChatGPT Developer Mode read proof succeeded: `Workflow Dev` found
+    `35f70887461e` by exact title.
+  - ChatGPT Developer Mode request write succeeded:
+    `submit_workflow_request` returned `req_1777701087_d215c1fa` in
+    `echoes-of-the-cosmos`.
+  - ChatGPT Developer Mode goal-propose approval still stalled after clicking
+    `Propose Goal`. A fresh chat with `Workflow Dev` attached reproduced the
+    stall; the opened tool-call payload still showed the legacy
+    `Goals`/`action: "propose"` router shape. The platform MCP Server section
+    lists the narrow `/mcp-directory` tool set, including
+    `propose_workflow_goal`, so this looks like a stale ChatGPT dev-attachment
+    or BUG-034 approval-routing issue rather than the old
+    `_ensure_author_server_db` backend failure.
 
 Not yet tested:
 
-- Positive Test Case 5, because it creates a shared/public goal proposal and a
-  queued Workflow request, and the first approved attempt exposed the live
-  `/mcp-directory` goal-tool import regression above.
+- Positive Test Case 5 is only partially proven: direct goal proposal works and
+  ChatGPT request submission works, but ChatGPT goal-proposal approval still
+  stalls after approval.
 - Negative cases 2 and 3, because the submitted prompts ask ChatGPT not to route
   unrelated email/credential/destructive work through Workflow; run them in
   Developer Mode before final submit and verify no Workflow write tool is called.


### PR DESCRIPTION
## Summary
- record that PR #149 is deployed and direct `/mcp-directory` goal writes now work
- record ChatGPT Developer Mode proof: goal read and request submission succeeded
- keep final submission blocked on BUG-034 because ChatGPT goal-proposal approval cards still stall and expose the legacy `Goals` action-router payload

## Verification
- `git diff --check`
- `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp --verbose` -> six consecutive green probes
- `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp-directory --verbose` -> green
- direct `/mcp-directory` `search_workflow_goals` found `35f70887461e`
- ChatGPT Developer Mode read proof and request write proof observed in-browser