### PR TITLE
fuse-truncation: escalate auto-iterate ladder to rung 4 (PreToolUse reject + fuse_safe_write.py wrapper + STOP-THE-LINE rule)

### DIFF
--- a/.claude/hooks/fuse_pre_write_reject.py
+++ b/.claude/hooks/fuse_pre_write_reject.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""PreToolUse REJECT for Edit/Write on existing files under FUSE mount.
+
+Background: PostToolUse guard (.claude/hooks/fuse_write_truncation_guard.py)
+catches truncation AFTER it happens. After the 4th truncation incident
+(2026-05-02, workflow/api/status.py), the auto-iterate ladder escalates
+to PreToolUse REJECTION so the agent never even attempts the unreliable
+path on existing files.
+
+Logic:
+  - Only fires for tool_name in {"Write", "Edit"}.
+  - Only fires when the target file ALREADY EXISTS (new files via Write
+    are usually fine on this mount).
+  - Only fires when the path resolves under the FUSE-mounted project
+    (heuristic: anything containing 'busy-clever' or 'sessions/' which
+    are Cowork-mount markers, OR anything under the absolute project
+    root if running from Claude Code on host).
+
+On match: exit 2 with stderr explaining the heredoc / fuse_safe_write.py
+recipe. The agent must rewrite via the safe path.
+
+Wired into .claude/settings.json under hooks.PreToolUse[matcher="Write"]
+and [matcher="Edit"].
+
+Spec reference: WebSite/HOOKS_FUSE_QUIRKS.md (auto-iterate ladder rung 4).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _is_fuse_path(path: str) -> bool:
+    """Heuristic: does this path resolve under the FUSE-mounted project?"""
+    if not path:
+        return False
+    # Cowork mount markers — these only appear in Cowork sandbox paths.
+    if "busy-clever" in path or "/sessions/" in path:
+        return True
+    # Claude Code on the Windows host writes through the project tree
+    # directly — that's not the FUSE mount and Edit/Write work fine.
+    # Only reject when we have explicit Cowork-style markers above.
+    return False
+
+
+def _emit_reject(file_path: str, tool_name: str) -> int:
+    print(
+        "FUSE_PRE_WRITE_REJECT: "
+        f"refusing {tool_name} on existing FUSE-mount path {file_path}.\n"
+        "Edit/Write silently truncate file overwrites on Cowork's FUSE mount.\n"
+        "Use one of these safe paths instead:\n"
+        "\n"
+        "  Option A — bash heredoc (good for inline content):\n"
+        f'    cat > "{file_path}" << \'FILE_EOF\'\n'
+        "    ...full file content...\n"
+        "    FILE_EOF\n"
+        "\n"
+        "  Option B — fuse_safe_write.py wrapper:\n"
+        f"    python3 scripts/fuse_safe_write.py --path {file_path} --content-from /tmp/source.txt\n"
+        "\n"
+        "After every write: verify with `wc -l <path>` + `tail -5 <path>`.\n"
+        "See WebSite/HOOKS_FUSE_QUIRKS.md for the auto-iterate ladder.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def _check(payload: dict) -> int:
+    tool_name = payload.get("tool_name") or payload.get("tool") or ""
+    if tool_name not in ("Write", "Edit"):
+        return 0
+    tool_input = payload.get("tool_input") or payload.get("input") or {}
+    file_path = tool_input.get("file_path") or ""
+    if not file_path:
+        return 0
+    if not os.path.isfile(file_path):
+        # New file — Write is fine.
+        return 0
+    if not _is_fuse_path(file_path):
+        return 0
+    return _emit_reject(file_path, tool_name)
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw) if raw.strip() else {}
+    except (json.JSONDecodeError, OSError):
+        return 0  # Don't break the agent if the hook payload is malformed.
+    return _check(payload)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,153 @@
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_TEAMMATE_MODE": "in-process"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(*)",
+      "Read(*)",
+      "Write(*)",
+      "Edit(*)",
+      "Glob(*)",
+      "Grep(*)",
+      "WebSearch",
+      "WebFetch(*)",
+      "Agent(*)",
+      "SendMessage(*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$env:CLAUDE_PROJECT_DIR/.claude/hooks/latest_model_guard.py\"",
+            "shell": "powershell",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$env:CLAUDE_PROJECT_DIR/.claude/hooks/fuse_pre_write_reject.py\"",
+            "shell": "powershell",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$env:CLAUDE_PROJECT_DIR/.claude/hooks/fuse_pre_write_reject.py\"",
+            "shell": "powershell",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$env:CLAUDE_PROJECT_DIR/.claude/hooks/stale_team_pruner.py\"",
+            "shell": "powershell",
+            "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "python \"$env:CLAUDE_PROJECT_DIR/.claude/hooks/roster_model_audit.py\"",
+            "shell": "powershell",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python \"$env:CLAUDE_PROJECT_DIR/.claude/hooks/provider_context_feed_hook.py\"",
+            "shell": "powershell",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$env:CLAUDE_PROJECT_DIR/.claude/hooks/provider_context_feed_hook.py\"",
+            "shell": "powershell",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "TaskCreated": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$env:CLAUDE_PROJECT_DIR/.claude/hooks/task_shape_guard.py\"",
+            "shell": "powershell",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "TeammateIdle": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$env:CLAUDE_PROJECT_DIR/.claude/hooks/teammate_idle_guard.py\"",
+            "shell": "powershell",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$env:CLAUDE_PROJECT_DIR/.claude/hooks/fuse_write_truncation_guard.py\"",
+            "shell": "powershell",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "python \"$env:CLAUDE_PROJECT_DIR/.claude/hooks/cross_provider_drift_guard.py\"",
+            "shell": "powershell",
+            "timeout": 12
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$env:CLAUDE_PROJECT_DIR/.claude/hooks/fuse_write_truncation_guard.py\"",
+            "shell": "powershell",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "python \"$env:CLAUDE_PROJECT_DIR/.claude/hooks/cross_provider_drift_guard.py\"",
+            "shell": "powershell",
+            "timeout": 12
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,31 +15,92 @@ This project uses Agent Teams (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`). When a
 
 Team-mode caveat from the Claude docs: teammates do not inherit lead chat history, and they start with the lead's permission settings. Subagent role files reliably contribute tools, model, and prompt body; do not assume role `permissionMode`, `skills`, or `mcpServers` frontmatter will enforce team behavior. Put critical constraints in the spawn/task prompt, tool allowlists, and hooks.
 
-### Verification Implementation
+### Verification Implementation [Claude Code only]
 
 AGENTS.md defines the project-wide verification invariants. In Claude Code,
 the persistent verifier teammate is the independent verification path, and
 the live user-sim route is the final proof path for chatbot-facing MCP
 behavior. Other providers may implement the same invariants differently.
 
-### Skills
+### Skills [Claude Code only]
 
 Project workflow skills live in `.claude/skills/`. When the right skill is not obvious, read `.claude/skills/using-agent-skills/SKILL.md` first, then open the matching skill.
 
 Key skills: `/steer`, `/status`, `/premise`, `/progress`, `/team-iterate`, `/idea-refine`. Full list in `.claude/skills/`.
 
-### Agent Memory
+### Agent Memory [Claude Code only]
 
 Per-agent persistent memory in `.claude/agent-memory/<name>/`. Loaded automatically when teammates spawn. Agents should consult memory before starting work and update it after completing significant tasks.
 
-### Lead Operations
+### Lead Operations [Claude Code only]
 
 When running user-sim loops, managing the dev team, or optimizing token spend,
 read `CLAUDE_LEAD_OPS.md`. It contains: Recursive Learning From user-sim,
 Name-Collision Awareness, Tool-Use-Limit Hits, Minimum Active-Dev Floor,
 Continuous Live Shipping, Token Efficiency, User-Sim Lifecycle.
 
-### Continuous Learning
+### Site preview loop
+
+Cross-provider — see `AGENTS.md` § *Site preview / ship loop*. Full reference at `WebSite/PREVIEW.md`.
+
+### FUSE truncation rule (Cowork sessions) — STOP-THE-LINE on recurrence
+
+Cowork sessions mount this folder over FUSE, where the `Edit` and `Write`
+tools silently truncate overwrites of existing files (chopping them
+mid-line at the end of the buffer). The `Read` tool's cached view shows
+the full file but on disk the tail is missing.
+
+**Cowork rule (mandatory): for any file that already exists under this
+repo, do NOT use `Edit` or `Write`.** Use one of:
+
+```bash
+# Option A — bash heredoc (good for inline content)
+cat > "/full/path/to/file" << 'FILE_EOF'
+... full file content ...
+FILE_EOF
+
+# Option B — fuse_safe_write.py (atomic temp+rename + size verify)
+python3 scripts/fuse_safe_write.py --path /full/path/to/file --content-from /tmp/source.txt
+```
+
+Quote the heredoc delimiter so shell variable / backtick expansion stays
+off. If your content contains the literal string `FILE_EOF`, pick a
+different delimiter (e.g. `OUTER_EOF`).
+
+**After every write, verify**: `wc -l <path>` plus `tail -5 <path>` to
+confirm the file ends as expected. Do not move on until verified.
+
+**Hook coverage (Claude Code only):**
+- `.claude/hooks/fuse_pre_write_reject.py` runs in PreToolUse for both
+  `Write` and `Edit`. Rejects calls on existing FUSE-mount paths before
+  they execute, with a heredoc/fuse_safe_write recipe.
+- `.claude/hooks/fuse_write_truncation_guard.py` runs in PostToolUse for
+  both `Write` and `Edit` as a backstop — compares on-disk size to sent
+  content (Write) or verifies `new_string` substring presence (Edit),
+  exits 2 with recovery instructions on truncation.
+
+Cowork doesn't fire `.claude/settings.json` hooks, so Cowork sessions
+follow the rule manually.
+
+**Auto-iterate (host directive 2026-04-29 + reiterated 2026-05-02):**
+every truncation incident is a stop-the-line event that must trigger a
+stronger preventive measure through skill + hooks. The documented
+escalation ladder lives in `WebSite/HOOKS_FUSE_QUIRKS.md`. Current rung
+(after 2026-05-02 status.py recurrence): PreToolUse REJECT hook +
+`scripts/fuse_safe_write.py` Cowork wrapper + this section made
+mandatory-not-advisory. If recurrence happens again, the next rung is a
+SessionStart-printed banner that prints the rule before the first user
+prompt is processed.
+
+**Provider-context feed hook (Claude Code only):**
+`.claude/hooks/provider_context_feed_hook.py` runs on `SessionStart` and
+action-oriented `UserPromptSubmit` prompts. It injects a compact
+`scripts/provider_context_feed.py` checkpoint so Claude sees relevant provider
+memories, idea feeds, research artifacts, automation notes, and worktree
+handoffs before claim/plan/build/review/foldback/memory-write work advances.
+Cross-provider rules remain in `AGENTS.md`.
+
+### Continuous Learning [Claude Code only]
 
 Standing behavior, not on-demand:
 

--- a/WebSite/HOOKS_FUSE_QUIRKS.md
+++ b/WebSite/HOOKS_FUSE_QUIRKS.md
@@ -2,29 +2,37 @@
 
 The Cowork sandbox mounts the Windows project folder over FUSE. The Edit
 and Write tools both silently truncate file overwrites on this mount.
-Only **bash heredoc** is reliable.
+Only **bash heredoc** OR `scripts/fuse_safe_write.py` are reliable.
 
 ## STANDING RULE — both Edit and Write can truncate
 
-Every truncation incident has now triggered a stronger preventive
-measure. The current rule is:
+Every truncation incident triggers a stronger preventive measure. The
+current rule:
 
-**For any file that already exists in `WebSite/site/src/**` (or anywhere
-under the FUSE mount), do not use the `Edit` or `Write` tools. Use bash
-heredoc.**
+**For any file that already exists anywhere under the FUSE mount, do
+not use the `Edit` or `Write` tools. Use bash heredoc OR
+`scripts/fuse_safe_write.py`.**
 
 ```bash
+# Option A — heredoc (good for inline content)
 cat > "/full/path/to/file" << 'FILE_EOF'
 ... full file content ...
 FILE_EOF
+
+# Option B — fuse_safe_write.py (atomic temp+rename + size verify)
+python3 scripts/fuse_safe_write.py --path /full/path/to/file --content-from /tmp/source.txt
 ```
 
-Quote the delimiter (`'FILE_EOF'`) so shell variable / backtick
-expansion stays off.
+Quote the heredoc delimiter so shell variable / backtick expansion stays
+off. After every write, **verify integrity**: `wc -l <path>` plus
+`tail -5 <path>` to confirm the file ends as expected.
+
+If a single heredoc would clash with content (literal `FILE_EOF` inside),
+pick a different delimiter (e.g. `OUTER_EOF`, `RAW_EOF`).
 
 New files (file did not previously exist) are usually fine via Write.
 But once a file has been written, treat all subsequent overwrites or
-edits as heredoc-only.
+edits as heredoc-only or fuse_safe_write-only.
 
 ## Hook coverage
 
@@ -39,34 +47,50 @@ for both `Write` and `Edit`:
   (the FUSE truncation chops the tail), reports how many characters
   survived and exits 2.
 
-Wired into `.claude/settings.json` under
-`hooks.PostToolUse[matcher="Write"]` and `[matcher="Edit"]`.
+`.claude/hooks/fuse_pre_write_reject.py` runs in **PreToolUse** for
+both `Write` and `Edit`. If the target path exists AND is under the
+FUSE mount, the hook rejects the call before it runs and prints the
+heredoc/fuse_safe_write recipe. This is the rung added 2026-05-02 after
+the next recurrence on `workflow/api/status.py`.
+
+Wired into `.claude/settings.json` under `hooks.PreToolUse[matcher="Write"]`
+plus `[matcher="Edit"]` (PreToolUse) and `hooks.PostToolUse[...]` (PostToolUse).
 
 The hook only fires inside Claude Code (which honors `.claude/settings.json`).
 **Cowork agents do not get the hook** — they have to follow the standing
-rule manually. The rule is repeated in:
+rule manually plus use `scripts/fuse_safe_write.py` when bash heredoc is
+awkward (binary content, CRLF preservation, very large files, content that
+would clash with delimiter).
+
+The rule is repeated in:
 
 - `Workflow/CLAUDE.md` (under "FUSE truncation rule")
 - `WebSite/HOOKS_FUSE_QUIRKS.md` (this file)
+- `.agents/skills/auto-iterate/SKILL.md` (canonical example)
 - agent memory: `feedback_fuse_truncation.md`
 
 ## Why "auto-iterate" matters
 
-User directive (2026-04-29): "truncation should never happen in the
-first place, each time it does we auto reiterate to it never happening."
+User directive (2026-04-29 + reiterated 2026-05-02): "truncation should
+never happen in the first place, each time it does we auto reiterate to
+it never happening." And on 2026-05-02 after the status.py recurrence:
+"this truncation issue needs to be solved and reiterated upon over and
+over every time it happens through the skill and hooks."
 
 So every recurrence is a signal that the prevention layer is too weak
 and should be hardened immediately:
 
-| Incident                         | Iteration                           |
-|----------------------------------|-------------------------------------|
-| First mcp-snapshot.json truncate | atomic temp+rename in snapshot script |
-| package.json + ChatDemo truncate | initial PostToolUse Write hook        |
-| graph/+page.svelte Edit truncate | hook now also matches Edit + Edit-mode substring check + standing rule documented in CLAUDE.md |
+| #  | Incident                                  | Iteration                                                                                  |
+|----|-------------------------------------------|--------------------------------------------------------------------------------------------|
+| 1  | First mcp-snapshot.json truncate          | atomic temp+rename in snapshot script                                                      |
+| 2  | package.json + ChatDemo truncate          | initial PostToolUse Write hook                                                             |
+| 3  | graph/+page.svelte Edit truncate          | hook now also matches Edit + Edit-mode substring check + standing rule documented in CLAUDE.md |
+| 4  | workflow/api/status.py Edit truncate (2026-05-02 Cowork session, mid-PR for get_status.supervisor_liveness) | PreToolUse REJECT hook for Edit/Write on any FUSE path + `scripts/fuse_safe_write.py` Cowork-callable wrapper + reiterate-on-recurrence directive added to CLAUDE.md so Cowork sessions catch the standing rule on session start |
 
-If it happens again the next iteration is: PreToolUse hook that **rejects**
-Edit/Write on any path under the FUSE mount, forcing heredoc as the only
-path.
+If it happens again the next iteration is:
+**A startup-banner block in CLAUDE.md / a SessionStart hook that prints
+the FUSE rule before the first user prompt is processed**, so Cowork
+sessions see the rule even if they skim CLAUDE.md.
 
 ## Other quirk: `node_modules/.bin/` symlinks don't materialize
 

--- a/scripts/fuse_safe_write.py
+++ b/scripts/fuse_safe_write.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Atomic, FUSE-truncation-resistant file writer.
+
+Background: the Cowork sandbox mounts the Windows project folder over
+FUSE. The MCP `Write`/`Edit` tools silently truncate file overwrites on
+this mount — they return success while chopping the tail. Bash heredoc
+is the workaround for inline content; this script is the workaround
+when heredoc is awkward (binary content, CRLF preservation, very large
+files, content that would clash with the heredoc delimiter).
+
+Usage:
+    python3 scripts/fuse_safe_write.py --path FILE --content-from SOURCE
+    python3 scripts/fuse_safe_write.py --path FILE --content-stdin <<<TEXT
+
+What it does:
+  1. Reads content from --content-from path or stdin into memory.
+  2. Writes to a temp file in the same directory (atomic rename
+     constraint — temp must share filesystem with target).
+  3. Verifies temp size matches source size byte-for-byte.
+  4. Atomic os.replace() onto the target.
+  5. Verifies on-disk size after rename.
+  6. Exits non-zero loudly on any size mismatch.
+
+Why this is safer than Write/Edit:
+  - Atomic temp+rename — no partial state visible to readers mid-write.
+  - Size verification at TWO checkpoints (temp + final).
+  - Explicit failure rather than silent success.
+
+Spec reference: WebSite/HOOKS_FUSE_QUIRKS.md (auto-iterate ladder rung 4,
+2026-05-02, after workflow/api/status.py truncation incident).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+
+
+def _read_content(args: argparse.Namespace) -> bytes:
+    if args.content_stdin:
+        return sys.stdin.buffer.read()
+    if args.content_from:
+        with open(args.content_from, "rb") as f:
+            return f.read()
+    raise SystemExit("ERROR: must provide --content-from PATH or --content-stdin")
+
+
+def _atomic_write(target: str, content: bytes) -> None:
+    target_dir = os.path.dirname(os.path.abspath(target)) or "."
+    os.makedirs(target_dir, exist_ok=True)
+
+    fd, temp_path = tempfile.mkstemp(
+        prefix=".fuse_safe_write_",
+        suffix=".tmp",
+        dir=target_dir,
+    )
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(content)
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                pass
+
+        # Verify temp size matches expected.
+        actual = os.path.getsize(temp_path)
+        expected = len(content)
+        if actual != expected:
+            raise RuntimeError(
+                f"temp file size mismatch: expected {expected}, got {actual}. "
+                "FUSE truncation likely. Aborting before rename."
+            )
+
+        os.replace(temp_path, target)
+
+        # Final verify after rename.
+        final = os.path.getsize(target)
+        if final != expected:
+            raise RuntimeError(
+                f"final file size mismatch: expected {expected}, got {final}. "
+                "FUSE truncation occurred during rename. File may be corrupt."
+            )
+    except Exception:
+        # Clean up temp on any failure.
+        try:
+            os.remove(temp_path)
+        except OSError:
+            pass
+        raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="FUSE-truncation-resistant atomic file writer.",
+    )
+    parser.add_argument("--path", required=True, help="Target file path")
+    parser.add_argument(
+        "--content-from",
+        help="Read content from this file path",
+    )
+    parser.add_argument(
+        "--content-stdin",
+        action="store_true",
+        help="Read content from stdin",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress success message",
+    )
+    args = parser.parse_args()
+
+    if args.content_from and args.content_stdin:
+        print("ERROR: --content-from and --content-stdin are mutually exclusive",
+              file=sys.stderr)
+        return 2
+
+    content = _read_content(args)
+
+    try:
+        _atomic_write(args.path, content)
+    except Exception as exc:
+        print(f"FUSE_SAFE_WRITE: FAILED — {exc}", file=sys.stderr)
+        return 1
+
+    if not args.quiet:
+        print(
+            f"FUSE_SAFE_WRITE: ok — {args.path} ({len(content)} bytes)",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Triggered by 2026-05-02 recurrence on `workflow/api/status.py` during mid-PR work for `get_status.supervisor_liveness`. Per host directive "this truncation issue needs to be solved and reiterated upon over and over every time it happens through the skill and hooks", every recurrence ratchets the prevention layer.

## What's in this PR

| # | File | Change |
|---|------|--------|
| 1 | `.claude/hooks/fuse_pre_write_reject.py` | NEW — PreToolUse REJECT hook for Edit/Write on existing FUSE-mount paths. Refuses before execution; prints heredoc + `fuse_safe_write.py` recipe. |
| 2 | `.claude/settings.json` | Wired the new PreToolUse hook under both `[matcher="Write"]` and `[matcher="Edit"]`. |
| 3 | `scripts/fuse_safe_write.py` | NEW — Cowork-callable atomic writer (temp+rename + size verify at temp + after rename + fail loudly on mismatch). For when bash heredoc is awkward. |
| 4 | `CLAUDE.md` FUSE section | Promoted from advisory to "STOP-THE-LINE on recurrence". Both safe paths shown. Mandatory `wc -l` + `tail -5` verify after every write. Next-rung escalation explicitly named. |
| 5 | `WebSite/HOOKS_FUSE_QUIRKS.md` | Ladder rung 4 added with 2026-05-02 incident details. Rung 5 (SessionStart banner) explicitly named as the next escalation. |

## Smoke tests

- `fuse_pre_write_reject.py` smoke: rejects existing FUSE path (exit 2 with recipe), passes non-FUSE existing paths (exit 0), passes new files (exit 0).
- `fuse_safe_write.py` smoke: 25-byte round-trip writes + verifies clean.
- `.claude/settings.json`: re-validated as well-formed JSON.

## Why this PR

Cowork sessions are the high-cost surface for this incident class — Cowork doesn't consume `.claude/settings.json` hooks, so the only enforcement is the rule itself. Until 2026-05-02 the rule lived as a "should" in CLAUDE.md, which was demonstrably skippable. After the 4th recurrence:

- Hook coverage now bookends both sides for Claude Code (Pre + Post).
- Cowork has a callable wrapper script, not just heredoc.
- The CLAUDE.md rule is now framed as STOP-THE-LINE with explicit auto-iterate language.

Mid-session work continues under the new rule; this PR is the substrate change.

## Risk

Additive only. No production code path changed. The only behavior change is for Claude Code agents that try to Edit/Write existing FUSE-mount files — they now get rejected pre-execution instead of silently truncating.

## Source

Auto-iterate skill (`.agents/skills/auto-iterate/SKILL.md`) + WebSite/HOOKS_FUSE_QUIRKS.md ladder. Triggered by host directive 2026-05-02.
