### PR TITLE
wiki: compact file_bug response (drop branch_task mirror by default; verbose=True restores)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1249,6 +1249,7 @@ def _wiki_file_bug(
     kind: str = "bug",
     tags: str = "",
     force_new: bool = False,
+    verbose: bool = False,
     **_kwargs: Any,
 ) -> str:
     """File a bug / feature request / design proposal to pages/bugs/.
@@ -1440,24 +1441,33 @@ def _wiki_file_bug(
                 "status": "queued",
                 "dispatcher_request_id": request_id,
             }
-            try:
-                from workflow.branch_tasks import read_queue
+            # Default response shape is compact — callers needing the
+            # full BranchTask mirror pass verbose=True. Cuts the typical
+            # file_bug response from ~3.7 KB to ~600 bytes (no 23-field
+            # BranchTask dump that mirrors inputs.request_text). The
+            # trigger_attempt_id + dispatcher_request_id below are already
+            # enough for chatbots/canaries to join request -> run; the full
+            # mirror is operator-only and can be fetched on-demand via
+            # ``universe action=queue_list`` with the branch_task_id.
+            if verbose:
+                try:
+                    from workflow.branch_tasks import read_queue
 
-                task = next(
-                    (
-                        t for t in read_queue(universe_path)
-                        if t.branch_task_id == request_id
-                    ),
-                    None,
-                )
-                if task is not None:
-                    investigation["branch_task"] = task.to_dict()
-            except Exception as _queue_exc:  # noqa: BLE001
-                _logger_wiki.warning(
-                    "file_bug investigation task read failed for %s: %s",
-                    bug_id,
-                    _queue_exc,
-                )
+                    task = next(
+                        (
+                            t for t in read_queue(universe_path)
+                            if t.branch_task_id == request_id
+                        ),
+                        None,
+                    )
+                    if task is not None:
+                        investigation["branch_task"] = task.to_dict()
+                except Exception as _queue_exc:  # noqa: BLE001
+                    _logger_wiki.warning(
+                        "file_bug investigation task read failed for %s: %s",
+                        bug_id,
+                        _queue_exc,
+                    )
             if _receipt is not None:
                 try:
                     _receipt = _tr.mark_queued(
@@ -1535,6 +1545,7 @@ def wiki(
     force_new: bool = False,
     bug_id: str = "",
     reporter_context: str = "",
+    verbose: bool = False,
 ) -> str:
     """Dispatch entry for the wiki MCP tool. See universe_server.py for the
     chatbot-facing docstring; this function is the implementation invoked by
@@ -1624,6 +1635,7 @@ def wiki(
         "force_new": force_new,
         "bug_id": bug_id,
         "reporter_context": reporter_context,
+        "verbose": verbose,
     }
 
     return handler(**kwargs)

