### PR TITLE
get_status: add supervisor_liveness field (pairs with PR #212)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
@@ -39,6 +39,217 @@ def _policy_hash(payload: dict[str, Any]) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+# Heartbeat refresh interval observed in fantasy_daemon's BUG-011 Phase A
+# implementation (PR #212). 2x interval is the threshold for "stale heartbeat".
+_HEARTBEAT_REFRESH_INTERVAL_S = 60
+_HEARTBEAT_STALE_THRESHOLD_S = _HEARTBEAT_REFRESH_INTERVAL_S * 2
+
+# Threshold for "stuck pending" — a pending task older than this without
+# claim implies dispatcher pickup or worker liveness issue (today's
+# BUG-009 class).
+_STUCK_PENDING_THRESHOLD_S = 120
+
+
+def _parse_iso_to_epoch(value: str) -> float | None:
+    """Best-effort ISO-8601 parser; returns None on empty/unparseable input.
+
+    Defensive — never raises so a malformed lease timestamp can't break
+    the status probe. Pre-#212 BranchTasks have empty strings for the new
+    fields; this returns None for those.
+    """
+    if not value:
+        return None
+    try:
+        from datetime import datetime
+        # fromisoformat handles "+00:00" but not "Z" suffix on older Pythons.
+        cleaned = value.replace("Z", "+00:00")
+        return datetime.fromisoformat(cleaned).timestamp()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _compute_supervisor_liveness(
+    udir: Any,
+    *,
+    now_ts: float | None = None,
+) -> dict[str, Any]:
+    """Aggregate BranchTask queue + BUG-011 Phase A lease fields into a
+    structured liveness snapshot.
+
+    Pairs with PR #212 (write-only lease metadata fields). Uses
+    ``getattr`` with defaults so this works both pre- and post-PR-#212
+    deployment: pre-#212 BranchTasks lack the lease fields and surface
+    as ``"lease_data_unavailable"`` rather than crashing the probe.
+
+    Surfaces the diagnostic the BUG-009 incident (2026-05-02) cost an
+    hour of triage to find: container alive but daemon subprocess
+    wedged. With this field, the same diagnosis becomes
+    ``stuck_pending_max_age_s`` + ``stale_running_tasks`` readable from
+    ``get_status``.
+    """
+    import time as _time
+    if now_ts is None:
+        now_ts = _time.time()
+
+    out: dict[str, Any] = {
+        "queue_state": {
+            "depth": 0,
+            "pending": 0,
+            "running": 0,
+            "succeeded": 0,
+            "failed": 0,
+            "cancelled": 0,
+            "stuck_pending_max_age_s": 0,
+            "stuck_running_max_age_s": 0,
+        },
+        "running_tasks_lease": [],
+        "stale_running_tasks": [],
+        "warnings": [],
+        "lease_data_available": True,
+    }
+
+    try:
+        from workflow.branch_tasks import read_queue
+        queue = read_queue(udir)
+    except Exception as exc:  # noqa: BLE001 — best-effort observability
+        out["warnings"].append(f"queue_read_failed: {exc}")
+        return out
+
+    out["queue_state"]["depth"] = len(queue)
+    if not queue:
+        return out
+
+    any_lease_field_seen = False
+    pending_ages: list[float] = []
+    running_ages: list[float] = []
+
+    for task in queue:
+        status = getattr(task, "status", "") or ""
+        if status in out["queue_state"]:
+            out["queue_state"][status] = out["queue_state"].get(status, 0) + 1
+
+        # Pending-task age (queued_at -> now). Detects dispatcher pickup
+        # gaps even before a task gets claimed (today's BUG-009 pattern).
+        queued_at = getattr(task, "queued_at", "") or ""
+        queued_ts = _parse_iso_to_epoch(queued_at) if queued_at else None
+        if status == "pending" and queued_ts is not None:
+            age = max(0.0, now_ts - queued_ts)
+            pending_ages.append(age)
+
+        if status != "running":
+            continue
+
+        # Lease metadata (PR #212). Defensive getattr so pre-#212 tasks
+        # surface as empty strings rather than AttributeError.
+        worker_owner_id = getattr(task, "worker_owner_id", "") or ""
+        lease_expires_at = getattr(task, "lease_expires_at", "") or ""
+        heartbeat_at = getattr(task, "heartbeat_at", "") or ""
+        last_progress_at = getattr(task, "last_progress_at", "") or ""
+
+        if worker_owner_id or lease_expires_at or heartbeat_at:
+            any_lease_field_seen = True
+
+        lease_expires_ts = _parse_iso_to_epoch(lease_expires_at)
+        heartbeat_ts = _parse_iso_to_epoch(heartbeat_at)
+        progress_ts = _parse_iso_to_epoch(last_progress_at)
+
+        lease_remaining_s: int | None = None
+        if lease_expires_ts is not None:
+            lease_remaining_s = int(lease_expires_ts - now_ts)
+
+        heartbeat_age_s: int | None = None
+        if heartbeat_ts is not None:
+            heartbeat_age_s = max(0, int(now_ts - heartbeat_ts))
+
+        progress_age_s: int | None = None
+        if progress_ts is not None:
+            progress_age_s = max(0, int(now_ts - progress_ts))
+
+        # Running-task age tracked for the queue summary even if no lease
+        # data exists (pre-#212 fallback).
+        if heartbeat_ts is not None:
+            running_ages.append(now_ts - heartbeat_ts)
+        elif queued_ts is not None:
+            running_ages.append(max(0.0, now_ts - queued_ts))
+
+        record = {
+            "branch_task_id": getattr(task, "branch_task_id", ""),
+            "worker_owner_id": worker_owner_id,
+            "lease_expires_at": lease_expires_at,
+            "lease_remaining_s": lease_remaining_s,
+            "heartbeat_at": heartbeat_at,
+            "heartbeat_age_s": heartbeat_age_s,
+            "last_progress_at": last_progress_at,
+            "progress_age_s": progress_age_s,
+        }
+        out["running_tasks_lease"].append(record)
+
+        # Stale detection: heartbeat older than 2x refresh OR lease
+        # expired. Both signal the daemon owning this task is dead/wedged.
+        # Phase C (Codex) will use the same predicate to actively
+        # reclaim; this field lets operators see the condition before
+        # that ships.
+        is_stale = False
+        stale_reasons: list[str] = []
+        if (
+            heartbeat_age_s is not None
+            and heartbeat_age_s > _HEARTBEAT_STALE_THRESHOLD_S
+        ):
+            is_stale = True
+            stale_reasons.append(
+                f"heartbeat_age_s={heartbeat_age_s} > "
+                f"threshold={_HEARTBEAT_STALE_THRESHOLD_S}"
+            )
+        if lease_remaining_s is not None and lease_remaining_s <= 0:
+            is_stale = True
+            stale_reasons.append(
+                f"lease_expired ({lease_remaining_s}s ago)"
+            )
+
+        if is_stale:
+            stale = dict(record)
+            stale["stale_reasons"] = stale_reasons
+            out["stale_running_tasks"].append(stale)
+
+    if pending_ages:
+        out["queue_state"]["stuck_pending_max_age_s"] = int(max(pending_ages))
+    if running_ages:
+        out["queue_state"]["stuck_running_max_age_s"] = int(max(running_ages))
+
+    # If any pending task is past the stuck threshold, surface a
+    # warning. Today's BUG-009 RCA: a pending task that sits >2min
+    # without claim means the supervisor restart logic isn't reaching
+    # the queue (the exact pattern PR #205 fixed).
+    if (
+        out["queue_state"]["stuck_pending_max_age_s"]
+        > _STUCK_PENDING_THRESHOLD_S
+    ):
+        out["warnings"].append(
+            f"stuck_pending: oldest pending task is "
+            f"{out['queue_state']['stuck_pending_max_age_s']}s old "
+            f"(threshold {_STUCK_PENDING_THRESHOLD_S}s). Likely "
+            "supervisor restart loop, dispatcher disabled, or daemon "
+            "subprocess wedged. See PR #206 spec for incident pattern."
+        )
+
+    if out["queue_state"]["running"] > 0 and not any_lease_field_seen:
+        out["lease_data_available"] = False
+        out["warnings"].append(
+            "lease_data_unavailable: running tasks present but no lease "
+            "fields populated. Either pre-PR-#212 deploy, or daemon is "
+            "not stamping heartbeats. Reclaim heuristics cannot run."
+        )
+
+    if out["stale_running_tasks"]:
+        out["warnings"].append(
+            f"{len(out['stale_running_tasks'])} stale running task(s) "
+            "(heartbeat past threshold or lease expired). BUG-011 "
+            "Phase C reclaim would reclaim these once shipped."
+        )
+
+    return out
+
+
 def get_status(universe_id: str = "") -> str:
     """Factual snapshot of the daemon's identity + routing config.
 
@@ -349,6 +560,22 @@ def get_status(universe_id: str = "") -> str:
     except Exception:  # noqa: BLE001 — best-effort observability
         missing_data_files = []
 
+    # supervisor_liveness — BUG-009 incident (2026-05-02) cost ~1hr of
+    # triage finding "container alive but daemon subprocess wedged"
+    # without SSH. This block surfaces the diagnosis from the public MCP
+    # probe: queue counts + per-running-task lease/heartbeat ages +
+    # stale-detection. Pairs with PR #212 (BUG-011 Phase A lease metadata
+    # writes); the helper is defensive so a missing branch_tasks file or
+    # pre-#212 task shape cannot break the status probe.
+    try:
+        supervisor_liveness = _compute_supervisor_liveness(udir)
+    except Exception as exc:  # noqa: BLE001 — best-effort observability
+        supervisor_liveness = {
+            "error": "compute_failed",
+            "detail": str(exc),
+            "lease_data_available": False,
+        }
+
     response = {
         "schema_version": 1,
         "active_host": policy_payload["active_host"],
@@ -368,6 +595,7 @@ def get_status(universe_id: str = "") -> str:
         "per_provider_cooldown_remaining": per_provider_cooldown_remaining,
         "sandbox_status": sandbox_status,
         "missing_data_files": missing_data_files,
+        "supervisor_liveness": supervisor_liveness,
         "universe_id": uid,
         "universe_exists": universe_exists,
     }

--- a/tests/test_supervisor_liveness.py
+++ b/tests/test_supervisor_liveness.py
@@ -1,0 +1,301 @@
+"""Tests for ``workflow.api.status._compute_supervisor_liveness``.
+
+Pairs with PR #212 (BUG-011 Phase A lease metadata fields). This test
+file uses ``getattr`` defaults to verify the supervisor_liveness helper
+works both pre- and post-PR-#212.
+
+Spec source: PR #206 (docs/specs/daemon-liveness-watchdog.md).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from workflow.api.status import (
+    _HEARTBEAT_STALE_THRESHOLD_S,
+    _STUCK_PENDING_THRESHOLD_S,
+    _compute_supervisor_liveness,
+    _parse_iso_to_epoch,
+)
+from workflow.branch_tasks import BranchTask, append_task
+
+
+# ── _parse_iso_to_epoch unit ───────────────────────────────────────────────
+
+
+def test_parse_iso_to_epoch_handles_empty_string():
+    assert _parse_iso_to_epoch("") is None
+
+
+def test_parse_iso_to_epoch_handles_none_safely():
+    # Defensive: getattr default is "" but a None could leak through.
+    assert _parse_iso_to_epoch(None or "") is None
+
+
+def test_parse_iso_to_epoch_handles_z_suffix():
+    iso = "2026-05-02T22:30:00Z"
+    epoch = _parse_iso_to_epoch(iso)
+    assert epoch is not None
+    assert epoch > 0
+
+
+def test_parse_iso_to_epoch_handles_offset_suffix():
+    iso = "2026-05-02T22:30:00+00:00"
+    epoch = _parse_iso_to_epoch(iso)
+    assert epoch is not None
+
+
+def test_parse_iso_to_epoch_returns_none_on_garbage():
+    assert _parse_iso_to_epoch("not-a-timestamp") is None
+
+
+# ── _compute_supervisor_liveness — empty queue ─────────────────────────────
+
+
+def test_empty_queue_returns_zero_counts(tmp_path):
+    out = _compute_supervisor_liveness(tmp_path)
+    assert out["queue_state"]["depth"] == 0
+    assert out["queue_state"]["pending"] == 0
+    assert out["queue_state"]["running"] == 0
+    assert out["running_tasks_lease"] == []
+    assert out["stale_running_tasks"] == []
+    assert out["warnings"] == []
+    assert out["lease_data_available"] is True
+
+
+def test_missing_queue_file_does_not_raise(tmp_path):
+    # tmp_path with no branch_tasks.json — read_queue should return [].
+    out = _compute_supervisor_liveness(tmp_path)
+    assert "queue_state" in out
+
+
+# ── queue counts ───────────────────────────────────────────────────────────
+
+
+def test_queue_counts_by_status(tmp_path):
+    for status, count in [("pending", 2), ("running", 1), ("succeeded", 3), ("failed", 1)]:
+        for i in range(count):
+            t = BranchTask(
+                branch_task_id=f"bt-{status}-{i}",
+                branch_def_id="branch-1",
+                universe_id="u",
+                status=status,
+            )
+            append_task(tmp_path, t)
+    out = _compute_supervisor_liveness(tmp_path)
+    assert out["queue_state"]["pending"] == 2
+    assert out["queue_state"]["running"] == 1
+    assert out["queue_state"]["succeeded"] == 3
+    assert out["queue_state"]["failed"] == 1
+    assert out["queue_state"]["depth"] == 7
+
+
+# ── pending-age detection (BUG-009 incident pattern) ───────────────────────
+
+
+def test_stuck_pending_above_threshold_emits_warning(tmp_path):
+    # Manually craft a pending task with queued_at well in the past.
+    old = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+    t = BranchTask(
+        branch_task_id="bt-stuck",
+        branch_def_id="branch-1",
+        universe_id="u",
+        status="pending",
+        queued_at=old,
+    )
+    append_task(tmp_path, t)
+    out = _compute_supervisor_liveness(tmp_path)
+    assert out["queue_state"]["stuck_pending_max_age_s"] >= 600
+    assert any("stuck_pending" in w for w in out["warnings"])
+
+
+def test_recent_pending_no_warning(tmp_path):
+    t = BranchTask(
+        branch_task_id="bt-fresh",
+        branch_def_id="branch-1",
+        universe_id="u",
+        status="pending",
+        queued_at=datetime.now(timezone.utc).isoformat(),
+    )
+    append_task(tmp_path, t)
+    out = _compute_supervisor_liveness(tmp_path)
+    assert out["queue_state"]["stuck_pending_max_age_s"] < _STUCK_PENDING_THRESHOLD_S
+    assert not any("stuck_pending" in w for w in out["warnings"])
+
+
+# ── lease metadata path (post-#212) ────────────────────────────────────────
+
+
+def _running_task_with_lease(
+    *,
+    task_id: str,
+    heartbeat_age_s: int,
+    lease_remaining_s: int,
+    progress_age_s: int = 0,
+) -> dict:
+    """Build a serialized BranchTask dict with PR #212 lease fields."""
+    now = datetime.now(timezone.utc)
+    return {
+        "branch_task_id": task_id,
+        "branch_def_id": "branch-1",
+        "universe_id": "u",
+        "inputs": {},
+        "trigger_source": "owner_queued",
+        "priority_weight": 0.0,
+        "queued_at": (now - timedelta(seconds=heartbeat_age_s + 30)).isoformat(),
+        "claimed_by": "daemon::owner",
+        "status": "running",
+        "bid": 0.0,
+        "goal_id": "",
+        "required_llm_type": "",
+        "evidence_url": "",
+        "error": "",
+        "cancel_requested": False,
+        "request_type": "branch_run",
+        "deadline": "",
+        "worker_owner_id": "daemon::owner",
+        "lease_expires_at": (now + timedelta(seconds=lease_remaining_s)).isoformat(),
+        "heartbeat_at": (now - timedelta(seconds=heartbeat_age_s)).isoformat(),
+        "last_progress_at": (now - timedelta(seconds=progress_age_s)).isoformat(),
+    }
+
+
+def _write_raw_queue(tmp_path, tasks: list[dict]) -> None:
+    import json
+    (tmp_path / "branch_tasks.json").write_text(json.dumps(tasks), encoding="utf-8")
+
+
+def test_running_task_with_fresh_lease_not_stale(tmp_path):
+    _write_raw_queue(
+        tmp_path,
+        [_running_task_with_lease(
+            task_id="bt-fresh",
+            heartbeat_age_s=10,
+            lease_remaining_s=290,
+        )],
+    )
+    out = _compute_supervisor_liveness(tmp_path)
+    assert out["queue_state"]["running"] == 1
+    assert len(out["running_tasks_lease"]) == 1
+    record = out["running_tasks_lease"][0]
+    assert record["worker_owner_id"] == "daemon::owner"
+    assert record["heartbeat_age_s"] is not None
+    assert record["heartbeat_age_s"] < _HEARTBEAT_STALE_THRESHOLD_S
+    assert record["lease_remaining_s"] is not None
+    assert record["lease_remaining_s"] > 0
+    assert out["stale_running_tasks"] == []
+    assert out["lease_data_available"] is True
+
+
+def test_stale_heartbeat_flagged_as_stale(tmp_path):
+    _write_raw_queue(
+        tmp_path,
+        [_running_task_with_lease(
+            task_id="bt-zombie",
+            heartbeat_age_s=_HEARTBEAT_STALE_THRESHOLD_S + 60,
+            lease_remaining_s=120,  # lease still ok
+        )],
+    )
+    out = _compute_supervisor_liveness(tmp_path)
+    assert len(out["stale_running_tasks"]) == 1
+    stale = out["stale_running_tasks"][0]
+    assert stale["branch_task_id"] == "bt-zombie"
+    assert any("heartbeat_age_s" in r for r in stale["stale_reasons"])
+    assert any("stale running task" in w for w in out["warnings"])
+
+
+def test_expired_lease_flagged_as_stale(tmp_path):
+    _write_raw_queue(
+        tmp_path,
+        [_running_task_with_lease(
+            task_id="bt-expired",
+            heartbeat_age_s=30,  # heartbeat fresh
+            lease_remaining_s=-60,  # lease expired 60s ago
+        )],
+    )
+    out = _compute_supervisor_liveness(tmp_path)
+    assert len(out["stale_running_tasks"]) == 1
+    stale = out["stale_running_tasks"][0]
+    assert any("lease_expired" in r for r in stale["stale_reasons"])
+
+
+def test_both_stale_signals_combined(tmp_path):
+    _write_raw_queue(
+        tmp_path,
+        [_running_task_with_lease(
+            task_id="bt-doubly-dead",
+            heartbeat_age_s=_HEARTBEAT_STALE_THRESHOLD_S + 60,
+            lease_remaining_s=-30,
+        )],
+    )
+    out = _compute_supervisor_liveness(tmp_path)
+    assert len(out["stale_running_tasks"]) == 1
+    stale = out["stale_running_tasks"][0]
+    # Both reasons should be recorded.
+    assert len(stale["stale_reasons"]) == 2
+
+
+# ── pre-#212 fallback (no lease fields populated) ──────────────────────────
+
+
+def test_running_task_without_lease_fields_emits_lease_unavailable_warning(tmp_path):
+    # Pre-PR-#212 BranchTasks have no lease metadata.
+    t = BranchTask(
+        branch_task_id="bt-pre212",
+        branch_def_id="branch-1",
+        universe_id="u",
+        status="running",
+        claimed_by="daemon::owner",
+        queued_at=datetime.now(timezone.utc).isoformat(),
+    )
+    append_task(tmp_path, t)
+    out = _compute_supervisor_liveness(tmp_path)
+    assert out["queue_state"]["running"] == 1
+    assert out["lease_data_available"] is False
+    assert any("lease_data_unavailable" in w for w in out["warnings"])
+
+
+# ── integration with get_status ────────────────────────────────────────────
+
+
+def test_get_status_response_includes_supervisor_liveness(tmp_path, monkeypatch):
+    import json
+    from workflow.api.status import get_status
+
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "test-universe")
+    universe = tmp_path / "test-universe"
+    universe.mkdir(parents=True, exist_ok=True)
+
+    response = json.loads(get_status())
+    assert "supervisor_liveness" in response
+    assert "queue_state" in response["supervisor_liveness"]
+    assert "running_tasks_lease" in response["supervisor_liveness"]
+    assert "stale_running_tasks" in response["supervisor_liveness"]
+
+
+def test_get_status_supervisor_liveness_reflects_stuck_pending(tmp_path, monkeypatch):
+    import json
+    from workflow.api.status import get_status
+
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "test-universe")
+    universe = tmp_path / "test-universe"
+    universe.mkdir(parents=True, exist_ok=True)
+
+    old = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+    append_task(universe, BranchTask(
+        branch_task_id="bt-stuck",
+        branch_def_id="branch-1",
+        universe_id="test-universe",
+        status="pending",
+        queued_at=old,
+    ))
+
+    response = json.loads(get_status())
+    sl = response["supervisor_liveness"]
+    assert sl["queue_state"]["pending"] == 1
+    assert sl["queue_state"]["stuck_pending_max_age_s"] >= 300
+    assert any("stuck_pending" in w for w in sl["warnings"])

