### PR TITLE
ci: make auto-fix writer queue fair and verification-ready

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -158,6 +158,8 @@ jobs:
                   repo,
                   state: 'open',
                   labels: labelName,
+                  sort: 'created',
+                  direction: 'asc',
                   per_page: 100,
                 });
                 for (const issue of issues) {
@@ -476,6 +478,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Python dev dependencies
+        if: >
+          steps.check-disabled.outputs.disabled == 'false' &&
+          steps.auth.outputs.mode != 'none'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
 
       - name: Extract request metadata
         if: >

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -112,6 +112,13 @@ def test_discover_retries_unreviewed_attempted_needs_human_with_auth(wf):
     assert "retryAttempted" in script
 
 
+def test_discover_scheduled_backfill_reads_oldest_pending_first(wf):
+    discover_step = wf["jobs"]["discover"]["steps"][0]
+    script = str(discover_step.get("with", {}).get("script", ""))
+    assert "sort: 'created'" in script
+    assert "direction: 'asc'" in script
+
+
 # ---------------------------------------------------------------------------
 # Disable toggle
 # ---------------------------------------------------------------------------
@@ -399,6 +406,34 @@ def test_codex_step_enforces_post_generation_verification(wf):
     assert "verification_status" in run_script
     assert "Post-Codex verification failed; leaving request retryable" in run_script
     assert "exit \"$verification_status\"" in run_script
+
+
+def test_python_dev_dependencies_are_installed_before_subscription_writers(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    install_index = next(
+        (
+            index
+            for index, step in enumerate(steps)
+            if step.get("name") == "Install Python dev dependencies"
+        ),
+        None,
+    )
+    claude_index = next(
+        index for index, step in enumerate(steps) if step.get("id") == "claude-oauth"
+    )
+    codex_index = next(
+        index for index, step in enumerate(steps) if step.get("id") == "codex-subscription"
+    )
+    assert install_index is not None, "Must install ruff/pytest before writer verification"
+    assert install_index < claude_index
+    assert install_index < codex_index
+
+    install_step = steps[install_index]
+    run_script = str(install_step.get("run", ""))
+    assert "python -m pip install --upgrade pip" in run_script
+    assert 'python -m pip install -e ".[dev]"' in run_script
+    assert "steps.check-disabled.outputs.disabled == 'false'" in str(install_step.get("if", ""))
+    assert "steps.auth.outputs.mode != 'none'" in str(install_step.get("if", ""))
 
 
 def test_no_pr_step_marks_review_without_failing_workflow(wf):


### PR DESCRIPTION
## Summary
- make scheduled auto-fix discovery request issues oldest-first with explicit `sort: created` / `direction: asc`
- install Workflow dev dependencies before subscription-backed writer steps so `python -m ruff` and focused `pytest` verification are available deterministically
- add static workflow tests for both invariants

## Why
Claude/Codex coordination and live queue evidence showed two writer-readiness blockers before app-layer auto-change review:
- #302 failed post-Codex verification with missing `ruff`/`pytest`
- #322 showed the runner can still surface brittle local dependency state
- #311 and other older pipeline-improving requests are starved while newer issues are selected first

This does not try to solve #286's narrower repo-context bug or the later intent-steward design. It just makes the existing auto-fix writer fairer and verification-ready.

## Tests
- `python -m pytest tests/test_auto_fix_workflow.py -q`
- `python -m ruff check tests/test_auto_fix_workflow.py`
- `git diff --check`

Writer family: Codex
Required checker family: Claude