### PR TITLE
docs: record OpenAI post-continue proof

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -9,7 +9,7 @@ Live steering only. **Budget 4 KB / 60 lines.** Concerns/Work = one line each; l
 - [filed:2026-04-20 verified:2026-04-27] `test_node_eval` roundtrip flake: Fix B landed 16d4823; watch ≥30d.
 - [filed:2026-04-18 verified:2026-04-28] `add_canon_from_path` sensitivity: host Qs reframed by commons-first audit F3.
 - [filed:2026-04-24] Task #9 host Qs: GH Actions GROQ/GEMINI/XAI secrets + rotation e2e after deploy step.
-- **[P1 filed:2026-04-25 verified:2026-05-02]** BUG-034 ChatGPT goal-propose approval stalls; dev chat still calls legacy Goals router.
+- **[P1 filed:2026-04-25 verified:2026-05-02]** BUG-034: after Platform scan+Continue, ChatGPT still sends `propose_workflow_goal` through legacy `Goals`; one error + one hang.
 - [filed:2026-04-28] Claude card matcher cleanup conflicts with legacy connector fallback test.
 - **[P1 filed:2026-04-30]** Castles II run `28479d8ddfb44488` failed `provider_exhausted` at discovery; blocks branch-run proof (BUG-038).
 
@@ -22,7 +22,8 @@ Run `python scripts/claim_check.py --provider <name>` before claiming. Claim by 
 | Task | Files | Depends | Status |
 |------|-------|---------|--------|
 | Scorched exact-original proof - mount guard green; needs rights-cleared Kickstart + input/sound/tank-hit acceptance. | WebSite/site/static/play/scorched-tanks/licensed/kickstart-a500-1.3.rom (deployment-only; do not commit ROM) | rights-cleared Kickstart | host-action |
-| Directory submissions + first-use evidence - #149 deployed; direct goal write + ChatGPT search/request green. Final blocked on BUG-034 propose-card stall, mobile, legal fields, submit approval. | chatgpt-app-submission.json, docs/ops/mcp-*.md, docs/ops/openai-app-submission-prep-2026-05-02.md | action-time compliance/final-submit approval | host-action |
+| Directory submissions + first-use evidence - #149 deployed; direct goal write + ChatGPT search/request green; Platform scan+Continue done. Docs proof branch `codex/openai-postcontinue-identity` / `../wf-openai-postcontinue-identity`; final blocked on BUG-034 legacy `Goals` routing, mobile, legal fields, submit approval. | chatgpt-app-submission.json, docs/ops/mcp-*.md, docs/ops/openai-app-submission-prep-2026-05-02.md | action-time compliance/final-submit approval | host-action |
+| Provider identity bridge - branch `codex/provider-identity-bridge`, worktree `../wf-provider-identity-bridge`, draft PR expected after PLAN owner clears; link Claude/ChatGPT/Codex/OpenClaw without chatbot-login-only authority for daemon, money, or connected-account control. | docs/design-notes/2026-05-02-provider-identity-bridge.md, PLAN.md | current PLAN claim clears; host approves design | pending |
 | Community loop canonical invoke smoke - parent `4da58d59ff4c4e18`/child `c788bb7380484196` hit Codex/bwrap; PR #157 draft fixes provider fail-loud/runtime; rerun after Claude review+merge. | workflow/providers/{base,codex_provider}.py, workflow/runs.py, workflow/graph_compiler.py, workflow/api/runs.py, tests/test_{providers,sandbox_unavailable,graph_compiler_empty_response,node_timeout,sub_branch_invocation,wait_for_run}.py, docs/exec-plans/active/2026-04-30-live-community-reiteration-loop.md, MCP live branches fd5c66b1d87d/e019229850f9 | Claude review of #157 | claimed:codex-loop-uptime-chatgpt |
 | Daemon soul followups - flagship core routing + host review/editor. | workflow/daemon_{registry,wiki,memory}.py, workflow/dispatcher.py, workflow/api/universe.py, fantasy_daemon/api.py, tests/ | - | dev-ready |
 | Enable Actions PR creation for auto-fix - repo has read-only workflow perms; permission flip needs action-time confirmation. | GitHub repo settings | PR #100/#104 show branch push works | host-action |

