### PR TITLE
deploy-prod: route rollback-red deploy failures to P0 triage

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -410,3 +410,13 @@ Notes:
   content-hash guard so long pages can be edited server-side.
 - Ship condition: focused wiki tests, ruff, plugin mirror build, diff-check,
   and PR opened for Claude/Cowork review.
+
+## Deploy-Failed P0 Triage - 2026-05-05
+
+- 2026-05-05 create `../wf-deploy-failed-p0-triage` on
+  `codex/deploy-failed-p0-triage` by codex-gpt5-desktop.
+- Source: live MCP 502 after deploy rollback failed; P0 triage recovered only
+  after `p0-outage` was manually added to deploy-failed issue #400.
+- Purpose: make rollback-red deploy failures auto-enter existing P0 triage.
+- Ship condition: deploy workflow structure tests pass, diff-check clean, PR
+  opened for Claude/Cowork review.

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -8,10 +8,10 @@ name: Deploy prod
 # run a post-deploy canary against `tinyassets.io/mcp`, and on canary
 # red, auto-rollback to the previous tag.
 #
-# Alarm hook: deploy failures open a GitHub issue labeled `deploy-failed`
-# — distinct from the canary-triggered `p0-outage` issue shape from
-# Row H. That way host can tell "deploy broke" from "daemon died
-# spontaneously."
+# Alarm hook: deploy failures open a GitHub issue labeled `deploy-failed`.
+# If rollback also leaves the daemon red, the issue additionally gets
+# `p0-outage` so the existing P0 auto-triage workflow can repair the host
+# without a human label relay.
 #
 # Required repo secrets (Settings → Secrets and variables → Actions):
 #   DO_DROPLET_HOST  — Droplet public IP (e.g. 161.35.237.133)
@@ -378,6 +378,7 @@ jobs:
           fi
 
       - name: Rollback on failure
+        id: rollback
         if: failure() && steps.deploy.outcome == 'success'
         env:
           PREV_IMAGE: ${{ steps.prev.outputs.previous }}
@@ -406,44 +407,66 @@ jobs:
         env:
           NEW_TAG: ${{ steps.tag.outputs.tag }}
           PREV_IMAGE: ${{ steps.prev.outputs.previous }}
+          ROLLBACK_OUTCOME: ${{ steps.rollback.outcome }}
         with:
           script: |
-            const label = "deploy-failed";
-            // Ensure label exists.
-            try {
-              await github.rest.issues.getLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: label,
-              });
-            } catch (e) {
-              if (e.status === 404) {
-                await github.rest.issues.createLabel({
+            const deployLabel = "deploy-failed";
+            const p0Label = "p0-outage";
+            const labels = [deployLabel];
+            const rollbackStillRed = process.env.ROLLBACK_OUTCOME === "failure";
+            if (rollbackStillRed) {
+              labels.push(p0Label);
+            }
+
+            const labelDefs = {
+              [deployLabel]: {
+                color: 'fbca04',
+                description: 'CI deploy to DO Droplet failed; auto-rollback attempted.',
+              },
+              [p0Label]: {
+                color: 'd73a4a',
+                description: 'Auto-opened by uptime canary on public MCP outage.',
+              },
+            };
+            for (const name of labels) {
+              try {
+                await github.rest.issues.getLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  name: label,
-                  color: 'fbca04',
-                  description: 'CI deploy to DO Droplet failed; auto-rollback attempted.',
+                  name,
                 });
-              } else {
-                throw e;
+              } catch (e) {
+                if (e.status === 404) {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name,
+                    ...labelDefs[name],
+                  });
+                } else {
+                  throw e;
+                }
               }
             }
+
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: `Deploy failed — ${process.env.NEW_TAG} @ ${new Date().toISOString()}`,
-              labels: [label],
+              labels,
               body: [
                 `Auto-opened by the deploy-prod workflow.`,
                 ``,
                 `- Attempted: \`${process.env.NEW_TAG}\``,
                 `- Rolled back to: \`${process.env.PREV_IMAGE}\``,
+                `- Rollback outcome: \`${process.env.ROLLBACK_OUTCOME || 'skipped'}\``,
                 `- Run: ${runUrl}`,
                 ``,
                 `Check the run logs for the failing step (build, deploy, canary, or rollback).`,
-                `If rollback canary is also red, the daemon is down — investigate urgently.`,
+                rollbackStillRed
+                  ? `Rollback canary stayed red, so this issue is also labeled \`${p0Label}\` and P0 auto-triage should attempt repair.`
+                  : `If rollback canary is also red, the daemon is down — investigate urgently.`,
               ].join('\n'),
             });
 

--- a/tests/test_deploy_prod_workflow.py
+++ b/tests/test_deploy_prod_workflow.py
@@ -220,6 +220,32 @@ def test_rollback_conditioned_on_failure():
     pytest.fail("'Rollback on failure' step not found")
 
 
+def test_rollback_step_has_id_for_deploy_failed_routing():
+    wf = _load()
+    for step in _steps(wf):
+        if "rollback on failure" in (step.get("name") or "").lower():
+            assert step.get("id") == "rollback"
+            return
+    pytest.fail("'Rollback on failure' step not found")
+
+
+def test_deploy_failed_issue_gets_p0_label_when_rollback_fails():
+    wf = _load()
+    issue_step = next(
+        (s for s in _steps(wf) if s.get("name") == "Open deploy-failed issue"),
+        None,
+    )
+    assert issue_step is not None
+    env = issue_step.get("env") or {}
+    assert env.get("ROLLBACK_OUTCOME") == "${{ steps.rollback.outcome }}"
+
+    script = issue_step.get("with", {}).get("script", "") or ""
+    assert 'const p0Label = "p0-outage"' in script
+    assert 'process.env.ROLLBACK_OUTCOME === "failure"' in script
+    assert "labels.push(p0Label)" in script
+    assert "P0 auto-triage should attempt repair" in script
+
+
 # ---------------------------------------------------------------------------
 # (i) Codex subscription auth sync
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a rollback step id so deploy-prod can inspect rollback outcome
- label deploy-failed issues with p0-outage when rollback itself fails, letting existing P0 auto-triage repair the host automatically
- cover the routing contract in deploy workflow structure tests

## Verification
- python -m pytest tests\\test_deploy_prod_workflow.py -q
- python -m ruff check tests\\test_deploy_prod_workflow.py
- git diff --check

Local actionlint is not installed; PR CI should run actionlint.