### PR TITLE
auto_ship: dry-run shipper validator (PR #198 Phase 1)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auto_ship.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auto_ship.py
@@ -1,0 +1,419 @@
+"""Auto-ship dry-run shipper — PR #198 Phase 1.
+
+Pure-Python validator that runs a coding_packet (or constructed ship_request)
+through the auto-ship safety envelope from
+``docs/milestones/auto-ship-canary-v0.md`` §5.2, §6.1, §6.2, §6.3 and returns
+a structured ship_decision explaining whether the packet WOULD ship, why,
+and what rollback handle would be used.
+
+Phase 1 contract: NO repo writes, NO IO, NO network. Validator only.
+``ship_status`` is always ``"skipped"`` in this phase — the ``would_open_pr``
+field tells callers whether the packet PASSED the envelope. Phase 2 (PR-open
+mode) wires the actual repo operation behind a flag; Phase 3 enables
+auto-merge for narrow canary classes after one successful PR-open round.
+
+Pairs with:
+- ``docs/specs/loop-outcome-rubric-v0.md`` (PR #211) — defines what KEEP +
+  evidence-bundle-complete actually mean. The validator below enforces the
+  envelope; the rubric defines what packets ARE before the envelope sees them.
+- ``docs/milestones/auto-ship-canary-v0.md`` (PR #198) — milestone spec
+  this module implements one phase of.
+
+The shipper is the LAST enforcement layer. The release_gate may recommend
+auto-ship; the shipper is what actually decides whether the recommendation
+is safe enough to act on. Every check below is structural — no LLM in the
+loop, no prose interpretation.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# ── Envelope constants from auto-ship-canary-v0.md §6 ─────────────────────
+
+#: Ship classes allowed for v0 (§6.2). Any other class is blocked.
+ALLOWED_SHIP_CLASSES: frozenset[str] = frozenset({
+    "docs_canary",
+    "metadata_canary",
+    "test_fixture_canary",
+})
+
+#: Path prefixes a v0 canary patch may touch (§6.2). Forbidden paths win on conflict.
+ALLOWED_PATH_PREFIXES: tuple[str, ...] = (
+    "docs/autoship-canaries/",
+    "workflow/autoship_canaries/",
+    "tests/fixtures/autoship_canaries/",
+)
+
+#: Path prefixes that must NEVER auto-ship (§6.2). Even matches against an allowed
+#: prefix get rejected if any forbidden prefix also matches — defense in depth.
+FORBIDDEN_PATH_PREFIXES: tuple[str, ...] = (
+    "workflow/runtime/",
+    "workflow/providers/",
+    "workflow/api/",
+    "workflow/wiki/",
+    "workflow/dispatcher/",
+    ".github/",
+    "scripts/deploy/",
+    "migrations/",
+)
+
+#: Forbidden substring patterns in a path (§6.2). Case-insensitive match.
+FORBIDDEN_PATH_SUBSTRINGS: tuple[str, ...] = (
+    ".env",
+    "secret",
+    "auth",
+)
+
+#: Required packet fields (§6.1) that must hold a non-empty value.
+REQUIRED_FIELDS_NONEMPTY: tuple[str, ...] = (
+    "release_gate_result",
+    "ship_class",
+    "child_keep_reject_decision",
+    "stable_evidence_handle",
+    "automation_claim_status",
+    "rollback_plan",
+)
+
+#: Allowed values for automation_claim_status (§6.1).
+ALLOWED_AUTOMATION_CLAIM_STATUS: frozenset[str] = frozenset({
+    "child_attached_with_handle",
+    "parent_completed_with_handle",
+    "direct_packet_with_handle",
+})
+
+#: Minimum child_score for KEEP (§6.1 + rubric §5).
+KEEP_SCORE_MIN: float = 9.0
+
+#: Maximum diff size in bytes for a v0 canary patch.
+#: Tight bound on purpose — canary patches should be a few lines, not a refactor.
+DIFF_SIZE_BYTES_MAX: int = 8 * 1024  # 8 KB
+
+#: Heuristic regex patterns flagging probable secrets in diff content.
+#: Conservative — false positives are tolerable; false negatives ship secrets.
+SECRET_REGEX_PATTERNS: tuple[str, ...] = (
+    r"sk-[A-Za-z0-9_-]{20,}",          # OpenAI / Anthropic style
+    r"AIza[A-Za-z0-9_-]{35}",          # Google API
+    r"ghp_[A-Za-z0-9]{36}",            # GitHub PAT (classic)
+    r"github_pat_[A-Za-z0-9_]{22,}",   # GitHub PAT (fine-grained)
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----",  # PEM private keys
+    r"xox[baprs]-[A-Za-z0-9-]{10,}",   # Slack tokens
+    r"AKIA[0-9A-Z]{16}",               # AWS access key id
+)
+
+
+def _normalize_path(path: str) -> str:
+    """Cheap path normalization — strip literal leading ``./``, collapse ``//``,
+    NO symlink resolution (caller's responsibility if needed).
+
+    Defense against trivially-encoded forbidden paths like ``./workflow/api/x``
+    or ``workflow//api/x``. Real symlink resolution happens upstream — this is
+    just structural normalization. Note: uses ``removeprefix`` (Python 3.9+)
+    rather than ``lstrip`` so paths like ``.github/x`` (which start with a dot
+    but not the literal ``./`` prefix) are preserved verbatim — otherwise the
+    forbidden-prefix check would miss them.
+    """
+    if not path:
+        return ""
+    p = path
+    # Strip literal "./" prefix if present (do not strip ".github/" -> "github/").
+    while p.startswith("./"):
+        p = p[2:]
+    while "//" in p:
+        p = p.replace("//", "/")
+    return p
+
+
+def _path_violations(changed_paths: list[str]) -> list[dict[str, Any]]:
+    """Return one violation record per (path, rule) violation. Empty if clean."""
+    out: list[dict[str, Any]] = []
+    if not isinstance(changed_paths, list):
+        return [{
+            "rule_id": "changed_paths_not_list",
+            "field": "changed_paths",
+            "severity": "block",
+            "message": (
+                f"changed_paths must be a list of strings; got {type(changed_paths).__name__}"
+            ),
+        }]
+    if not changed_paths:
+        out.append({
+            "rule_id": "changed_paths_empty",
+            "field": "changed_paths",
+            "severity": "block",
+            "message": "changed_paths is empty — auto-ship requires at least one path",
+        })
+    for raw_path in changed_paths:
+        if not isinstance(raw_path, str) or not raw_path:
+            out.append({
+                "rule_id": "changed_path_invalid",
+                "field": "changed_paths",
+                "severity": "block",
+                "message": f"changed_paths entry is not a non-empty string: {raw_path!r}",
+            })
+            continue
+        normalized = _normalize_path(raw_path)
+        lower = normalized.lower()
+        # Forbidden first — wins even if also matches an allowed prefix.
+        for forbidden in FORBIDDEN_PATH_PREFIXES:
+            if normalized.startswith(forbidden):
+                out.append({
+                    "rule_id": "changed_path_forbidden_prefix",
+                    "field": "changed_paths",
+                    "severity": "block",
+                    "message": (
+                        f"path {raw_path!r} starts with forbidden prefix "
+                        f"{forbidden!r} — auto-ship cannot touch this surface"
+                    ),
+                })
+                break
+        for sub in FORBIDDEN_PATH_SUBSTRINGS:
+            if sub in lower:
+                out.append({
+                    "rule_id": "changed_path_forbidden_substring",
+                    "field": "changed_paths",
+                    "severity": "block",
+                    "message": (
+                        f"path {raw_path!r} contains forbidden substring "
+                        f"{sub!r} (env / secret / auth surface)"
+                    ),
+                })
+                break
+        # Allowed-prefix check (only if not already forbidden).
+        if not any(normalized.startswith(p) for p in ALLOWED_PATH_PREFIXES):
+            out.append({
+                "rule_id": "changed_path_not_allowed",
+                "field": "changed_paths",
+                "severity": "block",
+                "message": (
+                    f"path {raw_path!r} is not under any allowed canary prefix "
+                    f"({', '.join(ALLOWED_PATH_PREFIXES)})"
+                ),
+            })
+    return out
+
+
+def _diff_violations(diff: str) -> list[dict[str, Any]]:
+    """Diff-size, binary, and secret checks (§6.3)."""
+    out: list[dict[str, Any]] = []
+    if not isinstance(diff, str):
+        return [{
+            "rule_id": "diff_not_string",
+            "field": "diff",
+            "severity": "block",
+            "message": f"diff must be a string; got {type(diff).__name__}",
+        }]
+    if len(diff.encode("utf-8")) > DIFF_SIZE_BYTES_MAX:
+        out.append({
+            "rule_id": "diff_too_large",
+            "field": "diff",
+            "severity": "block",
+            "message": (
+                f"diff is {len(diff.encode('utf-8'))} bytes; v0 canary cap is "
+                f"{DIFF_SIZE_BYTES_MAX} bytes"
+            ),
+        })
+    if "\0" in diff:
+        out.append({
+            "rule_id": "diff_binary_content",
+            "field": "diff",
+            "severity": "block",
+            "message": "diff contains a null byte — auto-ship rejects binary content",
+        })
+    for pat in SECRET_REGEX_PATTERNS:
+        if re.search(pat, diff):
+            out.append({
+                "rule_id": "diff_secret_pattern",
+                "field": "diff",
+                "severity": "block",
+                "message": (
+                    "diff matched a heuristic secret pattern — auto-ship "
+                    "blocks. False positive? Manually review before shipping."
+                ),
+            })
+            # Don't break — we want all matches recorded for audit.
+    return out
+
+
+def validate_ship_request(packet: dict[str, Any]) -> dict[str, Any]:
+    """Run the auto-ship safety envelope on ``packet``. Returns a ship_decision dict.
+
+    Pure: no IO, no network, no repo writes. Caller decides what to do with
+    the decision.
+
+    Decision shape::
+
+        {
+            "ship_status": "skipped",        # always "skipped" in Phase 1 (dry-run)
+            "would_open_pr": bool,           # True iff envelope passed
+            "validation_result": "passed" | "blocked",
+            "violations": list[dict],        # rule violations; empty when passed
+            "rollback_handle": str | None,   # "revert:<plan>" when passed; None when blocked
+            "dry_run": True,                 # always True in Phase 1
+        }
+
+    Each violation record::
+
+        {
+            "rule_id": str,        # short stable identifier for the rule
+            "field": str | None,   # packet field that violated, when applicable
+            "severity": "block",   # all envelope violations are blocking in v0
+            "message": str,        # human-readable explanation
+        }
+
+    The validator is conservative: it BLOCKS on any unmet rule. There is no
+    "warning" tier in v0 — anything that doesn't pass cannot ship.
+    """
+    if not isinstance(packet, dict):
+        return {
+            "ship_status": "skipped",
+            "would_open_pr": False,
+            "validation_result": "blocked",
+            "violations": [{
+                "rule_id": "packet_not_dict",
+                "field": None,
+                "severity": "block",
+                "message": (
+                    f"packet must be a dict; got {type(packet).__name__}"
+                ),
+            }],
+            "rollback_handle": None,
+            "dry_run": True,
+        }
+
+    violations: list[dict[str, Any]] = []
+
+    # §6.1 — required packet fields must be present + non-empty
+    for field in REQUIRED_FIELDS_NONEMPTY:
+        value = packet.get(field)
+        if value is None or value == "":
+            violations.append({
+                "rule_id": f"required_field_missing:{field}",
+                "field": field,
+                "severity": "block",
+                "message": f"packet is missing required field {field!r}",
+            })
+
+    # §6.1 — field-value gates (only checked when field is present)
+    if packet.get("release_gate_result") not in (None, ""):
+        if packet["release_gate_result"] != "APPROVE_AUTO_SHIP":
+            violations.append({
+                "rule_id": "release_gate_not_approved",
+                "field": "release_gate_result",
+                "severity": "block",
+                "message": (
+                    f"release_gate_result must be 'APPROVE_AUTO_SHIP'; got "
+                    f"{packet['release_gate_result']!r}"
+                ),
+            })
+
+    if packet.get("child_keep_reject_decision") not in (None, ""):
+        if packet["child_keep_reject_decision"] != "KEEP":
+            violations.append({
+                "rule_id": "child_decision_not_keep",
+                "field": "child_keep_reject_decision",
+                "severity": "block",
+                "message": (
+                    f"child_keep_reject_decision must be 'KEEP'; got "
+                    f"{packet['child_keep_reject_decision']!r}"
+                ),
+            })
+
+    if "child_score" in packet:
+        score = packet["child_score"]
+        if not isinstance(score, (int, float)):
+            violations.append({
+                "rule_id": "child_score_not_numeric",
+                "field": "child_score",
+                "severity": "block",
+                "message": f"child_score must be numeric; got {type(score).__name__}",
+            })
+        elif score < KEEP_SCORE_MIN:
+            violations.append({
+                "rule_id": "child_score_below_threshold",
+                "field": "child_score",
+                "severity": "block",
+                "message": (
+                    f"child_score {score} below KEEP threshold {KEEP_SCORE_MIN}"
+                ),
+            })
+
+    if "risk_level" in packet and packet["risk_level"] != "low":
+        violations.append({
+            "rule_id": "risk_level_not_low",
+            "field": "risk_level",
+            "severity": "block",
+            "message": (
+                f"risk_level must be 'low' for v0 canary; got {packet['risk_level']!r}"
+            ),
+        })
+
+    if "blocked_execution_record" in packet and packet["blocked_execution_record"] != {}:
+        violations.append({
+            "rule_id": "blocked_execution_record_nonempty",
+            "field": "blocked_execution_record",
+            "severity": "block",
+            "message": (
+                "blocked_execution_record must be empty dict — packet has unresolved "
+                "execution blocks"
+            ),
+        })
+
+    if packet.get("automation_claim_status") not in (None, ""):
+        if packet["automation_claim_status"] not in ALLOWED_AUTOMATION_CLAIM_STATUS:
+            violations.append({
+                "rule_id": "automation_claim_status_not_allowed",
+                "field": "automation_claim_status",
+                "severity": "block",
+                "message": (
+                    f"automation_claim_status {packet['automation_claim_status']!r} "
+                    f"not in allowlist ({', '.join(sorted(ALLOWED_AUTOMATION_CLAIM_STATUS))})"
+                ),
+            })
+
+    # §6.2 — ship class
+    if packet.get("ship_class") not in (None, ""):
+        if packet["ship_class"] not in ALLOWED_SHIP_CLASSES:
+            violations.append({
+                "rule_id": "ship_class_not_allowed",
+                "field": "ship_class",
+                "severity": "block",
+                "message": (
+                    f"ship_class {packet['ship_class']!r} not in v0 allowlist "
+                    f"({', '.join(sorted(ALLOWED_SHIP_CLASSES))})"
+                ),
+            })
+
+    # §6.2 — path checks
+    violations.extend(_path_violations(packet.get("changed_paths", [])))
+
+    # §6.3 — diff-content checks
+    violations.extend(_diff_violations(packet.get("diff", "")))
+
+    # Decision
+    if violations:
+        return {
+            "ship_status": "skipped",
+            "would_open_pr": False,
+            "validation_result": "blocked",
+            "violations": violations,
+            "rollback_handle": None,
+            "dry_run": True,
+        }
+
+    # Passed — compute rollback handle from packet
+    rollback_plan = packet.get("rollback_plan", "")
+    handle_target = (
+        rollback_plan
+        if rollback_plan and rollback_plan != "auto"
+        else packet.get("stable_evidence_handle", "unknown")
+    )
+    return {
+        "ship_status": "skipped",  # Phase 1 is dry-run only
+        "would_open_pr": True,
+        "validation_result": "passed",
+        "violations": [],
+        "rollback_handle": f"revert:{handle_target}",
+        "dry_run": True,
+    }

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auto_ship.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auto_ship.py
@@ -71,6 +71,9 @@ REQUIRED_FIELDS_NONEMPTY: tuple[str, ...] = (
     "release_gate_result",
     "ship_class",
     "child_keep_reject_decision",
+    "child_score",
+    "risk_level",
+    "blocked_execution_record",
     "stable_evidence_handle",
     "automation_claim_status",
     "rollback_plan",
@@ -81,6 +84,12 @@ ALLOWED_AUTOMATION_CLAIM_STATUS: frozenset[str] = frozenset({
     "child_attached_with_handle",
     "parent_completed_with_handle",
     "direct_packet_with_handle",
+})
+
+#: Allowed coding_packet.status values for auto-ship (§6.1).
+ALLOWED_CODING_PACKET_STATUSES: frozenset[str] = frozenset({
+    "KEEP_READY",
+    "AUTO_SHIP_READY",
 })
 
 #: Minimum child_score for KEEP (§6.1 + rubric §5).
@@ -236,6 +245,29 @@ def _diff_violations(diff: str) -> list[dict[str, Any]]:
     return out
 
 
+def _coding_packet_status(packet: dict[str, Any]) -> Any:
+    """Extract coding_packet.status from supported packet shapes."""
+    coding_packet = packet.get("coding_packet")
+    if isinstance(coding_packet, dict):
+        status = coding_packet.get("status")
+        if status not in (None, ""):
+            return status
+
+    status = packet.get("coding_packet_status")
+    if status not in (None, ""):
+        return status
+
+    source_packet = packet.get("source_packet")
+    if isinstance(source_packet, dict):
+        source_coding_packet = source_packet.get("coding_packet")
+        if isinstance(source_coding_packet, dict):
+            status = source_coding_packet.get("status")
+            if status not in (None, ""):
+                return status
+
+    return None
+
+
 def validate_ship_request(packet: dict[str, Any]) -> dict[str, Any]:
     """Run the auto-ship safety envelope on ``packet``. Returns a ship_decision dict.
 
@@ -295,7 +327,29 @@ def validate_ship_request(packet: dict[str, Any]) -> dict[str, Any]:
                 "message": f"packet is missing required field {field!r}",
             })
 