--- a/docs/design-notes/2026-05-02-provider-identity-bridge.md
+++ b/docs/design-notes/2026-05-02-provider-identity-bridge.md
@@ -1,0 +1,114 @@
+# Provider Identity Bridge
+
+Status: proposed capture from 2026-05-02 host direction. Not yet promoted into
+`PLAN.md` because `PLAN.md` is currently claimed by another lane.
+
+## Problem
+
+The same human may reach Workflow through Claude, ChatGPT, Codex, OpenClaw,
+local IDE hosts, and future MCP clients. The product goal is that the user can
+control their own daemons, capacity grants, money-adjacent balances, and
+connected account assets from whichever logged-in chatbot they are using.
+
+The unsafe shortcut is treating "the chatbot session is logged in" as Workflow
+account authority by itself. Provider login proves that the user is logged into
+that provider account. It does not prove which Workflow account it should bind
+to, which daemon/runtime/capacity scopes it controls, or whether money,
+credential, or account-access authority has been delegated.
+
+## Proposed Boundary
+
+Use a provider identity bridge:
+
+1. Workflow account identity remains canonical. Launch design currently names
+   GitHub OAuth as the first identity primitive, with native accounts later if
+   needed.
+2. Each chatbot/provider identity becomes a verified external identity binding
+   on the Workflow account: `provider`, `provider_subject`, verification time,
+   assurance level, scopes, revocation status, and last proof.
+3. Binding a provider requires an explicit linking ceremony: OAuth/PKCE where
+   available, or a signed one-time nonce shown in Workflow and returned through
+   the provider client. A provider session cannot self-assert ownership.
+4. Once linked, low-risk reads and reversible controls may feel automatic from
+   that provider, but every operation still checks tenant, owner, grant,
+   runtime lease, state scope, target version, and action class.
+5. High-risk classes stay gated even for linked sessions: irreversible actions,
+   credential custody, external account writes, financial/crypto transfers,
+   regulated submissions, and final publish/submit boundaries.
+6. For crypto or money-like flows, Workflow may prepare, validate, simulate,
+   queue, explain, and hand off. It must not execute prohibited transfers on
+   the user's behalf. Reversible internal ledger proposals can be batched only
+   when the reversal semantics are real and tested.
+
+## Relationship To Existing Plan
+
+This follows existing constraints rather than replacing them:
+
+- `PLAN.md` already says GitHub OAuth is the launch identity primitive and
+  sessions are scoped per user.
+- `PLAN.md` says human control belongs at irreversible boundaries and
+  reversibility earns batched autonomy.
+- `PLAN.md` says provider compliance is a product boundary: Workflow can
+  prepare, explain, validate, simulate, or hand off provider-forbidden actions,
+  but cannot disguise the final prohibited action as daemon work.
+- `docs/design-notes/2026-05-01-hostless-byok-cloud-daemon-capacity.md`
+  requires ownership-scoped control semantics, no subscription cookie/session
+  scraping, broker-only credential use, scoped write proxies, budget
+  reservation, revocation, and simulated multi-user proof.
+
+## Data Shape Sketch
+
+```text
+workflow_users
+  id
+  primary_identity_provider
+  created_at
+
+external_identity_bindings
+  id
+  workflow_user_id
+  provider                 # github | openai | anthropic | codex | openclaw | ...
+  provider_subject_hash
+  display_hint
+  assurance_level          # unverified | nonce | oauth | workspace_admin
+  scopes                   # read, reversible_control, propose, publish_request, ...
+  status                   # active | revoked | rotation_needed
+  verified_at
+  last_seen_at
+
+authority_grants
+  id
+  workflow_user_id
+  binding_id
+  grant_type               # daemon_control | capacity | credential | ledger | account_asset
+  allowed_actions
+  reversible_until
+  budget_or_limit
+  status
+```
+
+## Open Questions
+
+- Which provider bindings are acceptable for launch besides GitHub OAuth?
+- Does ChatGPT/OpenAI app identity expose a stable subject suitable for account
+  linking, or must first launch use a Workflow-side nonce?
+- Which actions can be made genuinely reversible enough for checkpoint/batched
+  approval, and which must stay final-step handoff?
+- What is the minimum simulated multi-user test proving that Claude, ChatGPT,
+  Codex, and OpenClaw sessions cannot cross-control another user's daemon,
+  capacity, money-like grants, or connected accounts?
+
+## Next Step
+
+Current STATUS lane:
+
+- Proposed branch: `codex/provider-identity-bridge`
+- Proposed worktree: `../wf-provider-identity-bridge`
+- PR expectation: draft PR until the current `PLAN.md` owner clears or
+  explicitly coordinates the edit
+- First write set: this note plus `PLAN.md`; implementation files are not
+  chosen yet
+
+Do not implement runtime identity or account-control code from this capture
+alone. First refactor the lane against current auth/control-plane work, active
+review gates, prior-provider memory refs, and related compliance implications.

