### PR TITLE
[codex] Record OpenAI strict redaction proof

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -172,3 +172,13 @@ Notes:
   submission blockers.
 - Ship condition: STATUS/docs show PR #183 deploy proof; ChatGPT web/mobile
   proof and final submit approval remain open.
+
+## OpenAI Postdeploy Proof - 2026-05-02
+
+- 2026-05-02 reuse `../wf-openai-submission-hardening` on
+  `codex/openai-postdeploy-proof` by codex-gpt5-desktop-openai-submission
+  after PR #184 deployed.
+- STATUS row: Directory submissions + first-use evidence.
+- Purpose: record strict live redaction proof after deploy run `25260784025`.
+- Ship condition: STATUS/docs show strict `/mcp-directory` proof; ChatGPT
+  web/mobile proof and final submit approval remain open.

--- a/STATUS.md
+++ b/STATUS.md
@@ -9,7 +9,7 @@ Live steering only. **Budget 4 KB / 60 lines.** Concerns/Work = one line each; l
 - [filed:2026-04-20 verified:2026-04-27] `test_node_eval` roundtrip flake: Fix B landed 16d4823; watch ≥30d.
 - [filed:2026-04-18 verified:2026-04-28] `add_canon_from_path` sensitivity: host Qs reframed by commons-first audit F3.
 - [filed:2026-04-24] Task #9 host Qs: GH Actions GROQ/GEMINI/XAI secrets + rotation e2e after deploy step.
-- **[P1 filed:2026-04-25 verified:2026-05-02]** BUG-034: PR #161 fixed legacy alias/`Unknown action`; public canaries green 2026-05-02T12:56-07:00; clean ChatGPT approval/write proof still pending. (see BUG-034)
+- **[P1 filed:2026-04-25 verified:2026-05-02]** BUG-034: PR #161 fixed legacy alias/`Unknown action`; public canaries green 2026-05-02T13:13-07:00; clean ChatGPT approval/write proof still pending. (see BUG-034)
 - [filed:2026-04-28] Claude card matcher cleanup conflicts with legacy connector fallback test.
 - **[P1 filed:2026-04-30]** Castles II run `28479d8ddfb44488` failed `provider_exhausted` at discovery; blocks branch-run proof (BUG-038).
 
@@ -22,7 +22,7 @@ Run `python scripts/claim_check.py --provider <name>` before claiming. Claim by 
 | Task | Files | Depends | Status |
 |------|-------|---------|--------|
 | Scorched exact-original proof - mount guard green; needs rights-cleared Kickstart + input/sound/tank-hit acceptance. | WebSite/site/static/play/scorched-tanks/licensed/kickstart-a500-1.3.rom (deployment-only; do not commit ROM) | rights-cleared Kickstart | host-action |
-| Directory submissions + first-use evidence - PR #183 deployed raw redaction; `codex/openai-live-proof` polishes diagnostic labels; needs ChatGPT/Claude proof + first-user evidence. | chatgpt-app-submission.json, docs/ops/mcp-*.md, docs/ops/openai-app-submission-prep-2026-05-02.md, docs/ops/mcp-host-proof-registry.md, workflow/directory_server.py, packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py, tests/test_directory_server.py | action-time compliance/final-submit approval | claimed:codex-gpt5-desktop-openai-submission |
+| Directory submissions + first-use evidence - PR #184 deployed strict `/mcp-directory` redaction; canaries green 2026-05-02T13:13-07:00; needs clean ChatGPT/Claude proof + first-user evidence. | chatgpt-app-submission.json, docs/ops/mcp-*.md, docs/ops/openai-app-submission-prep-2026-05-02.md, docs/ops/mcp-host-proof-registry.md | action-time compliance/final-submit approval | claimed:codex-gpt5-desktop-openai-submission |
 | Community loop post-merge proof - #157 merged at `d897177`; verify deployed MCP, rerun canonical invoke smoke, then rendered connector proof. | output/user_sim_session.md, output/claude_chat_trace.md, .agents/uptime.log, MCP live branches fd5c66b1d87d/e019229850f9 | deploy of `d897177` | claimed:codex-loop-uptime-chatgpt |
 | Daemon soul followups - flagship core routing + host review/editor. | workflow/daemon_{registry,wiki,memory}.py, workflow/dispatcher.py, workflow/api/universe.py, fantasy_daemon/api.py, tests/ | - | dev-ready |
 | Enable Actions PR creation for auto-fix - repo has read-only workflow perms; permission flip needs action-time confirmation. | GitHub repo settings | PR #100/#104 show branch push works | host-action |

