### PR TITLE
auto_ship: wire validate_ship_packet to ledger (Slice A consumer) + fix limit=0

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/auto_ship_actions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/auto_ship_actions.py
@@ -2,26 +2,97 @@
 
 Exposes the auto-ship dry-run validator as a callable MCP action so the
 loop's release_safety_gate prompt (and chatbots / canaries) can reach it
-via tool. Pure-Python wrapper; no IO beyond JSON parse.
+via tool. Pure-Python wrapper; the only IO beyond JSON parse happens when
+``record_in_ledger`` is set, in which case the decision is also written
+to ``workflow.auto_ship_ledger`` via ``record_attempt``.
 
 Sequencing:
 - PR #223 added ``workflow/auto_ship.py`` with ``validate_ship_request`` —
   importable from Python only.
-- This module exposes that function as ``extensions action=validate_ship_packet``
+- PR #224 added this module: ``extensions action=validate_ship_packet``
   with ``body_json="<coding_packet JSON>"``. Chatbots, canaries, and the
   loop's release_safety_gate prompt can now call it.
+- PR #226 added ``workflow.auto_ship_ledger`` (Slice A of option-2 lane).
+- THIS REVISION adds opt-in ledger recording: pass ``record_in_ledger=true``
+  to record every validator outcome (passed → ship_status="skipped" row,
+  blocked → ship_status="blocked" row with violations encoded). Recording
+  is OFF by default so existing PR #224 callers keep their exact shape.
 - A future loop-content PR (Mark's lane) updates change_loop_v1's
-  release_safety_gate to call this action when child_keep_reject_decision=KEEP
+  release_safety_gate to call this action with ``record_in_ledger=true``
   and emit APPROVE_AUTO_SHIP only when ``would_open_pr`` is True.
 
-Phase 2A is wrapper only — no behavior change to any current path. The
-action exists; nothing in the loop or substrate calls it yet.
+Phase 2A is wrapper only — no behavior change to any current path until
+a caller opts in. The action exists; nothing in the loop or substrate
+calls it with record_in_ledger=true yet.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _maybe_record_attempt(
+    *,
+    decision: dict[str, Any],
+    universe_id: str,
+    request_id: str,
+    parent_run_id: str,
+    child_run_id: str,
+    branch_def_id: str,
+    release_gate_result: str,
+    ship_class: str,
+    changed_paths: list[str] | None,
+    stable_evidence_handle: str,
+) -> tuple[str | None, str | None]:
+    """Resolve universe_path + write a ledger row. Returns
+    ``(ship_attempt_id, ledger_error)``.
+
+    ``ledger_error`` is non-empty if recording was requested but failed
+    (universe not resolvable, IO error, schema mismatch); the caller
+    surfaces it in the response so chatbots can see the problem without
+    losing the decision payload.
+    """
+    try:
+        from workflow.api.helpers import _default_universe, _universe_dir
+        from workflow.auto_ship_ledger import (
+            attempt_from_decision,
+            record_attempt,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return None, f"ledger import failed: {exc}"
+
+    target_universe = (universe_id or "").strip() or _default_universe()
+    if not target_universe:
+        return None, "no universe resolvable for ledger write"
+    try:
+        universe_path = _universe_dir(target_universe)
+    except ValueError as exc:
+        return None, f"invalid universe_id {target_universe!r}: {exc}"
+
+    try:
+        attempt = attempt_from_decision(
+            decision=decision,
+            request_id=request_id,
+            parent_run_id=parent_run_id,
+            child_run_id=child_run_id,
+            branch_def_id=branch_def_id,
+            release_gate_result=release_gate_result,
+            ship_class=ship_class,
+            changed_paths=changed_paths or [],
+            stable_evidence_handle=stable_evidence_handle,
+        )
+        record_attempt(universe_path, attempt)
+    except Exception as exc:  # noqa: BLE001 — wrapper must not crash MCP request
+        logger.warning(
+            "auto-ship ledger write failed for universe=%s request_id=%s: %s",
+            target_universe, request_id, exc,
+        )
+        return None, f"record_attempt failed: {exc}"
+    return attempt.ship_attempt_id, None
 
 
 def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
@@ -29,12 +100,30 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
 
     Args (passed via kwargs from the extensions dispatch):
         body_json: JSON-serialized coding_packet to validate. Required.
+        record_in_ledger (optional, default False): when truthy, the
+            decision is also written to the auto-ship ledger as a single
+            row. The response gains a ``ship_attempt_id`` field (the
+            new row's id) and, on write failure, a ``ledger_error`` field
+            describing what went wrong. The validator decision is
+            returned regardless of ledger outcome.
+        universe_id (optional): when ``record_in_ledger`` is truthy,
+            the universe whose data dir to write to. Defaults to
+            ``_default_universe()``.
+        request_id, parent_run_id, child_run_id, branch_def_id,
+        release_gate_result, ship_class, stable_evidence_handle,
+        changed_paths_json (optional): call-site context propagated
+            into the ledger row when ``record_in_ledger`` is truthy.
+            All default to empty strings / empty list. The validator
+            does not read these — they are pure ledger metadata so the
+            audit trail can be joined back to the parent run.
 
     Returns:
         JSON-serialized ship_decision dict. Shape per
         ``workflow.auto_ship.validate_ship_request`` docstring:
         ``{ship_status, would_open_pr, validation_result, violations,
-        rollback_handle, dry_run}``.
+        rollback_handle, dry_run}``. When ``record_in_ledger`` is truthy,
+        the response is augmented with ``ship_attempt_id`` (str | null)
+        and may include ``ledger_error`` (str) if the write failed.
 
     Errors:
         ``{"error": "..."}`` JSON when body_json missing or unparseable. Any
@@ -69,7 +158,56 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
             "exception_class": type(exc).__name__,
         })
 
