### PR TITLE
watch: count push-blocked writer issues as needs-human

### DIFF
--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -354,6 +354,7 @@ def queue_stage(
     missing_codex_subscription: list[dict[str, Any]] = []
     auth_missing: list[dict[str, Any]] = []
     provider_exhausted: list[dict[str, Any]] = []
+    branch_push_blocked: list[dict[str, Any]] = []
     reviewed_terminal: list[dict[str, Any]] = []
     attempted: list[dict[str, Any]] = []
     pending: list[dict[str, Any]] = []
@@ -361,7 +362,10 @@ def queue_stage(
 
     for issue in issues:
         labels = _labels(issue)
-        if BLOCKED_LABEL in labels and labels.isdisjoint(TERMINAL_REVIEW_LABELS):
+        if BLOCKED_LABEL in labels and (
+            labels.isdisjoint(TERMINAL_REVIEW_LABELS)
+            or BRANCH_PUSH_BLOCKED_LABEL in labels
+        ):
             needs_human.append(issue)
             if CLAUDE_SUBSCRIPTION_MISSING_LABEL in labels:
                 missing_subscription.append(issue)
@@ -369,6 +373,8 @@ def queue_stage(
                 missing_codex_subscription.append(issue)
             if AUTH_MISSING_LABEL in labels:
                 auth_missing.append(issue)
+            if BRANCH_PUSH_BLOCKED_LABEL in labels:
+                branch_push_blocked.append(issue)
             elif PROVIDER_EXHAUSTED_LABEL in labels:
                 provider_exhausted.append(issue)
         elif not labels.isdisjoint(TERMINAL_REVIEW_LABELS):
@@ -391,6 +397,9 @@ def queue_stage(
             issue.get("number") for issue in missing_codex_subscription
         ],
         "auth_missing": [issue.get("number") for issue in auth_missing],
+        "branch_push_blocked": [
+            issue.get("number") for issue in branch_push_blocked
+        ],
         "provider_exhausted": [issue.get("number") for issue in provider_exhausted],
         "pending": [issue.get("number") for issue in pending],
         "old_pending": [issue.get("number") for issue in old_pending],
@@ -417,6 +426,8 @@ def queue_stage(
             )
         elif auth_missing:
             root_cause = "approved subscription-backed writer auth is missing"
+        elif branch_push_blocked:
+            root_cause = "automated writer produced a patch but branch push was blocked"
         elif provider_exhausted:
             root_cause = "approved writer provider returned quota/capacity exhaustion"
         pending_clause = (

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -142,3 +142,38 @@ def test_workflow_stage_keeps_in_progress_meaningful_run(monkeypatch):
 
     assert stage["status"] == "yellow"
     assert stage["details"]["run_id"] == 3
+
+
+def test_queue_stage_counts_push_blocked_issue_as_needs_human(monkeypatch):
+    now = dt.datetime(2026, 5, 5, 4, 20, tzinfo=dt.timezone.utc)
+
+    def fake_list_loop_issues(*_args, **_kwargs):
+        return [
+            {
+                "number": 298,
+                "title": "Writer produced a patch but could not push it",
+                "created_at": "2026-05-05T03:00:00Z",
+                "html_url": "https://example.test/issues/298",
+                "labels": [
+                    {"name": watch.BLOCKED_LABEL},
+                    {"name": watch.ATTEMPTED_LABEL},
+                    {"name": watch.REVIEWED_LABEL},
+                    {"name": watch.BRANCH_PUSH_BLOCKED_LABEL},
+                ],
+            }
+        ]
+
+    monkeypatch.setattr(watch, "list_loop_issues", fake_list_loop_issues)
+
+    stage = watch.queue_stage(
+        "owner/repo",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+        now=now,
+        max_pending_age_min=45,
+    )
+
+    assert stage["status"] == "red"
+    assert stage["details"]["needs_human"] == [298]
+    assert stage["details"]["reviewed_terminal"] == []


### PR DESCRIPTION
## Summary
- Counts `needs-human` issues with `auto-fix-branch-push-blocked` as active writer queue blockers instead of reviewed-terminal items.
- Adds `branch_push_blocked` issue numbers to community-loop watch details and a focused regression test.

## Why
Issue #298 exposed that the writer can produce a patch but fail to push because of `github_actions_workflow_permission_missing`. The current watch hid those issues in `reviewed_terminal`, undercounting writer health risk.

## Verification
- RED first: `python -m pytest tests/test_community_loop_watch.py::test_queue_stage_counts_push_blocked_issue_as_needs_human -q` failed before the code change.
- `python -m pytest tests/test_community_loop_watch.py -q` -> 7 passed.
- `python -m ruff check scripts/community_loop_watch.py tests/test_community_loop_watch.py` -> pass.
- `git diff --check` -> pass.
- Live probe after patch: `python scripts/community_loop_watch.py --json` still exits red, now with `branch_push_blocked` and `needs_human` including #306/#305/#303/#298/#295/#264/#258/#233/#209/#87.

Required checker family: Claude/Cowork.