--- a/docs/ops/mcp-host-proof-registry.md
+++ b/docs/ops/mcp-host-proof-registry.md
@@ -27,8 +27,8 @@ spec" or "planned", not "works".
 
 | Gate | Status | Evidence | Notes |
 |---|---|---|---|
-| Public MCP endpoint | live-green | 2026-05-02T12:56-07:00: `mcp_public_canary.py --url https://tinyassets.io/mcp --timeout 15 --verbose` OK; `mcp_tool_canary.py --url https://tinyassets.io/mcp --timeout 20 --verbose` OK | Legacy custom connector surface remains available |
-| Directory-safe MCP endpoint | live-green; privacy-hardening deployed | 2026-05-02T12:56-07:00: `mcp_public_canary.py --url https://tinyassets.io/mcp-directory --timeout 15 --verbose` OK; `mcp_tool_canary.py --url https://tinyassets.io/mcp-directory --timeout 20 --verbose` OK from updated worktree; live status redaction probe OK | Use for host-directory review and ChatGPT app submission proof |
+| Public MCP endpoint | live-green | 2026-05-02T13:13-07:00: `mcp_public_canary.py --url https://tinyassets.io/mcp --timeout 15 --verbose` OK; `mcp_tool_canary.py --url https://tinyassets.io/mcp --timeout 20 --verbose` OK | Legacy custom connector surface remains available |
+| Directory-safe MCP endpoint | live-green; strict privacy hardening deployed | 2026-05-02T13:13-07:00: `mcp_public_canary.py --url https://tinyassets.io/mcp-directory --timeout 15 --verbose` OK; `mcp_tool_canary.py --url https://tinyassets.io/mcp-directory --timeout 20 --verbose` OK; strict live status redaction probe OK | Use for host-directory review and ChatGPT app submission proof |
 | Official MCP Registry metadata | published-live | 2026-05-01: `mcp-publisher` v1.7.6 published `io.github.Jonnyton/workflow-universe-server` 0.1.0; registry API search returned status `active` | Points clients at `https://tinyassets.io/mcp-directory` |
 | AI-readable web docs | live | `WebSite/site/static/llms.txt` live from PR #134; update in progress for registry publication | Needs periodic source freshness check |
 | `/connect` customer chooser | live | PR #134 deployed; Playwright desktop/mobile smoke on 2026-05-01 | Copy separates registry live from Claude/ChatGPT directory acceptance |
@@ -47,9 +47,17 @@ spec" or "planned", not "works".
   `get_workflow_status` returned `directory_privacy_note`, with raw
   `activity_log_tail`, raw `last_n_calls`, `policy_hash`, `session_boundary`,
   `host_id`, and storage subsystem `path` fields absent.
-- Follow-up branch `codex/openai-live-proof` removes remaining review-noisy
+- PR #184 (`30363c7`) removed remaining review-noisy
   `activity_log_tail_count`, `last_n_calls_count`, and
-  `evidence_caveats.last_n_calls` labels before final OpenAI submit proof.
+  `evidence_caveats.last_n_calls` labels. Deploy prod run `25260784025`
+  passed and deployed image tag `30363c709a28`.
+- Strict live redaction proof passed at 2026-05-02T13:13-07:00:
+  `evidence` only contains `activity_log_line_count` and
+  `last_completed_request_llm_used`; `evidence_caveats` only contains
+  `last_completed_request_llm_used`; and `activity_log_tail`, `last_n_calls`,
+  `activity_log_tail_count`, `last_n_calls_count`, `policy_hash`,
+  `session_boundary`, `host_id`, and storage subsystem `path` fields are
+  absent.
 - ChatGPT Developer Mode proof history is preserved in
   `docs/ops/openai-app-submission-chatgpt-proof-2026-05-02.md`.
 
@@ -97,8 +105,8 @@ spec" or "planned", not "works".
 | Official MCP Registry | Registry-aware MCP hosts | published-live | 2026-05-01 proof: `mcp-publisher publish packaging/registry/server.json`; API search returned `io.github.Jonnyton/workflow-universe-server` active/latest |
 | Claude.ai custom connector | Logged-in Claude user | protocol-live; UI refresh needed | Full surface is `https://tinyassets.io/mcp`; protocol proof green 2026-05-01; live Claude.ai proof still needs refresh |
 | Claude Connectors Directory | Logged-in Claude users/admins | form-reached; submit blocked on contact/final-submit approval | 2026-05-02: in-app browser reached Google Form page 2 from official Claude submission docs; stopped before entering required contact/org fields because submission records Google identity and transmits contact data |
