### PR TITLE
auto_ship_ledger: append-only attempts store (PR #198 §8 Slice A)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auto_ship_ledger.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auto_ship_ledger.py
@@ -1,0 +1,444 @@
+"""Auto-ship attempts ledger — PR #198 §8 (option-2 Slice A).
+
+Append-only structured store for ship attempts. Every call into
+``workflow.auto_ship.validate_ship_request`` that produces a final
+ship_decision should be recorded here so that:
+
+1. The loop's release_safety_gate has an audit trail of every packet it
+   accepted/rejected.
+2. The post-merge observation gate (PR #198 §5.2 + §10 Phase 4 — Slice
+   B / ``observation_gate_result``) can join PR opens back to the
+   original validation that approved them.
+3. Rollback decisions (Slice C) can locate the rollback_handle that was
+   recorded when the attempt was approved.
+
+Storage: ``<universe_path>/auto_ship_attempts.jsonl`` — one
+``ShipAttempt`` per line. Append-on-create, full read-modify-write on
+update. This matches the ``branch_tasks.json`` precedent: small file,
+race-safe via sidecar ``.lock``, no schema migration cost. We can
+graduate to sqlite later if attempt volume warrants.
+
+Spec source:
+- ``docs/milestones/auto-ship-canary-v0.md`` §8 Evidence record (field
+  list + suggested artifact paths)
+- ``docs/milestones/auto-ship-canary-v0.md`` §10 Phase 1/2/3 (which
+  ship_status transitions are valid in which phase)
+
+Phase 1 contract: a successful ``validate_ship_request`` records an
+attempt with ``ship_status="skipped"`` and ``would_open_pr=true``. A
+blocked validation records ``ship_status="blocked"`` and the violations
+in ``error_message``. No PR is ever opened from this module — Phase 2
+will mutate ``ship_status`` to ``"opened"`` once it lands, then to
+``"merged"`` or ``"failed"`` depending on CI + merge result.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import secrets
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+
+LEDGER_FILENAME = "auto_ship_attempts.jsonl"
+LOCK_FILENAME = "auto_ship_attempts.jsonl.lock"
+
+#: Valid ``ship_status`` values across Phase 1-3 (§10).
+VALID_SHIP_STATUSES: frozenset[str] = frozenset({
+    "skipped",   # Phase 1 — validator passed but no PR open requested
+    "blocked",   # validator blocked — error_class+error_message set
+    "opened",    # Phase 2 — PR opened, awaiting CI/merge
+    "merged",    # Phase 3 — PR merged, observation window starts
+    "failed",    # PR opened but CI failed or merge rejected
+    "rolled_back",  # Slice C — observation gate triggered a revert PR
+})
+
+#: Mutable fields ``update_attempt`` is allowed to change after creation.
+#: ``ship_attempt_id`` and ``created_at`` are immutable; everything else
+#: in the schema may evolve as the attempt advances through phases.
+MUTABLE_FIELDS: frozenset[str] = frozenset({
+    "ship_status",
+    "pr_url",
+    "commit_sha",
+    "ci_status",
+    "rollback_handle",
+    "stable_evidence_handle",
+    "updated_at",
+    "error_class",
+    "error_message",
+    "observation_status",
+    "observation_status_at",
+})
+
+
+@dataclass
+class ShipAttempt:
+    """One row in the auto-ship attempts ledger.
+
+    Field naming matches ``docs/milestones/auto-ship-canary-v0.md`` §8
+    exactly so committed-artifact JSON (the per-attempt evidence file)
+    can be derived from this row without renames.
+
+    A few extension fields beyond the §8 list are present so Slice B
+    (observation gate) and Slice C (rollback) don't have to widen the
+    schema later:
+
+    - ``observation_status`` / ``observation_status_at`` — the post-merge
+      health verdict from the observation gate (§5.2 Phase 4).
+    - ``would_open_pr`` — the validator's Phase 1 verdict, distinct from
+      ``ship_status`` so a Phase 1 ``skipped`` row still records whether
+      it WOULD have opened a PR if Phase 2 had been live.
+
+    Defaults are ``""`` for strings and ``None`` for optional sub-fields
+    so empty-row JSON has stable shape for diff review.
+    """
+
+    ship_attempt_id: str
+    created_at: str
+    updated_at: str
+    ship_status: str
+    request_id: str = ""
+    parent_run_id: str = ""
+    child_run_id: str = ""
+    branch_def_id: str = ""
+    release_gate_result: str = ""
+    ship_class: str = ""
+    pr_url: str = ""
+    commit_sha: str = ""
+    changed_paths_json: str = ""
+    ci_status: str = ""
+    rollback_handle: str = ""
+    stable_evidence_handle: str = ""
+    error_class: str = ""
+    error_message: str = ""
+    would_open_pr: bool = False
+    observation_status: str = ""
+    observation_status_at: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, row: dict) -> "ShipAttempt":
+        # Forward-compat: ignore unknown keys so an older runtime can
+        # still read newer rows.
+        known = {f for f in cls.__dataclass_fields__}
+        clean = {k: v for k, v in row.items() if k in known}
+        return cls(**clean)
+
+
+# ── ID generation ─────────────────────────────────────────────────────────
+
+
+def new_attempt_id(*, now: datetime | None = None) -> str:
+    """Stable ``ship_<YYYYMMDD>_<8hex>`` identifier matching §8 example.
+
+    The hex tail is from ``secrets.token_hex(4)`` so two attempts
+    minted in the same UTC second do not collide. Test code can
+    inject ``now`` to make IDs deterministic.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    return f"ship_{now.strftime('%Y%m%d')}_{secrets.token_hex(4)}"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ── Paths ────────────────────────────────────────────────────────────────
+
+
+def ledger_path(universe_path: Path) -> Path:
+    return Path(universe_path) / LEDGER_FILENAME
+
+
+def _lock_path(universe_path: Path) -> Path:
+    return Path(universe_path) / LOCK_FILENAME
+
+
+# ── File lock (mirrors workflow.branch_tasks._file_lock) ──────────────────
+
+
+@contextlib.contextmanager
+def _file_lock(universe_path: Path) -> Iterator[None]:
+    """Cross-platform exclusive lock on a sidecar ``.lock`` file.
+
+    Same primitive as ``workflow.branch_tasks._file_lock`` — kept as a
+    private mirror rather than importing it because the lock is
+    namespaced to ``auto_ship_attempts.jsonl.lock``, not to the queue
+    file. Two concurrent ledger writes serialize; ledger writes do
+    NOT serialize against branch_tasks writes (they touch different
+    files anyway).
+    """
+    Path(universe_path).mkdir(parents=True, exist_ok=True)
+    lock_file = _lock_path(universe_path)
+    fd = os.open(str(lock_file), os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        if sys.platform == "win32":
+            import msvcrt
+            while True:
+                try:
+                    msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                    break
+                except OSError:
+                    time.sleep(0.05)
+        else:
+            import fcntl
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if sys.platform == "win32":
+                import msvcrt
+                try:
+                    os.lseek(fd, 0, 0)
+                    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+                except OSError:
+                    pass
+            else:
+                import fcntl
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                except OSError:
+                    pass
+    finally:
+        os.close(fd)
+
+
+# ── Read / write primitives ──────────────────────────────────────────────
+
+
+def _read_raw(lp: Path) -> list[dict]:
+    """Read all rows from the JSONL file. Returns [] if missing or empty.
+
+    Skips blank lines silently. Raises ``RuntimeError`` on a malformed
+    JSON line — Hard Rule 8 (no silent fallback on corrupt data).
+    """
+    if not lp.exists():
+        return []
+    rows: list[dict] = []
+    with lp.open("r", encoding="utf-8") as fh:
+        for lineno, line in enumerate(fh, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise RuntimeError(
+                    f"Corrupt ledger row at {lp}:{lineno}: {exc}"
+                ) from exc
+            if not isinstance(row, dict):
+                raise RuntimeError(
+                    f"Ledger row at {lp}:{lineno} is not a JSON object"
+                )
+            rows.append(row)
+    return rows
+
+
+def _write_raw(lp: Path, rows: list[dict]) -> None:
+    """Atomic temp+rename rewrite of the entire ledger.
+
+    Used by ``update_attempt``. ``record_attempt`` uses a true append
+    instead so it does not have to re-serialize the whole file.
+    """
+    lp.parent.mkdir(parents=True, exist_ok=True)
+    tmp = lp.with_suffix(lp.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, default=str))
+            fh.write("\n")
+    os.replace(tmp, lp)
+
+
+# ── Public API ───────────────────────────────────────────────────────────
+
+
+def read_attempts(
+    universe_path: Path,
+    *,
+    limit: int | None = None,
+    ship_status: str | None = None,
+) -> list[ShipAttempt]:
+    """File-locked read. Returns [] on missing file.
+
+    ``limit`` returns the most recent N attempts (tail); ``ship_status``
+    filters to that status only. Both filters apply if both are given;
+    ``limit`` is applied AFTER ``ship_status`` so callers can ask for
+    "the last 10 merged attempts" cleanly.
+    """
+    lp = ledger_path(universe_path)
+    with _file_lock(universe_path):
+        raw = _read_raw(lp)
+    attempts = [ShipAttempt.from_dict(row) for row in raw]
+    if ship_status is not None:
+        attempts = [a for a in attempts if a.ship_status == ship_status]
+    if limit is not None:
+        attempts = attempts[-limit:]
+    return attempts
+
+
+def find_attempt(
+    universe_path: Path, ship_attempt_id: str,
+) -> ShipAttempt | None:
+    """File-locked lookup by ship_attempt_id. Returns None if not found."""
+    lp = ledger_path(universe_path)
+    with _file_lock(universe_path):
+        raw = _read_raw(lp)
+    for row in raw:
+        if row.get("ship_attempt_id") == ship_attempt_id:
+            return ShipAttempt.from_dict(row)
+    return None
+
+
+def record_attempt(universe_path: Path, attempt: ShipAttempt) -> None:
+    """File-locked append. Validates ``ship_status``; stamps timestamps
+    if missing.
+
+    Raises ``ValueError`` on invalid ``ship_status`` or duplicate
+    ``ship_attempt_id``. Duplicate detection is by full read so the
+    ledger can be modest (~1k rows) before the read becomes a
+    bottleneck; at that point graduate to sqlite.
+    """
+    if attempt.ship_status not in VALID_SHIP_STATUSES:
+        raise ValueError(
+            f"Invalid ship_status {attempt.ship_status!r}; allowed: "
+            f"{', '.join(sorted(VALID_SHIP_STATUSES))}"
+        )
+    if not attempt.ship_attempt_id:
+        raise ValueError("ship_attempt_id is required")
+    if not attempt.created_at:
+        attempt.created_at = _now_iso()
+    if not attempt.updated_at:
+        attempt.updated_at = attempt.created_at
+
+    lp = ledger_path(universe_path)
+    with _file_lock(universe_path):
+        raw = _read_raw(lp)
+        for row in raw:
+            if row.get("ship_attempt_id") == attempt.ship_attempt_id:
+                raise ValueError(
+                    f"ship_attempt_id {attempt.ship_attempt_id!r} already "
+                    f"recorded — use update_attempt to mutate"
+                )
+        # True append, no full rewrite — JSONL's main ergonomic win.
+        lp.parent.mkdir(parents=True, exist_ok=True)
+        with lp.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(attempt.to_dict(), default=str))
+            fh.write("\n")
+
+
+def update_attempt(
+    universe_path: Path,
+    ship_attempt_id: str,
+    **fields,
+) -> ShipAttempt:
+    """File-locked read-modify-write update of one row.
+
+    ``fields`` may only contain keys in ``MUTABLE_FIELDS``. ``updated_at``
+    is auto-stamped to the current time on every successful update;
+    callers do not need to pass it.
+
+    Raises ``KeyError`` if no row with that ``ship_attempt_id`` exists.
+    Raises ``ValueError`` on attempt to mutate an immutable field or
+    set ``ship_status`` to an invalid value.
+    """
+    illegal = set(fields) - MUTABLE_FIELDS
+    if illegal:
+        raise ValueError(
+            f"Cannot mutate immutable field(s): {', '.join(sorted(illegal))}"
+        )
+    if "ship_status" in fields and fields["ship_status"] not in VALID_SHIP_STATUSES:
+        raise ValueError(
+            f"Invalid ship_status {fields['ship_status']!r}; allowed: "
+            f"{', '.join(sorted(VALID_SHIP_STATUSES))}"
+        )
+
+    lp = ledger_path(universe_path)
+    with _file_lock(universe_path):
+        raw = _read_raw(lp)
+        for idx, row in enumerate(raw):
+            if row.get("ship_attempt_id") == ship_attempt_id:
+                row.update({k: v for k, v in fields.items() if k != "updated_at"})
+                row["updated_at"] = fields.get("updated_at") or _now_iso()
+                raw[idx] = row
+                _write_raw(lp, raw)
+                return ShipAttempt.from_dict(row)
+        raise KeyError(
+            f"ship_attempt_id {ship_attempt_id!r} not found in ledger at {lp}"
+        )
+
+
+# ── Convenience constructor for the common Phase 1 path ──────────────────
+
+
+def attempt_from_decision(
+    *,
+    decision: dict,
+    request_id: str = "",
+    parent_run_id: str = "",
+    child_run_id: str = "",
+    branch_def_id: str = "",
+    release_gate_result: str = "",
+    ship_class: str = "",
+    changed_paths: list[str] | None = None,
+    stable_evidence_handle: str = "",
+    now: datetime | None = None,
+) -> ShipAttempt:
+    """Build a ``ShipAttempt`` row from a ``validate_ship_request``
+    decision plus the call-site context the validator does not see.
+
+    Phase 1 caller expectation:
+
+    >>> dec = validate_ship_request(packet)
+    >>> row = attempt_from_decision(
+    ...     decision=dec,
+    ...     request_id=packet.get("request_id", ""),
+    ...     parent_run_id=packet.get("parent_run_id", ""),
+    ...     ship_class=packet.get("ship_class", ""),
+    ...     changed_paths=packet.get("changed_paths", []),
+    ...     release_gate_result=packet.get("release_gate_result", ""),
+    ...     stable_evidence_handle=packet.get("stable_evidence_handle", ""),
+    ... )
+    >>> record_attempt(universe_path, row)
+
+    Phase 2 then calls ``update_attempt`` to fill ``pr_url`` and flip
+    ``ship_status`` to ``"opened"``.
+    """
+    ts = (now or datetime.now(timezone.utc)).isoformat()
+    if decision.get("validation_result") == "passed":
+        ship_status = "skipped"
+        error_class = ""
+        error_message = ""
+    else:
+        ship_status = "blocked"
+        violations = decision.get("violations", [])
+        error_class = (
+            ",".join(sorted({v.get("rule_id", "") for v in violations}))
+            if violations else "blocked"
+        )
+        error_message = json.dumps(violations, default=str)
+    return ShipAttempt(
+        ship_attempt_id=new_attempt_id(now=now),
+        created_at=ts,
+        updated_at=ts,
+        ship_status=ship_status,
+        request_id=request_id,
+        parent_run_id=parent_run_id,
+        child_run_id=child_run_id,
+        branch_def_id=branch_def_id,
+        release_gate_result=release_gate_result,
+        ship_class=ship_class,
+        changed_paths_json=json.dumps(changed_paths or []),
+        rollback_handle=decision.get("rollback_handle", "") or "",
+        stable_evidence_handle=stable_evidence_handle,
+        would_open_pr=bool(decision.get("would_open_pr")),
+        error_class=error_class,
+        error_message=error_message,
+    )

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auto_ship_ledger.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auto_ship_ledger.py
@@ -40,7 +40,7 @@ import os
 import secrets
 import sys
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator
@@ -280,6 +280,8 @@ def read_attempts(
     if ship_status is not None:
         attempts = [a for a in attempts if a.ship_status == ship_status]
     if limit is not None:
+        if limit <= 0:
+            return []
         attempts = attempts[-limit:]
     return attempts
 

--- a/tests/test_auto_ship_ledger.py
+++ b/tests/test_auto_ship_ledger.py
@@ -37,7 +37,6 @@ from workflow.auto_ship_ledger import (
     update_attempt,
 )
 
-
 # ── ID generation ─────────────────────────────────────────────────────────
 
 
@@ -200,6 +199,17 @@ def test_read_attempts_limit_returns_tail(tmp_path: Path):
         ))
     last3 = read_attempts(tmp_path, limit=3)
     assert [r.ship_attempt_id for r in last3] == ["ship_07", "ship_08", "ship_09"]
