### PR TITLE
[auto-change] BUG-053: lint a single wiki page without backlog noise

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -624,17 +624,7 @@ def _wiki_promote(
     meta, body = _parse_frontmatter(content)
 
     if not skip_lint:
-        issues: list[str] = []
-        if not meta.get("title"):
-            issues.append("Missing title in frontmatter")
-        if not meta.get("type"):
-            issues.append("Missing type in frontmatter")
-        if not meta.get("sources") and not meta.get("path"):
-            issues.append("Missing sources in frontmatter")
-        if len(body.strip()) < 50:
-            issues.append("Body too short (< 50 chars)")
-        if not re.search(r"\[\[.+?\]\]", body) and found_category != "projects":
-            issues.append("No wikilinks found -- pages should cross-reference")
+        issues = _promotion_lint_issues(meta, body, found_category)
         if issues:
             return json.dumps({
                 "error": "Promotion blocked.",
@@ -765,7 +755,131 @@ def _wiki_supersede(
         return json.dumps({"error": f"Failed to supersede: {exc}"})
 
 
-def _wiki_lint(**_kwargs: Any) -> str:
+def _promotion_lint_issues(
+    meta: dict[str, str],
+    body: str,
+    category: str,
+) -> list[str]:
+    issues: list[str] = []
+    if not meta.get("title"):
+        issues.append("Missing title in frontmatter")
+    if not meta.get("type"):
+        issues.append("Missing type in frontmatter")
+    if not meta.get("sources") and not meta.get("path"):
+        issues.append("Missing sources in frontmatter")
+    if len(body.strip()) < 50:
+        issues.append("Body too short (< 50 chars)")
+    if not re.search(r"\[\[.+?\]\]", body) and category != "projects":
+        issues.append("No wikilinks found -- pages should cross-reference")
+    return issues
+
+
+def _wiki_lint_single_page(page: str) -> str:
+    resolved = _resolve_page(page)
+    if resolved is None:
+        return json.dumps({"error": f"Page not found: {page}"})
+
+    rel = _page_rel_path(resolved)
+    is_draft = _wiki_drafts_dir() in resolved.parents
+    category = resolved.parent.name
+    raw = _read_text(resolved)
+    meta, body = _parse_frontmatter(raw)
+    page_name = resolved.stem
+    page_names = {p.stem for p in _find_all_pages(_wiki_pages_dir())}
+    issues: list[str] = []
+
+    for m in re.findall(r"\[\[([^\]]+)\]\]", raw):
+        link = m.lower().replace(" ", "-")
+        if link not in page_names:
+            issues.append(f"MISSING: [[{link}]]")
+
+    if is_draft:
+        issues.extend(_promotion_lint_issues(meta, body, category))
+    else:
+        idx_content = _read_text(_wiki_index_path())
+        indexed = {
+            m.lower().replace(" ", "-")
+            for m in re.findall(r"\[\[([^\]]+)\]\]", idx_content)
+        }
+        inbound = 0
+        for p in _find_all_pages(_wiki_pages_dir()):
+            if p == resolved:
+                continue
+            for m in re.findall(r"\[\[([^\]]+)\]\]", _read_text(p)):
+                link = m.lower().replace(" ", "-")
+                if link == page_name:
+                    inbound += 1
+
+        if inbound == 0 and page_name not in indexed:
+            issues.append(f"ORPHAN: {page_name}")
+        if page_name not in indexed:
+            issues.append(f"NOT INDEXED: {page_name}")
+
+        _append_page_metadata_lint(issues, page_name, meta)
+
+    if not issues:
+        return json.dumps({"status": "healthy", "page": rel, "issues": []})
+    return json.dumps({
+        "status": "issues_found",
+        "page": rel,
+        "count": len(issues),
+        "issues": issues,
+    })
+
+
+def _append_page_metadata_lint(
+    issues: list[str],
+    page_name: str,
+    meta: dict[str, str],
+) -> None:
+    now = datetime.now(timezone.utc)
+    confidence = (meta.get("confidence") or "").strip().lower()
+    updated_str = meta.get("updated")
+    days_since: int | None = None
+    if updated_str:
+        try:
+            updated_date = datetime.fromisoformat(updated_str).replace(
+                tzinfo=timezone.utc
+            )
+            days_since = (now - updated_date).days
+        except ValueError:
+            pass
+
+    if confidence == "superseded":
+        successor = (meta.get("superseded_by") or "").strip()
+        if successor and successor not in {
+            p.stem for p in _find_all_pages(_wiki_pages_dir())
+        }:
+            issues.append(
+                f"BROKEN SUPERSESSION: {page_name} points to "
+                f"[[{successor}]] which does not exist"
+            )
+        return
+
+    if (
+        (not confidence or confidence == "high")
+        and days_since is not None
+        and days_since > 90
+    ):
+        issues.append(f"STALE HIGH: {page_name} (last updated {days_since} days ago)")
+    if confidence == "low" and days_since is not None and days_since > 30:
+        issues.append(
+            f"LINGERING LOW: {page_name} (confidence: low for {days_since} days)"
+        )
+    if not confidence and meta.get("title"):
+        issues.append(f"NO CONFIDENCE: {page_name}")
+    if (
+        not meta.get("sources")
+        and not meta.get("path")
+        and meta.get("type") != "project"
+    ):
+        issues.append(f"NO SOURCES: {page_name}")
+
+
+def _wiki_lint(page: str = "", **_kwargs: Any) -> str:
+    if page:
+        return _wiki_lint_single_page(page)
+
     all_pages = _find_all_pages(_wiki_pages_dir())
     all_drafts = _find_all_pages(_wiki_drafts_dir())
     page_names: set[str] = set()

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -407,6 +407,59 @@ class TestWikiLint:
         issues = result.get("issues", [])
         assert any("ORPHAN" in i and "orphan-page" in i for i in issues)
 
+    def test_lint_single_page_excludes_whole_wiki_backlog(self, wiki_dir):
+        clean_content = (
+            "---\ntitle: Clean Page\ntype: concept\n"
+            "confidence: medium\nsources: [test]\n---\n\n"
+            "A clean page that links to [[test-project]] and has enough body "
+            "content for page-specific linting.\n"
+        )
+        (wiki_dir / "pages" / "concepts" / "clean-page.md").write_text(
+            clean_content, encoding="utf-8"
+        )
+        (wiki_dir / "index.md").write_text(
+            (wiki_dir / "index.md").read_text(encoding="utf-8")
+            + "- [[clean-page]] -- Clean Page\n",
+            encoding="utf-8",
+        )
+        (wiki_dir / "pages" / "concepts" / "orphan-page.md").write_text(
+            "---\ntitle: Orphan\ntype: concept\nconfidence: high\n"
+            "sources: [test]\n---\n\nUnrelated orphan backlog.\n",
+            encoding="utf-8",
+        )
+        wiki(
+            "write",
+            category="concepts",
+            filename="pending-draft",
+            content="---\ntitle: Pending Draft\ntype: concept\n---\n\nDraft backlog.",
+        )
+
+        result = json.loads(wiki("lint", page="clean-page"))
+
+        assert result["status"] == "healthy"
+        assert result["issues"] == []
+
+    def test_lint_single_draft_reports_promotion_blockers_only(self, wiki_dir):
+        wiki(
+            "write",
+            category="notes",
+            filename="skinny",
+            content="---\ntitle: Skinny\n---\ntoo short\n",
+        )
+        (wiki_dir / "pages" / "concepts" / "orphan-page.md").write_text(
+            "---\ntitle: Orphan\ntype: concept\nconfidence: high\n"
+            "sources: [test]\n---\n\nUnrelated orphan backlog.\n",
+            encoding="utf-8",
+        )
+
+        result = json.loads(wiki("lint", page="skinny"))
+        issues = result.get("issues", [])
+
+        assert result["status"] == "issues_found"
+        assert any("Missing type" in issue for issue in issues)
+        assert any("Body too short" in issue for issue in issues)
+        assert not any("orphan-page" in issue for issue in issues)
+
 
 class TestWikiSupersede:
     def test_supersede_page(self, wiki_dir):

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -624,17 +624,7 @@ def _wiki_promote(
     meta, body = _parse_frontmatter(content)
 
     if not skip_lint:
-        issues: list[str] = []
-        if not meta.get("title"):
-            issues.append("Missing title in frontmatter")
-        if not meta.get("type"):
-            issues.append("Missing type in frontmatter")
-        if not meta.get("sources") and not meta.get("path"):
-            issues.append("Missing sources in frontmatter")
-        if len(body.strip()) < 50:
-            issues.append("Body too short (< 50 chars)")
-        if not re.search(r"\[\[.+?\]\]", body) and found_category != "projects":
-            issues.append("No wikilinks found -- pages should cross-reference")
+        issues = _promotion_lint_issues(meta, body, found_category)
         if issues:
             return json.dumps({
                 "error": "Promotion blocked.",
@@ -765,7 +755,131 @@ def _wiki_supersede(
         return json.dumps({"error": f"Failed to supersede: {exc}"})
 
 
-def _wiki_lint(**_kwargs: Any) -> str:
+def _promotion_lint_issues(
+    meta: dict[str, str],
+    body: str,
+    category: str,
+) -> list[str]:
+    issues: list[str] = []
+    if not meta.get("title"):
+        issues.append("Missing title in frontmatter")
+    if not meta.get("type"):
+        issues.append("Missing type in frontmatter")
+    if not meta.get("sources") and not meta.get("path"):
+        issues.append("Missing sources in frontmatter")
+    if len(body.strip()) < 50:
+        issues.append("Body too short (< 50 chars)")
+    if not re.search(r"\[\[.+?\]\]", body) and category != "projects":
+        issues.append("No wikilinks found -- pages should cross-reference")
+    return issues
+
+
+def _wiki_lint_single_page(page: str) -> str:
+    resolved = _resolve_page(page)
+    if resolved is None:
+        return json.dumps({"error": f"Page not found: {page}"})
+
+    rel = _page_rel_path(resolved)
+    is_draft = _wiki_drafts_dir() in resolved.parents
+    category = resolved.parent.name
+    raw = _read_text(resolved)
+    meta, body = _parse_frontmatter(raw)
+    page_name = resolved.stem
+    page_names = {p.stem for p in _find_all_pages(_wiki_pages_dir())}
+    issues: list[str] = []
+
+    for m in re.findall(r"\[\[([^\]]+)\]\]", raw):
+        link = m.lower().replace(" ", "-")
+        if link not in page_names:
+            issues.append(f"MISSING: [[{link}]]")
+
+    if is_draft:
+        issues.extend(_promotion_lint_issues(meta, body, category))
+    else:
+        idx_content = _read_text(_wiki_index_path())
+        indexed = {
+            m.lower().replace(" ", "-")
+            for m in re.findall(r"\[\[([^\]]+)\]\]", idx_content)
+        }
+        inbound = 0
+        for p in _find_all_pages(_wiki_pages_dir()):
+            if p == resolved:
+                continue
+            for m in re.findall(r"\[\[([^\]]+)\]\]", _read_text(p)):
+                link = m.lower().replace(" ", "-")
+                if link == page_name:
+                    inbound += 1
+
+        if inbound == 0 and page_name not in indexed:
+            issues.append(f"ORPHAN: {page_name}")
+        if page_name not in indexed:
+            issues.append(f"NOT INDEXED: {page_name}")
+
+        _append_page_metadata_lint(issues, page_name, meta)
+
+    if not issues:
+        return json.dumps({"status": "healthy", "page": rel, "issues": []})
+    return json.dumps({
+        "status": "issues_found",
+        "page": rel,
+        "count": len(issues),
+        "issues": issues,
+    })
+
+
+def _append_page_metadata_lint(
+    issues: list[str],
+    page_name: str,
+    meta: dict[str, str],
+) -> None:
+    now = datetime.now(timezone.utc)
+    confidence = (meta.get("confidence") or "").strip().lower()
+    updated_str = meta.get("updated")
+    days_since: int | None = None
+    if updated_str:
+        try:
+            updated_date = datetime.fromisoformat(updated_str).replace(
+                tzinfo=timezone.utc
+            )
+            days_since = (now - updated_date).days
+        except ValueError:
+            pass
+
+    if confidence == "superseded":
+        successor = (meta.get("superseded_by") or "").strip()
+        if successor and successor not in {
+            p.stem for p in _find_all_pages(_wiki_pages_dir())
+        }:
+            issues.append(
+                f"BROKEN SUPERSESSION: {page_name} points to "
+                f"[[{successor}]] which does not exist"
+            )
+        return
+
+    if (
+        (not confidence or confidence == "high")
+        and days_since is not None
+        and days_since > 90
+    ):
+        issues.append(f"STALE HIGH: {page_name} (last updated {days_since} days ago)")
+    if confidence == "low" and days_since is not None and days_since > 30:
+        issues.append(
+            f"LINGERING LOW: {page_name} (confidence: low for {days_since} days)"
+        )
+    if not confidence and meta.get("title"):
+        issues.append(f"NO CONFIDENCE: {page_name}")
+    if (
+        not meta.get("sources")
+        and not meta.get("path")
+        and meta.get("type") != "project"
+    ):
+        issues.append(f"NO SOURCES: {page_name}")
+
+
+def _wiki_lint(page: str = "", **_kwargs: Any) -> str:
+    if page:
+        return _wiki_lint_single_page(page)
+
     all_pages = _find_all_pages(_wiki_pages_dir())
     all_drafts = _find_all_pages(_wiki_drafts_dir())
     page_names: set[str] = set()


### PR DESCRIPTION
Promotes the loop-generated BUG-053 branch that Actions could not turn into a PR because PR creation is disabled for the workflow token.\n\nThe patch adds wiki action=lint page=<slug> behavior so a single page or draft reports only its own blockers instead of returning the whole-wiki backlog. This should make promotion/debug loops faster and less noisy for chatbots and operators.\n\nVerification from Codex review worktree on 2026-05-03:\n- python -m pytest tests/test_wiki_tools.py -q -> 63 passed\n- python -m ruff check workflow/api/wiki.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py tests/test_wiki_tools.py -> pass\n- python packaging/claude-plugin/build_plugin.py -> probe-ok, no dirty output\n\nCoordination: requesting Cowork review per the activity.log dual-review convention before merge.\n\nCloses #232