### PR TITLE
wiki: add safe partial patch action for long pages

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -399,3 +399,14 @@ Notes:
 - Ship condition: static workflow tests, ruff, diff-check, PR opened for
   Cowork/Claude review; recovery verified by a later writer run advancing past
   the repeated issue.
+
+## Wiki Patch Action - 2026-05-05
+
+- 2026-05-05 create `../wf-wiki-patch-action` on
+  `codex/wiki-patch-action` by codex-gpt5-desktop.
+- Source: loop liveness incident: issue #347 blocked because `wiki read`
+  truncates long pages while `wiki write` requires full replacement.
+- Purpose: add a safe exact-match partial-patch wiki action with optional
+  content-hash guard so long pages can be edited server-side.
+- Ship condition: focused wiki tests, ruff, plugin mirror build, diff-check,
+  and PR opened for Claude/Cowork review.

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -19,6 +19,7 @@ but importable for tests via `workflow.universe_server` re-exports.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
@@ -528,6 +529,71 @@ def _wiki_write(
         })
     except OSError as exc:
         return json.dumps({"error": f"Failed to write draft: {exc}"})
+
+
+def _wiki_patch(
+    page: str = "",
+    old_text: str = "",
+    new_text: str = "",
+    expected_sha256: str = "",
+    log_entry: str = "",
+    dry_run: bool = True,
+    **_kwargs: Any,
+) -> str:
+    if not page:
+        return json.dumps({"error": "page parameter is required."})
+    if not old_text:
+        return json.dumps({"error": "old_text parameter is required."})
+
+    resolved = _resolve_page(page)
+    if resolved is None:
+        return json.dumps({"error": f"Page not found: {page}"})
+
+    text = _read_text(resolved)
+    old_sha = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    rel = _page_rel_path(resolved)
+
+    if expected_sha256 and expected_sha256 != old_sha:
+        return json.dumps({
+            "error": "content hash mismatch",
+            "status": "conflict",
+            "path": rel,
+            "expected_sha256": expected_sha256,
+            "actual_sha256": old_sha,
+        })
+
+    matches = text.count(old_text)
+    if matches != 1:
+        return json.dumps({
+            "error": "old_text must match exactly once",
+            "status": "conflict",
+            "path": rel,
+            "matches": matches,
+            "sha256": old_sha,
+        })
+
+    patched = text.replace(old_text, new_text, 1)
+    new_sha = hashlib.sha256(patched.encode("utf-8")).hexdigest()
+    response = {
+        "path": rel,
+        "matches": matches,
+        "old_sha256": old_sha,
+        "new_sha256": new_sha,
+        "old_total_chars": len(text),
+        "new_total_chars": len(patched),
+    }
+
+    if dry_run:
+        response.update({"status": "dry_run", "would_write": old_sha != new_sha})
+        return json.dumps(response)
+
+    try:
+        resolved.write_text(patched, encoding="utf-8")
+        _append_wiki_log(f"patch | {rel} | {log_entry or 'exact replacement'}")
+        response.update({"status": "patched"})
+        return json.dumps(response)
+    except OSError as exc:
+        return json.dumps({"error": f"Failed to patch: {exc}"})
 
 
 def _wiki_consolidate(
@@ -1668,6 +1734,9 @@ def wiki(
     filename: str = "",
     content: str = "",
     log_entry: str = "",
+    old_text: str = "",
+    new_text: str = "",
+    expected_sha256: str = "",
     source_url: str = "",
     old_page: str = "",
     new_draft: str = "",
@@ -1735,6 +1804,7 @@ def wiki(
         "list": _wiki_list,
         "lint": _wiki_lint,
         "write": _wiki_write,
+        "patch": _wiki_patch,
         "consolidate": _wiki_consolidate,
         "promote": _wiki_promote,
         "ingest": _wiki_ingest,
@@ -1758,6 +1828,9 @@ def wiki(
         "filename": filename,
         "content": content,
         "log_entry": log_entry,
+        "old_text": old_text,
+        "new_text": new_text,
+        "expected_sha256": expected_sha256,
         "source_url": source_url,
         "old_page": old_page,
         "new_draft": new_draft,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -886,6 +886,9 @@ def wiki(
     filename: str = "",
     content: str = "",
     log_entry: str = "",
+    old_text: str = "",
+    new_text: str = "",
+    expected_sha256: str = "",
     source_url: str = "",
     old_page: str = "",
     new_draft: str = "",
@@ -924,8 +927,10 @@ def wiki(
 
     Args:
         action: One of — reads: read, search, list, lint;
-            writes: write, consolidate, promote, ingest, supersede,
+            writes: write, patch, consolidate, promote, ingest, supersede,
             sync_projects, file_bug, cosign_bug.
+        old_text/new_text: For action="patch", exact text to replace server-side.
+        expected_sha256: Optional full-page hash guard for action="patch".
     """
     return _wiki_impl(
         action=action,
@@ -935,6 +940,9 @@ def wiki(
         filename=filename,
         content=content,
         log_entry=log_entry,
+        old_text=old_text,
+        new_text=new_text,
+        expected_sha256=expected_sha256,
         source_url=source_url,
         old_page=old_page,
         new_draft=new_draft,

--- a/tests/test_api_wiki.py
+++ b/tests/test_api_wiki.py
@@ -7,6 +7,7 @@ directly to lock in the canonical implementation surface.
 
 from __future__ import annotations
 
+import hashlib
 import json
 
 import pytest
@@ -258,6 +259,100 @@ def test_wiki_write_drafts_then_promote_roundtrip(wiki_env):
     promoted = json.loads(wiki(action="promote", filename="my-note"))
     assert promoted["status"] == "promoted"
     assert "pages/notes/my-note.md" in promoted["path"]
+
+
+def test_wiki_patch_updates_long_page_without_full_replace(wiki_env):
+    path = wiki_env / "pages" / "notes" / "long-note.md"
+    original = (
+        "---\ntitle: Long Note\ntype: note\nsources: []\n---\n\n"
+        "intro marker\n"
+        + ("x" * 16000)
+        + "\noriginal tail marker\n"
+    )
+    path.write_text(original, encoding="utf-8")
+
+    read_result = json.loads(wiki(action="read", page="long-note"))
+    assert read_result["truncated"] is True
+    assert "original tail marker" not in read_result["content"]
+
+    result = json.loads(
+        wiki(
+            action="patch",
+            page="long-note",
+            old_text="intro marker",
+            new_text="intro marker\npatched detail",
+            expected_sha256=hashlib.sha256(original.encode("utf-8")).hexdigest(),
+            dry_run=False,
+            log_entry="test partial patch",
+        )
+    )
+
+    assert result["status"] == "patched"
+    assert result["path"] == "pages/notes/long-note.md"
+    patched = path.read_text(encoding="utf-8")
+    assert "intro marker\npatched detail" in patched
+    assert "original tail marker" in patched
+    assert len(patched) > 15000
+
+
+def test_wiki_patch_dry_run_reports_without_writing(wiki_env):
+    path = wiki_env / "pages" / "notes" / "dry-run-note.md"
+    original = "---\ntitle: Dry\ntype: note\n---\n\nbefore\n"
+    path.write_text(original, encoding="utf-8")
+
+    result = json.loads(
+        wiki(
+            action="patch",
+            page="dry-run-note",
+            old_text="before",
+            new_text="after",
+        )
+    )
+
+    assert result["status"] == "dry_run"
+    assert result["would_write"] is True
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_wiki_patch_rejects_hash_mismatch_without_writing(wiki_env):
+    path = wiki_env / "pages" / "notes" / "hash-note.md"
+    original = "---\ntitle: Hash\ntype: note\n---\n\nbefore\n"
+    path.write_text(original, encoding="utf-8")
+
+    result = json.loads(
+        wiki(
+            action="patch",
+            page="hash-note",
+            old_text="before",
+            new_text="after",
+            expected_sha256="0" * 64,
+            dry_run=False,
+        )
+    )
+
+    assert result["error"] == "content hash mismatch"
+    assert result["status"] == "conflict"
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_wiki_patch_rejects_ambiguous_old_text_without_writing(wiki_env):
+    path = wiki_env / "pages" / "notes" / "ambiguous-note.md"
+    original = "---\ntitle: Ambiguous\ntype: note\n---\n\nsame\nsame\n"
+    path.write_text(original, encoding="utf-8")
+
+    result = json.loads(
+        wiki(
+            action="patch",
+            page="ambiguous-note",
+            old_text="same",
+            new_text="different",
+            dry_run=False,
+        )
+    )
+
+    assert result["error"] == "old_text must match exactly once"
+    assert result["matches"] == 2
+    assert path.read_text(encoding="utf-8") == original
 
 
 def test_wiki_promote_lint_blocks_when_required_fields_missing(wiki_env):

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -19,6 +19,7 @@ but importable for tests via `workflow.universe_server` re-exports.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
@@ -528,6 +529,71 @@ def _wiki_write(
         })
     except OSError as exc:
         return json.dumps({"error": f"Failed to write draft: {exc}"})
+
+
+def _wiki_patch(
+    page: str = "",
+    old_text: str = "",
+    new_text: str = "",
+    expected_sha256: str = "",
+    log_entry: str = "",
+    dry_run: bool = True,
+    **_kwargs: Any,
+) -> str:
+    if not page:
+        return json.dumps({"error": "page parameter is required."})
+    if not old_text:
+        return json.dumps({"error": "old_text parameter is required."})
+
+    resolved = _resolve_page(page)
+    if resolved is None:
+        return json.dumps({"error": f"Page not found: {page}"})
+
+    text = _read_text(resolved)
+    old_sha = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    rel = _page_rel_path(resolved)
+
+    if expected_sha256 and expected_sha256 != old_sha:
+        return json.dumps({
+            "error": "content hash mismatch",
+            "status": "conflict",
+            "path": rel,
+            "expected_sha256": expected_sha256,
+            "actual_sha256": old_sha,
+        })
+
+    matches = text.count(old_text)
+    if matches != 1:
+        return json.dumps({
+            "error": "old_text must match exactly once",
+            "status": "conflict",
+            "path": rel,
+            "matches": matches,
+            "sha256": old_sha,
+        })
+
+    patched = text.replace(old_text, new_text, 1)
+    new_sha = hashlib.sha256(patched.encode("utf-8")).hexdigest()
+    response = {
+        "path": rel,
+        "matches": matches,
+        "old_sha256": old_sha,
+        "new_sha256": new_sha,
+        "old_total_chars": len(text),
+        "new_total_chars": len(patched),
+    }
+
+    if dry_run:
+        response.update({"status": "dry_run", "would_write": old_sha != new_sha})
+        return json.dumps(response)
+
+    try:
+        resolved.write_text(patched, encoding="utf-8")
+        _append_wiki_log(f"patch | {rel} | {log_entry or 'exact replacement'}")
+        response.update({"status": "patched"})
+        return json.dumps(response)
+    except OSError as exc:
+        return json.dumps({"error": f"Failed to patch: {exc}"})
 
 
 def _wiki_consolidate(
@@ -1668,6 +1734,9 @@ def wiki(
     filename: str = "",
     content: str = "",
     log_entry: str = "",
+    old_text: str = "",
+    new_text: str = "",
+    expected_sha256: str = "",
     source_url: str = "",
     old_page: str = "",
     new_draft: str = "",
@@ -1735,6 +1804,7 @@ def wiki(
         "list": _wiki_list,
         "lint": _wiki_lint,
         "write": _wiki_write,
+        "patch": _wiki_patch,
         "consolidate": _wiki_consolidate,
         "promote": _wiki_promote,
         "ingest": _wiki_ingest,
@@ -1758,6 +1828,9 @@ def wiki(
         "filename": filename,
         "content": content,
         "log_entry": log_entry,
+        "old_text": old_text,
+        "new_text": new_text,
+        "expected_sha256": expected_sha256,
         "source_url": source_url,
         "old_page": old_page,
         "new_draft": new_draft,

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -886,6 +886,9 @@ def wiki(
     filename: str = "",
     content: str = "",
     log_entry: str = "",
+    old_text: str = "",
+    new_text: str = "",
+    expected_sha256: str = "",
     source_url: str = "",
     old_page: str = "",
     new_draft: str = "",
@@ -924,8 +927,10 @@ def wiki(
 
     Args:
         action: One of — reads: read, search, list, lint;
-            writes: write, consolidate, promote, ingest, supersede,
+            writes: write, patch, consolidate, promote, ingest, supersede,
             sync_projects, file_bug, cosign_bug.
+        old_text/new_text: For action="patch", exact text to replace server-side.
+        expected_sha256: Optional full-page hash guard for action="patch".
     """
     return _wiki_impl(
         action=action,
@@ -935,6 +940,9 @@ def wiki(
         filename=filename,
         content=content,
         log_entry=log_entry,
+        old_text=old_text,
+        new_text=new_text,
+        expected_sha256=expected_sha256,
         source_url=source_url,
         old_page=old_page,
         new_draft=new_draft,


### PR DESCRIPTION
## Summary
- adds `wiki action=patch` for exact server-side replacements on existing wiki pages
- keeps mutation safe by default with `dry_run=true`, exact-one-match enforcement, and optional `expected_sha256` conflict guard
- mirrors the action into the packaged MCP runtime and documents the chatbot-facing parameters

## Why
Issue #347 showed the loop could inspect a long live wiki page but could not safely fix it: `wiki read` truncates at 15k chars, while `wiki write` requires replacing the whole document. This gives the loop a narrow primitive for long-page edits without fetching or rewriting the unread tail.

## Verification
- `python -m pytest tests\\test_api_wiki.py tests\\test_wiki_tools.py -q` = 106 passed
- `python -m pytest tests\\test_wiki_file_bug.py tests\\test_wiki_file_bug_dedup.py -q` = 28 passed, 1 skipped
- `python -m ruff check workflow\\api\\wiki.py workflow\\universe_server.py tests\\test_api_wiki.py`
- `python -m ruff check packaging\\claude-plugin\\plugins\\workflow-universe-server\\runtime\\workflow\\api\\wiki.py packaging\\claude-plugin\\plugins\\workflow-universe-server\\runtime\\workflow\\universe_server.py`
- `python packaging\\claude-plugin\\build_plugin.py` = import probe ok
- `git diff --check`

## Coordination
Separate from #395. #395 fixes writer queue self-clear/retry classes; this PR addresses the next blocker surfaced by #347 once the queue got moving.