-    # §6.1 — field-value gates (only checked when field is present)
+    # §6.1 — field-value gates
+    coding_packet_status = _coding_packet_status(packet)
+    if coding_packet_status in (None, ""):
+        violations.append({
+            "rule_id": "coding_packet_status_missing",
+            "field": "coding_packet.status",
+            "severity": "block",
+            "message": (
+                "coding_packet.status is required and must prove KEEP_READY "
+                "or AUTO_SHIP_READY before auto-ship"
+            ),
+        })
+    elif coding_packet_status not in ALLOWED_CODING_PACKET_STATUSES:
+        violations.append({
+            "rule_id": "coding_packet_status_not_allowed",
+            "field": "coding_packet.status",
+            "severity": "block",
+            "message": (
+                f"coding_packet.status {coding_packet_status!r} not in allowlist "
+                f"({', '.join(sorted(ALLOWED_CODING_PACKET_STATUSES))})"
+            ),
+        })
+
     if packet.get("release_gate_result") not in (None, ""):
         if packet["release_gate_result"] != "APPROVE_AUTO_SHIP":
             violations.append({

--- a/tests/test_auto_ship.py
+++ b/tests/test_auto_ship.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import pytest
 
 from workflow.auto_ship import (
-    ALLOWED_PATH_PREFIXES,
     ALLOWED_SHIP_CLASSES,
     DIFF_SIZE_BYTES_MAX,
     FORBIDDEN_PATH_PREFIXES,
@@ -31,6 +30,7 @@ def _valid_packet(**overrides) -> dict:
         "release_gate_result": "APPROVE_AUTO_SHIP",
         "ship_class": "docs_canary",
         "child_keep_reject_decision": "KEEP",
+        "coding_packet": {"status": "KEEP_READY"},
         "child_score": 9.5,
         "risk_level": "low",
         "blocked_execution_record": {},
@@ -98,6 +98,9 @@ class TestRequiredFields:
         "release_gate_result",
         "ship_class",
         "child_keep_reject_decision",
+        "child_score",
+        "risk_level",
+        "blocked_execution_record",
         "stable_evidence_handle",
         "automation_claim_status",
         "rollback_plan",
@@ -125,6 +128,41 @@ class TestRequiredFields:
 
 
 class TestValueGates:
+    def test_missing_coding_packet_status_blocked(self):
+        packet = _valid_packet()
+        del packet["coding_packet"]
+        d = validate_ship_request(packet)
+        assert d["validation_result"] == "blocked"
+        assert any(
+            v["rule_id"] == "coding_packet_status_missing"
+            for v in d["violations"]
+        )
+
+    @pytest.mark.parametrize("status", ["KEEP_READY", "AUTO_SHIP_READY"])
+    def test_allowed_coding_packet_status_passes(self, status):
+        d = validate_ship_request(_valid_packet(coding_packet={"status": status}))
+        assert d["validation_result"] == "passed"
+
+    def test_top_level_coding_packet_status_passes(self):
+        packet = _valid_packet(coding_packet_status="KEEP_READY")
+        del packet["coding_packet"]
+        d = validate_ship_request(packet)
+        assert d["validation_result"] == "passed"
+
+    def test_source_packet_coding_packet_status_passes(self):
+        packet = _valid_packet(source_packet={"coding_packet": {"status": "KEEP_READY"}})
+        del packet["coding_packet"]
+        d = validate_ship_request(packet)
+        assert d["validation_result"] == "passed"
+
+    def test_bad_coding_packet_status_blocked(self):
+        d = validate_ship_request(_valid_packet(coding_packet={"status": "REVIEW_READY"}))
+        assert d["validation_result"] == "blocked"
+        assert any(
+            v["rule_id"] == "coding_packet_status_not_allowed"
+            for v in d["violations"]
+        )
+
     def test_release_gate_must_be_approve_auto_ship(self):
         for verdict in ("HOLD", "REVIEW_READY", "REJECT", "APPROVE", "OBSERVE"):
             d = validate_ship_request(_valid_packet(release_gate_result=verdict))
@@ -184,7 +222,8 @@ class TestValueGates:
             d = validate_ship_request(_valid_packet(automation_claim_status=bad))
             if bad == "child_invoked_with_handle":
                 # child_invoked_with_handle is NOT in v0 allowlist
-                # (allowlist: child_attached_with_handle, parent_completed_with_handle, direct_packet_with_handle)
+                # (allowlist: child_attached_with_handle,
+                # parent_completed_with_handle, direct_packet_with_handle)
                 assert d["validation_result"] == "blocked"
             else:
                 assert d["validation_result"] == "blocked"

--- a/tests/test_auto_ship.py
+++ b/tests/test_auto_ship.py
@@ -1,0 +1,385 @@
+"""Tests for ``workflow.auto_ship.validate_ship_request`` (PR #198 Phase 1).
+
+Covers the auto-ship safety envelope from
+``docs/milestones/auto-ship-canary-v0.md`` §6:
+  - §6.1 required packet fields + value gates
+  - §6.2 allowed ship classes + allowed/forbidden path prefixes
+  - §6.3 diff-size / binary / secret checks
+
+Phase 1 is dry-run only — ``ship_status`` is always ``"skipped"`` and
+``would_open_pr`` carries the actual passed/blocked signal.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from workflow.auto_ship import (
+    ALLOWED_PATH_PREFIXES,
+    ALLOWED_SHIP_CLASSES,
+    DIFF_SIZE_BYTES_MAX,
+    FORBIDDEN_PATH_PREFIXES,
+    KEEP_SCORE_MIN,
+    validate_ship_request,
+)
+
+
+def _valid_packet(**overrides) -> dict:
+    """Minimal packet that passes the envelope. Tests override fields to force
+    specific failures."""
+    base = {
+        "release_gate_result": "APPROVE_AUTO_SHIP",
+        "ship_class": "docs_canary",
+        "child_keep_reject_decision": "KEEP",
+        "child_score": 9.5,
+        "risk_level": "low",
+        "blocked_execution_record": {},
+        "stable_evidence_handle": "child_run:branch-x:run-y",
+        "automation_claim_status": "child_attached_with_handle",
+        "rollback_plan": "Revert commit <sha> or close PR if not merged",
+        "changed_paths": ["docs/autoship-canaries/first-loop-autoship.md"],
+        "diff": "+ added a timestamp\n- old timestamp\n",
+    }
+    base.update(overrides)
+    return base
+
+
+# ── Phase-1 dry-run shape contract ────────────────────────────────────────
+
+
+class TestPhase1Contract:
+    def test_dry_run_always_set(self):
+        d = validate_ship_request(_valid_packet())
+        assert d["dry_run"] is True
+
+    def test_ship_status_always_skipped_in_phase_1(self):
+        d_pass = validate_ship_request(_valid_packet())
+        d_fail = validate_ship_request(_valid_packet(release_gate_result="HOLD"))
+        assert d_pass["ship_status"] == "skipped"
+        assert d_fail["ship_status"] == "skipped"
+
+    def test_passed_decision_keys(self):
+        d = validate_ship_request(_valid_packet())
+        assert d["validation_result"] == "passed"
+        assert d["would_open_pr"] is True
+        assert d["violations"] == []
+        assert d["rollback_handle"].startswith("revert:")
+
+    def test_blocked_decision_keys(self):
+        d = validate_ship_request(_valid_packet(release_gate_result="HOLD"))
+        assert d["validation_result"] == "blocked"
+        assert d["would_open_pr"] is False
+        assert len(d["violations"]) >= 1
+        assert d["rollback_handle"] is None
+
+
+# ── Top-level packet shape ────────────────────────────────────────────────
+
+
+class TestPacketShape:
+    @pytest.mark.parametrize("not_a_dict", [None, "", 42, [], "{}"])
+    def test_non_dict_packet_blocked(self, not_a_dict):
+        d = validate_ship_request(not_a_dict)
+        assert d["validation_result"] == "blocked"
+        assert any(v["rule_id"] == "packet_not_dict" for v in d["violations"])
+
+    def test_empty_packet_blocks_with_required_field_violations(self):
+        d = validate_ship_request({})
+        assert d["validation_result"] == "blocked"
+        rule_ids = {v["rule_id"] for v in d["violations"]}
+        assert any(rid.startswith("required_field_missing:") for rid in rule_ids)
+
+
+# ── §6.1 required fields ──────────────────────────────────────────────────
+
+
+class TestRequiredFields:
+    @pytest.mark.parametrize("missing_field", [
+        "release_gate_result",
+        "ship_class",
+        "child_keep_reject_decision",
+        "stable_evidence_handle",
+        "automation_claim_status",
+        "rollback_plan",
+    ])
+    def test_each_required_field_when_missing(self, missing_field):
+        packet = _valid_packet()
+        del packet[missing_field]
+        d = validate_ship_request(packet)
+        assert d["validation_result"] == "blocked"
+        rule = f"required_field_missing:{missing_field}"
+        assert any(v["rule_id"] == rule for v in d["violations"]), \
+            f"expected violation rule_id={rule!r}; got {[v['rule_id'] for v in d['violations']]}"
+
+    @pytest.mark.parametrize("missing_field", [
+        "release_gate_result",
+        "stable_evidence_handle",
+        "rollback_plan",
+    ])
+    def test_each_required_field_when_empty_string(self, missing_field):
+        d = validate_ship_request(_valid_packet(**{missing_field: ""}))
+        assert d["validation_result"] == "blocked"
+
+
+# ── §6.1 value gates ──────────────────────────────────────────────────────
+
+
+class TestValueGates:
+    def test_release_gate_must_be_approve_auto_ship(self):
+        for verdict in ("HOLD", "REVIEW_READY", "REJECT", "APPROVE", "OBSERVE"):
+            d = validate_ship_request(_valid_packet(release_gate_result=verdict))
+            assert d["validation_result"] == "blocked"
+            assert any(
+                v["rule_id"] == "release_gate_not_approved"
+                for v in d["violations"]
+            )
+
+    def test_child_decision_must_be_keep(self):
+        for decision in ("REVIEW_READY", "REJECT", "SEND_BACK"):
+            d = validate_ship_request(_valid_packet(child_keep_reject_decision=decision))
+            assert d["validation_result"] == "blocked"
+            assert any(
+                v["rule_id"] == "child_decision_not_keep"
+                for v in d["violations"]
+            )
+
+    def test_child_score_below_threshold_blocked(self):
+        d = validate_ship_request(_valid_packet(child_score=KEEP_SCORE_MIN - 0.1))
+        assert d["validation_result"] == "blocked"
+        assert any(
+            v["rule_id"] == "child_score_below_threshold"
+            for v in d["violations"]
+        )
+
+    def test_child_score_at_threshold_passes(self):
+        d = validate_ship_request(_valid_packet(child_score=KEEP_SCORE_MIN))
+        assert d["validation_result"] == "passed"
+
+    def test_child_score_non_numeric_blocked(self):
+        d = validate_ship_request(_valid_packet(child_score="9.5"))
+        assert d["validation_result"] == "blocked"
+        assert any(
+            v["rule_id"] == "child_score_not_numeric"
+            for v in d["violations"]
+        )
+
+    def test_risk_level_not_low_blocked(self):
+        for risk in ("medium", "high", "critical", "unknown"):
+            d = validate_ship_request(_valid_packet(risk_level=risk))
+            assert d["validation_result"] == "blocked"
+            assert any(
+                v["rule_id"] == "risk_level_not_low" for v in d["violations"]
+            )
+
+    def test_blocked_execution_record_nonempty_blocked(self):
+        d = validate_ship_request(_valid_packet(blocked_execution_record={"reason": "x"}))
+        assert d["validation_result"] == "blocked"
+        assert any(
+            v["rule_id"] == "blocked_execution_record_nonempty"
+            for v in d["violations"]
+        )
+
+    def test_automation_claim_status_must_be_in_allowlist(self):
+        for bad in ("no_execution_claim", "child_invoked_with_handle", "anything_else"):
+            d = validate_ship_request(_valid_packet(automation_claim_status=bad))
+            if bad == "child_invoked_with_handle":
+                # child_invoked_with_handle is NOT in v0 allowlist
+                # (allowlist: child_attached_with_handle, parent_completed_with_handle, direct_packet_with_handle)
+                assert d["validation_result"] == "blocked"
+            else:
+                assert d["validation_result"] == "blocked"
+            assert any(
+                v["rule_id"] == "automation_claim_status_not_allowed"
+                for v in d["violations"]
+            )
+
+
+# ── §6.2 ship class allowlist ─────────────────────────────────────────────
+
+
+class TestShipClass:
+    @pytest.mark.parametrize("good", sorted(ALLOWED_SHIP_CLASSES))
+    def test_each_allowed_ship_class_passes(self, good):
+        # Need to also adjust changed_paths to match the class
+        path_map = {
+            "docs_canary": "docs/autoship-canaries/x.md",
+            "metadata_canary": "workflow/autoship_canaries/x.json",
+            "test_fixture_canary": "tests/fixtures/autoship_canaries/x.json",
+        }
+        d = validate_ship_request(_valid_packet(
+            ship_class=good,
+            changed_paths=[path_map[good]],
+        ))
+        assert d["validation_result"] == "passed"
+
+    def test_runtime_ship_class_blocked(self):
+        d = validate_ship_request(_valid_packet(ship_class="runtime_change"))
+        assert d["validation_result"] == "blocked"
+        assert any(
+            v["rule_id"] == "ship_class_not_allowed" for v in d["violations"]
+        )
+
+
+# ── §6.2 path allowlist + §6.2 forbidden ──────────────────────────────────
+
+
+class TestPaths:
+    def test_empty_changed_paths_blocked(self):
+        d = validate_ship_request(_valid_packet(changed_paths=[]))
+        assert d["validation_result"] == "blocked"
+        assert any(
+            v["rule_id"] == "changed_paths_empty" for v in d["violations"]
+        )
+
+    def test_path_not_under_allowed_prefix_blocked(self):
+        d = validate_ship_request(_valid_packet(
+            changed_paths=["docs/random/path.md"]
+        ))
+        assert d["validation_result"] == "blocked"
+        assert any(
+            v["rule_id"] == "changed_path_not_allowed" for v in d["violations"]
+        )
+
+    @pytest.mark.parametrize("bad", FORBIDDEN_PATH_PREFIXES)
+    def test_each_forbidden_prefix_blocked(self, bad):
+        d = validate_ship_request(_valid_packet(
+            changed_paths=[f"{bad}foo.py"]
+        ))
+        assert d["validation_result"] == "blocked"
+        assert any(
+            v["rule_id"] == "changed_path_forbidden_prefix"
+            for v in d["violations"]
+        )
+
+    def test_forbidden_substring_env_blocked(self):
+        d = validate_ship_request(_valid_packet(
+            changed_paths=["docs/autoship-canaries/.env.example"]
+        ))
+        assert d["validation_result"] == "blocked"
+        assert any(
+            v["rule_id"] == "changed_path_forbidden_substring"
+            for v in d["violations"]
+        )
+
+    def test_forbidden_substring_secret_blocked(self):
+        d = validate_ship_request(_valid_packet(
+            changed_paths=["docs/autoship-canaries/secrets-doc.md"]
+        ))
+        assert d["validation_result"] == "blocked"
+
+    def test_path_normalization_does_not_let_forbidden_in(self):
+        # ``./workflow/api/x`` normalizes to ``workflow/api/x`` and must be blocked
+        d = validate_ship_request(_valid_packet(
+            changed_paths=["./workflow/api/something.py"]
+        ))
+        assert d["validation_result"] == "blocked"
+        assert any(
+            v["rule_id"] == "changed_path_forbidden_prefix"
+            for v in d["violations"]
+        )
+
+    def test_invalid_changed_path_entry_blocked(self):
+        d = validate_ship_request(_valid_packet(changed_paths=[None, ""]))
+        assert d["validation_result"] == "blocked"
+        assert sum(
+            1 for v in d["violations"] if v["rule_id"] == "changed_path_invalid"
+        ) == 2
+
+
+# ── §6.3 diff-content checks ──────────────────────────────────────────────
+
+
+class TestDiffContent:
+    def test_diff_under_size_cap_passes(self):
+        d = validate_ship_request(_valid_packet(diff="x" * (DIFF_SIZE_BYTES_MAX - 100)))
+        assert d["validation_result"] == "passed"
+
+    def test_diff_over_size_cap_blocked(self):
+        d = validate_ship_request(_valid_packet(diff="x" * (DIFF_SIZE_BYTES_MAX + 1)))
+        assert d["validation_result"] == "blocked"
+        assert any(
+            v["rule_id"] == "diff_too_large" for v in d["violations"]
+        )
+
+    def test_binary_content_blocked(self):
+        d = validate_ship_request(_valid_packet(diff="some text\0more text"))
+        assert d["validation_result"] == "blocked"
+        assert any(
+            v["rule_id"] == "diff_binary_content" for v in d["violations"]
+        )
+
+    def test_openai_secret_in_diff_blocked(self):
+        d = validate_ship_request(_valid_packet(
+            diff="+ OPENAI_KEY = sk-abc1234567890def1234567890\n"
+        ))
+        assert d["validation_result"] == "blocked"
+        assert any(
+            v["rule_id"] == "diff_secret_pattern" for v in d["violations"]
+        )
+
+    def test_aws_secret_in_diff_blocked(self):
+        d = validate_ship_request(_valid_packet(
+            diff="+ AWS_ACCESS = AKIAIOSFODNN7EXAMPLE\n"
+        ))
+        assert d["validation_result"] == "blocked"
+
+    def test_private_key_block_blocked(self):
+        d = validate_ship_request(_valid_packet(
+            diff="-----BEGIN RSA PRIVATE KEY-----\nfake\n"
+        ))
+        assert d["validation_result"] == "blocked"
+
+    def test_diff_non_string_blocked(self):
+        d = validate_ship_request(_valid_packet(diff=42))
+        assert d["validation_result"] == "blocked"
+        assert any(
+            v["rule_id"] == "diff_not_string" for v in d["violations"]
+        )
+
+
+# ── Rollback handle composition ───────────────────────────────────────────
+
+
+class TestRollbackHandle:
+    def test_handle_uses_rollback_plan_when_present(self):
+        d = validate_ship_request(_valid_packet(rollback_plan="Revert commit abc123"))
+        assert d["rollback_handle"] == "revert:Revert commit abc123"
+
+    def test_handle_falls_back_to_evidence_handle_for_auto_plan(self):
+        d = validate_ship_request(_valid_packet(
+            rollback_plan="auto",
+            stable_evidence_handle="child_run:b:r",
+        ))
+        assert "child_run:b:r" in d["rollback_handle"]
+
+
+# ── Aggregate violation reporting ─────────────────────────────────────────
+
+
+class TestAggregateReporting:
+    def test_multiple_violations_all_collected(self):
+        # Build a packet that violates several rules at once.
+        bad = {
+            "release_gate_result": "HOLD",
+            "ship_class": "runtime_change",
+            "child_keep_reject_decision": "REJECT",
+            "child_score": 1.0,
+            "risk_level": "high",
+            "blocked_execution_record": {"x": 1},
+            "stable_evidence_handle": "h",
+            "automation_claim_status": "no_execution_claim",
+            "rollback_plan": "rb",
+            "changed_paths": ["workflow/api/foo.py"],  # forbidden prefix
+            "diff": "x",
+        }
+        d = validate_ship_request(bad)
+        assert d["validation_result"] == "blocked"
+        rule_ids = {v["rule_id"] for v in d["violations"]}
+        # Spot-check we collected several distinct violations rather than bailing on first
+        assert "release_gate_not_approved" in rule_ids
+        assert "child_decision_not_keep" in rule_ids
+        assert "child_score_below_threshold" in rule_ids
+        assert "risk_level_not_low" in rule_ids
+        assert "ship_class_not_allowed" in rule_ids
+        assert "automation_claim_status_not_allowed" in rule_ids
+        assert "changed_path_forbidden_prefix" in rule_ids

--- a/workflow/auto_ship.py
+++ b/workflow/auto_ship.py
@@ -1,0 +1,419 @@
+"""Auto-ship dry-run shipper — PR #198 Phase 1.
+
+Pure-Python validator that runs a coding_packet (or constructed ship_request)
+through the auto-ship safety envelope from
+``docs/milestones/auto-ship-canary-v0.md`` §5.2, §6.1, §6.2, §6.3 and returns
+a structured ship_decision explaining whether the packet WOULD ship, why,
+and what rollback handle would be used.
+
+Phase 1 contract: NO repo writes, NO IO, NO network. Validator only.
+``ship_status`` is always ``"skipped"`` in this phase — the ``would_open_pr``
+field tells callers whether the packet PASSED the envelope. Phase 2 (PR-open
+mode) wires the actual repo operation behind a flag; Phase 3 enables
+auto-merge for narrow canary classes after one successful PR-open round.
+
+Pairs with:
+- ``docs/specs/loop-outcome-rubric-v0.md`` (PR #211) — defines what KEEP +
+  evidence-bundle-complete actually mean. The validator below enforces the
+  envelope; the rubric defines what packets ARE before the envelope sees them.
+- ``docs/milestones/auto-ship-canary-v0.md`` (PR #198) — milestone spec
+  this module implements one phase of.
+
+The shipper is the LAST enforcement layer. The release_gate may recommend
+auto-ship; the shipper is what actually decides whether the recommendation
+is safe enough to act on. Every check below is structural — no LLM in the
+loop, no prose interpretation.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# ── Envelope constants from auto-ship-canary-v0.md §6 ─────────────────────
+
+#: Ship classes allowed for v0 (§6.2). Any other class is blocked.
+ALLOWED_SHIP_CLASSES: frozenset[str] = frozenset({
+    "docs_canary",
+    "metadata_canary",
+    "test_fixture_canary",
+})
+
+#: Path prefixes a v0 canary patch may touch (§6.2). Forbidden paths win on conflict.
+ALLOWED_PATH_PREFIXES: tuple[str, ...] = (
+    "docs/autoship-canaries/",
+    "workflow/autoship_canaries/",
+    "tests/fixtures/autoship_canaries/",
+)
+
+#: Path prefixes that must NEVER auto-ship (§6.2). Even matches against an allowed
+#: prefix get rejected if any forbidden prefix also matches — defense in depth.
+FORBIDDEN_PATH_PREFIXES: tuple[str, ...] = (
+    "workflow/runtime/",
+    "workflow/providers/",
+    "workflow/api/",
+    "workflow/wiki/",
+    "workflow/dispatcher/",
+    ".github/",
+    "scripts/deploy/",
+    "migrations/",
+)
+
+#: Forbidden substring patterns in a path (§6.2). Case-insensitive match.
+FORBIDDEN_PATH_SUBSTRINGS: tuple[str, ...] = (
+    ".env",
+    "secret",
+    "auth",
+)
+
+#: Required packet fields (§6.1) that must hold a non-empty value.
+REQUIRED_FIELDS_NONEMPTY: tuple[str, ...] = (
+    "release_gate_result",
+    "ship_class",
+    "child_keep_reject_decision",
+    "stable_evidence_handle",
+    "automation_claim_status",
+    "rollback_plan",
+)
+
+#: Allowed values for automation_claim_status (§6.1).
+ALLOWED_AUTOMATION_CLAIM_STATUS: frozenset[str] = frozenset({
+    "child_attached_with_handle",
+    "parent_completed_with_handle",
+    "direct_packet_with_handle",
+})
+
+#: Minimum child_score for KEEP (§6.1 + rubric §5).
+KEEP_SCORE_MIN: float = 9.0
+
+#: Maximum diff size in bytes for a v0 canary patch.
+#: Tight bound on purpose — canary patches should be a few lines, not a refactor.
+DIFF_SIZE_BYTES_MAX: int = 8 * 1024  # 8 KB
+
+#: Heuristic regex patterns flagging probable secrets in diff content.
+#: Conservative — false positives are tolerable; false negatives ship secrets.
+SECRET_REGEX_PATTERNS: tuple[str, ...] = (
+    r"sk-[A-Za-z0-9_-]{20,}",          # OpenAI / Anthropic style
+    r"AIza[A-Za-z0-9_-]{35}",          # Google API
+    r"ghp_[A-Za-z0-9]{36}",            # GitHub PAT (classic)
+    r"github_pat_[A-Za-z0-9_]{22,}",   # GitHub PAT (fine-grained)
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----",  # PEM private keys
+    r"xox[baprs]-[A-Za-z0-9-]{10,}",   # Slack tokens
+    r"AKIA[0-9A-Z]{16}",               # AWS access key id
+)
+
+
+def _normalize_path(path: str) -> str:
+    """Cheap path normalization — strip literal leading ``./``, collapse ``//``,
+    NO symlink resolution (caller's responsibility if needed).
+
+    Defense against trivially-encoded forbidden paths like ``./workflow/api/x``
+    or ``workflow//api/x``. Real symlink resolution happens upstream — this is
+    just structural normalization. Note: uses ``removeprefix`` (Python 3.9+)
+    rather than ``lstrip`` so paths like ``.github/x`` (which start with a dot
+    but not the literal ``./`` prefix) are preserved verbatim — otherwise the
+    forbidden-prefix check would miss them.
+    """
+    if not path:
+        return ""
+    p = path
+    # Strip literal "./" prefix if present (do not strip ".github/" -> "github/").
+    while p.startswith("./"):
+        p = p[2:]
+    while "//" in p:
+        p = p.replace("//", "/")
+    return p
+
+
+def _path_violations(changed_paths: list[str]) -> list[dict[str, Any]]:
+    """Return one violation record per (path, rule) violation. Empty if clean."""
+    out: list[dict[str, Any]] = []
+    if not isinstance(changed_paths, list):
+        return [{
+            "rule_id": "changed_paths_not_list",
+            "field": "changed_paths",
+            "severity": "block",
+            "message": (
+                f"changed_paths must be a list of strings; got {type(changed_paths).__name__}"
+            ),
+        }]
+    if not changed_paths:
+        out.append({
+            "rule_id": "changed_paths_empty",
+            "field": "changed_paths",
+            "severity": "block",
+            "message": "changed_paths is empty — auto-ship requires at least one path",
+        })
+    for raw_path in changed_paths:
+        if not isinstance(raw_path, str) or not raw_path:
+            out.append({
+                "rule_id": "changed_path_invalid",
+                "field": "changed_paths",
+                "severity": "block",
+                "message": f"changed_paths entry is not a non-empty string: {raw_path!r}",
+            })
+            continue
+        normalized = _normalize_path(raw_path)
+        lower = normalized.lower()
+        # Forbidden first — wins even if also matches an allowed prefix.
+        for forbidden in FORBIDDEN_PATH_PREFIXES:
+            if normalized.startswith(forbidden):
+                out.append({
+                    "rule_id": "changed_path_forbidden_prefix",
+                    "field": "changed_paths",
+                    "severity": "block",
+                    "message": (
+                        f"path {raw_path!r} starts with forbidden prefix "
+                        f"{forbidden!r} — auto-ship cannot touch this surface"
+                    ),
+                })
+                break
+        for sub in FORBIDDEN_PATH_SUBSTRINGS:
+            if sub in lower:
+                out.append({
+                    "rule_id": "changed_path_forbidden_substring",
+                    "field": "changed_paths",
+                    "severity": "block",
+                    "message": (
+                        f"path {raw_path!r} contains forbidden substring "
+                        f"{sub!r} (env / secret / auth surface)"
+                    ),
+                })
+                break
+        # Allowed-prefix check (only if not already forbidden).
+        if not any(normalized.startswith(p) for p in ALLOWED_PATH_PREFIXES):
+            out.append({
+                "rule_id": "changed_path_not_allowed",
+                "field": "changed_paths",
+                "severity": "block",
+                "message": (
+                    f"path {raw_path!r} is not under any allowed canary prefix "
+                    f"({', '.join(ALLOWED_PATH_PREFIXES)})"
+                ),
+            })
+    return out
+
+
+def _diff_violations(diff: str) -> list[dict[str, Any]]:
+    """Diff-size, binary, and secret checks (§6.3)."""
+    out: list[dict[str, Any]] = []
+    if not isinstance(diff, str):
+        return [{
+            "rule_id": "diff_not_string",
+            "field": "diff",
+            "severity": "block",
+            "message": f"diff must be a string; got {type(diff).__name__}",
+        }]
+    if len(diff.encode("utf-8")) > DIFF_SIZE_BYTES_MAX:
+        out.append({
+            "rule_id": "diff_too_large",
+            "field": "diff",
+            "severity": "block",
+            "message": (
+                f"diff is {len(diff.encode('utf-8'))} bytes; v0 canary cap is "
+                f"{DIFF_SIZE_BYTES_MAX} bytes"
+            ),
+        })
+    if "\0" in diff:
+        out.append({
+            "rule_id": "diff_binary_content",
+            "field": "diff",
+            "severity": "block",
+            "message": "diff contains a null byte — auto-ship rejects binary content",
+        })
+    for pat in SECRET_REGEX_PATTERNS:
+        if re.search(pat, diff):
+            out.append({
+                "rule_id": "diff_secret_pattern",
+                "field": "diff",
+                "severity": "block",
+                "message": (
+                    "diff matched a heuristic secret pattern — auto-ship "
+                    "blocks. False positive? Manually review before shipping."
+                ),
+            })
+            # Don't break — we want all matches recorded for audit.
+    return out
+
+
+def validate_ship_request(packet: dict[str, Any]) -> dict[str, Any]:
+    """Run the auto-ship safety envelope on ``packet``. Returns a ship_decision dict.
+
+    Pure: no IO, no network, no repo writes. Caller decides what to do with
+    the decision.
+
+    Decision shape::
+
+        {
+            "ship_status": "skipped",        # always "skipped" in Phase 1 (dry-run)
+            "would_open_pr": bool,           # True iff envelope passed
+            "validation_result": "passed" | "blocked",
+            "violations": list[dict],        # rule violations; empty when passed
+            "rollback_handle": str | None,   # "revert:<plan>" when passed; None when blocked
+            "dry_run": True,                 # always True in Phase 1
+        }
+
+    Each violation record::
+
+        {
+            "rule_id": str,        # short stable identifier for the rule
+            "field": str | None,   # packet field that violated, when applicable
+            "severity": "block",   # all envelope violations are blocking in v0
+            "message": str,        # human-readable explanation
+        }
+
+    The validator is conservative: it BLOCKS on any unmet rule. There is no
+    "warning" tier in v0 — anything that doesn't pass cannot ship.
+    """
+    if not isinstance(packet, dict):
+        return {
+            "ship_status": "skipped",
+            "would_open_pr": False,
+            "validation_result": "blocked",
+            "violations": [{
+                "rule_id": "packet_not_dict",
+                "field": None,
+                "severity": "block",
+                "message": (
+                    f"packet must be a dict; got {type(packet).__name__}"
+                ),
+            }],
+            "rollback_handle": None,
+            "dry_run": True,
+        }
+
+    violations: list[dict[str, Any]] = []
+
+    # §6.1 — required packet fields must be present + non-empty
+    for field in REQUIRED_FIELDS_NONEMPTY:
+        value = packet.get(field)
+        if value is None or value == "":
+            violations.append({
+                "rule_id": f"required_field_missing:{field}",
+                "field": field,
+                "severity": "block",
+                "message": f"packet is missing required field {field!r}",
+            })
+
+    # §6.1 — field-value gates (only checked when field is present)
+    if packet.get("release_gate_result") not in (None, ""):
+        if packet["release_gate_result"] != "APPROVE_AUTO_SHIP":
+            violations.append({
+                "rule_id": "release_gate_not_approved",
+                "field": "release_gate_result",
+                "severity": "block",
+                "message": (
+                    f"release_gate_result must be 'APPROVE_AUTO_SHIP'; got "
+                    f"{packet['release_gate_result']!r}"
+                ),
+            })
+
+    if packet.get("child_keep_reject_decision") not in (None, ""):
+        if packet["child_keep_reject_decision"] != "KEEP":
+            violations.append({
+                "rule_id": "child_decision_not_keep",
+                "field": "child_keep_reject_decision",
+                "severity": "block",
+                "message": (
+                    f"child_keep_reject_decision must be 'KEEP'; got "
+                    f"{packet['child_keep_reject_decision']!r}"
+                ),
+            })
+
+    if "child_score" in packet:
+        score = packet["child_score"]
+        if not isinstance(score, (int, float)):
+            violations.append({
+                "rule_id": "child_score_not_numeric",
+                "field": "child_score",
+                "severity": "block",
+                "message": f"child_score must be numeric; got {type(score).__name__}",
+            })
+        elif score < KEEP_SCORE_MIN:
+            violations.append({
+                "rule_id": "child_score_below_threshold",
+                "field": "child_score",
+                "severity": "block",
+                "message": (
+                    f"child_score {score} below KEEP threshold {KEEP_SCORE_MIN}"
+                ),
+            })
+
+    if "risk_level" in packet and packet["risk_level"] != "low":
+        violations.append({
+            "rule_id": "risk_level_not_low",
+            "field": "risk_level",
+            "severity": "block",
+            "message": (
+                f"risk_level must be 'low' for v0 canary; got {packet['risk_level']!r}"
+            ),
+        })
+
+    if "blocked_execution_record" in packet and packet["blocked_execution_record"] != {}:
+        violations.append({
+            "rule_id": "blocked_execution_record_nonempty",
+            "field": "blocked_execution_record",
+            "severity": "block",
+            "message": (
+                "blocked_execution_record must be empty dict — packet has unresolved "
+                "execution blocks"
+            ),
+        })
+
+    if packet.get("automation_claim_status") not in (None, ""):
+        if packet["automation_claim_status"] not in ALLOWED_AUTOMATION_CLAIM_STATUS:
+            violations.append({
+                "rule_id": "automation_claim_status_not_allowed",
+                "field": "automation_claim_status",
+                "severity": "block",
+                "message": (
+                    f"automation_claim_status {packet['automation_claim_status']!r} "
+                    f"not in allowlist ({', '.join(sorted(ALLOWED_AUTOMATION_CLAIM_STATUS))})"
+                ),
+            })
+
+    # §6.2 — ship class
+    if packet.get("ship_class") not in (None, ""):
+        if packet["ship_class"] not in ALLOWED_SHIP_CLASSES:
+            violations.append({
+                "rule_id": "ship_class_not_allowed",
+                "field": "ship_class",
+                "severity": "block",
+                "message": (
+                    f"ship_class {packet['ship_class']!r} not in v0 allowlist "
+                    f"({', '.join(sorted(ALLOWED_SHIP_CLASSES))})"
+                ),
+            })
+
+    # §6.2 — path checks
+    violations.extend(_path_violations(packet.get("changed_paths", [])))
+
+    # §6.3 — diff-content checks
+    violations.extend(_diff_violations(packet.get("diff", "")))
+
+    # Decision
+    if violations:
+        return {
+            "ship_status": "skipped",
+            "would_open_pr": False,
+            "validation_result": "blocked",
+            "violations": violations,
+            "rollback_handle": None,
+            "dry_run": True,
+        }
+
+    # Passed — compute rollback handle from packet
+    rollback_plan = packet.get("rollback_plan", "")
+    handle_target = (
+        rollback_plan
+        if rollback_plan and rollback_plan != "auto"
+        else packet.get("stable_evidence_handle", "unknown")
+    )
+    return {
+        "ship_status": "skipped",  # Phase 1 is dry-run only
+        "would_open_pr": True,
+        "validation_result": "passed",
+        "violations": [],
+        "rollback_handle": f"revert:{handle_target}",
+        "dry_run": True,
+    }

--- a/workflow/auto_ship.py
+++ b/workflow/auto_ship.py
@@ -71,6 +71,9 @@ REQUIRED_FIELDS_NONEMPTY: tuple[str, ...] = (
     "release_gate_result",
     "ship_class",
     "child_keep_reject_decision",
+    "child_score",
+    "risk_level",
+    "blocked_execution_record",
     "stable_evidence_handle",
     "automation_claim_status",
     "rollback_plan",
@@ -81,6 +84,12 @@ ALLOWED_AUTOMATION_CLAIM_STATUS: frozenset[str] = frozenset({
     "child_attached_with_handle",
     "parent_completed_with_handle",
     "direct_packet_with_handle",
+})
+
+#: Allowed coding_packet.status values for auto-ship (§6.1).
+ALLOWED_CODING_PACKET_STATUSES: frozenset[str] = frozenset({
+    "KEEP_READY",
+    "AUTO_SHIP_READY",
 })
 
 #: Minimum child_score for KEEP (§6.1 + rubric §5).
@@ -236,6 +245,29 @@ def _diff_violations(diff: str) -> list[dict[str, Any]]:
     return out
 
 
+def _coding_packet_status(packet: dict[str, Any]) -> Any:
+    """Extract coding_packet.status from supported packet shapes."""
+    coding_packet = packet.get("coding_packet")
+    if isinstance(coding_packet, dict):
+        status = coding_packet.get("status")
+        if status not in (None, ""):
+            return status
+
+    status = packet.get("coding_packet_status")
+    if status not in (None, ""):
+        return status
+
+    source_packet = packet.get("source_packet")
+    if isinstance(source_packet, dict):
+        source_coding_packet = source_packet.get("coding_packet")
+        if isinstance(source_coding_packet, dict):
+            status = source_coding_packet.get("status")
+            if status not in (None, ""):
+                return status
+
+    return None
+
+
 def validate_ship_request(packet: dict[str, Any]) -> dict[str, Any]:
     """Run the auto-ship safety envelope on ``packet``. Returns a ship_decision dict.
 
@@ -295,7 +327,29 @@ def validate_ship_request(packet: dict[str, Any]) -> dict[str, Any]:
                 "message": f"packet is missing required field {field!r}",
             })
 
-    # §6.1 — field-value gates (only checked when field is present)
+    # §6.1 — field-value gates
+    coding_packet_status = _coding_packet_status(packet)
+    if coding_packet_status in (None, ""):
+        violations.append({
+            "rule_id": "coding_packet_status_missing",
+            "field": "coding_packet.status",
+            "severity": "block",
+            "message": (
+                "coding_packet.status is required and must prove KEEP_READY "
+                "or AUTO_SHIP_READY before auto-ship"
+            ),
+        })
+    elif coding_packet_status not in ALLOWED_CODING_PACKET_STATUSES:
+        violations.append({
+            "rule_id": "coding_packet_status_not_allowed",
+            "field": "coding_packet.status",
+            "severity": "block",
+            "message": (
+                f"coding_packet.status {coding_packet_status!r} not in allowlist "
+                f"({', '.join(sorted(ALLOWED_CODING_PACKET_STATUSES))})"
+            ),
+        })
+
     if packet.get("release_gate_result") not in (None, ""):
         if packet["release_gate_result"] != "APPROVE_AUTO_SHIP":
             violations.append({


### PR DESCRIPTION
## Summary

Implements PR #198 (`docs/milestones/auto-ship-canary-v0.md`) Phase 1 — the auto-ship safety envelope as a pure-Python validator. No IO, no network, no repo writes. Returns a structured ship_decision dict explaining whether a coding_packet WOULD ship, why, and what rollback handle would be used.

## What it enforces (envelope §6)

| Check | Source | Behavior |
|---|---|---|
| Required packet fields present + non-empty | §6.1 | Block on any missing field |
| `release_gate_result == APPROVE_AUTO_SHIP` | §6.1 | Block any other verdict |
| `child_keep_reject_decision == KEEP` | §6.1 | Block REVIEW_READY/REJECT/SEND_BACK |
| `child_score >= 9.0` | §6.1 + Rubric §5 | Block under-threshold |
| `risk_level == low` | §6.1 | Block medium/high/critical |
| `blocked_execution_record == {}` | §6.1 | Block when execution gates have unresolved blocks |
| `automation_claim_status` in `{child_attached_with_handle, parent_completed_with_handle, direct_packet_with_handle}` | §6.1 | Block other values (incl. `child_invoked_with_handle` from BUG-051) |
| `ship_class` in v0 allowlist | §6.2 | Block runtime/migration/etc |
| `changed_paths` subset of allowed prefixes | §6.2 | Block any path outside docs/autoship-canaries/** etc |
| No forbidden path prefixes | §6.2 | Block workflow/runtime/**, workflow/api/**, .github/**, etc |
| No forbidden path substrings | §6.2 | Block .env, secret, auth in path |
| Diff size <= 8 KB | §6.3 | Cap canary patches tight |
| No binary content | §6.3 | Block null bytes |
| No heuristic secrets | §6.3 | Block OpenAI/AWS/GitHub PAT/PEM patterns |

All violations are blocking. No warning tier in v0 — anything that doesn't pass cannot ship.

## What it returns

```python
{
    "ship_status": "skipped",        # always "skipped" in Phase 1 (dry-run)
    "would_open_pr": bool,           # True iff envelope passed
    "validation_result": "passed" | "blocked",
    "violations": list[dict],        # rule violations; empty when passed
    "rollback_handle": str | None,   # "revert:<plan>" when passed; None when blocked
    "dry_run": True,                 # always True in Phase 1
}
```

Each violation: `{rule_id, field, severity, message}`.

## Tests (55 cases, all passing)

`tests/test_auto_ship.py` covers:
- Phase-1 contract (`dry_run` always set; `ship_status` always `"skipped"`)
- Top-level packet shape (non-dict blocked, empty packet enumerates required fields)
- Each of 6 required fields when missing + when empty-string
- Each value gate (release_gate, child_decision, child_score boundary + non-numeric, risk_level, blocked_execution_record, automation_claim_status)
- Each allowed ship_class passes; non-allowlist class blocked
- Each of 8 forbidden path prefixes blocked
- Path normalization (`./workflow/api/x` blocks correctly; `.github/x` blocks correctly — defends against `lstrip("./") `bug)
- Diff size cap boundary (just-under passes, just-over blocks)
- Binary content + multiple secret-pattern flavors (OpenAI, AWS, GitHub PAT, PEM)
- Rollback handle composition (uses `rollback_plan`; falls back to `evidence_handle` when `rollback_plan == "auto"`)
- Aggregate reporting (multi-violation packet collects ALL violations, doesn't bail on first)

## Why this is the right next move

Every recent loop run has surfaced the same gap:
- BUG-049/050/051: REVIEW_READY (loop produces packets, can't ship them)
- BUG-052: REJECT (loop refuses to claim KEEP without runtime evidence)
- FEAT-* runs: similar stuck-at-design pattern

The loop reasons but cannot do. This PR is the first piece of the substrate that lets the loop's candidate patches flow toward an actual PR. Phase 1 (this PR) ensures the envelope is structural and tested. Phase 2 wires the actual repo operation behind a flag. Phase 3 enables auto-merge for narrow canary classes after one successful PR-open round.

## Risk

Pure validator. No IO. No repo writes. Cannot ship anything in Phase 1 — the `ship_status` field is always `"skipped"`. Only effect on the system: the `validate_ship_request` function exists and is importable. No call sites added; release_safety_gate / coding_dispatch are not modified. Phase 2 will wire the call sites.

## Sequencing

This is the precondition for any subsequent ship attempt. Phase 2 (PR-open mode) and Phase 3 (auto-merge canaries) both call `validate_ship_request` first. Lands cleanly without coordination — no other open PR depends on it, and it doesn't change behavior of any current path.

## Source

Authored by Cowork session post-loop-iteration evolution work. Spec source: `docs/milestones/auto-ship-canary-v0.md` (PR #198, merged a3e6ec4). Pairs with PR #211 (`docs/specs/loop-outcome-rubric-v0.md`) which defines what KEEP + evidence-bundle-complete actually mean.
