### PR TITLE
status: surface auto-ship health from attempts ledger

### DIFF
--- a/.agents/activity.log
+++ b/.agents/activity.log
@@ -695,3 +695,13 @@ PR ladder summary at this point:
 - TBD post-Slice-B merge — Slice C Phase 4a (impl per #227 spec)
 
 **Cheats this session: 3 (all disclosed at 02:50Z, 0 since). 0 substrate moves outside the auto-ship lane.** Standing rules unchanged.
+
+2026-05-03T04:38Z [codex-gpt5-desktop] **Slice B pushed as PR #229 — get_status.auto_ship_health.**
+
+https://github.com/Jonnyton/Workflow/pull/229 — branch `codex/auto-ship-health-status` at `9510ae5`. This builds on Cowork Slice A / PR #226 by adding a read-only `auto_ship_health` block to `get_status`: last 10 compact recent attempts, opened PR observation windows, regressed rollback recommendations, `window_seconds`, `ledger_available`, and warnings. No observation poller, no rollback behavior, no ledger mutation — this is status surface only so the loop can see its auto-ship audit state without SSH or ad hoc file reads.
+
+Payload discipline: recent attempt rows omit `changed_paths_json`, omit empty optional fields, and cap long error text so `get_status` does not repeat the large-response bottleneck we saw with `file_bug`.
+
+Local gates: `python packaging/claude-plugin/build_plugin.py` → probe-ok; `python -m pytest tests/test_auto_ship_health_status.py tests/test_api_status.py tests/test_supervisor_liveness.py tests/test_auto_ship_ledger.py tests/test_auto_ship.py -q` → 131 passed; ruff on canonical+plugin status modules and new test → pass; `git diff --check` → pass. PR checks are running.
+
+Coordination suggestion: if #229 lands cleanly, Slice C can be the dry-run rollback primitive that consumes `observation_status="regressed"` + `rollback_handle`. Observation poller remains separate; do not combine it into the rollback primitive.

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
@@ -49,6 +49,11 @@ _HEARTBEAT_STALE_THRESHOLD_S = _HEARTBEAT_REFRESH_INTERVAL_S * 2
 # BUG-009 class).
 _STUCK_PENDING_THRESHOLD_S = 120
 
+# Auto-ship observation window surfaced in get_status.auto_ship_health.
+_AUTO_SHIP_OBSERVATION_WINDOW_S = 24 * 60 * 60
+_AUTO_SHIP_RECENT_ATTEMPT_LIMIT = 10
+_AUTO_SHIP_TEXT_FIELD_LIMIT = 500
+
 
 def _parse_iso_to_epoch(value: str) -> float | None:
     """Best-effort ISO-8601 parser; returns None on empty/unparseable input.
@@ -66,6 +71,206 @@ def _parse_iso_to_epoch(value: str) -> float | None:
         return datetime.fromisoformat(cleaned).timestamp()
     except Exception:  # noqa: BLE001
         return None
+
+
+def _auto_ship_window_seconds() -> tuple[int, list[str]]:
+    """Return configured auto-ship observation window with warnings.
+
+    Invalid config is surfaced in status warnings and falls back to the
+    conservative 24h default instead of breaking the public status probe.
+    """
+    raw = os.environ.get("WORKFLOW_AUTO_SHIP_OBSERVATION_WINDOW_SECONDS", "")
+    raw = raw.strip()
+    if not raw:
+        return _AUTO_SHIP_OBSERVATION_WINDOW_S, []
+    try:
+        value = int(raw)
+    except ValueError:
+        return _AUTO_SHIP_OBSERVATION_WINDOW_S, [
+            "invalid_window_seconds: "
+            f"WORKFLOW_AUTO_SHIP_OBSERVATION_WINDOW_SECONDS={raw!r}; "
+            f"using {_AUTO_SHIP_OBSERVATION_WINDOW_S}"
+        ]
+    if value <= 0:
+        return _AUTO_SHIP_OBSERVATION_WINDOW_S, [
+            "invalid_window_seconds: "
+            f"WORKFLOW_AUTO_SHIP_OBSERVATION_WINDOW_SECONDS must be > 0; "
+            f"using {_AUTO_SHIP_OBSERVATION_WINDOW_S}"
+        ]
+    return value, []
+
+
+def _compact_status_text(value: str) -> str:
+    if len(value) <= _AUTO_SHIP_TEXT_FIELD_LIMIT:
+        return value
+    return value[:_AUTO_SHIP_TEXT_FIELD_LIMIT] + "...[truncated]"
+
+
+def _compact_ship_attempt(attempt: Any) -> dict[str, Any]:
+    """Compact chatbot-facing summary of an auto-ship ledger row.
+
+    Omits empty optional fields and potentially bulky fields such as
+    changed_paths_json. The full structured ledger remains the source of
+    truth on disk.
+    """
+    summary = {
+        "ship_attempt_id": attempt.ship_attempt_id,
+        "request_id": attempt.request_id,
+        "release_gate_result": attempt.release_gate_result,
+        "ship_class": attempt.ship_class,
+        "ship_status": attempt.ship_status,
+        "would_open_pr": attempt.would_open_pr,
+        "updated_at": attempt.updated_at,
+    }
+    for field in (
+        "parent_run_id",
+        "child_run_id",
+        "branch_def_id",
+        "pr_url",
+        "commit_sha",
+        "ci_status",
+        "rollback_handle",
+        "stable_evidence_handle",
+        "observation_status",
+        "observation_status_at",
+        "error_class",
+        "error_message",
+    ):
+        value = getattr(attempt, field)
+        if not value:
+            continue
+        if field == "error_message":
+            value = _compact_status_text(value)
+        summary[field] = value
+    return summary
+
+
+def _observation_window_remaining_s(
+    attempt: Any,
+    *,
+    now_ts: float,
+    window_seconds: int,
+) -> int | None:
+    anchor = (
+        attempt.observation_status_at
+        or attempt.updated_at
+        or attempt.created_at
+        or ""
+    )
+    anchor_ts = _parse_iso_to_epoch(anchor)
+    if anchor_ts is None:
+        return None
+    elapsed = max(0, int(now_ts - anchor_ts))
+    return max(0, window_seconds - elapsed)
+
+
+def _opened_pr_summary(
+    attempt: Any,
+    *,
+    now_ts: float,
+    window_seconds: int,
+) -> dict[str, Any]:
+    summary = {
+        "ship_attempt_id": attempt.ship_attempt_id,
+        "request_id": attempt.request_id,
+        "pr_url": attempt.pr_url,
+        "ship_status": attempt.ship_status,
+        "ci_status": attempt.ci_status,
+        "observation_status": attempt.observation_status or "observing",
+        "observation_status_at": attempt.observation_status_at,
+        "observation_window_remaining_s": _observation_window_remaining_s(
+            attempt,
+            now_ts=now_ts,
+            window_seconds=window_seconds,
+        ),
+        "rollback_handle": attempt.rollback_handle,
+        "updated_at": attempt.updated_at,
+    }
+    return summary
+
+
+def _rollback_recommendation_summary(attempt: Any) -> dict[str, Any]:
+    return {
+        "ship_attempt_id": attempt.ship_attempt_id,
+        "request_id": attempt.request_id,
+        "ship_status": attempt.ship_status,
+        "pr_url": attempt.pr_url,
+        "commit_sha": attempt.commit_sha,
+        "rollback_handle": attempt.rollback_handle,
+        "observation_status": attempt.observation_status,
+        "observation_status_at": attempt.observation_status_at,
+        "reason": (
+            _compact_status_text(attempt.error_message)
+            if attempt.error_message
+            else "observation_status=regressed"
+        ),
+        "updated_at": attempt.updated_at,
+    }
+
+
+def _compute_auto_ship_health(
+    udir: Any,
+    *,
+    now_ts: float | None = None,
+) -> dict[str, Any]:
+    """Summarize the auto-ship attempt ledger for public get_status.
+
+    Slice B is read-only observability: no polling, no rollback, no
+    state mutation. The helper returns compact rows so chatbots can see
+    the loop's recent ship/audit state without loading the full ledger.
+    """
+    import time as _time
+    if now_ts is None:
+        now_ts = _time.time()
+
+    window_seconds, warnings = _auto_ship_window_seconds()
+    out: dict[str, Any] = {
+        "recent_attempts": [],
+        "opened_prs": [],
+        "rollback_recommendations": [],
+        "window_seconds": window_seconds,
+        "ledger_available": True,
+        "warnings": warnings,
+    }
+
+    try:
+        from workflow.auto_ship_ledger import read_attempts
+        attempts = read_attempts(Path(udir))
+    except Exception as exc:  # noqa: BLE001 — surfaced, not silent
+        out["ledger_available"] = False
+        out["warnings"].append(f"ledger_read_failed: {exc}")
+        return out
+
+    if not attempts:
+        return out
+
+    recent_attempts = list(reversed(attempts[-_AUTO_SHIP_RECENT_ATTEMPT_LIMIT:]))
+    opened_attempts = [
+        attempt for attempt in reversed(attempts)
+        if attempt.ship_status == "opened"
+    ]
+    regressed_attempts = [
+        attempt for attempt in reversed(attempts)
+        if attempt.ship_status in {"opened", "merged"}
+        and attempt.observation_status == "regressed"
+    ]
+
+    out["recent_attempts"] = [
+        _compact_ship_attempt(attempt) for attempt in recent_attempts
+    ]
+    out["opened_prs"] = [
+        _opened_pr_summary(
+            attempt,
+            now_ts=now_ts,
+            window_seconds=window_seconds,
+        )
+        for attempt in opened_attempts
+    ]
+    out["rollback_recommendations"] = [
+        _rollback_recommendation_summary(attempt)
+        for attempt in regressed_attempts
+    ]
+    return out
 
 
 def _compute_supervisor_liveness(
@@ -576,6 +781,20 @@ def get_status(universe_id: str = "") -> str:
             "lease_data_available": False,
         }
 
+    # auto_ship_health — PR #198 option-2 Slice B. Read-only summary of
+    # the append-only auto_ship_attempts ledger so the loop can observe
+    # recent ship attempts, open PR observation windows, and regressed
+    # attempts that need rollback consideration without SSH or ad hoc
+    # file reads.
+    try:
+        auto_ship_health = _compute_auto_ship_health(udir)
+    except Exception as exc:  # noqa: BLE001 — best-effort observability
+        auto_ship_health = {
+            "error": "compute_failed",
+            "detail": str(exc),
+            "ledger_available": False,
+        }
+
     response = {
         "schema_version": 1,
         "active_host": policy_payload["active_host"],
@@ -596,6 +815,7 @@ def get_status(universe_id: str = "") -> str:
         "sandbox_status": sandbox_status,
         "missing_data_files": missing_data_files,
         "supervisor_liveness": supervisor_liveness,
+        "auto_ship_health": auto_ship_health,
         "universe_id": uid,
         "universe_exists": universe_exists,
     }

--- a/tests/test_auto_ship_health_status.py
+++ b/tests/test_auto_ship_health_status.py
@@ -1,0 +1,151 @@
+"""Tests for get_status auto_ship_health observability.
+
+Pairs with PR #198 auto-ship canary v0 Slice B: surface a compact
+status summary over the Slice A auto_ship_attempts ledger without
+adding shipper behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from workflow.api.status import (
+    _compute_auto_ship_health,
+    _parse_iso_to_epoch,
+    get_status,
+)
+from workflow.auto_ship_ledger import ShipAttempt, ledger_path, record_attempt
+
+
+def _ts(minutes: int) -> str:
+    base = datetime(2026, 5, 3, 0, 0, tzinfo=timezone.utc)
+    return (base + timedelta(minutes=minutes)).isoformat()
+
+
+def _attempt(
+    idx: int,
+    *,
+    ship_status: str = "skipped",
+    pr_url: str = "",
+    observation_status: str = "",
+    rollback_handle: str = "",
+) -> ShipAttempt:
+    return ShipAttempt(
+        ship_attempt_id=f"ship_{idx:02d}",
+        request_id=f"REQ-{idx:02d}",
+        parent_run_id=f"parent-{idx:02d}",
+        child_run_id=f"child-{idx:02d}",
+        branch_def_id=f"branch-{idx:02d}",
+        release_gate_result="APPROVE_AUTO_SHIP",
+        ship_class="docs_canary",
+        ship_status=ship_status,
+        pr_url=pr_url,
+        commit_sha=f"commit-{idx:02d}" if ship_status in {"merged", "opened"} else "",
+        changed_paths_json='["docs/autoship-canaries/example.md"]',
+        ci_status="passed" if ship_status in {"merged", "opened"} else "",
+        rollback_handle=rollback_handle,
+        stable_evidence_handle=f"evidence:{idx:02d}",
+        created_at=_ts(idx),
+        updated_at=_ts(idx),
+        error_class="",
+        error_message="",
+        would_open_pr=True,
+        observation_status=observation_status,
+        observation_status_at=_ts(idx) if observation_status else "",
+    )
+
+
+def test_auto_ship_health_empty_ledger_shape(tmp_path):
+    health = _compute_auto_ship_health(tmp_path)
+    assert health == {
+        "recent_attempts": [],
+        "opened_prs": [],
+        "rollback_recommendations": [],
+        "window_seconds": 86400,
+        "ledger_available": True,
+        "warnings": [],
+    }
+
+
+def test_auto_ship_health_surfaces_corrupt_ledger(tmp_path):
+    ledger_path(tmp_path).write_text("not-json\n", encoding="utf-8")
+
+    health = _compute_auto_ship_health(tmp_path)
+
+    assert health["ledger_available"] is False
+    assert health["recent_attempts"] == []
+    assert any("ledger_read_failed" in w for w in health["warnings"])
+
+
+def test_auto_ship_health_summarizes_recent_open_and_regressed_attempts(tmp_path):
+    for idx in range(12):
+        kwargs = {}
+        if idx == 8:
+            kwargs = {
+                "ship_status": "opened",
+                "pr_url": "https://github.com/Jonnyton/Workflow/pull/308",
+            }
+        elif idx == 9:
+            kwargs = {
+                "ship_status": "opened",
+                "pr_url": "https://github.com/Jonnyton/Workflow/pull/309",
+                "observation_status": "regressed",
+                "rollback_handle": "revert:commit-09",
+            }
+        elif idx == 10:
+            kwargs = {
+                "ship_status": "merged",
+                "pr_url": "https://github.com/Jonnyton/Workflow/pull/310",
+                "observation_status": "regressed",
+                "rollback_handle": "revert:commit-10",
+            }
+        record_attempt(tmp_path, _attempt(idx, **kwargs))
+
+    now_ts = _parse_iso_to_epoch("2026-05-03T12:00:00+00:00")
+    assert now_ts is not None
+    health = _compute_auto_ship_health(tmp_path, now_ts=now_ts)
+
+    assert [a["ship_attempt_id"] for a in health["recent_attempts"]] == [
+        "ship_11",
+        "ship_10",
+        "ship_09",
+        "ship_08",
+        "ship_07",
+        "ship_06",
+        "ship_05",
+        "ship_04",
+        "ship_03",
+        "ship_02",
+    ]
+    # Compact summaries omit changed_paths_json to keep get_status small.
+    assert "changed_paths_json" not in health["recent_attempts"][0]
+    assert health["opened_prs"][0]["ship_attempt_id"] == "ship_09"
+    assert health["opened_prs"][0]["observation_status"] == "regressed"
+    assert health["opened_prs"][0]["observation_window_remaining_s"] > 0
+    assert health["opened_prs"][1]["ship_attempt_id"] == "ship_08"
+    assert health["opened_prs"][1]["observation_status"] == "observing"
+    assert [r["ship_attempt_id"] for r in health["rollback_recommendations"]] == [
+        "ship_10",
+        "ship_09",
+    ]
+    assert health["rollback_recommendations"][0]["rollback_handle"] == "revert:commit-10"
+
+
+def test_get_status_response_includes_auto_ship_health(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "test-universe")
+    universe = tmp_path / "test-universe"
+    universe.mkdir(parents=True, exist_ok=True)
+    record_attempt(universe, _attempt(1, ship_status="opened"))
+
+    response = json.loads(get_status())
+    assert "auto_ship_health" in response
+    assert (
+        response["auto_ship_health"]["recent_attempts"][0]["ship_attempt_id"]
+        == "ship_01"
+    )
+    assert (
+        response["auto_ship_health"]["opened_prs"][0]["ship_attempt_id"]
+        == "ship_01"
+    )

--- a/workflow/api/status.py
+++ b/workflow/api/status.py
@@ -49,6 +49,11 @@ _HEARTBEAT_STALE_THRESHOLD_S = _HEARTBEAT_REFRESH_INTERVAL_S * 2
 # BUG-009 class).
 _STUCK_PENDING_THRESHOLD_S = 120
 
+# Auto-ship observation window surfaced in get_status.auto_ship_health.
+_AUTO_SHIP_OBSERVATION_WINDOW_S = 24 * 60 * 60
+_AUTO_SHIP_RECENT_ATTEMPT_LIMIT = 10
+_AUTO_SHIP_TEXT_FIELD_LIMIT = 500
+
 
 def _parse_iso_to_epoch(value: str) -> float | None:
     """Best-effort ISO-8601 parser; returns None on empty/unparseable input.
@@ -66,6 +71,206 @@ def _parse_iso_to_epoch(value: str) -> float | None:
         return datetime.fromisoformat(cleaned).timestamp()
     except Exception:  # noqa: BLE001
         return None
+
+
+def _auto_ship_window_seconds() -> tuple[int, list[str]]:
+    """Return configured auto-ship observation window with warnings.
+
+    Invalid config is surfaced in status warnings and falls back to the
+    conservative 24h default instead of breaking the public status probe.
+    """
+    raw = os.environ.get("WORKFLOW_AUTO_SHIP_OBSERVATION_WINDOW_SECONDS", "")
+    raw = raw.strip()
+    if not raw:
+        return _AUTO_SHIP_OBSERVATION_WINDOW_S, []
+    try:
+        value = int(raw)
+    except ValueError:
+        return _AUTO_SHIP_OBSERVATION_WINDOW_S, [
+            "invalid_window_seconds: "
+            f"WORKFLOW_AUTO_SHIP_OBSERVATION_WINDOW_SECONDS={raw!r}; "
+            f"using {_AUTO_SHIP_OBSERVATION_WINDOW_S}"
+        ]
+    if value <= 0:
+        return _AUTO_SHIP_OBSERVATION_WINDOW_S, [
+            "invalid_window_seconds: "
+            f"WORKFLOW_AUTO_SHIP_OBSERVATION_WINDOW_SECONDS must be > 0; "
+            f"using {_AUTO_SHIP_OBSERVATION_WINDOW_S}"
+        ]
+    return value, []
+
+
+def _compact_status_text(value: str) -> str:
+    if len(value) <= _AUTO_SHIP_TEXT_FIELD_LIMIT:
+        return value
+    return value[:_AUTO_SHIP_TEXT_FIELD_LIMIT] + "...[truncated]"
+
+
+def _compact_ship_attempt(attempt: Any) -> dict[str, Any]:
+    """Compact chatbot-facing summary of an auto-ship ledger row.
+
+    Omits empty optional fields and potentially bulky fields such as
+    changed_paths_json. The full structured ledger remains the source of
+    truth on disk.
+    """
+    summary = {
+        "ship_attempt_id": attempt.ship_attempt_id,
+        "request_id": attempt.request_id,
+        "release_gate_result": attempt.release_gate_result,
+        "ship_class": attempt.ship_class,
+        "ship_status": attempt.ship_status,
+        "would_open_pr": attempt.would_open_pr,
+        "updated_at": attempt.updated_at,
+    }
+    for field in (
+        "parent_run_id",
+        "child_run_id",
+        "branch_def_id",
+        "pr_url",
+        "commit_sha",
+        "ci_status",
+        "rollback_handle",
+        "stable_evidence_handle",
+        "observation_status",
+        "observation_status_at",
+        "error_class",
+        "error_message",
+    ):
+        value = getattr(attempt, field)
+        if not value:
+            continue
+        if field == "error_message":
+            value = _compact_status_text(value)
+        summary[field] = value
+    return summary
+
+
+def _observation_window_remaining_s(
+    attempt: Any,
+    *,
+    now_ts: float,
+    window_seconds: int,
+) -> int | None:
+    anchor = (
+        attempt.observation_status_at
+        or attempt.updated_at
+        or attempt.created_at
+        or ""
+    )
+    anchor_ts = _parse_iso_to_epoch(anchor)
+    if anchor_ts is None:
+        return None
+    elapsed = max(0, int(now_ts - anchor_ts))
+    return max(0, window_seconds - elapsed)
+
+
+def _opened_pr_summary(
+    attempt: Any,
+    *,
+    now_ts: float,
+    window_seconds: int,
+) -> dict[str, Any]:
+    summary = {
+        "ship_attempt_id": attempt.ship_attempt_id,
+        "request_id": attempt.request_id,
+        "pr_url": attempt.pr_url,
+        "ship_status": attempt.ship_status,
+        "ci_status": attempt.ci_status,
+        "observation_status": attempt.observation_status or "observing",
+        "observation_status_at": attempt.observation_status_at,
+        "observation_window_remaining_s": _observation_window_remaining_s(
+            attempt,
+            now_ts=now_ts,
+            window_seconds=window_seconds,
+        ),
+        "rollback_handle": attempt.rollback_handle,
+        "updated_at": attempt.updated_at,
+    }
+    return summary
+
+
+def _rollback_recommendation_summary(attempt: Any) -> dict[str, Any]:
+    return {
+        "ship_attempt_id": attempt.ship_attempt_id,
+        "request_id": attempt.request_id,
+        "ship_status": attempt.ship_status,
+        "pr_url": attempt.pr_url,
+        "commit_sha": attempt.commit_sha,
+        "rollback_handle": attempt.rollback_handle,
+        "observation_status": attempt.observation_status,
+        "observation_status_at": attempt.observation_status_at,
+        "reason": (
+            _compact_status_text(attempt.error_message)
+            if attempt.error_message
+            else "observation_status=regressed"
+        ),
+        "updated_at": attempt.updated_at,
+    }
+
+
+def _compute_auto_ship_health(
+    udir: Any,
+    *,
+    now_ts: float | None = None,
+) -> dict[str, Any]:
+    """Summarize the auto-ship attempt ledger for public get_status.
+
+    Slice B is read-only observability: no polling, no rollback, no
+    state mutation. The helper returns compact rows so chatbots can see
+    the loop's recent ship/audit state without loading the full ledger.
+    """
+    import time as _time
+    if now_ts is None:
+        now_ts = _time.time()
+
+    window_seconds, warnings = _auto_ship_window_seconds()
+    out: dict[str, Any] = {
+        "recent_attempts": [],
+        "opened_prs": [],
+        "rollback_recommendations": [],
+        "window_seconds": window_seconds,
+        "ledger_available": True,
+        "warnings": warnings,
+    }
+
+    try:
+        from workflow.auto_ship_ledger import read_attempts
+        attempts = read_attempts(Path(udir))
+    except Exception as exc:  # noqa: BLE001 — surfaced, not silent
+        out["ledger_available"] = False
+        out["warnings"].append(f"ledger_read_failed: {exc}")
+        return out
+
+    if not attempts:
+        return out
+
+    recent_attempts = list(reversed(attempts[-_AUTO_SHIP_RECENT_ATTEMPT_LIMIT:]))
+    opened_attempts = [
+        attempt for attempt in reversed(attempts)
+        if attempt.ship_status == "opened"
+    ]
+    regressed_attempts = [
+        attempt for attempt in reversed(attempts)
+        if attempt.ship_status in {"opened", "merged"}
+        and attempt.observation_status == "regressed"
+    ]
+
+    out["recent_attempts"] = [
+        _compact_ship_attempt(attempt) for attempt in recent_attempts
+    ]
+    out["opened_prs"] = [
+        _opened_pr_summary(
+            attempt,
+            now_ts=now_ts,
+            window_seconds=window_seconds,
+        )
+        for attempt in opened_attempts
+    ]
+    out["rollback_recommendations"] = [
+        _rollback_recommendation_summary(attempt)
+        for attempt in regressed_attempts
+    ]
+    return out
 
 
 def _compute_supervisor_liveness(
@@ -576,6 +781,20 @@ def get_status(universe_id: str = "") -> str:
             "lease_data_available": False,
         }
 
+    # auto_ship_health — PR #198 option-2 Slice B. Read-only summary of
+    # the append-only auto_ship_attempts ledger so the loop can observe
+    # recent ship attempts, open PR observation windows, and regressed
+    # attempts that need rollback consideration without SSH or ad hoc
+    # file reads.
+    try:
+        auto_ship_health = _compute_auto_ship_health(udir)
+    except Exception as exc:  # noqa: BLE001 — best-effort observability
+        auto_ship_health = {
+            "error": "compute_failed",
+            "detail": str(exc),
+            "ledger_available": False,
+        }
+
     response = {
         "schema_version": 1,
         "active_host": policy_payload["active_host"],
@@ -596,6 +815,7 @@ def get_status(universe_id: str = "") -> str:
         "sandbox_status": sandbox_status,
         "missing_data_files": missing_data_files,
         "supervisor_liveness": supervisor_liveness,
+        "auto_ship_health": auto_ship_health,
         "universe_id": uid,
         "universe_exists": universe_exists,
     }


### PR DESCRIPTION
## Summary
- add `get_status.auto_ship_health` as PR #198 option-2 Slice B over the PR #226 `auto_ship_attempts` ledger
- surface recent attempts, opened PR observation windows, and regressed rollback recommendations without mutating ledger state
- keep rows compact by omitting `changed_paths_json`, empty optional fields, and capping long error text

## Verification
- `python packaging/claude-plugin/build_plugin.py` (probe-ok)
- `python -m pytest tests/test_auto_ship_health_status.py tests/test_api_status.py tests/test_supervisor_liveness.py tests/test_auto_ship_ledger.py tests/test_auto_ship.py -q` = 131 passed
- `python -m ruff check workflow/api/status.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py tests/test_auto_ship_health_status.py`
- `git diff --check`

References #226.