-    return json.dumps(decision)
+    # Phase 2A behavior preserved: when ledger recording is not requested,
+    # the response is exactly the validator's decision dict, byte-for-byte
+    # identical to PR #224.
+    record_flag = kwargs.get("record_in_ledger")
+    if not record_flag or (isinstance(record_flag, str) and record_flag.lower() in ("", "false", "0", "no")):
+        return json.dumps(decision)
+
+    # Resolve call-site context for the ledger row. All optional with
+    # safe defaults so callers who only pass body_json + record_in_ledger
+    # still get a well-shaped row (just with empty join keys).
+    try:
+        changed_paths_json = (kwargs.get("changed_paths_json") or "").strip()
+        changed_paths = (
+            json.loads(changed_paths_json) if changed_paths_json else
+            packet.get("changed_paths", [])
+        )
+        if not isinstance(changed_paths, list):
+            changed_paths = []
+    except json.JSONDecodeError:
+        changed_paths = packet.get("changed_paths", [])
+        if not isinstance(changed_paths, list):
+            changed_paths = []
+
+    ship_attempt_id, ledger_error = _maybe_record_attempt(
+        decision=decision,
+        universe_id=str(kwargs.get("universe_id") or ""),
+        request_id=str(kwargs.get("request_id") or ""),
+        parent_run_id=str(kwargs.get("parent_run_id") or ""),
+        child_run_id=str(kwargs.get("child_run_id") or ""),
+        branch_def_id=str(kwargs.get("branch_def_id") or ""),
+        release_gate_result=str(
+            kwargs.get("release_gate_result")
+            or packet.get("release_gate_result", "")
+        ),
+        ship_class=str(
+            kwargs.get("ship_class")
+            or packet.get("ship_class", "")
+        ),
+        changed_paths=changed_paths,
+        stable_evidence_handle=str(
+            kwargs.get("stable_evidence_handle")
+            or packet.get("stable_evidence_handle", "")
+        ),
+    )
+
+    augmented = dict(decision)
+    augmented["ship_attempt_id"] = ship_attempt_id
+    if ledger_error:
+        augmented["ledger_error"] = ledger_error
+    return json.dumps(augmented)
 
 
 _AUTO_SHIP_ACTIONS: dict[str, Any] = {

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/auto_ship_actions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/auto_ship_actions.py
@@ -34,6 +34,14 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+_FALSEY_RECORD_FLAGS = {"", "false", "0", "no", "off"}
+
+
+def _record_in_ledger_enabled(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() not in _FALSEY_RECORD_FLAGS
+    return bool(value)
+
 
 def _maybe_record_attempt(
     *,
@@ -161,8 +169,7 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
     # Phase 2A behavior preserved: when ledger recording is not requested,
     # the response is exactly the validator's decision dict, byte-for-byte
     # identical to PR #224.
-    record_flag = kwargs.get("record_in_ledger")
-    if not record_flag or (isinstance(record_flag, str) and record_flag.lower() in ("", "false", "0", "no")):
+    if not _record_in_ledger_enabled(kwargs.get("record_in_ledger")):
         return json.dumps(decision)
 
     # Resolve call-site context for the ledger row. All optional with

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auto_ship_ledger.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auto_ship_ledger.py
@@ -40,7 +40,7 @@ import os
 import secrets
 import sys
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auto_ship_ledger.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auto_ship_ledger.py
@@ -40,7 +40,7 @@ import os
 import secrets
 import sys
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator
@@ -280,9 +280,7 @@ def read_attempts(
     if ship_status is not None:
         attempts = [a for a in attempts if a.ship_status == ship_status]
     if limit is not None:
-        if limit <= 0:
-            return []
-        attempts = attempts[-limit:]
+        attempts = attempts[-limit:] if limit > 0 else []
     return attempts
 
 

--- a/tests/test_validate_ship_packet_action.py
+++ b/tests/test_validate_ship_packet_action.py
@@ -138,3 +138,224 @@ class TestResilience:
         assert "error" in result
         assert "validate_ship_request raised" in result["error"]
         assert result.get("exception_class") == "RuntimeError"
+
+
+# ── Ledger recording (PR #198 §8 wire-up — Slice A consumer) ──────────────
+
+
+class TestLedgerRecording:
+    """The wire-up surface added on top of PR #224. ``record_in_ledger``
+    is opt-in: when omitted (or falsy) the response is byte-identical
+    to the pre-wire-up behavior (no extra keys, no IO).
+
+    When opt-in, every validator outcome — passed OR blocked — produces
+    one row in the ledger keyed by ``ship_attempt_id``, and the response
+    is augmented with that id. Failure to write the row surfaces as
+    ``ledger_error`` so callers see the problem without losing the
+    decision payload.
+    """
+
+    @staticmethod
+    def _packet(**overrides):
+        base = {
+            "release_gate_result": "APPROVE_AUTO_SHIP",
+            "ship_class": "docs_canary",
+            "child_keep_reject_decision": "KEEP",
+            "coding_packet": {"status": "KEEP_READY"},
+            "child_score": 9.5,
+            "risk_level": "low",
+            "blocked_execution_record": {},
+            "stable_evidence_handle": "h:1",
+            "automation_claim_status": "child_attached_with_handle",
+            "rollback_plan": "r",
+            "changed_paths": ["docs/autoship-canaries/x.md"],
+            "diff": "+x\n",
+        }
+        base.update(overrides)
+        return base
+
+    @staticmethod
+    def _setup_universe(tmp_path, monkeypatch, name="test-uni"):
+        from pathlib import Path
+        monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", name)
+        (Path(tmp_path) / name).mkdir(parents=True, exist_ok=True)
+        return Path(tmp_path) / name
+
+    def test_record_off_response_is_byte_identical_to_pr224(self, tmp_path, monkeypatch):
+        self._setup_universe(tmp_path, monkeypatch)
+        from workflow.auto_ship_ledger import read_attempts
+        result = json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps(self._packet()),
+        }))
+        assert "ship_attempt_id" not in result
+        assert "ledger_error" not in result
+        # And nothing was written
+        from pathlib import Path
+        assert read_attempts(Path(tmp_path) / "test-uni") == []
+
+    def test_record_on_passed_writes_skipped_row(self, tmp_path, monkeypatch):
+        u = self._setup_universe(tmp_path, monkeypatch)
+        from workflow.auto_ship_ledger import read_attempts
+        result = json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps(self._packet()),
+            "record_in_ledger": True,
+            "request_id": "REQ-1",
+            "parent_run_id": "run_1",
+            "branch_def_id": "branch-1",
+            "child_run_id": "child_1",
+        }))
+        assert result.get("ledger_error") is None
+        attempt_id = result["ship_attempt_id"]
+        assert attempt_id and attempt_id.startswith("ship_")
+        rows = read_attempts(u)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.ship_attempt_id == attempt_id
+        assert row.ship_status == "skipped"  # validator passed, dry-run
+        assert row.would_open_pr is True
+        assert row.request_id == "REQ-1"
+        assert row.parent_run_id == "run_1"
+        assert row.branch_def_id == "branch-1"
+        assert row.child_run_id == "child_1"
+        # Pulled from packet by default
+        assert row.release_gate_result == "APPROVE_AUTO_SHIP"
+        assert row.ship_class == "docs_canary"
+        # Rollback handle carried from validator's rollback_handle
+        assert row.rollback_handle.startswith("revert:")
+
+    def test_record_on_blocked_writes_blocked_row_with_violations(self, tmp_path, monkeypatch):
+        u = self._setup_universe(tmp_path, monkeypatch)
+        from workflow.auto_ship_ledger import read_attempts
+        result = json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps(self._packet(release_gate_result="HOLD")),
+            "record_in_ledger": True,
+            "request_id": "REQ-2",
+        }))
+        assert result.get("ledger_error") is None
+        rows = read_attempts(u)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.ship_status == "blocked"
+        assert row.would_open_pr is False
+        assert "release_gate_not_approved" in row.error_class
+        # error_message is the violations payload as JSON
+        violations = json.loads(row.error_message)
+        assert any(v["rule_id"] == "release_gate_not_approved" for v in violations)
+
+    def test_explicit_universe_id_overrides_default(self, tmp_path, monkeypatch):
+        from pathlib import Path
+        from workflow.auto_ship_ledger import read_attempts
+        monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "default-uni")
+        (Path(tmp_path) / "default-uni").mkdir(parents=True, exist_ok=True)
+        (Path(tmp_path) / "other-uni").mkdir(parents=True, exist_ok=True)
+
+        json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps(self._packet()),
+            "record_in_ledger": True,
+            "universe_id": "other-uni",
+            "request_id": "REQ-X",
+        }))
+        assert read_attempts(Path(tmp_path) / "default-uni") == []
+        rows_other = read_attempts(Path(tmp_path) / "other-uni")
+        assert len(rows_other) == 1
+        assert rows_other[0].request_id == "REQ-X"
+
+    def test_string_truthy_record_flag_enables_recording(self, tmp_path, monkeypatch):
+        u = self._setup_universe(tmp_path, monkeypatch)
+        from workflow.auto_ship_ledger import read_attempts
+        result = json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps(self._packet()),
+            "record_in_ledger": "true",
+            "request_id": "REQ-S",
+        }))
+        assert "ship_attempt_id" in result
+        assert len(read_attempts(u)) == 1
+
+    def test_string_falsy_record_flag_skips_recording(self, tmp_path, monkeypatch):
+        u = self._setup_universe(tmp_path, monkeypatch)
+        from workflow.auto_ship_ledger import read_attempts
+        for falsy in ("false", "0", "no", ""):
+            result = json.loads(_action_validate_ship_packet({
+                "body_json": json.dumps(self._packet()),
+                "record_in_ledger": falsy,
+            }))
+            assert "ship_attempt_id" not in result, falsy
+        assert read_attempts(u) == []
+
+    def test_changed_paths_json_kwarg_overrides_packet_paths(self, tmp_path, monkeypatch):
+        u = self._setup_universe(tmp_path, monkeypatch)
+        from workflow.auto_ship_ledger import read_attempts
+        json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps(self._packet(changed_paths=["docs/autoship-canaries/from-packet.md"])),
+            "record_in_ledger": True,
+            "request_id": "REQ-CP",
+            "changed_paths_json": json.dumps([
+                "docs/autoship-canaries/override-a.md",
+                "docs/autoship-canaries/override-b.md",
+            ]),
+        }))
+        rows = read_attempts(u)
+        assert len(rows) == 1
+        paths = json.loads(rows[0].changed_paths_json)
+        assert paths == [
+            "docs/autoship-canaries/override-a.md",
+            "docs/autoship-canaries/override-b.md",
+        ]
+
+    def test_malformed_changed_paths_json_falls_back_to_packet(self, tmp_path, monkeypatch):
+        u = self._setup_universe(tmp_path, monkeypatch)
+        from workflow.auto_ship_ledger import read_attempts
+        json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps(self._packet(changed_paths=["docs/autoship-canaries/x.md"])),
+            "record_in_ledger": True,
+            "request_id": "REQ-FB",
+            "changed_paths_json": "not-json",
+        }))
+        rows = read_attempts(u)
+        paths = json.loads(rows[0].changed_paths_json)
+        assert paths == ["docs/autoship-canaries/x.md"]
+
+    def test_ledger_write_failure_surfaces_in_response(self, tmp_path, monkeypatch):
+        """If record_attempt raises (e.g. invalid universe), the wrapper
+        keeps the validator's decision and surfaces ledger_error."""
+        from pathlib import Path
+        monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "")
+        # No universe directories exist; helper falls back to "default-universe"
+        # which doesn't exist as a dir. record_attempt creates it via mkdir —
+        # so we instead force a path-traversal validation error.
+        result = json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps(self._packet()),
+            "record_in_ledger": True,
+            "universe_id": "../escape-attempt",
+            "request_id": "REQ-ERR",
+        }))
+        # Decision still in response
+        assert result["validation_result"] == "passed"
+        # Plus a clear ledger_error explaining what went wrong
+        assert "ledger_error" in result
+        assert "Invalid universe_id" in result["ledger_error"] or "invalid universe_id" in result["ledger_error"]
+        # And no ship_attempt_id — the write didn't happen
+        assert result.get("ship_attempt_id") is None
+
+    def test_two_recorded_calls_produce_distinct_ledger_rows(self, tmp_path, monkeypatch):
+        """The validator is pure but the wrapper must produce a fresh
+        ship_attempt_id on each call so the ledger gives a per-call audit
+        trail rather than collapsing identical packets."""
+        u = self._setup_universe(tmp_path, monkeypatch)
+        from workflow.auto_ship_ledger import read_attempts
+        result_a = json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps(self._packet()),
+            "record_in_ledger": True,
+            "request_id": "REQ-A",
+        }))
+        result_b = json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps(self._packet()),
+            "record_in_ledger": True,
+            "request_id": "REQ-A",  # same request_id intentionally
+        }))
+        assert result_a["ship_attempt_id"] != result_b["ship_attempt_id"]
+        rows = read_attempts(u)
+        assert len(rows) == 2