--- a/tests/test_file_bug_compact_response.py
+++ b/tests/test_file_bug_compact_response.py
@@ -1,0 +1,159 @@
+"""Tests for FEAT-008-adjacent — compact ``file_bug`` response shape.
+
+After 2026-05-03 chatbot-side timeout finding (see ``.agents/activity.log``
+2026-05-03T02:50Z), the default ``wiki action=file_bug`` response is
+trimmed to drop the ``investigation.branch_task`` BranchTask mirror —
+which dumped 23 fields including the full ``inputs.request_text`` echo
+and pushed responses to ~3.7 KB even for tiny filings, exhausting
+ChatGPT connector-wrapper response budgets.
+
+Default response is now compact (~600 bytes). Operators / canaries that
+need the full BranchTask mirror pass ``verbose=True``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from workflow.api.wiki import _wiki_file_bug, wiki
+
+
+@pytest.fixture
+def wired_wiki(tmp_path, monkeypatch):
+    """Tmp wiki + canonical investigation branch wired so file_bug enqueues."""
+    wiki_root = tmp_path / "Wiki"
+    (wiki_root / "pages" / "bugs").mkdir(parents=True)
+    (wiki_root / "pages" / "feature-requests").mkdir(parents=True)
+    (wiki_root / "drafts" / "bugs").mkdir(parents=True)
+    (wiki_root / "drafts" / "feature-requests").mkdir(parents=True)
+    monkeypatch.setenv("WORKFLOW_WIKI_PATH", str(wiki_root))
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv(
+        "WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID",
+        "branch-canonical-test",
+    )
+    monkeypatch.delenv("WORKFLOW_REQUEST_TYPE_PRIORITIES", raising=False)
+    return wiki_root
+
+
+def _file_one(verbose: bool, wired_wiki) -> dict:
+    """Helper — file a tiny bug and return the parsed response."""
+    raw = _wiki_file_bug(
+        component="probe",
+        severity="cosmetic",
+        title=f"compact-response-test-{verbose}",
+        observed="x",
+        expected="y",
+        kind="feature",
+        verbose=verbose,
+    )
+    return json.loads(raw)
+
+
+# ── Default response (compact) ─────────────────────────────────────────────
+
+
+class TestDefaultCompact:
+    def test_default_response_omits_branch_task_mirror(self, wired_wiki):
+        resp = _file_one(verbose=False, wired_wiki=wired_wiki)
+        assert resp["status"] == "filed"
+        # investigation block exists with the IDs callers need…
+        assert "investigation" in resp
+        inv = resp["investigation"]
+        assert inv.get("status") == "queued"
+        assert "dispatcher_request_id" in inv
+        # …but NOT the bulky branch_task mirror
+        assert "branch_task" not in inv
+
+    def test_default_response_size_under_one_kb(self, wired_wiki):
+        resp = _file_one(verbose=False, wired_wiki=wired_wiki)
+        size = len(json.dumps(resp))
+        assert size < 1024, (
+            f"compact response should fit under 1KB; was {size} bytes. "
+            f"Keys: {sorted(resp.keys())}, "
+            f"investigation keys: {sorted(resp.get('investigation', {}).keys())}"
+        )
+
+    def test_default_response_preserves_top_level_fields(self, wired_wiki):
+        resp = _file_one(verbose=False, wired_wiki=wired_wiki)
+        for key in ("path", "bug_id", "status", "kind", "severity", "component", "note"):
+            assert key in resp, f"compact response dropped {key}"
+
+
+# ── Verbose response (legacy shape) ────────────────────────────────────────
+
+
+class TestVerboseRestoresMirror:
+    def test_verbose_includes_branch_task_mirror(self, wired_wiki):
+        resp = _file_one(verbose=True, wired_wiki=wired_wiki)
+        inv = resp["investigation"]
+        assert inv.get("status") == "queued"
+        assert "branch_task" in inv, (
+            "verbose=True must restore the legacy branch_task mirror"
+        )
+        bt = inv["branch_task"]
+        # spot-check a few of the 23 BranchTask fields
+        assert "branch_task_id" in bt
+        assert "branch_def_id" in bt
+        assert "inputs" in bt
+        assert bt.get("status") == "pending"
+
+    def test_verbose_branch_task_id_matches_dispatcher_request_id(self, wired_wiki):
+        resp = _file_one(verbose=True, wired_wiki=wired_wiki)
+        inv = resp["investigation"]
+        assert inv["branch_task"]["branch_task_id"] == inv["dispatcher_request_id"]
+
+
+# ── Wiki dispatch threading ────────────────────────────────────────────────
+
+
+class TestWikiDispatchThreadsVerbose:
+    def test_wiki_dispatch_default_omits_branch_task(self, wired_wiki):
+        raw = wiki(
+            action="file_bug",
+            component="probe",
+            severity="cosmetic",
+            title="dispatch-default-compact",
+            kind="feature",
+            observed="x",
+        )
+        resp = json.loads(raw)
+        inv = resp.get("investigation", {})
+        assert "branch_task" not in inv
+
+    def test_wiki_dispatch_verbose_includes_branch_task(self, wired_wiki):
+        raw = wiki(
+            action="file_bug",
+            component="probe",
+            severity="cosmetic",
+            title="dispatch-verbose-restored",
+            kind="feature",
+            observed="x",
+            verbose=True,
+        )
+        resp = json.loads(raw)
+        inv = resp.get("investigation", {})
+        assert "branch_task" in inv
+
+
+# ── Trigger receipt block (FEAT-004) is unaffected by verbose flag ────────
+
+
+class TestTriggerReceiptUnchanged:
+    def test_compact_response_still_emits_trigger_block(self, wired_wiki):
+        resp = _file_one(verbose=False, wired_wiki=wired_wiki)
+        assert "trigger" in resp, (
+            "compact response must still surface FEAT-004 trigger receipt"
+        )
+        trig = resp["trigger"]
+        assert trig.get("attempted") is True
+        assert "trigger_attempt_id" in trig
+        assert trig.get("status") == "queued"
+        assert "dispatcher_request_id" in trig
+
+    def test_trigger_block_present_in_verbose_too(self, wired_wiki):
+        resp = _file_one(verbose=True, wired_wiki=wired_wiki)
+        assert "trigger" in resp
+        assert resp["trigger"].get("attempted") is True

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1249,6 +1249,7 @@ def _wiki_file_bug(
     kind: str = "bug",
     tags: str = "",
     force_new: bool = False,
+    verbose: bool = False,
     **_kwargs: Any,
 ) -> str:
     """File a bug / feature request / design proposal to pages/bugs/.
@@ -1440,24 +1441,33 @@ def _wiki_file_bug(
                 "status": "queued",
                 "dispatcher_request_id": request_id,
             }
-            try:
-                from workflow.branch_tasks import read_queue
+            # Default response shape is compact — callers needing the
+            # full BranchTask mirror pass verbose=True. Cuts the typical
+            # file_bug response from ~3.7 KB to ~600 bytes (no 23-field
+            # BranchTask dump that mirrors inputs.request_text). The
+            # trigger_attempt_id + dispatcher_request_id below are already
+            # enough for chatbots/canaries to join request -> run; the full
+            # mirror is operator-only and can be fetched on-demand via
+            # ``universe action=queue_list`` with the branch_task_id.
+            if verbose:
+                try:
+                    from workflow.branch_tasks import read_queue
 