-| ChatGPT custom MCP / developer mode | Logged-in eligible ChatGPT user/workspace | partial proof; clean write proof pending | PR #161 fixed the legacy `Goals` alias path; public canaries green 2026-05-02T12:56-07:00; needs rendered ChatGPT approval/write proof with no hang/5xx |
-| ChatGPT App Directory | Logged-in ChatGPT users/admins | app draft; submit blocked | `chatgpt-app-submission.json` covers the 11 directory tools; 2026-05-02 dashboard draft reached Submit page with `/mcp-directory`; PR #183 redaction deploy/proof is green; final submit still blocked on live web/mobile golden prompts, privacy/legal fields, assets/release notes, and action-time host approval |
+| ChatGPT custom MCP / developer mode | Logged-in eligible ChatGPT user/workspace | partial proof; clean write proof pending | PR #161 fixed the legacy `Goals` alias path; public canaries green 2026-05-02T13:13-07:00; needs rendered ChatGPT approval/write proof with no hang/5xx |
+| ChatGPT App Directory | Logged-in ChatGPT users/admins | app draft; submit blocked | `chatgpt-app-submission.json` covers the 11 directory tools; 2026-05-02 dashboard draft reached Submit page with `/mcp-directory`; PR #184 strict redaction deploy/proof is green; final submit still blocked on live web/mobile golden prompts, privacy/legal fields, assets/release notes, and action-time host approval |
 | ChatGPT guest | No logged-in chatbot account | unsupported by ChatGPT path | Route to local/self-hosted/no-chatbot-login options |
 | Mistral Le Chat MCP connector | Logged-in Mistral user/admin | planned | Need connector config proof and directory/submission research |
 | Open WebUI | No hosted chatbot login if self-hosted | verified: local Docker 0.9.2 | 2026-05-01 proof: `docs/ops/open-webui-runtime-proof-2026-05-01.md`; Streamable HTTP MCP to `https://tinyassets.io/mcp-directory`, auth `None`, chat invoked `workflow_get_workflow_status` |

--- a/docs/ops/openai-app-submission-prep-2026-05-02.md
+++ b/docs/ops/openai-app-submission-prep-2026-05-02.md
@@ -88,10 +88,10 @@ and now returns redacted status with `directory_privacy_note`, without raw
 log/call arrays, host identifiers, local paths, session-boundary account data,
 or internal hashes.
 
-Follow-up branch `codex/openai-live-proof` removes the remaining
-review-noisy diagnostic count/caveat labels
-(`activity_log_tail_count`, `last_n_calls_count`, and
-`evidence_caveats.last_n_calls`) before final OpenAI submit proof.
+PR #184 / merge `30363c7` removed the remaining review-noisy diagnostic
+count/caveat labels (`activity_log_tail_count`, `last_n_calls_count`, and
+`evidence_caveats.last_n_calls`) before final OpenAI submit proof. Deploy prod
+run `25260784025` passed and deployed image tag `30363c709a28`.
 
 ## OpenAI Dashboard State
 
@@ -154,6 +154,17 @@ Suggested release notes:
 - `python scripts/mcp_tool_canary.py --url https://tinyassets.io/mcp --timeout 20 --verbose` passed.
 - `python scripts/mcp_tool_canary.py --url https://tinyassets.io/mcp-directory --timeout 20 --verbose` passed from the updated worktree and invoked `get_workflow_status`.
 - `python scripts/mcp_probe.py --url https://tinyassets.io/mcp-directory --tool get_workflow_status --args "{}" --raw` returned `directory_privacy_note`, with raw `activity_log_tail`, raw `last_n_calls`, `policy_hash`, `session_boundary`, `host_id`, and storage subsystem `path` fields absent.
-- Follow-up not yet deployed at this snapshot: `codex/openai-live-proof`
-  removes `activity_log_tail_count`, `last_n_calls_count`, and
-  `evidence_caveats.last_n_calls`; rerun the final probe after that deploy.
+2026-05-02T13:13-07:00 from deployed `main` merge `30363c7`:
+
+- PR #184 merged and deploy prod run `25260784025` passed for image tag
+  `30363c709a28`.
+- `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp --timeout 15 --verbose` passed.
+- `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp-directory --timeout 15 --verbose` passed.
+- `python scripts/mcp_tool_canary.py --url https://tinyassets.io/mcp --timeout 20 --verbose` passed.
+- `python scripts/mcp_tool_canary.py --url https://tinyassets.io/mcp-directory --timeout 20 --verbose` passed and invoked `get_workflow_status`.
+- Strict live redaction probe passed: `evidence` only contains
+  `activity_log_line_count` and `last_completed_request_llm_used`;
+  `evidence_caveats` only contains `last_completed_request_llm_used`; and
+  `activity_log_tail`, `last_n_calls`, `activity_log_tail_count`,
+  `last_n_calls_count`, `policy_hash`, `session_boundary`, `host_id`, and
+  storage subsystem `path` fields are absent.

