### PR TITLE
tests: cover public extensions ledger recording

### DIFF
--- a/tests/test_validate_ship_packet_action.py
+++ b/tests/test_validate_ship_packet_action.py
@@ -102,6 +102,8 @@ class TestDispatchIntegration:
             "universe_id",
             "request_id",
             "parent_run_id",
+            "child_run_id",
+            "branch_def_id",
             "release_gate_result",
             "ship_class",
             "changed_paths_json",
@@ -194,6 +196,59 @@ class TestDispatchIntegration:
         assert json.loads(row.changed_paths_json) == [
             "docs/autoship-canaries/from-dispatch.md",
         ]
+
+    def test_public_extensions_wrapper_records_ledger_row(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """The public MCP wrapper forwards ledger fields to the action."""
+        from workflow import universe_server as us
+        from workflow.auto_ship_ledger import read_attempts
+
+        monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "default-uni")
+        universe = tmp_path / "wrapper-uni"
+        universe.mkdir(parents=True, exist_ok=True)
+        packet = {
+            "release_gate_result": "APPROVE_AUTO_SHIP",
+            "ship_class": "docs_canary",
+            "child_keep_reject_decision": "KEEP",
+            "coding_packet": {"status": "KEEP_READY"},
+            "child_score": 9.5,
+            "risk_level": "low",
+            "blocked_execution_record": {},
+            "stable_evidence_handle": "packet-evidence",
+            "automation_claim_status": "child_attached_with_handle",
+            "rollback_plan": "Revert commit <sha>",
+            "changed_paths": ["docs/autoship-canaries/from-packet.md"],
+            "diff": "+ x\n",
+        }
+
+        result_str = us.extensions(
+            action="validate_ship_packet",
+            body_json=json.dumps(packet),
+            record_in_ledger="true",
+            universe_id="wrapper-uni",
+            request_id="REQ-WRAPPER",
+            parent_run_id="parent-run",
+            child_run_id="child-run",
+            branch_def_id="branch-def",
+            stable_evidence_handle="wrapper-evidence",
+        )
+        result = json.loads(result_str)
+
+        assert result.get("ledger_error") is None
+        assert result["ship_attempt_id"]
+        rows = read_attempts(universe)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.ship_attempt_id == result["ship_attempt_id"]
+        assert row.request_id == "REQ-WRAPPER"
+        assert row.parent_run_id == "parent-run"
+        assert row.child_run_id == "child-run"
+        assert row.branch_def_id == "branch-def"
+        assert row.stable_evidence_handle == "wrapper-evidence"
 
     def test_open_auto_ship_pr_routes_to_handler_disabled(self, tmp_path, monkeypatch):
         from workflow.auto_ship_ledger import ShipAttempt, find_attempt, record_attempt


### PR DESCRIPTION
Follow-up to #287 and supersedes the useful test-only parts of closed #285.

Scope:
- Extend the public `extensions()` signature contract test to include `child_run_id` and `branch_def_id`.
- Add a public-wrapper success-path regression proving `workflow.universe_server.extensions(action=validate_ship_packet, record_in_ledger=true, ...)` records a ledger row with request/parent/child/branch/evidence fields.

This branch was cut from post-#287 `main`, so it does not carry the stale autonomous cluster base from #285.

Local gates:
- `python -m pytest tests/test_validate_ship_packet_action.py -q` -> 25 passed, 8 warnings
- `python -m ruff check tests/test_validate_ship_packet_action.py` -> pass
- `git diff --check` -> clean

Review note: tests-only follow-up; do not merge without the normal opposite-family checker key.