-                task = next(
-                    (
-                        t for t in read_queue(universe_path)
-                        if t.branch_task_id == request_id
-                    ),
-                    None,
-                )
-                if task is not None:
-                    investigation["branch_task"] = task.to_dict()
-            except Exception as _queue_exc:  # noqa: BLE001
-                _logger_wiki.warning(
-                    "file_bug investigation task read failed for %s: %s",
-                    bug_id,
-                    _queue_exc,
-                )
+                    task = next(
+                        (
+                            t for t in read_queue(universe_path)
+                            if t.branch_task_id == request_id
+                        ),
+                        None,
+                    )
+                    if task is not None:
+                        investigation["branch_task"] = task.to_dict()
+                except Exception as _queue_exc:  # noqa: BLE001
+                    _logger_wiki.warning(
+                        "file_bug investigation task read failed for %s: %s",
+                        bug_id,
+                        _queue_exc,
+                    )
             if _receipt is not None:
                 try:
                     _receipt = _tr.mark_queued(
@@ -1535,6 +1545,7 @@ def wiki(
     force_new: bool = False,
     bug_id: str = "",
     reporter_context: str = "",
+    verbose: bool = False,
 ) -> str:
     """Dispatch entry for the wiki MCP tool. See universe_server.py for the
     chatbot-facing docstring; this function is the implementation invoked by
@@ -1624,6 +1635,7 @@ def wiki(
         "force_new": force_new,
         "bug_id": bug_id,
         "reporter_context": reporter_context,
+        "verbose": verbose,
     }
 
     return handler(**kwargs)


### PR DESCRIPTION
## Summary

Default `wiki action=file_bug` response was 3,708 bytes for a tiny filing because `investigation.branch_task` mirrored the full 23-field BranchTask (including `inputs.request_text` echoing the body back). On the chatbot path that response size pushed ChatGPT's connector wrapper past its response generation budget — file_bug calls timed out 2+ minutes in with "Something went wrong" errors.

This PR gates the branch_task mirror behind a new `verbose=True` param. Default response drops to ~600 bytes; the compact shape still has everything chatbots/users need (top-level fields, `investigation.dispatcher_request_id`, full `trigger` block from FEAT-004). Operators wanting the full mirror opt in.

## Empirical context

| Path | Latency | Response size |
|---|---|---|
| Direct MCP curl (same payload) | 269 ms | 3,708 B |
| ChatGPT connector wrapper | 2+ min, then errors | (never received) |

Daemon side is fine. Bottleneck is on ChatGPT's wrapper handling that response — likely response-budget exhaustion from the bulky BranchTask mirror echoing inputs back. See `.agents/activity.log` 2026-05-03T02:50Z entry for the full diagnosis.

## What changed

- `workflow/api/wiki.py` `_wiki_file_bug` signature gains `verbose: bool = False`.
- The block that reads the queue + attaches `task.to_dict()` to `investigation["branch_task"]` is now gated on `if verbose:`.
- `wiki()` dispatch function gains `verbose: bool = False` param + threads it through `kwargs`.
- Mirror updated at `packaging/claude-plugin/.../api/wiki.py`.
- Tests in `tests/test_file_bug_compact_response.py` cover: default omits `branch_task`, default response under 1KB, verbose=True restores mirror, branch_task_id matches dispatcher_request_id when verbose, FEAT-004 trigger block unaffected by flag.

## What does NOT change

- `investigation.dispatcher_request_id` — still present in compact response (chatbots use this for tracing).
- `trigger.trigger_attempt_id` — still present (FEAT-004 receipt path unchanged).
- Top-level fields (path, bug_id, status, etc) — unchanged.
- Any existing caller that doesn't pass `verbose` continues to work; the field they didn't use is now absent. Callers that DO depend on `investigation.branch_task` should pass `verbose=True`.

## Risk

Backward-compat-breaking ONLY for callers that explicitly read `investigation.branch_task`. Verified by grep against repo: no in-tree caller does. External callers that need it pass `verbose=True`. The full BranchTask is also reachable via `universe action=queue_list` filtered by branch_task_id.

## Pairs with

Codex working in parallel on trimming the wiki tool description (the OTHER half of the chatbot bottleneck — the 20+ pre-flight searches before file_bug). Both PRs target the same level-1 break: chatbot file_bug reliability. Either deploys before the other; both want to land soon.

## Source

Authored by Cowork session after caught-and-self-corrected probe cheats this cycle (FEAT-008 + FEAT-010 in queue are Cowork operator probes, not user filings — see `.agents/activity.log` 2026-05-03T02:50Z for disclosure). The level-1 bottleneck the cheats accidentally surfaced is the substrate problem this PR addresses.
