### PR TITLE
providers: default Codex worker model to CLI-supported gpt-5.4

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/codex_provider.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/codex_provider.py
@@ -7,6 +7,7 @@ Claude, making it ideal as a judge when Claude is the writer.
 from __future__ import annotations
 
 import asyncio
+import os
 import shlex
 import shutil
 import subprocess
@@ -48,6 +49,11 @@ def _resolve_codex_cmd() -> tuple[list[str], bool]:
     return ["codex"], False
 
 
+def _codex_model() -> str:
+    """Return the Codex CLI model to request for provider calls."""
+    return os.environ.get("WORKFLOW_CODEX_MODEL", "gpt-5.4").strip() or "gpt-5.4"
+
+
 class CodexProvider(BaseProvider):
     """Calls GPT via the ``codex exec`` CLI binary."""
 
@@ -67,7 +73,7 @@ class CodexProvider(BaseProvider):
         full_input = f"{system}\n\n{prompt}" if system else prompt
 
         base_cmd, use_shell = _resolve_codex_cmd()
-        model = "gpt-5.5"
+        model = _codex_model()
         sandbox_status = get_sandbox_status()
         sandbox_args = (
             ["--full-auto"]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -673,6 +673,35 @@ class TestCodexProvider:
         assert "--ephemeral" in captured_cmd
         assert "-C" in captured_cmd
         assert "-m" in captured_cmd
+        assert captured_cmd[captured_cmd.index("-m") + 1] == "gpt-5.4"
+
+    @pytest.mark.asyncio
+    async def test_model_can_be_overridden_by_env(self, monkeypatch):
+        """Operators can move the provider forward after the deployed CLI supports it."""
+        from workflow.providers.codex_provider import CodexProvider
+
+        captured_cmd = []
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"hello", b""))
+        mock_proc.returncode = 0
+        mock_proc.kill = AsyncMock()
+        mock_proc.wait = AsyncMock()
+
+        async def _fake_exec(*args, **kwargs):
+            captured_cmd.extend(args)
+            return mock_proc
+
+        monkeypatch.setenv("WORKFLOW_CODEX_MODEL", "gpt-5.5")
+        with (
+            patch("workflow.providers.codex_provider._resolve_codex_cmd",
+                  return_value=(["codex"], False)),
+            patch("workflow.providers.codex_provider.get_sandbox_status",
+                  return_value={"bwrap_available": True, "reason": None}),
+            patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+        ):
+            provider = CodexProvider()
+            await provider.complete("prompt", "system", ModelConfig())
+
         assert captured_cmd[captured_cmd.index("-m") + 1] == "gpt-5.5"
 
     @pytest.mark.asyncio

--- a/workflow/providers/codex_provider.py
+++ b/workflow/providers/codex_provider.py
@@ -7,6 +7,7 @@ Claude, making it ideal as a judge when Claude is the writer.
 from __future__ import annotations
 
 import asyncio
+import os
 import shlex
 import shutil
 import subprocess
@@ -48,6 +49,11 @@ def _resolve_codex_cmd() -> tuple[list[str], bool]:
     return ["codex"], False
 
 
+def _codex_model() -> str:
+    """Return the Codex CLI model to request for provider calls."""
+    return os.environ.get("WORKFLOW_CODEX_MODEL", "gpt-5.4").strip() or "gpt-5.4"
+
+
 class CodexProvider(BaseProvider):
     """Calls GPT via the ``codex exec`` CLI binary."""
 
@@ -67,7 +73,7 @@ class CodexProvider(BaseProvider):
         full_input = f"{system}\n\n{prompt}" if system else prompt
 
         base_cmd, use_shell = _resolve_codex_cmd()
-        model = "gpt-5.5"
+        model = _codex_model()
         sandbox_status = get_sandbox_status()
         sandbox_args = (
             ["--full-auto"]


### PR DESCRIPTION
## Summary

Restores cloud-worker prompt-node execution after the live provider-exhaustion regression.

Live evidence:
- `51a86ded03fe4e5e` failed at `child_prompt` with `All providers exhausted for role=writer`.
- Fresh post-deploy smoke `f564a77d85424322` failed the same way after deploy-prod green.
- Local repro with Codex CLI 0.104.0: `codex exec -m gpt-5.5 ...` fails with "model requires a newer version of Codex"; `gpt-5.4` succeeds.

Fix:
- Default `CodexProvider` to `gpt-5.4` instead of hardcoded `gpt-5.5`.
- Add `WORKFLOW_CODEX_MODEL` override so operators can move forward once the deployed CLI supports a newer model.
- Refresh claude-plugin runtime mirror.

## Test plan

- `python packaging/claude-plugin/build_plugin.py`
- `python -m pytest tests\test_providers.py::TestCodexProvider tests\test_provider_binary_probe.py tests\test_sandbox_unavailable.py::TestCodexProviderBwrapDetection -q`
- `python -m ruff check workflow\providers\codex_provider.py tests\test_providers.py packaging\claude-plugin\plugins\workflow-universe-server\runtime\workflow\providers\codex_provider.py`
- `python -m pytest tests\test_providers.py::TestCodexProvider -q`

Post-merge/deploy verification planned: rerun live one-node branch `cf16ed712016`; expected output key should contain `LIVE_PROVIDER_THREAD_OK` instead of provider_exhausted.

Coordination: PR #182 provider-exhaustion pickup, FEAT-004 should follow after this is green.