+
+
+def test_read_attempts_limit_zero_returns_empty(tmp_path: Path):
+    for i in range(3):
+        record_attempt(tmp_path, ShipAttempt(
+            ship_attempt_id=f"ship_{i:02d}",
+            created_at="",
+            updated_at="",
+            ship_status="skipped",
+        ))
+    assert read_attempts(tmp_path, limit=0) == []
 
 
 def test_read_attempts_filter_then_limit(tmp_path: Path):

--- a/tests/test_auto_ship_ledger.py
+++ b/tests/test_auto_ship_ledger.py
@@ -1,0 +1,498 @@
+"""Tests for ``workflow.auto_ship_ledger`` (PR #198 §8 — Slice A).
+
+Spec source: ``docs/milestones/auto-ship-canary-v0.md`` §8.
+
+Coverage:
+- ID generation shape + collision resistance
+- ``ShipAttempt`` dataclass round-trip + forward-compat (unknown keys)
+- ``record_attempt`` happy path + duplicate detection + status validation
+- ``update_attempt`` mutable-only enforcement + auto updated_at + KeyError
+- ``read_attempts`` filters (ship_status + limit) + missing file = []
+- Concurrent appenders via threads — file lock contract
+- Corrupt JSONL row raises ``RuntimeError`` (Hard Rule 8 — no silent skip)
+- ``attempt_from_decision`` Phase 1 conversion (passed → skipped, blocked
+  → blocked + violations encoded in error_message)
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from workflow.auto_ship_ledger import (
+    LEDGER_FILENAME,
+    MUTABLE_FIELDS,
+    VALID_SHIP_STATUSES,
+    ShipAttempt,
+    attempt_from_decision,
+    find_attempt,
+    ledger_path,
+    new_attempt_id,
+    read_attempts,
+    record_attempt,
+    update_attempt,
+)
+
+
+# ── ID generation ─────────────────────────────────────────────────────────
+
+
+def test_new_attempt_id_shape_matches_spec_example():
+    fixed = datetime(2026, 5, 2, 0, 0, 0, tzinfo=timezone.utc)
+    aid = new_attempt_id(now=fixed)
+    assert aid.startswith("ship_20260502_"), aid
+    # spec example shows 8-hex tail (token_hex(4))
+    assert len(aid.split("_")[-1]) == 8
+
+
+def test_new_attempt_id_unique_in_same_second():
+    fixed = datetime(2026, 5, 2, 0, 0, 0, tzinfo=timezone.utc)
+    ids = {new_attempt_id(now=fixed) for _ in range(200)}
+    # 200 calls in the same second should not collide — token_hex(4) is
+    # 32 bits of entropy, birthday bound is ~64K.
+    assert len(ids) == 200
+
+
+# ── ShipAttempt round-trip ────────────────────────────────────────────────
+
+
+def test_shipattempt_to_from_dict_round_trip():
+    a = ShipAttempt(
+        ship_attempt_id="ship_x",
+        created_at="2026-05-02T00:00:00+00:00",
+        updated_at="2026-05-02T00:00:00+00:00",
+        ship_status="skipped",
+        request_id="REQ-1",
+        ship_class="docs_canary",
+        would_open_pr=True,
+    )
+    d = a.to_dict()
+    a2 = ShipAttempt.from_dict(d)
+    assert a == a2
+
+
+def test_shipattempt_from_dict_ignores_unknown_keys():
+    """Forward compat — older runtime should still read newer rows."""
+    row = {
+        "ship_attempt_id": "ship_x",
+        "created_at": "2026-05-02T00:00:00+00:00",
+        "updated_at": "2026-05-02T00:00:00+00:00",
+        "ship_status": "skipped",
+        "future_field_we_dont_know_yet": "ignored",
+    }
+    a = ShipAttempt.from_dict(row)
+    assert a.ship_attempt_id == "ship_x"
+
+
+# ── record_attempt ────────────────────────────────────────────────────────
+
+
+def test_record_attempt_creates_file(tmp_path: Path):
+    a = ShipAttempt(
+        ship_attempt_id="ship_1",
+        created_at="",  # will be auto-stamped
+        updated_at="",
+        ship_status="skipped",
+    )
+    record_attempt(tmp_path, a)
+    lp = ledger_path(tmp_path)
+    assert lp.exists()
+    # JSONL — exactly one line
+    lines = lp.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    row = json.loads(lines[0])
+    assert row["ship_attempt_id"] == "ship_1"
+    assert row["created_at"]  # auto-stamped
+    assert row["updated_at"] == row["created_at"]
+
+
+def test_record_attempt_appends_not_rewrites(tmp_path: Path):
+    for i in range(3):
+        record_attempt(tmp_path, ShipAttempt(
+            ship_attempt_id=f"ship_{i}",
+            created_at="",
+            updated_at="",
+            ship_status="skipped",
+        ))
+    lp = ledger_path(tmp_path)
+    lines = lp.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 3
+
+
+def test_record_attempt_rejects_duplicate_id(tmp_path: Path):
+    a = ShipAttempt(
+        ship_attempt_id="ship_dup",
+        created_at="",
+        updated_at="",
+        ship_status="skipped",
+    )
+    record_attempt(tmp_path, a)
+    with pytest.raises(ValueError, match="already"):
+        record_attempt(tmp_path, a)
+
+
+def test_record_attempt_rejects_unknown_ship_status(tmp_path: Path):
+    a = ShipAttempt(
+        ship_attempt_id="ship_x",
+        created_at="",
+        updated_at="",
+        ship_status="garbage",
+    )
+    with pytest.raises(ValueError, match="Invalid ship_status"):
+        record_attempt(tmp_path, a)
+
+
+def test_record_attempt_rejects_empty_id(tmp_path: Path):
+    a = ShipAttempt(
+        ship_attempt_id="",
+        created_at="",
+        updated_at="",
+        ship_status="skipped",
+    )
+    with pytest.raises(ValueError, match="ship_attempt_id is required"):
+        record_attempt(tmp_path, a)
+
+
+# ── read_attempts ─────────────────────────────────────────────────────────
+
+
+def test_read_attempts_empty_when_missing(tmp_path: Path):
+    assert read_attempts(tmp_path) == []
+
+
+def test_read_attempts_returns_in_append_order(tmp_path: Path):
+    for i in range(5):
+        record_attempt(tmp_path, ShipAttempt(
+            ship_attempt_id=f"ship_{i}",
+            created_at="",
+            updated_at="",
+            ship_status="skipped",
+            request_id=f"R{i}",
+        ))
+    rows = read_attempts(tmp_path)
+    assert [r.ship_attempt_id for r in rows] == [f"ship_{i}" for i in range(5)]
+
+
+def test_read_attempts_ship_status_filter(tmp_path: Path):
+    for status, idx in [("skipped", 0), ("blocked", 1), ("skipped", 2)]:
+        record_attempt(tmp_path, ShipAttempt(
+            ship_attempt_id=f"ship_{idx}",
+            created_at="",
+            updated_at="",
+            ship_status=status,
+        ))
+    skipped = read_attempts(tmp_path, ship_status="skipped")
+    assert len(skipped) == 2
+    assert all(r.ship_status == "skipped" for r in skipped)
+
+
+def test_read_attempts_limit_returns_tail(tmp_path: Path):
+    for i in range(10):
+        record_attempt(tmp_path, ShipAttempt(
+            ship_attempt_id=f"ship_{i:02d}",
+            created_at="",
+            updated_at="",
+            ship_status="skipped",
+        ))
+    last3 = read_attempts(tmp_path, limit=3)
+    assert [r.ship_attempt_id for r in last3] == ["ship_07", "ship_08", "ship_09"]
+
+
+def test_read_attempts_filter_then_limit(tmp_path: Path):
+    for i in range(10):
+        status = "skipped" if i % 2 == 0 else "blocked"
+        record_attempt(tmp_path, ShipAttempt(
+            ship_attempt_id=f"ship_{i:02d}",
+            created_at="",
+            updated_at="",
+            ship_status=status,
+        ))
+    # 5 skipped rows; tail 2 = ship_06 and ship_08
+    last2_skipped = read_attempts(tmp_path, ship_status="skipped", limit=2)
+    assert [r.ship_attempt_id for r in last2_skipped] == ["ship_06", "ship_08"]
+
+
+def test_read_attempts_corrupt_row_raises(tmp_path: Path):
+    """Hard Rule 8 — no silent fallback on corrupt data."""
+    lp = ledger_path(tmp_path)
+    lp.parent.mkdir(parents=True, exist_ok=True)
+    lp.write_text(
+        '{"ship_attempt_id":"ship_a","created_at":"x","updated_at":"x",'
+        '"ship_status":"skipped"}\n'
+        'not-json\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(RuntimeError, match="Corrupt ledger row"):
+        read_attempts(tmp_path)
+
+
+def test_read_attempts_blank_lines_skipped(tmp_path: Path):
+    """Blank lines between rows must not crash — git autocrlf, editor
+    EOF newlines, etc. produce them."""
+    lp = ledger_path(tmp_path)
+    lp.parent.mkdir(parents=True, exist_ok=True)
+    lp.write_text(
+        '\n'
+        '{"ship_attempt_id":"ship_a","created_at":"x","updated_at":"x","ship_status":"skipped"}\n'
+        '\n'
+        '{"ship_attempt_id":"ship_b","created_at":"x","updated_at":"x","ship_status":"skipped"}\n'
+        '\n',
+        encoding="utf-8",
+    )
+    rows = read_attempts(tmp_path)
+    assert [r.ship_attempt_id for r in rows] == ["ship_a", "ship_b"]
+
+
+# ── find_attempt ─────────────────────────────────────────────────────────
+
+
+def test_find_attempt_returns_none_when_missing(tmp_path: Path):
+    assert find_attempt(tmp_path, "nope") is None
+
+
+def test_find_attempt_returns_row(tmp_path: Path):
+    record_attempt(tmp_path, ShipAttempt(
+        ship_attempt_id="ship_x",
+        created_at="",
+        updated_at="",
+        ship_status="skipped",
+        request_id="REQ-X",
+    ))
+    found = find_attempt(tmp_path, "ship_x")
+    assert found is not None
+    assert found.request_id == "REQ-X"
+
+
+# ── update_attempt ───────────────────────────────────────────────────────
+
+
+def test_update_attempt_mutates_allowed_field(tmp_path: Path):
+    record_attempt(tmp_path, ShipAttempt(
+        ship_attempt_id="ship_a",
+        created_at="2026-05-01T00:00:00+00:00",
+        updated_at="2026-05-01T00:00:00+00:00",
+        ship_status="skipped",
+    ))
+    upd = update_attempt(
+        tmp_path, "ship_a",
+        ship_status="opened", pr_url="https://github.com/x/y/pull/1",
+    )
+    assert upd.ship_status == "opened"
+    assert upd.pr_url == "https://github.com/x/y/pull/1"
+    # updated_at must bump; created_at must NOT
+    assert upd.created_at == "2026-05-01T00:00:00+00:00"
+    assert upd.updated_at != "2026-05-01T00:00:00+00:00"
+    # Persistence
+    rd = find_attempt(tmp_path, "ship_a")
+    assert rd is not None and rd.ship_status == "opened"
+
+
+def test_update_attempt_rejects_immutable_field(tmp_path: Path):
+    record_attempt(tmp_path, ShipAttempt(
+        ship_attempt_id="ship_a",
+        created_at="",
+        updated_at="",
+        ship_status="skipped",
+    ))
+    with pytest.raises(ValueError, match="immutable"):
+        update_attempt(tmp_path, "ship_a", request_id="changed")
+
+
+def test_update_attempt_rejects_changing_created_at(tmp_path: Path):
+    """created_at is in identity territory — once stamped at record
+    time, no caller may change it. Same protection as ship_attempt_id
+    (which Python's kwarg shadowing already protects)."""
+    record_attempt(tmp_path, ShipAttempt(
+        ship_attempt_id="ship_a",
+        created_at="",
+        updated_at="",
+        ship_status="skipped",
+    ))
+    with pytest.raises(ValueError, match="immutable"):
+        update_attempt(tmp_path, "ship_a", created_at="2026-01-01T00:00:00+00:00")
+
+
+def test_update_attempt_rejects_invalid_ship_status(tmp_path: Path):
+    record_attempt(tmp_path, ShipAttempt(
+        ship_attempt_id="ship_a",
+        created_at="",
+        updated_at="",
+        ship_status="skipped",
+    ))
+    with pytest.raises(ValueError, match="Invalid ship_status"):
+        update_attempt(tmp_path, "ship_a", ship_status="garbage")
+
+
+def test_update_attempt_raises_keyerror_on_missing(tmp_path: Path):
+    with pytest.raises(KeyError, match="not found"):
+        update_attempt(tmp_path, "no-such", ship_status="merged")
+
+
+def test_update_attempt_caller_provided_updated_at_is_honored(tmp_path: Path):
+    """Slice C / replay code may need to pin updated_at to a synthetic
+    timestamp instead of now()."""
+    record_attempt(tmp_path, ShipAttempt(
+        ship_attempt_id="ship_a",
+        created_at="",
+        updated_at="",
+        ship_status="skipped",
+    ))
+    pinned = "2026-05-02T12:00:00+00:00"
+    upd = update_attempt(
+        tmp_path, "ship_a",
+        ship_status="opened", updated_at=pinned,
+    )
+    assert upd.updated_at == pinned
+
+
+# ── concurrent append ───────────────────────────────────────────────────
+
+
+def test_concurrent_appends_serialize_via_lock(tmp_path: Path):
+    """Five threads each appending one row should produce exactly five
+    rows in total — no lost writes from racing on the file."""
+    errors: list[str] = []
+
+    def worker(idx: int):
+        try:
+            record_attempt(tmp_path, ShipAttempt(
+                ship_attempt_id=f"ship_{idx:02d}",
+                created_at="",
+                updated_at="",
+                ship_status="skipped",
+                request_id=f"R{idx}",
+            ))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"{idx}: {exc!r}")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert errors == [], errors
+    rows = read_attempts(tmp_path)
+    assert len({r.ship_attempt_id for r in rows}) == 5
+
+
+# ── attempt_from_decision (Phase 1 convenience) ─────────────────────────
+
+
+def test_attempt_from_decision_passed_becomes_skipped():
+    fixed = datetime(2026, 5, 3, 5, 30, 0, tzinfo=timezone.utc)
+    decision = {
+        "ship_status": "skipped",
+        "would_open_pr": True,
+        "validation_result": "passed",
+        "violations": [],
+        "rollback_handle": "revert:outcome:abc123",
+        "dry_run": True,
+    }
+    row = attempt_from_decision(
+        decision=decision,
+        request_id="REQ-1",
+        parent_run_id="run_1",
+        ship_class="docs_canary",
+        changed_paths=["docs/autoship-canaries/x.md"],
+        release_gate_result="APPROVE_AUTO_SHIP",
+        stable_evidence_handle="outcome:abc123",
+        now=fixed,
+    )
+    assert row.ship_status == "skipped"
+    assert row.would_open_pr is True
+    assert row.error_class == ""
+    assert row.error_message == ""
+    assert row.rollback_handle == "revert:outcome:abc123"
+    assert json.loads(row.changed_paths_json) == ["docs/autoship-canaries/x.md"]
+
+
+def test_attempt_from_decision_blocked_encodes_violations():
+    decision = {
+        "ship_status": "skipped",
+        "would_open_pr": False,
+        "validation_result": "blocked",
+        "violations": [
+            {"rule_id": "risk_level_not_low", "field": "risk_level"},
+            {"rule_id": "ship_class_not_allowed", "field": "ship_class"},
+        ],
+        "rollback_handle": None,
+        "dry_run": True,
+    }
+    row = attempt_from_decision(decision=decision)
+    assert row.ship_status == "blocked"
+    assert row.would_open_pr is False
+    # error_class is sorted unique rule_ids comma-joined
+    assert row.error_class == "risk_level_not_low,ship_class_not_allowed"
+    # Full violations preserved as JSON for downstream debugging
+    parsed = json.loads(row.error_message)
+    assert len(parsed) == 2
+    assert {v["rule_id"] for v in parsed} == {
+        "risk_level_not_low", "ship_class_not_allowed",
+    }
+
+
+def test_attempt_from_decision_blocked_with_no_violations_uses_fallback():
+    """Defensive: if validate_ship_request ever returns blocked but no
+    violations (shouldn't happen, but if the schema drifts), error_class
+    must still be non-empty so downstream filters work."""
+    decision = {
+        "ship_status": "skipped",
+        "would_open_pr": False,
+        "validation_result": "blocked",
+        "violations": [],
+        "rollback_handle": None,
+        "dry_run": True,
+    }
+    row = attempt_from_decision(decision=decision)
+    assert row.ship_status == "blocked"
+    assert row.error_class == "blocked"
+
+
+def test_attempt_from_decision_round_trip_through_record_and_read(tmp_path: Path):
+    """End-to-end: convert a real decision, persist, read back — schema
+    survives JSONL round-trip including the JSON-encoded fields."""
+    decision = {
+        "ship_status": "skipped",
+        "would_open_pr": True,
+        "validation_result": "passed",
+        "violations": [],
+        "rollback_handle": "revert:abc",
+        "dry_run": True,
+    }
+    row = attempt_from_decision(
+        decision=decision,
+        request_id="REQ-9",
+        ship_class="docs_canary",
+        changed_paths=["docs/autoship-canaries/foo.md", "docs/autoship-canaries/bar.md"],
+    )
+    record_attempt(tmp_path, row)
+    rd = find_attempt(tmp_path, row.ship_attempt_id)
+    assert rd is not None
+    assert rd.request_id == "REQ-9"
+    assert json.loads(rd.changed_paths_json) == [
+        "docs/autoship-canaries/foo.md", "docs/autoship-canaries/bar.md",
+    ]
+
+
+# ── public surface invariants ───────────────────────────────────────────
+
+
+def test_valid_ship_statuses_includes_all_phase_states():
+    for s in ("skipped", "blocked", "opened", "merged", "failed", "rolled_back"):
+        assert s in VALID_SHIP_STATUSES, s
+
+
+def test_mutable_fields_excludes_identity_fields():
+    """ship_attempt_id, created_at, request_id, parent_run_id, etc. are
+    immutable. updated_at IS mutable (and auto-managed)."""
+    for f in ("ship_attempt_id", "created_at", "request_id", "parent_run_id"):
+        assert f not in MUTABLE_FIELDS, f
+    assert "updated_at" in MUTABLE_FIELDS
+
+
+def test_ledger_filename_matches_spec_lowercase_snake():
+    assert LEDGER_FILENAME == "auto_ship_attempts.jsonl"