--- a/docs/ops/openai-app-submission-prep-2026-05-02.md
+++ b/docs/ops/openai-app-submission-prep-2026-05-02.md
@@ -219,6 +219,32 @@ Write-path attempt:
     `propose_workflow_goal`, so this looks like a stale ChatGPT dev-attachment
     or BUG-034 approval-routing issue rather than the old
     `_ensure_author_server_db` backend failure.
+- Follow-up after Platform MCP Server `Scan Tools` and `Continue` on
+  2026-05-02:
+  - Platform draft remained configured to `https://tinyassets.io/mcp-directory`
+    with the narrow tool set, including `propose_workflow_goal` and
+    `submit_workflow_request`; no legacy `Goals` tool appeared in the Platform
+    MCP Server section.
+  - Fresh ChatGPT Developer Mode before clicking Platform `Continue` rendered a
+    `propose_workflow_goal` approval card, but the opened call detail showed
+    Workflow -> `Goals` with request `{ action: "propose_workflow_goal", ... }`.
+    Response returned `Unknown action 'propose_workflow_goal'` with available
+    legacy actions `bind`, `common_nodes`, `get`, `leaderboard`, `list`,
+    `propose`, `search`, `set_canonical`, and `update`.
+  - After clicking Platform `Continue` into the Testing section, a second fresh
+    ChatGPT Developer Mode chat again rendered the `propose_workflow_goal`
+    approval card. After approval, the tool detail still showed Workflow ->
+    `Goals` with `action: "propose_workflow_goal"` and remained stuck at
+    `Access granted for Workflow` / `Thinking`; no response body appeared
+    before the browser automation timeout.
+  - Direct public canaries stayed green for both `https://tinyassets.io/mcp`
+    and `https://tinyassets.io/mcp-directory` after the hung ChatGPT attempt.
+    Direct `/mcp-directory` search did not show either post-rescan proof goal
+    title, so the ChatGPT attempts did not produce confirmed new goals.
+  - Current boundary: the app draft scan is fresh, but the ChatGPT Developer
+    Mode attachment still routes the goal approval through the legacy `Goals`
+    action wrapper. Treat this as BUG-034 / ChatGPT app-attachment routing until
+    a no-legacy tool-call proof succeeds.
 
 Not yet tested:
 


### PR DESCRIPTION
## Summary
- record the OpenAI Platform MCP scan + Continue retest evidence
- capture the remaining BUG-034 behavior: ChatGPT still routes goal proposal through legacy Goals action wrapper
- add proposed provider identity bridge note for Claude/ChatGPT/Codex/OpenClaw account linking boundaries

## Verification
- git diff --check
- git diff --cached --check
- python scripts/claim_check.py --provider codex-gpt5-desktop-openai-submit
- python scripts/worktree_status.py
- python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp --verbose
- python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp-directory --verbose