--- a/workflow/api/status.py
+++ b/workflow/api/status.py
@@ -39,6 +39,217 @@ def _policy_hash(payload: dict[str, Any]) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+# Heartbeat refresh interval observed in fantasy_daemon's BUG-011 Phase A
+# implementation (PR #212). 2x interval is the threshold for "stale heartbeat".
+_HEARTBEAT_REFRESH_INTERVAL_S = 60
+_HEARTBEAT_STALE_THRESHOLD_S = _HEARTBEAT_REFRESH_INTERVAL_S * 2
+
+# Threshold for "stuck pending" — a pending task older than this without
+# claim implies dispatcher pickup or worker liveness issue (today's
+# BUG-009 class).
+_STUCK_PENDING_THRESHOLD_S = 120
+
+
+def _parse_iso_to_epoch(value: str) -> float | None:
+    """Best-effort ISO-8601 parser; returns None on empty/unparseable input.
+
+    Defensive — never raises so a malformed lease timestamp can't break
+    the status probe. Pre-#212 BranchTasks have empty strings for the new
+    fields; this returns None for those.
+    """
+    if not value:
+        return None
+    try:
+        from datetime import datetime
+        # fromisoformat handles "+00:00" but not "Z" suffix on older Pythons.
+        cleaned = value.replace("Z", "+00:00")
+        return datetime.fromisoformat(cleaned).timestamp()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _compute_supervisor_liveness(
+    udir: Any,
+    *,
+    now_ts: float | None = None,
+) -> dict[str, Any]:
+    """Aggregate BranchTask queue + BUG-011 Phase A lease fields into a
+    structured liveness snapshot.
+
+    Pairs with PR #212 (write-only lease metadata fields). Uses
+    ``getattr`` with defaults so this works both pre- and post-PR-#212
+    deployment: pre-#212 BranchTasks lack the lease fields and surface
+    as ``"lease_data_unavailable"`` rather than crashing the probe.
+
+    Surfaces the diagnostic the BUG-009 incident (2026-05-02) cost an
+    hour of triage to find: container alive but daemon subprocess
+    wedged. With this field, the same diagnosis becomes
+    ``stuck_pending_max_age_s`` + ``stale_running_tasks`` readable from
+    ``get_status``.
+    """
+    import time as _time
+    if now_ts is None:
+        now_ts = _time.time()
+
+    out: dict[str, Any] = {
+        "queue_state": {
+            "depth": 0,
+            "pending": 0,
+            "running": 0,
+            "succeeded": 0,
+            "failed": 0,
+            "cancelled": 0,
+            "stuck_pending_max_age_s": 0,
+            "stuck_running_max_age_s": 0,
+        },
+        "running_tasks_lease": [],
+        "stale_running_tasks": [],
+        "warnings": [],
+        "lease_data_available": True,
+    }
+
+    try:
+        from workflow.branch_tasks import read_queue
+        queue = read_queue(udir)
+    except Exception as exc:  # noqa: BLE001 — best-effort observability
+        out["warnings"].append(f"queue_read_failed: {exc}")
+        return out
+
+    out["queue_state"]["depth"] = len(queue)
+    if not queue:
+        return out
+
+    any_lease_field_seen = False
+    pending_ages: list[float] = []
+    running_ages: list[float] = []
+
+    for task in queue:
+        status = getattr(task, "status", "") or ""
+        if status in out["queue_state"]:
+            out["queue_state"][status] = out["queue_state"].get(status, 0) + 1
+
+        # Pending-task age (queued_at -> now). Detects dispatcher pickup
+        # gaps even before a task gets claimed (today's BUG-009 pattern).
+        queued_at = getattr(task, "queued_at", "") or ""
+        queued_ts = _parse_iso_to_epoch(queued_at) if queued_at else None
+        if status == "pending" and queued_ts is not None:
+            age = max(0.0, now_ts - queued_ts)
+            pending_ages.append(age)
+
+        if status != "running":
+            continue
+
+        # Lease metadata (PR #212). Defensive getattr so pre-#212 tasks
+        # surface as empty strings rather than AttributeError.
+        worker_owner_id = getattr(task, "worker_owner_id", "") or ""
+        lease_expires_at = getattr(task, "lease_expires_at", "") or ""
+        heartbeat_at = getattr(task, "heartbeat_at", "") or ""
+        last_progress_at = getattr(task, "last_progress_at", "") or ""
+
+        if worker_owner_id or lease_expires_at or heartbeat_at:
+            any_lease_field_seen = True
+
+        lease_expires_ts = _parse_iso_to_epoch(lease_expires_at)
+        heartbeat_ts = _parse_iso_to_epoch(heartbeat_at)
+        progress_ts = _parse_iso_to_epoch(last_progress_at)
+
+        lease_remaining_s: int | None = None
+        if lease_expires_ts is not None:
+            lease_remaining_s = int(lease_expires_ts - now_ts)
+
+        heartbeat_age_s: int | None = None
+        if heartbeat_ts is not None:
+            heartbeat_age_s = max(0, int(now_ts - heartbeat_ts))
+
+        progress_age_s: int | None = None
+        if progress_ts is not None:
+            progress_age_s = max(0, int(now_ts - progress_ts))
+
+        # Running-task age tracked for the queue summary even if no lease
+        # data exists (pre-#212 fallback).
+        if heartbeat_ts is not None:
+            running_ages.append(now_ts - heartbeat_ts)
+        elif queued_ts is not None:
+            running_ages.append(max(0.0, now_ts - queued_ts))
+
+        record = {
+            "branch_task_id": getattr(task, "branch_task_id", ""),
+            "worker_owner_id": worker_owner_id,
+            "lease_expires_at": lease_expires_at,
+            "lease_remaining_s": lease_remaining_s,
+            "heartbeat_at": heartbeat_at,
+            "heartbeat_age_s": heartbeat_age_s,
+            "last_progress_at": last_progress_at,
+            "progress_age_s": progress_age_s,
+        }
+        out["running_tasks_lease"].append(record)
+
+        # Stale detection: heartbeat older than 2x refresh OR lease
+        # expired. Both signal the daemon owning this task is dead/wedged.
+        # Phase C (Codex) will use the same predicate to actively
+        # reclaim; this field lets operators see the condition before
+        # that ships.
+        is_stale = False
+        stale_reasons: list[str] = []
+        if (
+            heartbeat_age_s is not None
+            and heartbeat_age_s > _HEARTBEAT_STALE_THRESHOLD_S
+        ):
+            is_stale = True
+            stale_reasons.append(
+                f"heartbeat_age_s={heartbeat_age_s} > "
+                f"threshold={_HEARTBEAT_STALE_THRESHOLD_S}"
+            )
+        if lease_remaining_s is not None and lease_remaining_s <= 0:
+            is_stale = True
+            stale_reasons.append(
+                f"lease_expired ({lease_remaining_s}s ago)"
+            )
+
+        if is_stale:
+            stale = dict(record)
+            stale["stale_reasons"] = stale_reasons
+            out["stale_running_tasks"].append(stale)
+
+    if pending_ages:
+        out["queue_state"]["stuck_pending_max_age_s"] = int(max(pending_ages))
+    if running_ages:
+        out["queue_state"]["stuck_running_max_age_s"] = int(max(running_ages))
+
+    # If any pending task is past the stuck threshold, surface a
+    # warning. Today's BUG-009 RCA: a pending task that sits >2min
+    # without claim means the supervisor restart logic isn't reaching
+    # the queue (the exact pattern PR #205 fixed).
+    if (
+        out["queue_state"]["stuck_pending_max_age_s"]
+        > _STUCK_PENDING_THRESHOLD_S
+    ):
+        out["warnings"].append(
+            f"stuck_pending: oldest pending task is "
+            f"{out['queue_state']['stuck_pending_max_age_s']}s old "
+            f"(threshold {_STUCK_PENDING_THRESHOLD_S}s). Likely "
+            "supervisor restart loop, dispatcher disabled, or daemon "
+            "subprocess wedged. See PR #206 spec for incident pattern."
+        )
+
+    if out["queue_state"]["running"] > 0 and not any_lease_field_seen:
+        out["lease_data_available"] = False
+        out["warnings"].append(
+            "lease_data_unavailable: running tasks present but no lease "
+            "fields populated. Either pre-PR-#212 deploy, or daemon is "
+            "not stamping heartbeats. Reclaim heuristics cannot run."
+        )
+
+    if out["stale_running_tasks"]:
+        out["warnings"].append(
+            f"{len(out['stale_running_tasks'])} stale running task(s) "
+            "(heartbeat past threshold or lease expired). BUG-011 "
+            "Phase C reclaim would reclaim these once shipped."
+        )
+
+    return out
+
+
 def get_status(universe_id: str = "") -> str:
     """Factual snapshot of the daemon's identity + routing config.
 
@@ -349,6 +560,22 @@ def get_status(universe_id: str = "") -> str:
     except Exception:  # noqa: BLE001 — best-effort observability
         missing_data_files = []
 
+    # supervisor_liveness — BUG-009 incident (2026-05-02) cost ~1hr of
+    # triage finding "container alive but daemon subprocess wedged"
+    # without SSH. This block surfaces the diagnosis from the public MCP
+    # probe: queue counts + per-running-task lease/heartbeat ages +
+    # stale-detection. Pairs with PR #212 (BUG-011 Phase A lease metadata
+    # writes); the helper is defensive so a missing branch_tasks file or
+    # pre-#212 task shape cannot break the status probe.
+    try:
+        supervisor_liveness = _compute_supervisor_liveness(udir)
+    except Exception as exc:  # noqa: BLE001 — best-effort observability
+        supervisor_liveness = {
+            "error": "compute_failed",
+            "detail": str(exc),
+            "lease_data_available": False,
+        }
+
     response = {
         "schema_version": 1,
         "active_host": policy_payload["active_host"],
@@ -368,6 +595,7 @@ def get_status(universe_id: str = "") -> str:
         "per_provider_cooldown_remaining": per_provider_cooldown_remaining,
         "sandbox_status": sandbox_status,
         "missing_data_files": missing_data_files,
+        "supervisor_liveness": supervisor_liveness,
         "universe_id": uid,
         "universe_exists": universe_exists,
     }


### PR DESCRIPTION
## Summary

Adds a `supervisor_liveness` field to `get_status` response. Surfaces queue state + per-running-task lease/heartbeat ages + stale detection from the public MCP probe — closes the observability gap that cost ~1hr of triage during today's BUG-009 RCA.

Pairs with [PR #212](https://github.com/Jonnyton/Workflow/pull/212) (Codex's BUG-011 Phase A — write-only lease metadata fields on BranchTask). #212 writes the data; this PR surfaces it. Together they form the full observability story for the container-alive-but-daemon-wedged class.

## What's in the response

```json
{
  "supervisor_liveness": {
    "queue_state": {
      "depth": 16,
      "pending": 1, "running": 1, "succeeded": 14, "failed": 0, "cancelled": 0,
      "stuck_pending_max_age_s": 12,
      "stuck_running_max_age_s": 45
    },
    "running_tasks_lease": [
      {
        "branch_task_id": "...",
        "worker_owner_id": "daemon::workflow-developer-daemon::8d7892bfca2b4ce4",
        "lease_expires_at": "2026-05-02T22:35:00+00:00",
        "lease_remaining_s": 245,
        "heartbeat_at": "2026-05-02T22:30:12+00:00",
        "heartbeat_age_s": 12,
        "last_progress_at": "2026-05-02T22:30:08+00:00",
        "progress_age_s": 16
      }
    ],
    "stale_running_tasks": [],
    "warnings": [],
    "lease_data_available": true
  }
}
```

## Stale detection

A running task is `stale` when EITHER:
- `heartbeat_age_s > 120s` (2x the 60s refresh interval observed in fantasy_daemon's Phase A implementation), OR
- `lease_remaining_s <= 0` (lease expired).

Stale tasks land in `stale_running_tasks` with `stale_reasons`. BUG-011 Phase C reclaim (Codex's next lane) uses the same predicate to actively reclaim; this field exposes the condition before reclaim ships.

## Stuck-pending detection (BUG-009 incident pattern)

A pending task older than 120s without claim emits a warning. This is the exact pattern PR #205 fixed (supervisor restart loop killing daemon before claim). With this field, future incidents of that class are diagnosable from `get_status` in 30 seconds instead of an hour of SSH triage.

## Defensive design (pre/post-#212 compatibility)

Uses `getattr` with defaults for all PR #212 fields (`worker_owner_id`, `lease_expires_at`, `heartbeat_at`, `last_progress_at`). Pre-#212 deploys surface as `lease_data_available: false` + `lease_data_unavailable` warning rather than crashing the probe. Post-#212 deploys populate the lease records.

## Tests

`tests/test_supervisor_liveness.py` — 18 cases:
- `_parse_iso_to_epoch` unit (empty, Z suffix, offset, garbage)
- empty queue + missing queue file
- status counts
- stuck pending detection above + below threshold
- lease metadata path (fresh, stale heartbeat, expired lease, both)
- pre-#212 fallback warning
- `get_status` integration

## Plugin mirror

`packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py` updated.

## Risk

Additive field on `get_status`. No existing field changed. No code path outside `get_status` touched.

## Sequencing

After #212 merges, this PR's field starts populating with real lease data. Before #212 merges, this PR's field still works — surfaces `lease_data_unavailable` warning. So #212 + this PR can deploy in either order, but coordinate so the field shape is stable.

Spec reference: PR #206 (`docs/specs/daemon-liveness-watchdog.md`).