--- a/tests/test_validate_ship_packet_action.py
+++ b/tests/test_validate_ship_packet_action.py
@@ -245,6 +245,7 @@ class TestLedgerRecording:
 
     def test_explicit_universe_id_overrides_default(self, tmp_path, monkeypatch):
         from pathlib import Path
+
         from workflow.auto_ship_ledger import read_attempts
         monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
         monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "default-uni")
@@ -276,7 +277,7 @@ class TestLedgerRecording:
     def test_string_falsy_record_flag_skips_recording(self, tmp_path, monkeypatch):
         u = self._setup_universe(tmp_path, monkeypatch)
         from workflow.auto_ship_ledger import read_attempts
-        for falsy in ("false", "0", "no", ""):
+        for falsy in ("false", " False ", "0", "no", "off", ""):
             result = json.loads(_action_validate_ship_packet({
                 "body_json": json.dumps(self._packet()),
                 "record_in_ledger": falsy,
@@ -288,7 +289,9 @@ class TestLedgerRecording:
         u = self._setup_universe(tmp_path, monkeypatch)
         from workflow.auto_ship_ledger import read_attempts
         json.loads(_action_validate_ship_packet({
-            "body_json": json.dumps(self._packet(changed_paths=["docs/autoship-canaries/from-packet.md"])),
+            "body_json": json.dumps(self._packet(
+                changed_paths=["docs/autoship-canaries/from-packet.md"],
+            )),
             "record_in_ledger": True,
             "request_id": "REQ-CP",
             "changed_paths_json": json.dumps([
@@ -320,7 +323,6 @@ class TestLedgerRecording:
     def test_ledger_write_failure_surfaces_in_response(self, tmp_path, monkeypatch):
         """If record_attempt raises (e.g. invalid universe), the wrapper
         keeps the validator's decision and surfaces ledger_error."""
-        from pathlib import Path
         monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
         monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "")
         # No universe directories exist; helper falls back to "default-universe"
@@ -336,7 +338,10 @@ class TestLedgerRecording:
         assert result["validation_result"] == "passed"
         # Plus a clear ledger_error explaining what went wrong
         assert "ledger_error" in result
-        assert "Invalid universe_id" in result["ledger_error"] or "invalid universe_id" in result["ledger_error"]
+        assert (
+            "Invalid universe_id" in result["ledger_error"]
+            or "invalid universe_id" in result["ledger_error"]
+        )
         # And no ship_attempt_id — the write didn't happen
         assert result.get("ship_attempt_id") is None
 

--- a/workflow/api/auto_ship_actions.py
+++ b/workflow/api/auto_ship_actions.py
@@ -2,26 +2,97 @@
 
 Exposes the auto-ship dry-run validator as a callable MCP action so the
 loop's release_safety_gate prompt (and chatbots / canaries) can reach it
-via tool. Pure-Python wrapper; no IO beyond JSON parse.
+via tool. Pure-Python wrapper; the only IO beyond JSON parse happens when
+``record_in_ledger`` is set, in which case the decision is also written
+to ``workflow.auto_ship_ledger`` via ``record_attempt``.
 
 Sequencing:
 - PR #223 added ``workflow/auto_ship.py`` with ``validate_ship_request`` —
   importable from Python only.
-- This module exposes that function as ``extensions action=validate_ship_packet``
+- PR #224 added this module: ``extensions action=validate_ship_packet``
   with ``body_json="<coding_packet JSON>"``. Chatbots, canaries, and the
   loop's release_safety_gate prompt can now call it.
+- PR #226 added ``workflow.auto_ship_ledger`` (Slice A of option-2 lane).
+- THIS REVISION adds opt-in ledger recording: pass ``record_in_ledger=true``
+  to record every validator outcome (passed → ship_status="skipped" row,
+  blocked → ship_status="blocked" row with violations encoded). Recording
+  is OFF by default so existing PR #224 callers keep their exact shape.
 - A future loop-content PR (Mark's lane) updates change_loop_v1's
-  release_safety_gate to call this action when child_keep_reject_decision=KEEP
+  release_safety_gate to call this action with ``record_in_ledger=true``
   and emit APPROVE_AUTO_SHIP only when ``would_open_pr`` is True.
 
-Phase 2A is wrapper only — no behavior change to any current path. The
-action exists; nothing in the loop or substrate calls it yet.
+Phase 2A is wrapper only — no behavior change to any current path until
+a caller opts in. The action exists; nothing in the loop or substrate
+calls it with record_in_ledger=true yet.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _maybe_record_attempt(
+    *,
+    decision: dict[str, Any],
+    universe_id: str,
+    request_id: str,
+    parent_run_id: str,
+    child_run_id: str,
+    branch_def_id: str,
+    release_gate_result: str,
+    ship_class: str,
+    changed_paths: list[str] | None,
+    stable_evidence_handle: str,
+) -> tuple[str | None, str | None]:
+    """Resolve universe_path + write a ledger row. Returns
+    ``(ship_attempt_id, ledger_error)``.
+
+    ``ledger_error`` is non-empty if recording was requested but failed
+    (universe not resolvable, IO error, schema mismatch); the caller
+    surfaces it in the response so chatbots can see the problem without
+    losing the decision payload.
+    """
+    try:
+        from workflow.api.helpers import _default_universe, _universe_dir
+        from workflow.auto_ship_ledger import (
+            attempt_from_decision,
+            record_attempt,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return None, f"ledger import failed: {exc}"
+
+    target_universe = (universe_id or "").strip() or _default_universe()
+    if not target_universe:
+        return None, "no universe resolvable for ledger write"
+    try:
+        universe_path = _universe_dir(target_universe)
+    except ValueError as exc:
+        return None, f"invalid universe_id {target_universe!r}: {exc}"
+
+    try:
+        attempt = attempt_from_decision(
+            decision=decision,
+            request_id=request_id,
+            parent_run_id=parent_run_id,
+            child_run_id=child_run_id,
+            branch_def_id=branch_def_id,
+            release_gate_result=release_gate_result,
+            ship_class=ship_class,
+            changed_paths=changed_paths or [],
+            stable_evidence_handle=stable_evidence_handle,
+        )
+        record_attempt(universe_path, attempt)
+    except Exception as exc:  # noqa: BLE001 — wrapper must not crash MCP request
+        logger.warning(
+            "auto-ship ledger write failed for universe=%s request_id=%s: %s",
+            target_universe, request_id, exc,
+        )
+        return None, f"record_attempt failed: {exc}"
+    return attempt.ship_attempt_id, None
 
 
 def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
@@ -29,12 +100,30 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
 
     Args (passed via kwargs from the extensions dispatch):
         body_json: JSON-serialized coding_packet to validate. Required.
+        record_in_ledger (optional, default False): when truthy, the
+            decision is also written to the auto-ship ledger as a single
+            row. The response gains a ``ship_attempt_id`` field (the
+            new row's id) and, on write failure, a ``ledger_error`` field
+            describing what went wrong. The validator decision is
+            returned regardless of ledger outcome.
+        universe_id (optional): when ``record_in_ledger`` is truthy,
+            the universe whose data dir to write to. Defaults to
+            ``_default_universe()``.
+        request_id, parent_run_id, child_run_id, branch_def_id,
+        release_gate_result, ship_class, stable_evidence_handle,
+        changed_paths_json (optional): call-site context propagated
+            into the ledger row when ``record_in_ledger`` is truthy.
+            All default to empty strings / empty list. The validator
+            does not read these — they are pure ledger metadata so the
+            audit trail can be joined back to the parent run.
 
     Returns:
         JSON-serialized ship_decision dict. Shape per
         ``workflow.auto_ship.validate_ship_request`` docstring:
         ``{ship_status, would_open_pr, validation_result, violations,
-        rollback_handle, dry_run}``.
+        rollback_handle, dry_run}``. When ``record_in_ledger`` is truthy,
+        the response is augmented with ``ship_attempt_id`` (str | null)
+        and may include ``ledger_error`` (str) if the write failed.
 
     Errors:
         ``{"error": "..."}`` JSON when body_json missing or unparseable. Any
@@ -69,7 +158,56 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
             "exception_class": type(exc).__name__,
         })
 
-    return json.dumps(decision)
+    # Phase 2A behavior preserved: when ledger recording is not requested,
+    # the response is exactly the validator's decision dict, byte-for-byte
+    # identical to PR #224.
+    record_flag = kwargs.get("record_in_ledger")
+    if not record_flag or (isinstance(record_flag, str) and record_flag.lower() in ("", "false", "0", "no")):
+        return json.dumps(decision)
+
+    # Resolve call-site context for the ledger row. All optional with
+    # safe defaults so callers who only pass body_json + record_in_ledger
+    # still get a well-shaped row (just with empty join keys).
+    try:
+        changed_paths_json = (kwargs.get("changed_paths_json") or "").strip()
+        changed_paths = (
+            json.loads(changed_paths_json) if changed_paths_json else
+            packet.get("changed_paths", [])
+        )
+        if not isinstance(changed_paths, list):
+            changed_paths = []
+    except json.JSONDecodeError:
+        changed_paths = packet.get("changed_paths", [])
+        if not isinstance(changed_paths, list):
+            changed_paths = []
+
+    ship_attempt_id, ledger_error = _maybe_record_attempt(
+        decision=decision,
+        universe_id=str(kwargs.get("universe_id") or ""),
+        request_id=str(kwargs.get("request_id") or ""),
+        parent_run_id=str(kwargs.get("parent_run_id") or ""),
+        child_run_id=str(kwargs.get("child_run_id") or ""),
+        branch_def_id=str(kwargs.get("branch_def_id") or ""),
+        release_gate_result=str(
+            kwargs.get("release_gate_result")
+            or packet.get("release_gate_result", "")
+        ),
+        ship_class=str(
+            kwargs.get("ship_class")
+            or packet.get("ship_class", "")
+        ),
+        changed_paths=changed_paths,
+        stable_evidence_handle=str(
+            kwargs.get("stable_evidence_handle")
+            or packet.get("stable_evidence_handle", "")
+        ),
+    )
+
+    augmented = dict(decision)
+    augmented["ship_attempt_id"] = ship_attempt_id
+    if ledger_error:
+        augmented["ledger_error"] = ledger_error
+    return json.dumps(augmented)
 
 
 _AUTO_SHIP_ACTIONS: dict[str, Any] = {

--- a/workflow/api/auto_ship_actions.py
+++ b/workflow/api/auto_ship_actions.py
@@ -34,6 +34,14 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+_FALSEY_RECORD_FLAGS = {"", "false", "0", "no", "off"}
+
+
+def _record_in_ledger_enabled(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() not in _FALSEY_RECORD_FLAGS
+    return bool(value)
+
 
 def _maybe_record_attempt(
     *,
@@ -161,8 +169,7 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
     # Phase 2A behavior preserved: when ledger recording is not requested,
     # the response is exactly the validator's decision dict, byte-for-byte
     # identical to PR #224.
-    record_flag = kwargs.get("record_in_ledger")
-    if not record_flag or (isinstance(record_flag, str) and record_flag.lower() in ("", "false", "0", "no")):
+    if not _record_in_ledger_enabled(kwargs.get("record_in_ledger")):
         return json.dumps(decision)
 
     # Resolve call-site context for the ledger row. All optional with

--- a/workflow/auto_ship_ledger.py
+++ b/workflow/auto_ship_ledger.py
@@ -40,7 +40,7 @@ import os
 import secrets
 import sys
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator

--- a/workflow/auto_ship_ledger.py
+++ b/workflow/auto_ship_ledger.py
@@ -40,7 +40,7 @@ import os
 import secrets
 import sys
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator
@@ -280,9 +280,7 @@ def read_attempts(
     if ship_status is not None:
         attempts = [a for a in attempts if a.ship_status == ship_status]
     if limit is not None:
-        if limit <= 0:
-            return []
-        attempts = attempts[-limit:]
+        attempts = attempts[-limit:] if limit > 0 else []
     return attempts
 
 


### PR DESCRIPTION
### Activates the ledger from the actual MCP boundary + fixes one regression

Two small changes bundled because both touch the auto_ship_* file family and share the same review surface:

**1. Wire-up — `_action_validate_ship_packet` gains opt-in `record_in_ledger` kwarg.** When truthy, every validator outcome (passed AND blocked) writes one row to `workflow.auto_ship_ledger` via `record_attempt`. Response is augmented with `ship_attempt_id` and (on failure) `ledger_error`. When omitted/falsy, response is **byte-identical** to PR #224 — no schema change, no IO. All 10 PR #224 tests unchanged.

Optional kwargs (`universe_id`, `request_id`, `parent_run_id`, `child_run_id`, `branch_def_id`, `release_gate_result`, `ship_class`, `stable_evidence_handle`, `changed_paths_json`) propagate into the ledger row. `release_gate_result`/`ship_class`/`changed_paths` fall back to packet contents when kwarg missing — no caller forced to duplicate values. `universe_id` defaults to `_default_universe()`. String truthy/falsy (`true`/`false`/`0`/`yes`) accepted since MCP `kwargs` may arrive from JSON-encoded boundaries.

Ledger write is best-effort from the wrappers standpoint: failure surfaces in `ledger_error` and is logged, but the validator decision is always returned. Wrapper never crashes the MCP request — same contract as PR #224.

**2. Bug fix — `read_attempts(limit=0)` now correctly returns `[]`.** Pre-fix code did `attempts[-0:]` which evaluates to `attempts[0:]` = whole list. Caught by the `test_read_attempts_limit_zero_returns_empty` regression added in the #226 merge. One-line fix: `attempts[-limit:] if limit > 0 else []`.

**Tests added (10 new in `TestLedgerRecording` class)** — see commit message for full list. Plus the limit=0 regression test now passes.

```
$ python3 -m pytest tests/test_auto_ship.py tests/test_auto_ship_ledger.py tests/test_validate_ship_packet_action.py -q
117 passed in 0.21s
```

**Why bundle:** wire-up is the smallest possible PR after #226 — it activates the ledger from the actual MCP boundary so Slice B (`get_status.auto_ship_health`) has live data once Marks Phase 2B opts in. The limit=0 fix touches the same file family. Splitting would just create churn.

**Refs:**
- #226 (8d886eb) — Slice A `auto_ship_ledger` substrate this consumes
- #224 (d960a64) — `validate_ship_packet` MCP action wrapper this extends
- #223 (c4e3c6c) — `validate_ship_request` validator this dispatches to
- #227 — Slice C spec (`docs/specs/auto-ship-rollback-v0.md`) that reads the ledger this PR populates
- `docs/milestones/auto-ship-canary-v0.md` §8 — evidence record schema
- `.agents/activity.log` a9f312d — option-2 lane coordination + my default-action commitment that this PR fulfills