### PR TITLE
[auto-change] BUG-057: write completed investigation packets back to wiki

### DIFF
--- a/fantasy_daemon/__main__.py
+++ b/fantasy_daemon/__main__.py
@@ -691,15 +691,38 @@ def _branch_task_inputs_for_execution(claimed_task: Any) -> dict[str, Any]:
     return inputs
 
 
+def _coerce_bug_investigation_patch_packet(packet: Any) -> dict[str, Any]:
+    if isinstance(packet, dict) and packet:
+        return packet
+    if isinstance(packet, str) and packet.strip():
+        return {"implementation_sketch": packet.strip()}
+    return {}
+
+
 def _bug_investigation_patch_packet(output: dict[str, Any]) -> dict[str, Any]:
     """Return the completed investigation packet from known output shapes."""
-    for key in ("patch_packet", "candidate_patch_packet"):
-        packet = output.get(key)
-        if isinstance(packet, dict) and packet:
+    for key in ("patch_packet", "candidate_patch_packet", "child_candidate_patch_packet"):
+        packet = _coerce_bug_investigation_patch_packet(output.get(key))
+        if packet:
             return packet
     child_output = output.get("attached_child_output")
     if isinstance(child_output, dict):
         return _bug_investigation_patch_packet(child_output)
+    coding_packet = output.get("coding_packet")
+    if isinstance(coding_packet, dict):
+        packet: dict[str, Any] = {}
+        summary = str(coding_packet.get("candidate_packet_summary") or "").strip()
+        if summary:
+            packet["implementation_sketch"] = summary
+        tests = coding_packet.get("expected_tests")
+        if isinstance(tests, list):
+            test_plan = "\n".join(f"- {str(item).strip()}" for item in tests if str(item).strip())
+        else:
+            test_plan = str(tests or "").strip()
+        if test_plan:
+            packet["test_plan"] = test_plan
+        if packet:
+            return packet
     return {}
 
 

--- a/fantasy_daemon/__main__.py
+++ b/fantasy_daemon/__main__.py
@@ -691,6 +691,48 @@ def _branch_task_inputs_for_execution(claimed_task: Any) -> dict[str, Any]:
     return inputs
 
 