--- a/workflow/auto_ship_ledger.py
+++ b/workflow/auto_ship_ledger.py
@@ -1,0 +1,444 @@
+"""Auto-ship attempts ledger — PR #198 §8 (option-2 Slice A).
+
+Append-only structured store for ship attempts. Every call into
+``workflow.auto_ship.validate_ship_request`` that produces a final
+ship_decision should be recorded here so that:
+
+1. The loop's release_safety_gate has an audit trail of every packet it
+   accepted/rejected.
+2. The post-merge observation gate (PR #198 §5.2 + §10 Phase 4 — Slice
+   B / ``observation_gate_result``) can join PR opens back to the
+   original validation that approved them.
+3. Rollback decisions (Slice C) can locate the rollback_handle that was
+   recorded when the attempt was approved.
+
+Storage: ``<universe_path>/auto_ship_attempts.jsonl`` — one
+``ShipAttempt`` per line. Append-on-create, full read-modify-write on
+update. This matches the ``branch_tasks.json`` precedent: small file,
+race-safe via sidecar ``.lock``, no schema migration cost. We can
+graduate to sqlite later if attempt volume warrants.
+
+Spec source:
+- ``docs/milestones/auto-ship-canary-v0.md`` §8 Evidence record (field
+  list + suggested artifact paths)
+- ``docs/milestones/auto-ship-canary-v0.md`` §10 Phase 1/2/3 (which
+  ship_status transitions are valid in which phase)
+
+Phase 1 contract: a successful ``validate_ship_request`` records an
+attempt with ``ship_status="skipped"`` and ``would_open_pr=true``. A
+blocked validation records ``ship_status="blocked"`` and the violations
+in ``error_message``. No PR is ever opened from this module — Phase 2
+will mutate ``ship_status`` to ``"opened"`` once it lands, then to
+``"merged"`` or ``"failed"`` depending on CI + merge result.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import secrets
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+
+LEDGER_FILENAME = "auto_ship_attempts.jsonl"
+LOCK_FILENAME = "auto_ship_attempts.jsonl.lock"
+
+#: Valid ``ship_status`` values across Phase 1-3 (§10).
+VALID_SHIP_STATUSES: frozenset[str] = frozenset({
+    "skipped",   # Phase 1 — validator passed but no PR open requested
+    "blocked",   # validator blocked — error_class+error_message set
+    "opened",    # Phase 2 — PR opened, awaiting CI/merge
+    "merged",    # Phase 3 — PR merged, observation window starts
+    "failed",    # PR opened but CI failed or merge rejected
+    "rolled_back",  # Slice C — observation gate triggered a revert PR
+})
+
+#: Mutable fields ``update_attempt`` is allowed to change after creation.
+#: ``ship_attempt_id`` and ``created_at`` are immutable; everything else
+#: in the schema may evolve as the attempt advances through phases.
+MUTABLE_FIELDS: frozenset[str] = frozenset({
+    "ship_status",
+    "pr_url",
+    "commit_sha",
+    "ci_status",
+    "rollback_handle",
+    "stable_evidence_handle",
+    "updated_at",
+    "error_class",
+    "error_message",
+    "observation_status",
+    "observation_status_at",
+})
+
+
+@dataclass
+class ShipAttempt:
+    """One row in the auto-ship attempts ledger.
+
+    Field naming matches ``docs/milestones/auto-ship-canary-v0.md`` §8
+    exactly so committed-artifact JSON (the per-attempt evidence file)
+    can be derived from this row without renames.
+
+    A few extension fields beyond the §8 list are present so Slice B
+    (observation gate) and Slice C (rollback) don't have to widen the
+    schema later:
+
+    - ``observation_status`` / ``observation_status_at`` — the post-merge
+      health verdict from the observation gate (§5.2 Phase 4).
+    - ``would_open_pr`` — the validator's Phase 1 verdict, distinct from
+      ``ship_status`` so a Phase 1 ``skipped`` row still records whether
+      it WOULD have opened a PR if Phase 2 had been live.
+
+    Defaults are ``""`` for strings and ``None`` for optional sub-fields
+    so empty-row JSON has stable shape for diff review.
+    """
+
+    ship_attempt_id: str
+    created_at: str
+    updated_at: str
+    ship_status: str
+    request_id: str = ""
+    parent_run_id: str = ""
+    child_run_id: str = ""
+    branch_def_id: str = ""
+    release_gate_result: str = ""
+    ship_class: str = ""
+    pr_url: str = ""
+    commit_sha: str = ""
+    changed_paths_json: str = ""
+    ci_status: str = ""
+    rollback_handle: str = ""
+    stable_evidence_handle: str = ""
+    error_class: str = ""
+    error_message: str = ""
+    would_open_pr: bool = False
+    observation_status: str = ""
+    observation_status_at: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, row: dict) -> "ShipAttempt":
+        # Forward-compat: ignore unknown keys so an older runtime can
+        # still read newer rows.
+        known = {f for f in cls.__dataclass_fields__}
+        clean = {k: v for k, v in row.items() if k in known}
+        return cls(**clean)
+
+
+# ── ID generation ─────────────────────────────────────────────────────────
+
+
+def new_attempt_id(*, now: datetime | None = None) -> str:
+    """Stable ``ship_<YYYYMMDD>_<8hex>`` identifier matching §8 example.
+
+    The hex tail is from ``secrets.token_hex(4)`` so two attempts
+    minted in the same UTC second do not collide. Test code can
+    inject ``now`` to make IDs deterministic.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    return f"ship_{now.strftime('%Y%m%d')}_{secrets.token_hex(4)}"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ── Paths ────────────────────────────────────────────────────────────────
+
+
+def ledger_path(universe_path: Path) -> Path:
+    return Path(universe_path) / LEDGER_FILENAME
+
+
+def _lock_path(universe_path: Path) -> Path:
+    return Path(universe_path) / LOCK_FILENAME
+
+
+# ── File lock (mirrors workflow.branch_tasks._file_lock) ──────────────────
+
+
+@contextlib.contextmanager
+def _file_lock(universe_path: Path) -> Iterator[None]:
+    """Cross-platform exclusive lock on a sidecar ``.lock`` file.
+
+    Same primitive as ``workflow.branch_tasks._file_lock`` — kept as a
+    private mirror rather than importing it because the lock is
+    namespaced to ``auto_ship_attempts.jsonl.lock``, not to the queue
+    file. Two concurrent ledger writes serialize; ledger writes do
+    NOT serialize against branch_tasks writes (they touch different
+    files anyway).
+    """
+    Path(universe_path).mkdir(parents=True, exist_ok=True)
+    lock_file = _lock_path(universe_path)
+    fd = os.open(str(lock_file), os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        if sys.platform == "win32":
+            import msvcrt
+            while True:
+                try:
+                    msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                    break
+                except OSError:
+                    time.sleep(0.05)
+        else:
+            import fcntl
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if sys.platform == "win32":
+                import msvcrt
+                try:
+                    os.lseek(fd, 0, 0)
+                    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+                except OSError:
+                    pass
+            else:
+                import fcntl
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                except OSError:
+                    pass
+    finally:
+        os.close(fd)
+
+
+# ── Read / write primitives ──────────────────────────────────────────────
+
+
+def _read_raw(lp: Path) -> list[dict]:
+    """Read all rows from the JSONL file. Returns [] if missing or empty.
+
+    Skips blank lines silently. Raises ``RuntimeError`` on a malformed
+    JSON line — Hard Rule 8 (no silent fallback on corrupt data).
+    """
+    if not lp.exists():
+        return []
+    rows: list[dict] = []
+    with lp.open("r", encoding="utf-8") as fh:
+        for lineno, line in enumerate(fh, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise RuntimeError(
+                    f"Corrupt ledger row at {lp}:{lineno}: {exc}"
+                ) from exc
+            if not isinstance(row, dict):
+                raise RuntimeError(
+                    f"Ledger row at {lp}:{lineno} is not a JSON object"
+                )
+            rows.append(row)
+    return rows
+
+
+def _write_raw(lp: Path, rows: list[dict]) -> None:
+    """Atomic temp+rename rewrite of the entire ledger.
+
+    Used by ``update_attempt``. ``record_attempt`` uses a true append
+    instead so it does not have to re-serialize the whole file.
+    """
+    lp.parent.mkdir(parents=True, exist_ok=True)
+    tmp = lp.with_suffix(lp.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, default=str))
+            fh.write("\n")
+    os.replace(tmp, lp)
+
+
+# ── Public API ───────────────────────────────────────────────────────────
+
+
+def read_attempts(
+    universe_path: Path,
+    *,
+    limit: int | None = None,
+    ship_status: str | None = None,
+) -> list[ShipAttempt]:
+    """File-locked read. Returns [] on missing file.
+
+    ``limit`` returns the most recent N attempts (tail); ``ship_status``
+    filters to that status only. Both filters apply if both are given;
+    ``limit`` is applied AFTER ``ship_status`` so callers can ask for
+    "the last 10 merged attempts" cleanly.
+    """
+    lp = ledger_path(universe_path)
+    with _file_lock(universe_path):
+        raw = _read_raw(lp)
+    attempts = [ShipAttempt.from_dict(row) for row in raw]
+    if ship_status is not None:
+        attempts = [a for a in attempts if a.ship_status == ship_status]
+    if limit is not None:
+        attempts = attempts[-limit:]
+    return attempts
+
+
+def find_attempt(
+    universe_path: Path, ship_attempt_id: str,
+) -> ShipAttempt | None:
+    """File-locked lookup by ship_attempt_id. Returns None if not found."""
+    lp = ledger_path(universe_path)
+    with _file_lock(universe_path):
+        raw = _read_raw(lp)
+    for row in raw:
+        if row.get("ship_attempt_id") == ship_attempt_id:
+            return ShipAttempt.from_dict(row)
+    return None
+
+
+def record_attempt(universe_path: Path, attempt: ShipAttempt) -> None:
+    """File-locked append. Validates ``ship_status``; stamps timestamps
+    if missing.
+
+    Raises ``ValueError`` on invalid ``ship_status`` or duplicate
+    ``ship_attempt_id``. Duplicate detection is by full read so the
+    ledger can be modest (~1k rows) before the read becomes a
+    bottleneck; at that point graduate to sqlite.
+    """
+    if attempt.ship_status not in VALID_SHIP_STATUSES:
+        raise ValueError(
+            f"Invalid ship_status {attempt.ship_status!r}; allowed: "
+            f"{', '.join(sorted(VALID_SHIP_STATUSES))}"
+        )
+    if not attempt.ship_attempt_id:
+        raise ValueError("ship_attempt_id is required")
+    if not attempt.created_at:
+        attempt.created_at = _now_iso()
+    if not attempt.updated_at:
+        attempt.updated_at = attempt.created_at
+
+    lp = ledger_path(universe_path)
+    with _file_lock(universe_path):
+        raw = _read_raw(lp)
+        for row in raw:
+            if row.get("ship_attempt_id") == attempt.ship_attempt_id:
+                raise ValueError(
+                    f"ship_attempt_id {attempt.ship_attempt_id!r} already "
+                    f"recorded — use update_attempt to mutate"
+                )
+        # True append, no full rewrite — JSONL's main ergonomic win.
+        lp.parent.mkdir(parents=True, exist_ok=True)
+        with lp.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(attempt.to_dict(), default=str))
+            fh.write("\n")
+
+
+def update_attempt(
+    universe_path: Path,
+    ship_attempt_id: str,
+    **fields,
+) -> ShipAttempt:
+    """File-locked read-modify-write update of one row.
+
+    ``fields`` may only contain keys in ``MUTABLE_FIELDS``. ``updated_at``
+    is auto-stamped to the current time on every successful update;
+    callers do not need to pass it.
+
+    Raises ``KeyError`` if no row with that ``ship_attempt_id`` exists.
+    Raises ``ValueError`` on attempt to mutate an immutable field or
+    set ``ship_status`` to an invalid value.
+    """
+    illegal = set(fields) - MUTABLE_FIELDS
+    if illegal:
+        raise ValueError(
+            f"Cannot mutate immutable field(s): {', '.join(sorted(illegal))}"
+        )
+    if "ship_status" in fields and fields["ship_status"] not in VALID_SHIP_STATUSES:
+        raise ValueError(
+            f"Invalid ship_status {fields['ship_status']!r}; allowed: "
+            f"{', '.join(sorted(VALID_SHIP_STATUSES))}"
+        )
+
+    lp = ledger_path(universe_path)
+    with _file_lock(universe_path):
+        raw = _read_raw(lp)
+        for idx, row in enumerate(raw):
+            if row.get("ship_attempt_id") == ship_attempt_id:
+                row.update({k: v for k, v in fields.items() if k != "updated_at"})
+                row["updated_at"] = fields.get("updated_at") or _now_iso()
+                raw[idx] = row
+                _write_raw(lp, raw)
+                return ShipAttempt.from_dict(row)
+        raise KeyError(
+            f"ship_attempt_id {ship_attempt_id!r} not found in ledger at {lp}"
+        )
+
+
+# ── Convenience constructor for the common Phase 1 path ──────────────────
+
+
+def attempt_from_decision(
+    *,
+    decision: dict,
+    request_id: str = "",
+    parent_run_id: str = "",
+    child_run_id: str = "",
+    branch_def_id: str = "",
+    release_gate_result: str = "",
+    ship_class: str = "",
+    changed_paths: list[str] | None = None,
+    stable_evidence_handle: str = "",
+    now: datetime | None = None,
+) -> ShipAttempt:
+    """Build a ``ShipAttempt`` row from a ``validate_ship_request``
+    decision plus the call-site context the validator does not see.
+
+    Phase 1 caller expectation:
+
+    >>> dec = validate_ship_request(packet)
+    >>> row = attempt_from_decision(
+    ...     decision=dec,
+    ...     request_id=packet.get("request_id", ""),
+    ...     parent_run_id=packet.get("parent_run_id", ""),
+    ...     ship_class=packet.get("ship_class", ""),
+    ...     changed_paths=packet.get("changed_paths", []),
+    ...     release_gate_result=packet.get("release_gate_result", ""),
+    ...     stable_evidence_handle=packet.get("stable_evidence_handle", ""),
+    ... )
+    >>> record_attempt(universe_path, row)
+
+    Phase 2 then calls ``update_attempt`` to fill ``pr_url`` and flip
+    ``ship_status`` to ``"opened"``.
+    """
+    ts = (now or datetime.now(timezone.utc)).isoformat()
+    if decision.get("validation_result") == "passed":
+        ship_status = "skipped"
+        error_class = ""
+        error_message = ""
+    else:
+        ship_status = "blocked"
+        violations = decision.get("violations", [])
+        error_class = (
+            ",".join(sorted({v.get("rule_id", "") for v in violations}))
+            if violations else "blocked"
+        )
+        error_message = json.dumps(violations, default=str)
+    return ShipAttempt(
+        ship_attempt_id=new_attempt_id(now=now),
+        created_at=ts,
+        updated_at=ts,
+        ship_status=ship_status,
+        request_id=request_id,
+        parent_run_id=parent_run_id,
+        child_run_id=child_run_id,
+        branch_def_id=branch_def_id,
+        release_gate_result=release_gate_result,
+        ship_class=ship_class,
+        changed_paths_json=json.dumps(changed_paths or []),
+        rollback_handle=decision.get("rollback_handle", "") or "",
+        stable_evidence_handle=stable_evidence_handle,
+        would_open_pr=bool(decision.get("would_open_pr")),
+        error_class=error_class,
+        error_message=error_message,
+    )

