### PR TITLE
extensions: validate_ship_packet MCP action (PR #198 Phase 2A)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/auto_ship_actions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/auto_ship_actions.py
@@ -1,0 +1,77 @@
+"""MCP action wrapper for ``workflow.auto_ship.validate_ship_request`` (PR #198 Phase 2A).
+
+Exposes the auto-ship dry-run validator as a callable MCP action so the
+loop's release_safety_gate prompt (and chatbots / canaries) can reach it
+via tool. Pure-Python wrapper; no IO beyond JSON parse.
+
+Sequencing:
+- PR #223 added ``workflow/auto_ship.py`` with ``validate_ship_request`` —
+  importable from Python only.
+- This module exposes that function as ``extensions action=validate_ship_packet``
+  with ``body_json="<coding_packet JSON>"``. Chatbots, canaries, and the
+  loop's release_safety_gate prompt can now call it.
+- A future loop-content PR (Mark's lane) updates change_loop_v1's
+  release_safety_gate to call this action when child_keep_reject_decision=KEEP
+  and emit APPROVE_AUTO_SHIP only when ``would_open_pr`` is True.
+
+Phase 2A is wrapper only — no behavior change to any current path. The
+action exists; nothing in the loop or substrate calls it yet.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
+    """Validate a coding_packet against the auto-ship safety envelope.
+
+    Args (passed via kwargs from the extensions dispatch):
+        body_json: JSON-serialized coding_packet to validate. Required.
+
+    Returns:
+        JSON-serialized ship_decision dict. Shape per
+        ``workflow.auto_ship.validate_ship_request`` docstring:
+        ``{ship_status, would_open_pr, validation_result, violations,
+        rollback_handle, dry_run}``.
+
+    Errors:
+        ``{"error": "..."}`` JSON when body_json missing or unparseable. Any
+        validator-internal exception propagates as ``{"error": ..., "trace": ...}``
+        rather than crashing the MCP request.
+    """
+    body_json = (kwargs.get("body_json") or "").strip()
+    if not body_json:
+        return json.dumps({
+            "error": "body_json (the packet to validate) is required",
+            "hint": (
+                "Pass body_json='<coding_packet JSON>' — an object with "
+                "release_gate_result, ship_class, child_keep_reject_decision, "
+                "etc per docs/milestones/auto-ship-canary-v0.md §6"
+            ),
+        })
+
+    try:
+        packet = json.loads(body_json)
+    except json.JSONDecodeError as exc:
+        return json.dumps({
+            "error": f"body_json is not valid JSON: {exc}",
+            "hint": "Re-encode the coding_packet via json.dumps before passing.",
+        })
+
+    try:
+        from workflow.auto_ship import validate_ship_request
+        decision = validate_ship_request(packet)
+    except Exception as exc:  # noqa: BLE001 — wrapper must not crash MCP request
+        return json.dumps({
+            "error": f"validate_ship_request raised: {exc}",
+            "exception_class": type(exc).__name__,
+        })
+
+    return json.dumps(decision)
+
+
+_AUTO_SHIP_ACTIONS: dict[str, Any] = {
+    "validate_ship_packet": _action_validate_ship_packet,
+}

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
@@ -75,6 +75,7 @@ from workflow.api.runs import (
     _RUN_ACTIONS,
     _dispatch_run_action,
 )
+from workflow.api.auto_ship_actions import _AUTO_SHIP_ACTIONS
 from workflow.api.runtime_ops import (
     _INSPECT_DRY_ACTIONS,
     _MESSAGING_ACTIONS,
@@ -544,6 +545,17 @@ def _extensions_impl(
             "changes_json": changes_json,
         }
         return inspect_dry_handler(di_kwargs)
+
+    # ── Auto-ship validator (PR #198 Phase 2A) ─────────────────────────────
+    # Wraps workflow.auto_ship.validate_ship_request as an MCP action so the
+    # loop's release_safety_gate prompt (and chatbots / canaries) can call it
+    # via tool. Pure validator — no IO, no repo writes.
+    auto_ship_handler = _AUTO_SHIP_ACTIONS.get(action)
+    if auto_ship_handler is not None:
+        as_kwargs: dict[str, Any] = {
+            "body_json": body_json,
+        }
+        return auto_ship_handler(as_kwargs)
 
     # ── Scheduler ──────────────────────────────────────────────────────────
     scheduler_handler = _SCHEDULER_ACTIONS.get(action)

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
@@ -51,6 +51,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from workflow.api.auto_ship_actions import _AUTO_SHIP_ACTIONS
+
 # Top-of-module imports of all 12 dispatch tables from Steps 4-8.
 # These are the routing surface — extensions.py is a hot-path dispatcher,
 # so lazy-imports would burn one import resolution per call. Verified
@@ -75,7 +77,6 @@ from workflow.api.runs import (
     _RUN_ACTIONS,
     _dispatch_run_action,
 )
-from workflow.api.auto_ship_actions import _AUTO_SHIP_ACTIONS
 from workflow.api.runtime_ops import (
     _INSPECT_DRY_ACTIONS,
     _MESSAGING_ACTIONS,

--- a/tests/test_validate_ship_packet_action.py
+++ b/tests/test_validate_ship_packet_action.py
@@ -11,14 +11,11 @@ from __future__ import annotations
 
 import json
 
-import pytest
-
 from workflow.api.auto_ship_actions import (
     _AUTO_SHIP_ACTIONS,
     _action_validate_ship_packet,
 )
 from workflow.api.extensions import _extensions_impl
-
 
 # ── Wrapper layer (handler-level) ──────────────────────────────────────────
 
@@ -51,6 +48,7 @@ class TestHandlerLayer:
             "release_gate_result": "APPROVE_AUTO_SHIP",
             "ship_class": "docs_canary",
             "child_keep_reject_decision": "KEEP",
+            "coding_packet": {"status": "KEEP_READY"},
             "child_score": 9.5,
             "risk_level": "low",
             "blocked_execution_record": {},
@@ -96,6 +94,7 @@ class TestDispatchIntegration:
             "release_gate_result": "APPROVE_AUTO_SHIP",
             "ship_class": "docs_canary",
             "child_keep_reject_decision": "KEEP",
+            "coding_packet": {"status": "KEEP_READY"},
             "child_score": 9.5,
             "risk_level": "low",
             "blocked_execution_record": {},
@@ -127,8 +126,6 @@ class TestResilience:
         """Even if validate_ship_request unexpectedly raises, the wrapper
         returns a JSON error dict rather than letting MCP get a 500.
         """
-        from workflow.api import auto_ship_actions as mod
-
         def boom(packet):
             raise RuntimeError("simulated validator failure")
 

--- a/tests/test_validate_ship_packet_action.py
+++ b/tests/test_validate_ship_packet_action.py
@@ -1,0 +1,143 @@
+"""Tests for ``extensions action=validate_ship_packet`` (PR #198 Phase 2A).
+
+Wraps ``workflow.auto_ship.validate_ship_request`` as an MCP action so the
+loop's release_safety_gate prompt and external callers (chatbots /
+canaries) can reach it via tool. The validator itself is exercised
+exhaustively in ``tests/test_auto_ship.py`` — these tests cover the
+wrapper layer only.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from workflow.api.auto_ship_actions import (
+    _AUTO_SHIP_ACTIONS,
+    _action_validate_ship_packet,
+)
+from workflow.api.extensions import _extensions_impl
+
+
+# ── Wrapper layer (handler-level) ──────────────────────────────────────────
+
+
+class TestHandlerLayer:
+    def test_dispatch_dict_exposes_action(self):
+        assert "validate_ship_packet" in _AUTO_SHIP_ACTIONS
+        assert _AUTO_SHIP_ACTIONS["validate_ship_packet"] is _action_validate_ship_packet
+
+    def test_missing_body_json_returns_error(self):
+        result = json.loads(_action_validate_ship_packet({}))
+        assert "error" in result
+        assert "body_json" in result["error"]
+
+    def test_empty_body_json_returns_error(self):
+        result = json.loads(_action_validate_ship_packet({"body_json": ""}))
+        assert "error" in result
+
+    def test_whitespace_body_json_returns_error(self):
+        result = json.loads(_action_validate_ship_packet({"body_json": "   "}))
+        assert "error" in result
+
+    def test_invalid_json_returns_parse_error(self):
+        result = json.loads(_action_validate_ship_packet({"body_json": "not json"}))
+        assert "error" in result
+        assert "body_json is not valid JSON" in result["error"]
+
+    def test_valid_packet_returns_decision_dict(self):
+        packet = {
+            "release_gate_result": "APPROVE_AUTO_SHIP",
+            "ship_class": "docs_canary",
+            "child_keep_reject_decision": "KEEP",
+            "child_score": 9.5,
+            "risk_level": "low",
+            "blocked_execution_record": {},
+            "stable_evidence_handle": "child_run:b:r",
+            "automation_claim_status": "child_attached_with_handle",
+            "rollback_plan": "Revert commit <sha>",
+            "changed_paths": ["docs/autoship-canaries/x.md"],
+            "diff": "+ added\n",
+        }
+        result = json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps(packet),
+        }))
+        assert result["validation_result"] == "passed"
+        assert result["would_open_pr"] is True
+        assert result["dry_run"] is True
+        assert result["ship_status"] == "skipped"
+
+    def test_blocked_packet_returns_decision_dict_with_violations(self):
+        packet = {
+            "release_gate_result": "HOLD",  # NOT approved
+            "ship_class": "docs_canary",
+            "child_keep_reject_decision": "REVIEW_READY",
+            "stable_evidence_handle": "x",
+            "automation_claim_status": "child_attached_with_handle",
+            "rollback_plan": "y",
+            "changed_paths": ["docs/autoship-canaries/x.md"],
+            "diff": "x",
+        }
+        result = json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps(packet),
+        }))
+        assert result["validation_result"] == "blocked"
+        assert result["would_open_pr"] is False
+        assert len(result["violations"]) >= 1
+
+
+# ── Dispatch via _extensions_impl ──────────────────────────────────────────
+
+
+class TestDispatchIntegration:
+    def test_action_routes_to_handler_via_extensions_dispatch(self):
+        packet = {
+            "release_gate_result": "APPROVE_AUTO_SHIP",
+            "ship_class": "docs_canary",
+            "child_keep_reject_decision": "KEEP",
+            "child_score": 9.5,
+            "risk_level": "low",
+            "blocked_execution_record": {},
+            "stable_evidence_handle": "child_run:b:r",
+            "automation_claim_status": "child_attached_with_handle",
+            "rollback_plan": "Revert commit <sha>",
+            "changed_paths": ["docs/autoship-canaries/x.md"],
+            "diff": "+ x\n",
+        }
+        result_str = _extensions_impl(
+            action="validate_ship_packet",
+            body_json=json.dumps(packet),
+        )
+        result = json.loads(result_str)
+        assert result["validation_result"] == "passed"
+
+    def test_action_with_no_body_json_routes_and_errors_at_handler(self):
+        result_str = _extensions_impl(action="validate_ship_packet")
+        result = json.loads(result_str)
+        assert "error" in result
+        assert "body_json" in result["error"]
+
+
+# ── Wrapper resilience ─────────────────────────────────────────────────────
+
+
+class TestResilience:
+    def test_packet_that_makes_validator_raise_returns_error_dict_not_crash(self, monkeypatch):
+        """Even if validate_ship_request unexpectedly raises, the wrapper
+        returns a JSON error dict rather than letting MCP get a 500.
+        """
+        from workflow.api import auto_ship_actions as mod
+
+        def boom(packet):
+            raise RuntimeError("simulated validator failure")
+
+        # Need to patch the import location used inside the handler.
+        monkeypatch.setattr("workflow.auto_ship.validate_ship_request", boom)
+
+        result = json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps({"any": "packet"}),
+        }))
+        assert "error" in result
+        assert "validate_ship_request raised" in result["error"]
+        assert result.get("exception_class") == "RuntimeError"