--- a/docs/ops/openai-app-submission-readiness-2026-05-02.md
+++ b/docs/ops/openai-app-submission-readiness-2026-05-02.md
@@ -41,15 +41,12 @@ Sources:
 Verdict: not ready for final submit yet.
 
 Source packet is review-aligned and deployed, but final submission should wait
-for one final redaction-polish deploy, hosted ChatGPT proof, and action-time
-approval:
+for hosted ChatGPT proof and action-time approval:
 
-1. This follow-up branch must land/deploy to remove review-noisy diagnostic
-   count/caveat labels from the directory status payload.
-2. ChatGPT web must complete the golden prompts without `Unknown action`, hang,
+1. ChatGPT web must complete the golden prompts without `Unknown action`, hang,
    or 5xx.
-3. ChatGPT mobile must complete the main read/write flows.
-4. Host must approve legal/compliance checkboxes and final submit.
+2. ChatGPT mobile must complete the main read/write flows.
+3. Host must approve legal/compliance checkboxes and final submit.
 
 Closed 2026-05-02T12:56-07:00:
 
@@ -64,9 +61,25 @@ Closed 2026-05-02T12:56-07:00:
   `activity_log_tail`, raw `last_n_calls`, `policy_hash`,
   `session_boundary`, `host_id`, or storage subsystem `path` fields. It
   returns `directory_privacy_note`.
-- This follow-up branch removes remaining review-noisy
-  `activity_log_tail_count`, `last_n_calls_count`, and
-  `evidence_caveats.last_n_calls` labels before final OpenAI submit proof.
+- PR #184 later removed remaining review-noisy `activity_log_tail_count`,
+  `last_n_calls_count`, and `evidence_caveats.last_n_calls` labels before
+  final OpenAI submit proof.
+
+Closed 2026-05-02T13:13-07:00:
+
+- PR #184 merged to `main` at `30363c7`.
+- Deploy prod run `25260784025` passed and deployed image tag
+  `30363c709a28`.
+- Public canaries passed for both `https://tinyassets.io/mcp` and
+  `https://tinyassets.io/mcp-directory`.
+- `python scripts/mcp_tool_canary.py --url https://tinyassets.io/mcp-directory --timeout 20 --verbose`
+  passed and invoked `get_workflow_status`.
+- Strict live redaction probe passed: `evidence` only contains
+  `activity_log_line_count` and `last_completed_request_llm_used`;
+  `evidence_caveats` only contains `last_completed_request_llm_used`; and
+  `activity_log_tail`, `last_n_calls`, `activity_log_tail_count`,
+  `last_n_calls_count`, `policy_hash`, `session_boundary`, `host_id`, and
+  storage subsystem `path` fields are absent.
 
 Historical ChatGPT Developer Mode proof and BUG-034 boundaries are preserved in
 `docs/ops/openai-app-submission-chatgpt-proof-2026-05-02.md`.


### PR DESCRIPTION
## Summary
- records PR #184 deploy-prod proof for strict `/mcp-directory` status redaction
- updates STATUS and OpenAI submission prep/readiness docs to remove the redaction-polish blocker
- keeps final OpenAI submit blocked on ChatGPT web/mobile proof and action-time legal/compliance/publisher approval

## Live evidence
- PR #184 merged at `30363c7`
- deploy-prod run `25260784025` passed and deployed image tag `30363c709a28`
- `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp --timeout 15 --verbose`
- `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp-directory --timeout 15 --verbose`
- `python scripts/mcp_tool_canary.py --url https://tinyassets.io/mcp --timeout 20 --verbose`
- `python scripts/mcp_tool_canary.py --url https://tinyassets.io/mcp-directory --timeout 20 --verbose`
- strict structured probe: `evidence` only contains `activity_log_line_count` and `last_completed_request_llm_used`; `evidence_caveats` only contains `last_completed_request_llm_used`; removed raw/diagnostic keys are absent

## Validation
- `git diff --check`
- `git diff --cached --check`
- `python scripts/claim_check.py --provider codex-gpt5-desktop-openai-submission --check-files ...`
- pre-commit mojibake scan, cross-provider drift, and skills-valid passed