### PR TITLE
auto-fix: create Codex PRs with workflow push token

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -410,3 +410,14 @@ Notes:
   content-hash guard so long pages can be edited server-side.
 - Ship condition: focused wiki tests, ruff, plugin mirror build, diff-check,
   and PR opened for Claude/Cowork review.
+
+## Auto-Fix PR Token - 2026-05-05
+
+- 2026-05-05 create `../wf-auto-fix-pr-token` on
+  `codex/auto-fix-pr-token` by codex-gpt5-desktop.
+- Source: post-#395 proof opened PR #397, but the PR had no status checks
+  because it was created through the default Actions token.
+- Purpose: prefer `WORKFLOW_PUSH_TOKEN` for Codex PR creation so pull_request
+  checks fire on loop-created PRs.
+- Ship condition: workflow static tests, actionlint, diff-check, PR opened for
+  Claude/Cowork review.

--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -413,7 +413,7 @@ jobs:
             echo ""
             echo "- selected writer mode: \`${mode}\`"
             echo "- required checker family: \`${checker_family}\`"
-            echo "- WORKFLOW_PUSH_TOKEN is optional, but required for automated branches that edit .github/workflows/*."
+            echo "- WORKFLOW_PUSH_TOKEN is optional, but required for automated branches that edit .github/workflows/* and for loop-created PRs to trigger pull_request checks."
             echo "- API-key secrets are intentionally ignored for default daemon writers."
             echo "- OPENAI_API_KEY configured: \`${HAS_OPENAI_API_KEY_CONFIGURED}\`"
             echo "- ANTHROPIC_API_KEY configured: \`${HAS_ANTHROPIC_API_KEY_CONFIGURED}\`"
@@ -653,6 +653,8 @@ jobs:
           git checkout -B "$branch"
           if [[ -n "${WORKFLOW_PUSH_TOKEN:-}" ]]; then
             git remote set-url origin "https://x-access-token:${WORKFLOW_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+            git config --local --unset-all "http.https://github.com/.extraheader" || true
+            git config --local --unset-all "http.https://github.com/${GITHUB_REPOSITORY}.extraheader" || true
           fi
           unset WORKFLOW_PUSH_TOKEN
 
@@ -812,6 +814,8 @@ jobs:
           PR_TITLE: ${{ steps.meta.outputs.pr_title }}
           ISSUE_NUMBER: ${{ steps.meta.outputs.issue_number }}
         with:
+          # PAT-created PRs fire pull_request checks; GITHUB_TOKEN-created PRs do not.
+          github-token: ${{ secrets.WORKFLOW_PUSH_TOKEN || github.token }}
           script: |
             const branch = process.env.CODEX_BRANCH;
             const issueNumber = Number(process.env.ISSUE_NUMBER);
@@ -1088,7 +1092,7 @@ jobs:
                   ? `Branch push blocked: \`${codexPushBlockReason || 'unknown'}\``
                   : '',
                 codexPushBlocked && codexPushBlockReason === 'github_actions_workflow_permission_missing'
-                  ? 'Configure `WORKFLOW_PUSH_TOKEN` with repo Contents write and Workflows write so automated workflow-file branches can push.'
+                  ? 'Configure `WORKFLOW_PUSH_TOKEN` with repo Contents write, Workflows write, and Pull requests write so automated workflow-file branches can push and loop-created PRs can trigger checks.'
                   : '',
                 codexPrBlocked && branch
                   ? `Auto-fix branch: https://github.com/${context.repo.owner}/${context.repo.repo}/tree/${branch}`

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -195,6 +195,7 @@ def test_auth_step_reports_workflow_push_token(wf):
     assert "WORKFLOW_PUSH_TOKEN" in str(auth_step.get("env", {}))
     assert "has_workflow_push_token" in run_script
     assert ".github/workflows/*" in run_script
+    assert "trigger pull_request checks" in run_script
 
 
 def test_auth_step_reports_api_keys_as_diagnostics_only(wf):
@@ -288,6 +289,8 @@ def test_codex_subscription_step_uses_workflow_push_token_for_git_push(wf):
     assert "WORKFLOW_PUSH_TOKEN" in str(codex_step.get("env", {}))
     assert "git remote set-url origin" in run_script
     assert "x-access-token" in run_script
+    assert 'git config --local --unset-all "http.https://github.com/.extraheader"' in run_script
+    assert "http.https://github.com/${GITHUB_REPOSITORY}.extraheader" in run_script
     assert "unset WORKFLOW_PUSH_TOKEN" in run_script
 
 
@@ -368,6 +371,19 @@ def test_codex_pr_gets_cross_family_checker(wf):
     assert "writer:codex" in script
     assert "checker:claude" in script
     assert "Required checker family: Claude" in script
+
+
+def test_codex_pr_creation_uses_workflow_push_token_for_checks(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    codex_pr_step = next((s for s in steps if s.get("id") == "codex-pr-create"), None)
+    assert codex_pr_step is not None, "Must create a PR for Codex-authored changes"
+    with_block = codex_pr_step.get("with", {})
+    assert with_block.get("github-token") == (
+        "${{ secrets.WORKFLOW_PUSH_TOKEN || github.token }}"
+    ), (
+        "Codex PR creation must prefer WORKFLOW_PUSH_TOKEN so pull_request "
+        "checks fire on loop-created PRs."
+    )
 
 
 def test_codex_pr_creation_policy_block_is_classified(wf):
@@ -520,6 +536,7 @@ def test_no_pr_step_marks_review_without_failing_workflow(wf):
     assert "Workflow push token present" in script
     assert "WORKFLOW_PUSH_TOKEN" in script
     assert "Workflows write" in script
+    assert "Pull requests write" in script
 
 
 def test_pr_blocked_label_is_defined(wf):


### PR DESCRIPTION
## Summary
- make the Codex auto-fix PR creation step prefer WORKFLOW_PUSH_TOKEN over the default Actions token
- update writer-auth diagnostics to say the token is also needed for loop-created PR checks
- add static workflow tests for the PR-token contract

## Verification
- python -m pytest tests\\test_auto_fix_workflow.py -q
- python -m ruff check tests\\test_auto_fix_workflow.py
- git diff --check

Local actionlint was unavailable; the pre-commit hook skipped it and CI actionlint should validate this workflow change.

Requires Claude/Cowork checker key.