+def _bug_investigation_patch_packet(output: dict[str, Any]) -> dict[str, Any]:
+    """Return the completed investigation packet from known output shapes."""
+    for key in ("patch_packet", "candidate_patch_packet"):
+        packet = output.get(key)
+        if isinstance(packet, dict) and packet:
+            return packet
+    child_output = output.get("attached_child_output")
+    if isinstance(child_output, dict):
+        return _bug_investigation_patch_packet(child_output)
+    return {}
+
+
+def _maybe_attach_bug_investigation_patch_packet(
+    claimed_task: Any,
+    run_status: str,
+    run_output: dict[str, Any],
+) -> dict[str, Any]:
+    """Attach completed bug-investigation output to the source wiki page."""
+    request_type = str(getattr(claimed_task, "request_type", "") or "branch_run")
+    if request_type != "bug_investigation":
+        return {"status": "skipped", "reason": "not_bug_investigation"}
+    if run_status != "completed":
+        return {"status": "skipped", "reason": f"run_status:{run_status}"}
+
+    inputs = dict(getattr(claimed_task, "inputs", {}) or {})
+    bug_id = str(inputs.get("bug_id") or run_output.get("bug_id") or "").strip()
+    if not bug_id:
+        return {"status": "skipped", "reason": "missing_bug_id"}
+
+    patch_packet = _bug_investigation_patch_packet(run_output)
+    if not patch_packet:
+        return {"status": "skipped", "reason": "missing_patch_packet"}
+
+    try:
+        from workflow.bug_investigation import attach_patch_packet_comment
+
+        return attach_patch_packet_comment(bug_id, patch_packet)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("bug_investigation patch-packet attach failed")
+        return {"status": "error", "bug_id": bug_id, "error": str(exc)}
+
+
 def _try_execute_claimed_branch_task(
     universe_path: Path,
     claimed_task: Any,
@@ -756,6 +798,13 @@ def _try_execute_claimed_branch_task(
             "run_status": outcome.status,
             "actor": actor,
         }
+        attach_result = _maybe_attach_bug_investigation_patch_packet(
+            claimed_task,
+            outcome.status,
+            outcome.output if isinstance(outcome.output, dict) else {},
+        )
+        if attach_result.get("status") != "skipped":
+            metadata["wiki_patch_packet"] = attach_result
         success = outcome.status == RUN_STATUS_COMPLETED
         error = outcome.error if outcome.error else (
             "" if success else f"run_status:{outcome.status}"

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/bug_investigation.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/bug_investigation.py
@@ -162,7 +162,7 @@ def attach_patch_packet_comment(
         next_h2 = re.search(r"\n## ", existing[head_idx + len(_PATCH_PACKET_HEADING):])
         if next_h2:
             tail = existing[head_idx + len(_PATCH_PACKET_HEADING) + next_h2.start():]
-            body = existing[:head_idx].rstrip() + packet_section + "\n\n" + tail.lstrip("# \n")
+            body = existing[:head_idx].rstrip() + packet_section + "\n\n" + tail.lstrip("\n")
         else:
             body = existing[:head_idx].rstrip() + packet_section + "\n"
     else:

--- a/tests/test_bug_investigation.py
+++ b/tests/test_bug_investigation.py
@@ -252,6 +252,23 @@ class TestAttachPatchPacketComment:
         assert "new cause" in written
         assert "old cause" not in written
 
+    def test_reattach_preserves_following_heading(self, tmp_path):
+        bugs_dir = _make_bugs_dir(tmp_path)
+        initial_page = (
+            _SAMPLE_PAGE
+            + "\n\n## Patch Packet\n\n### Root Cause\n\nold cause\n\n"
+            + "## Related\n\n- BUG-041\n"
+        )
+        page = _write_bug_page(bugs_dir, "bug-042-widget-explodes.md", initial_page)
+
+        result = self._call("BUG-042", {"root_cause": "new cause"}, tmp_path)
+
+        assert result["status"] == "attached"
+        written = page.read_text(encoding="utf-8")
+        assert "## Related\n\n- BUG-041" in written
+        assert "\nRelated\n" not in written
+        assert "old cause" not in written
+
     def test_empty_patch_packet_returns_error(self, tmp_path):
         """Empty patch_packet → error returned, no write attempted."""
         bugs_dir = _make_bugs_dir(tmp_path)

--- a/tests/test_bug_investigation_dispatcher.py
+++ b/tests/test_bug_investigation_dispatcher.py
@@ -322,3 +322,107 @@ class TestBugInvestigationDirectRunRouting:
         inputs = _branch_task_inputs_for_execution(task)
 
         assert inputs == {"bug_id": "BUG-009"}
+
+
+class TestBugInvestigationPatchPacketWriteBack:
+    def _make_bug_page(self, tmp_path):
+        bugs_dir = tmp_path / "pages" / "bugs"
+        bugs_dir.mkdir(parents=True)
+        page = bugs_dir / "bug-057-write-completed-loop-investigation.md"
+        page.write_text(
+            "---\nbug_id: BUG-057\ntitle: Write back investigation\n---\n\n"
+            "## Description\n\nInvestigation output should be visible on the request page.\n",
+            encoding="utf-8",
+        )
+        return page
+
+    def test_completed_bug_investigation_attaches_patch_packet_to_wiki(
+        self, tmp_path, monkeypatch
+    ):
+        from fantasy_daemon.__main__ import (
+            _maybe_attach_bug_investigation_patch_packet,
+        )
+
+        page = self._make_bug_page(tmp_path)
+        monkeypatch.setattr("workflow.storage.wiki_path", lambda: tmp_path)
+        task = BranchTask(
+            branch_task_id="bt-bug",
+            branch_def_id="change-loop",
+            universe_id="u",
+            inputs={"bug_id": "BUG-057"},
+            request_type=REQUEST_TYPE_BUG_INVESTIGATION,
+        )
+
+        result = _maybe_attach_bug_investigation_patch_packet(
+            task,
+            "completed",
+            {
+                "patch_packet": {
+                    "root_cause": "completed run output was never attached",
+                    "test_plan": "assert wiki page contains patch packet",
+                }
+            },
+        )
+
+        assert result["status"] == "attached"
+        written = page.read_text(encoding="utf-8")
+        assert "## Patch Packet" in written
+        assert "completed run output was never attached" in written
+
+    def test_non_completed_bug_investigation_does_not_attach_false_packet(
+        self, tmp_path, monkeypatch
+    ):
+        from fantasy_daemon.__main__ import (
+            _maybe_attach_bug_investigation_patch_packet,
+        )
+
+        page = self._make_bug_page(tmp_path)
+        monkeypatch.setattr("workflow.storage.wiki_path", lambda: tmp_path)
+        task = BranchTask(
+            branch_task_id="bt-bug",
+            branch_def_id="change-loop",
+            universe_id="u",
+            inputs={"bug_id": "BUG-057"},
+            request_type=REQUEST_TYPE_BUG_INVESTIGATION,
+        )
+
+        result = _maybe_attach_bug_investigation_patch_packet(
+            task,
+            "failed",
+            {"patch_packet": {"root_cause": "not proven"}},
+        )
+
+        assert result == {"status": "skipped", "reason": "run_status:failed"}
+        assert "## Patch Packet" not in page.read_text(encoding="utf-8")
+
+    def test_attaches_candidate_packet_from_attached_child_output(
+        self, tmp_path, monkeypatch
+    ):
+        from fantasy_daemon.__main__ import (
+            _maybe_attach_bug_investigation_patch_packet,
+        )
+
+        page = self._make_bug_page(tmp_path)
+        monkeypatch.setattr("workflow.storage.wiki_path", lambda: tmp_path)
+        task = BranchTask(
+            branch_task_id="bt-bug",
+            branch_def_id="change-loop",
+            universe_id="u",
+            inputs={"bug_id": "BUG-057"},
+            request_type=REQUEST_TYPE_BUG_INVESTIGATION,
+        )
+
+        result = _maybe_attach_bug_investigation_patch_packet(
+            task,
+            "completed",
+            {
+                "attached_child_output": {
+                    "candidate_patch_packet": {
+                        "implementation_sketch": "attach child packet output",
+                    }
+                }
+            },
+        )
+
+        assert result["status"] == "attached"
+        assert "attach child packet output" in page.read_text(encoding="utf-8")

--- a/tests/test_bug_investigation_dispatcher.py
+++ b/tests/test_bug_investigation_dispatcher.py
@@ -426,3 +426,76 @@ class TestBugInvestigationPatchPacketWriteBack:
 
         assert result["status"] == "attached"
         assert "attach child packet output" in page.read_text(encoding="utf-8")
+
+    def test_attaches_live_parent_child_candidate_packet_string(
+        self, tmp_path, monkeypatch
+    ):
+        from fantasy_daemon.__main__ import (
+            _maybe_attach_bug_investigation_patch_packet,
+        )
+
+        page = self._make_bug_page(tmp_path)
+        monkeypatch.setattr("workflow.storage.wiki_path", lambda: tmp_path)
+        task = BranchTask(
+            branch_task_id="bt-bug",
+            branch_def_id="change-loop",
+            universe_id="u",
+            inputs={"bug_id": "BUG-057"},
+            request_type=REQUEST_TYPE_BUG_INVESTIGATION,
+        )
+
+        result = _maybe_attach_bug_investigation_patch_packet(
+            task,
+            "completed",
+            {
+                "child_candidate_patch_packet": (
+                    "The patch packet is in "
+                    "[candidate_patch_packet.md](/tmp/workflow/candidate_patch_packet.md:1)."
+                ),
+                "child_run_id": "e12caa6629ff48d6",
+                "coding_packet": {
+                    "status": "CHILD_REVIEW_READY",
+                    "candidate_packet_summary": "freshness_scope_check before PR creation",
+                },
+            },
+        )
+
+        assert result["status"] == "attached"
+        written = page.read_text(encoding="utf-8")
+        assert "## Patch Packet" in written
+        assert "candidate_patch_packet.md" in written
+        assert "### Implementation Sketch" in written
+
+    def test_attaches_live_child_candidate_packet_string(
+        self, tmp_path, monkeypatch
+    ):
+        from fantasy_daemon.__main__ import (
+            _maybe_attach_bug_investigation_patch_packet,
+        )
+
+        page = self._make_bug_page(tmp_path)
+        monkeypatch.setattr("workflow.storage.wiki_path", lambda: tmp_path)
+        task = BranchTask(
+            branch_task_id="bt-bug",
+            branch_def_id="change-loop",
+            universe_id="u",
+            inputs={"bug_id": "BUG-057"},
+            request_type=REQUEST_TYPE_BUG_INVESTIGATION,
+        )
+
+        result = _maybe_attach_bug_investigation_patch_packet(
+            task,
+            "completed",
+            {
+                "candidate_patch_packet": (
+                    "**candidate_patch_packet**\n\n"
+                    "`repo_availability_gate` blocks coding before source is present."
+                ),
+                "keep_reject_decision": "REVIEW_READY",
+            },
+        )
+
+        assert result["status"] == "attached"
+        written = page.read_text(encoding="utf-8")
+        assert "repo_availability_gate" in written
+        assert "### Implementation Sketch" in written

--- a/workflow/bug_investigation.py
+++ b/workflow/bug_investigation.py
@@ -162,7 +162,7 @@ def attach_patch_packet_comment(
         next_h2 = re.search(r"\n## ", existing[head_idx + len(_PATCH_PACKET_HEADING):])
         if next_h2:
             tail = existing[head_idx + len(_PATCH_PACKET_HEADING) + next_h2.start():]
-            body = existing[:head_idx].rstrip() + packet_section + "\n\n" + tail.lstrip("# \n")
+            body = existing[:head_idx].rstrip() + packet_section + "\n\n" + tail.lstrip("\n")
         else:
             body = existing[:head_idx].rstrip() + packet_section + "\n"
     else:


### PR DESCRIPTION
## Summary
Manual bridge PR for loop-created branch `auto-change/issue-246-codex-25294020515`.

The branch was created by the live loop for BUG-057 after Wave-1. Codex is only opening the PR because auto-ship slice #3 is not merged/deployed yet; this should become loop-owned once PR #248 lands and the feature flag is enabled.

## Loop intent
- Attach completed bug-investigation patch packet output back to the source wiki bug page.
- Preserve skipped behavior for non-bug-investigation tasks, non-completed runs, and missing packet output.
- Adds tests around direct helper behavior.

## Operator note
This is not a merge approval. It is surfaced for Cowork/Codex dual review under the current bridge pattern.