### PR TITLE
[auto-change] BUG-055: restart worldbuild after queued BranchTasks

### DIFF
--- a/fantasy_daemon/branch_registrations.py
+++ b/fantasy_daemon/branch_registrations.py
@@ -183,6 +183,13 @@ def _restartable_work_exists(universe_path: Path) -> bool:
             for target in load_work_targets(universe_path)
         ):
             return True
+        from workflow.dispatcher import load_dispatcher_config, select_next_task
+
+        if select_next_task(
+            universe_path,
+            config=load_dispatcher_config(universe_path),
+        ):
+            return True
         requests_path = universe_path / REQUESTS_FILENAME
         if requests_path.exists():
             requests = json.loads(requests_path.read_text(encoding="utf-8"))

--- a/tests/test_unified_execution.py
+++ b/tests/test_unified_execution.py
@@ -459,6 +459,40 @@ def test_boundary_state_round_trip(fresh_registrations, monkeypatch):
     assert "selected_target_id" not in out
 
 
+def test_worldbuild_soft_stop_clears_when_branch_task_queue_has_work(tmp_path):
+    """BUG-055: a checkpointed ``worldbuild_stuck`` stop must not keep
+    exiting when the durable BranchTask queue has pickable work.
+    """
+    from fantasy_daemon.branch_registrations import clear_restartable_soft_stop
+    from workflow.branch_tasks import BranchTask, append_task
+
+    append_task(
+        tmp_path,
+        BranchTask(
+            branch_task_id="bt-1",
+            branch_def_id="fantasy_author:universe_cycle_wrapper",
+            universe_id="u1",
+            status="pending",
+            trigger_source="owner_queued",
+        ),
+    )
+
+    repaired = clear_restartable_soft_stop({
+        "universe_id": "u1",
+        "universe_path": str(tmp_path),
+        "health": {
+            "stopped": True,
+            "idle_reason": "worldbuild_stuck",
+            "worldbuild_noop_streak": 3,
+            "cycle_noop_streak": 0,
+        },
+    })
+
+    assert repaired["health"]["stopped"] is False
+    assert repaired["health"]["idle_reason"] == ""
+    assert repaired["health"]["worldbuild_noop_streak"] == 0
+
+
 # ───────────────────────────────────────────────────────────────────────
 # Checkpoint regression under flag-on (§4.11, option-1 accepted)
 # ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Promotes the loop-generated BUG-055 branch that Actions could not turn into a PR because PR creation is disabled for the workflow token.\n\nThe patch lets the restartable soft-stop check see pending, dispatcher-eligible BranchTasks before preserving a checkpointed worldbuild_stuck stop. That matches the live symptom: queue state stays healthy, but the universe wrapper repeatedly exits with worldbuild_stuck and zero output.\n\nVerification from Codex review worktree on 2026-05-03:\n- python -m pytest tests/test_unified_execution.py -q -> 28 passed\n- python -m ruff check fantasy_daemon/branch_registrations.py tests/test_unified_execution.py -> pass\n\nCoordination: requesting Cowork review per the activity.log dual-review convention before merge.\n\nCloses #234