### PR TITLE
[auto-change] BUG-059: Loop-created PRs from stale auto-change branches show phantom deletions in diff; reviewer manually disambiguates real payload from stale-base noise

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -31,7 +31,7 @@ name: Auto-fix change
 # Variables -> Actions -> New repository variable). Flip to false to re-enable.
 # Variable-based toggle preserves the secrets; no data loss.
 #
-# Branch naming: auto-change/issue-<N>
+# Branch naming: auto-change/issue-<N>-<writer>-<run_id>
 # PR title/body are requested in the prompt because claude-code-action@v1 no
 # longer accepts the v0 `pr_title` / `pr_body` inputs.
 
@@ -594,7 +594,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           base_branch: main
           branch_prefix: auto-change/
-          branch_name_template: issue-${{ steps.meta.outputs.issue_number }}
+          branch_name_template: issue-${{ steps.meta.outputs.issue_number }}-claude-${{ github.run_id }}
           prompt: |
             You are handling a community change request in the Workflow repository.
 
@@ -650,7 +650,8 @@ jobs:
           unset OPENAI_API_KEY ANTHROPIC_API_KEY ANTHROPIC_BASE_URL GEMINI_API_KEY GROQ_API_KEY XAI_API_KEY
 
           npm install -g @openai/codex
-          git checkout -B "$branch"
+          git fetch --no-tags --prune origin main
+          git checkout -B "$branch" "origin/main"
           if [[ -n "${WORKFLOW_PUSH_TOKEN:-}" ]]; then
             git remote set-url origin "https://x-access-token:${WORKFLOW_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
             git config --local --unset-all "http.https://github.com/.extraheader" || true

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -403,11 +403,21 @@ def test_branch_naming_convention(wf):
     assert oauth_step is not None, "Must have a Claude OAuth step"
     with_block = oauth_step.get("with", {})
     assert with_block.get("branch_prefix") == "auto-change/"
-    assert "issue-${{ steps.meta.outputs.issue_number }}" == with_block.get(
-        "branch_name_template"
-    ), (
-        "Branch must follow auto-change/issue-<N> naming convention"
-    )
+    branch_template = str(with_block.get("branch_name_template", ""))
+    assert "issue-${{ steps.meta.outputs.issue_number }}" in branch_template
+    assert "claude-${{ github.run_id }}" in branch_template
+    assert with_block.get("branch_name_template") != (
+        "issue-${{ steps.meta.outputs.issue_number }}"
+    ), "Claude must not reuse a stale auto-change/issue-<N> branch across runs"
+
+
+def test_codex_branch_is_created_from_fresh_origin_main(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    codex_step = next((s for s in steps if s.get("id") == "codex-subscription"), None)
+    assert codex_step is not None, "Must have a Codex subscription writer step"
+    run_script = codex_step.get("run", "")
+    assert "git fetch --no-tags --prune origin main" in run_script
+    assert 'git checkout -B "$branch" "origin/main"' in run_script
 
 
 def test_pr_title_includes_auto_fix_prefix(wf):


### PR DESCRIPTION
Fixes #258

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.