### PR TITLE
[auto-change] WIKI-DOCS: classify refactoring attribution plans as project design

### DIFF
--- a/docs/ops/wiki-bug-sync-runbook.md
+++ b/docs/ops/wiki-bug-sync-runbook.md
@@ -62,7 +62,7 @@ commits increments back. This makes reruns idempotent.
 | `pages/plans/patch-*` | `request:patch` |
 | `pages/workflows/*` | `request:branch-refinement` |
 | builder notes under `pages/notes/*` | `request:branch-refinement` |
-| strategic/roadmap/design/architecture plans | `request:project-design` |
+| strategic/roadmap/design/architecture/refactoring/attribution plans | `request:project-design` |
 | other promoted plans/concepts | `request:docs-ops` |
 
 ## Manual trigger

--- a/scripts/wiki_bug_sync.py
+++ b/scripts/wiki_bug_sync.py
@@ -288,6 +288,7 @@ def _change_kind(entry: dict[str, Any]) -> str | None:
     path = str(entry.get("path", "")).lower()
     entry_type = str(entry.get("type", "")).lower()
     title = str(entry.get("title", "")).lower()
+    design_text = f"{path} {entry_type} {title}"
 
     # BUG pages are handled by the numeric cursor lane above.
     if _bug_number(path) is not None or entry_type == "bug" or "/bugs/" in path:
@@ -301,12 +302,20 @@ def _change_kind(entry: dict[str, Any]) -> str | None:
         return "branch-refinement"
     if path.startswith("pages/notes/") and ("builder" in entry_type or "builder" in title):
         return "branch-refinement"
-    if path.startswith("pages/plans/") and (
-        "roadmap" in path
-        or "strategic" in path
-        or "architecture" in path
-        or "design" in path
-        or "synthesis" in path
+    if path.startswith("pages/plans/") and any(
+        marker in design_text
+        for marker in (
+            "architecture",
+            "attribution",
+            "design",
+            "operating-model",
+            "operating model",
+            "refactoring",
+            "roadmap",
+            "strategic",
+            "substrate",
+            "synthesis",
+        )
     ):
         return "project-design"
     if path.startswith("pages/plans/") or path.startswith("pages/concepts/"):

--- a/tests/test_wiki_bug_sync.py
+++ b/tests/test_wiki_bug_sync.py
@@ -16,6 +16,7 @@ from wiki_bug_sync import (  # noqa: E402
     create_gh_issue,
     fetch_bug_detail,
     list_new_bugs,
+    list_new_change_requests,
     read_cursor,
     sync,
     write_cursor,
@@ -152,6 +153,44 @@ def test_list_new_bugs_sorted_ascending():
     }
     result = list_new_bugs(wiki_list, cursor=2)
     assert [e["bug_number"] for e in result] == [3, 4, 5]
+
+
+# ---------------------------------------------------------------------------
+# list_new_change_requests
+# ---------------------------------------------------------------------------
+
+
+def test_live_wiki_refactoring_request_is_project_design():
+    wiki_list = {
+        "promoted": [
+            {
+                "path": (
+                    "pages/plans/"
+                    "live-wiki-refactoring-and-multi-generation-attribution.md"
+                ),
+                "title": "Live Wiki Refactoring + Multi-Generation Attribution",
+                "type": "unknown",
+            }
+        ]
+    }
+    result = list_new_change_requests(wiki_list, seen_paths=set())
+    assert len(result) == 1
+    assert result[0]["request_kind"] == "project-design"
+
+
+def test_plain_promoted_plan_remains_docs_ops():
+    wiki_list = {
+        "promoted": [
+            {
+                "path": "pages/plans/methods-prose-rubric.md",
+                "title": "Methods-Prose Rubric",
+                "type": "plan",
+            }
+        ]
+    }
+    result = list_new_change_requests(wiki_list, seen_paths=set())
+    assert len(result) == 1
+    assert result[0]["request_kind"] == "docs-ops"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Promotes the loop-generated branch for #235 that Actions could not turn into a PR because PR creation is disabled for the workflow token.\n\nThe patch broadens wiki-change-sync request classification so refactoring/attribution/operating-model design plans route as equest:project-design instead of falling through to docs-ops. That matches the user's intent for live wiki refactoring and multi-generation attribution proposals: these are project-shaping design inputs, not routine docs chores.\n\nVerification from Codex review worktree on 2026-05-03:\n- python -m pytest tests/test_wiki_bug_sync.py -q -> 23 passed\n- python -m ruff check scripts/wiki_bug_sync.py tests/test_wiki_bug_sync.py -> pass\n\nCoordination: requesting Cowork review per the activity.log dual-review convention before merge.\n\nCloses #235