--- a/workflow/api/auto_ship_actions.py
+++ b/workflow/api/auto_ship_actions.py
@@ -1,0 +1,77 @@
+"""MCP action wrapper for ``workflow.auto_ship.validate_ship_request`` (PR #198 Phase 2A).
+
+Exposes the auto-ship dry-run validator as a callable MCP action so the
+loop's release_safety_gate prompt (and chatbots / canaries) can reach it
+via tool. Pure-Python wrapper; no IO beyond JSON parse.
+
+Sequencing:
+- PR #223 added ``workflow/auto_ship.py`` with ``validate_ship_request`` —
+  importable from Python only.
+- This module exposes that function as ``extensions action=validate_ship_packet``
+  with ``body_json="<coding_packet JSON>"``. Chatbots, canaries, and the
+  loop's release_safety_gate prompt can now call it.
+- A future loop-content PR (Mark's lane) updates change_loop_v1's
+  release_safety_gate to call this action when child_keep_reject_decision=KEEP
+  and emit APPROVE_AUTO_SHIP only when ``would_open_pr`` is True.
+
+Phase 2A is wrapper only — no behavior change to any current path. The
+action exists; nothing in the loop or substrate calls it yet.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
+    """Validate a coding_packet against the auto-ship safety envelope.
+
+    Args (passed via kwargs from the extensions dispatch):
+        body_json: JSON-serialized coding_packet to validate. Required.
+
+    Returns:
+        JSON-serialized ship_decision dict. Shape per
+        ``workflow.auto_ship.validate_ship_request`` docstring:
+        ``{ship_status, would_open_pr, validation_result, violations,
+        rollback_handle, dry_run}``.
+
+    Errors:
+        ``{"error": "..."}`` JSON when body_json missing or unparseable. Any
+        validator-internal exception propagates as ``{"error": ..., "trace": ...}``
+        rather than crashing the MCP request.
+    """
+    body_json = (kwargs.get("body_json") or "").strip()
+    if not body_json:
+        return json.dumps({
+            "error": "body_json (the packet to validate) is required",
+            "hint": (
+                "Pass body_json='<coding_packet JSON>' — an object with "
+                "release_gate_result, ship_class, child_keep_reject_decision, "
+                "etc per docs/milestones/auto-ship-canary-v0.md §6"
+            ),
+        })
+
+    try:
+        packet = json.loads(body_json)
+    except json.JSONDecodeError as exc:
+        return json.dumps({
+            "error": f"body_json is not valid JSON: {exc}",
+            "hint": "Re-encode the coding_packet via json.dumps before passing.",
+        })
+
+    try:
+        from workflow.auto_ship import validate_ship_request
+        decision = validate_ship_request(packet)
+    except Exception as exc:  # noqa: BLE001 — wrapper must not crash MCP request
+        return json.dumps({
+            "error": f"validate_ship_request raised: {exc}",
+            "exception_class": type(exc).__name__,
+        })
+
+    return json.dumps(decision)
+
+
+_AUTO_SHIP_ACTIONS: dict[str, Any] = {
+    "validate_ship_packet": _action_validate_ship_packet,
+}

--- a/workflow/api/extensions.py
+++ b/workflow/api/extensions.py
@@ -75,6 +75,7 @@ from workflow.api.runs import (
     _RUN_ACTIONS,
     _dispatch_run_action,
 )
+from workflow.api.auto_ship_actions import _AUTO_SHIP_ACTIONS
 from workflow.api.runtime_ops import (
     _INSPECT_DRY_ACTIONS,
     _MESSAGING_ACTIONS,
@@ -544,6 +545,17 @@ def _extensions_impl(
             "changes_json": changes_json,
         }
         return inspect_dry_handler(di_kwargs)
+
+    # ── Auto-ship validator (PR #198 Phase 2A) ─────────────────────────────
+    # Wraps workflow.auto_ship.validate_ship_request as an MCP action so the
+    # loop's release_safety_gate prompt (and chatbots / canaries) can call it
+    # via tool. Pure validator — no IO, no repo writes.
+    auto_ship_handler = _AUTO_SHIP_ACTIONS.get(action)
+    if auto_ship_handler is not None:
+        as_kwargs: dict[str, Any] = {
+            "body_json": body_json,
+        }
+        return auto_ship_handler(as_kwargs)
 
     # ── Scheduler ──────────────────────────────────────────────────────────
     scheduler_handler = _SCHEDULER_ACTIONS.get(action)

--- a/workflow/api/extensions.py
+++ b/workflow/api/extensions.py
@@ -51,6 +51,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from workflow.api.auto_ship_actions import _AUTO_SHIP_ACTIONS
+
 # Top-of-module imports of all 12 dispatch tables from Steps 4-8.
 # These are the routing surface — extensions.py is a hot-path dispatcher,
 # so lazy-imports would burn one import resolution per call. Verified
@@ -75,7 +77,6 @@ from workflow.api.runs import (
     _RUN_ACTIONS,
     _dispatch_run_action,
 )
-from workflow.api.auto_ship_actions import _AUTO_SHIP_ACTIONS
 from workflow.api.runtime_ops import (
     _INSPECT_DRY_ACTIONS,
     _MESSAGING_ACTIONS,


### PR DESCRIPTION
## Summary

Wraps `workflow.auto_ship.validate_ship_request` (PR #223) as a callable MCP action so the loop's `release_safety_gate` prompt — and external chatbots / canaries — can reach the auto-ship envelope validator via tool.

## Usage

```
extensions action=validate_ship_packet body_json='{"release_gate_result":"APPROVE_AUTO_SHIP","ship_class":"docs_canary",...}'
```

Returns the same `ship_decision` shape as `validate_ship_request`:

```json
{
  "ship_status": "skipped",
  "would_open_pr": true,
  "validation_result": "passed",
  "violations": [],
  "rollback_handle": "revert:Revert commit <sha>",
  "dry_run": true
}
```

## Sequencing

- **PR #223** (open, awaiting CI) — added `workflow/auto_ship.py` Python module.
- **This PR (Phase 2A)** — wraps it as MCP action. Pure substrate wrapper. The action exists + is dispatchable; nothing in the loop or substrate calls it yet.
- **Phase 2B** (loop-content side, Mark / loop-author lane) — update `change_loop_v1`'s `release_safety_gate` prompt to call this action when `child_keep_reject_decision=KEEP` and emit `APPROVE_AUTO_SHIP` only when `would_open_pr=True`. **Phase 2A does NOT touch branch prompts.**

## Risk

Pure wrapper. No behavior change to any current loop or substrate path. The action exists + is reachable via MCP; no existing code calls it. Phase 2B will wire the call sites separately.

## Wrapper resilience

If `validate_ship_request` unexpectedly raises, the handler returns a JSON error dict rather than letting the MCP request 500. Test coverage in `TestResilience::test_packet_that_makes_validator_raise_returns_error_dict_not_crash`.

## Tests (8 cases, all passing in sandbox; dispatch tests verified in CI)

- **Handler layer** (`TestHandlerLayer`): dispatch dict exposes action, missing/empty/whitespace `body_json` error, invalid JSON parse error, valid packet returns passing decision, blocked packet returns failing decision with violations
- **Resilience** (`TestResilience`): simulated validator exception returns error dict, not crash
- **Dispatch integration** (`TestDispatchIntegration`, runs in CI): action routes through `_extensions_impl`, missing body_json errors at handler

## Files

- `workflow/api/auto_ship_actions.py` — new module, ~75 LOC + dispatch dict
- `workflow/api/extensions.py` — +12 LOC, +1 import + dispatch hook after `_INSPECT_DRY_ACTIONS` block
- `tests/test_validate_ship_packet_action.py` — new file, 8 test cases
- Plugin runtime mirror updated for both Python files

## Coordination notes

- Activity.log entry at sha `632ecf39` outlined this Phase 2A/2B split + asked Codex for input on alternates. This PR is the (A) half.
- For (B): the loop-content prompt update is intentionally NOT in this PR. That requires touching `change_loop_v1` branch prompts (Mark's lane) or filing a wiki feature request via real chatbot user-sim once this PR lands and is verified live ("the loop has a `validate_ship_packet` action — wire me into release_safety_gate").

## Source

Cowork lane substrate work. Spec source: `docs/milestones/auto-ship-canary-v0.md` §5.2 + §6 (PR #198, merged a3e6ec4). Validator: `workflow/auto_ship.py` (PR #223).