--- a/workflow/auto_ship_ledger.py
+++ b/workflow/auto_ship_ledger.py
@@ -40,7 +40,7 @@ import os
 import secrets
 import sys
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator
@@ -280,6 +280,8 @@ def read_attempts(
     if ship_status is not None:
         attempts = [a for a in attempts if a.ship_status == ship_status]
     if limit is not None:
+        if limit <= 0:
+            return []
         attempts = attempts[-limit:]
     return attempts
 


### PR DESCRIPTION
### Slice A of option-2 (per Codex 03:56Z review on PR #223)

Implements the structured-store half of `auto_ship_attempts` from `docs/milestones/auto-ship-canary-v0.md` §8. Append-only JSONL store at `<universe_path>/auto_ship_attempts.jsonl` so every ship attempt the loop produces (Phase 1 dry-run, Phase 2 PR-open, Phase 3 merge, Slice C rollback) lands in one auditable place.

**Foundation for** Slice B (`observation_gate_result` surface in `get_status` — reads from this ledger) and Slice C (rollback primitive — writes new attempts when reverting). Both can land in parallel after this PR.

**Pairs with** PR #223 (`workflow.auto_ship.validate_ship_request`) — the ledger is what the validator-driven release_safety_gate writes into. Phase 1 wiring (record_attempt called from the gate) is intentionally NOT in this PR — substrate first, then the wire-up PR which is small.

**Public API** (workflow.auto_ship_ledger):
- `ShipAttempt` dataclass — schema fields match spec §8 verbatim plus 3 forward-compat fields
- `record_attempt(universe_path, attempt)` — file-locked append, rejects duplicate id + invalid status
- `update_attempt(universe_path, ship_attempt_id, **fields)` — read-modify-write under lock; only `MUTABLE_FIELDS` may change; identity fields raise ValueError; updated_at auto-stamps
- `read_attempts(universe_path, *, ship_status=, limit=)` — file-locked read with optional filters
- `find_attempt(universe_path, ship_attempt_id)` — single-row lookup
- `attempt_from_decision(...)` — convenience constructor that maps a `validate_ship_request` decision into a row

**Why JSONL not sqlite**: matches `branch_tasks.json` precedent, append-on-create is single-line write, per-row diff review is human-readable. Module note documents the sqlite graduation path.

**Tests** (32 cases, all green locally): ID shape, dataclass round-trip + forward-compat, all happy paths, all rejection paths (duplicate id, invalid ship_status, immutable field, missing id), filter semantics (ship_status + limit), blank-line tolerance, corrupt-row error (Hard Rule 8), 5-thread concurrent appends (lock contract), and `attempt_from_decision` for both passed and blocked decisions plus full record→read round-trip.

Local `python3 -m pytest tests/test_auto_ship.py tests/test_auto_ship_ledger.py -q`: **96 passed in 0.19s** (32 new + 64 existing auto_ship).

Coordination context in `.agents/activity.log` `f2d0865` (Cowork option-2 lane claim).
