### PR TITLE
[auto-change] BUG-060: Loop investigations start with empty coding workspace instead of repo source/tests

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/codex_provider.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/codex_provider.py
@@ -12,8 +12,8 @@ import shlex
 import shutil
 import subprocess
 import sys
-import tempfile
 import time
+from pathlib import Path
 
 from workflow.exceptions import (
     ProviderError,
@@ -54,6 +54,14 @@ def _codex_model() -> str:
     return os.environ.get("WORKFLOW_CODEX_MODEL", "gpt-5.4").strip() or "gpt-5.4"
 
 
+def _codex_workdir() -> str:
+    """Return the source workspace Codex should inspect for coding tasks."""
+    configured = os.environ.get("WORKFLOW_CODEX_WORKDIR", "").strip()
+    if configured:
+        return configured
+    return str(Path(__file__).resolve().parents[2])
+
+
 class CodexProvider(BaseProvider):
     """Calls GPT via the ``codex exec`` CLI binary."""
 
@@ -80,11 +88,11 @@ class CodexProvider(BaseProvider):
             if sandbox_status.get("bwrap_available")
             else ["--dangerously-bypass-approvals-and-sandbox"]
         )
-        # Prompt-node calls need Codex as a subscription-backed text model,
-        # not as a repo-editing agent. Run from an empty ephemeral directory.
+        # Prompt-node calls use Codex as a subscription-backed text model, but
+        # loop-investigation coding prompts still need repo source/tests mounted.
         # Prefer Codex's sandboxed auto mode when bwrap is actually usable;
         # bwrap-less hosts fall back to the hosted subscription mode already
-        # used by auto-fix, with API keys stripped and an empty working dir.
+        # used by auto-fix, with API keys stripped.
         cmd = [
             *base_cmd,
             "exec",
@@ -97,40 +105,39 @@ class CodexProvider(BaseProvider):
         proc_env = subprocess_env_without_api_keys()
 
         win_kw = _no_window_kwargs()
-        with tempfile.TemporaryDirectory(prefix="workflow-codex-provider-") as workdir:
-            cmd_with_cwd = [*cmd, "-C", workdir]
-            if use_shell:
-                proc = await asyncio.create_subprocess_shell(
-                    shlex.join(cmd_with_cwd),
-                    stdin=asyncio.subprocess.PIPE,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    env=proc_env,
-                    **win_kw,
-                )
-            else:
-                proc = await asyncio.create_subprocess_exec(
-                    *cmd_with_cwd,
-                    stdin=asyncio.subprocess.PIPE,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    env=proc_env,
-                    **win_kw,
-                )
+        cmd_with_cwd = [*cmd, "-C", _codex_workdir()]
+        if use_shell:
+            proc = await asyncio.create_subprocess_shell(
+                shlex.join(cmd_with_cwd),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=proc_env,
+                **win_kw,
+            )
+        else:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd_with_cwd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=proc_env,
+                **win_kw,
+            )
 
-            start = time.monotonic()
+        start = time.monotonic()
 
-            try:
-                stdout, stderr = await asyncio.wait_for(
-                    proc.communicate(input=full_input.encode("utf-8")),
-                    timeout=config.timeout,
-                )
-            except asyncio.TimeoutError:
-                proc.kill()
-                await proc.wait()
-                raise ProviderTimeoutError(
-                    f"codex exec exceeded {config.timeout}s timeout"
-                )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=full_input.encode("utf-8")),
+                timeout=config.timeout,
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise ProviderTimeoutError(
+                f"codex exec exceeded {config.timeout}s timeout"
+            )
 
         elapsed_ms = (time.monotonic() - start) * 1000
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import time
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -674,6 +675,37 @@ class TestCodexProvider:
         assert "-C" in captured_cmd
         assert "-m" in captured_cmd
         assert captured_cmd[captured_cmd.index("-m") + 1] == "gpt-5.4"
+
+    @pytest.mark.asyncio
+    async def test_runs_from_repo_root_so_coding_tasks_can_read_source(self):
+        """BUG-060: loop investigations need repo source/tests, not an empty tempdir."""
+        import workflow.providers.codex_provider as codex_provider
+        from workflow.providers.codex_provider import CodexProvider
+
+        captured_cmd = []
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"hello", b""))
+        mock_proc.returncode = 0
+        mock_proc.kill = AsyncMock()
+        mock_proc.wait = AsyncMock()
+
+        async def _fake_exec(*args, **kwargs):
+            captured_cmd.extend(args)
+            return mock_proc
+
+        with (
+            patch("workflow.providers.codex_provider._resolve_codex_cmd",
+                  return_value=(["codex"], False)),
+            patch("workflow.providers.codex_provider.get_sandbox_status",
+                  return_value={"bwrap_available": False, "reason": "test"}),
+            patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+        ):
+            provider = CodexProvider()
+            await provider.complete("prompt", "system", ModelConfig())
+
+        repo_root = Path(codex_provider.__file__).resolve().parents[2]
+        assert "-C" in captured_cmd
+        assert captured_cmd[captured_cmd.index("-C") + 1] == str(repo_root)
 
     @pytest.mark.asyncio
     async def test_model_can_be_overridden_by_env(self, monkeypatch):

--- a/workflow/providers/codex_provider.py
+++ b/workflow/providers/codex_provider.py
@@ -12,8 +12,8 @@ import shlex
 import shutil
 import subprocess
 import sys
-import tempfile
 import time
+from pathlib import Path
 
 from workflow.exceptions import (
     ProviderError,
@@ -54,6 +54,14 @@ def _codex_model() -> str:
     return os.environ.get("WORKFLOW_CODEX_MODEL", "gpt-5.4").strip() or "gpt-5.4"
 
 
+def _codex_workdir() -> str:
+    """Return the source workspace Codex should inspect for coding tasks."""
+    configured = os.environ.get("WORKFLOW_CODEX_WORKDIR", "").strip()
+    if configured:
+        return configured
+    return str(Path(__file__).resolve().parents[2])
+
+
 class CodexProvider(BaseProvider):
     """Calls GPT via the ``codex exec`` CLI binary."""
 
@@ -80,11 +88,11 @@ class CodexProvider(BaseProvider):
             if sandbox_status.get("bwrap_available")
             else ["--dangerously-bypass-approvals-and-sandbox"]
         )
-        # Prompt-node calls need Codex as a subscription-backed text model,
-        # not as a repo-editing agent. Run from an empty ephemeral directory.
+        # Prompt-node calls use Codex as a subscription-backed text model, but
+        # loop-investigation coding prompts still need repo source/tests mounted.
         # Prefer Codex's sandboxed auto mode when bwrap is actually usable;
         # bwrap-less hosts fall back to the hosted subscription mode already
-        # used by auto-fix, with API keys stripped and an empty working dir.
+        # used by auto-fix, with API keys stripped.
         cmd = [
             *base_cmd,
             "exec",
@@ -97,40 +105,39 @@ class CodexProvider(BaseProvider):
         proc_env = subprocess_env_without_api_keys()
 
         win_kw = _no_window_kwargs()
-        with tempfile.TemporaryDirectory(prefix="workflow-codex-provider-") as workdir:
-            cmd_with_cwd = [*cmd, "-C", workdir]
-            if use_shell:
-                proc = await asyncio.create_subprocess_shell(
-                    shlex.join(cmd_with_cwd),
-                    stdin=asyncio.subprocess.PIPE,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    env=proc_env,
-                    **win_kw,
-                )
-            else:
-                proc = await asyncio.create_subprocess_exec(
-                    *cmd_with_cwd,
-                    stdin=asyncio.subprocess.PIPE,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    env=proc_env,
-                    **win_kw,
-                )
+        cmd_with_cwd = [*cmd, "-C", _codex_workdir()]
+        if use_shell:
+            proc = await asyncio.create_subprocess_shell(
+                shlex.join(cmd_with_cwd),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=proc_env,
+                **win_kw,
+            )
+        else:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd_with_cwd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=proc_env,
+                **win_kw,
+            )
 
-            start = time.monotonic()
+        start = time.monotonic()
 
-            try:
-                stdout, stderr = await asyncio.wait_for(
-                    proc.communicate(input=full_input.encode("utf-8")),
-                    timeout=config.timeout,
-                )
-            except asyncio.TimeoutError:
-                proc.kill()
-                await proc.wait()
-                raise ProviderTimeoutError(
-                    f"codex exec exceeded {config.timeout}s timeout"
-                )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=full_input.encode("utf-8")),
+                timeout=config.timeout,
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise ProviderTimeoutError(
+                f"codex exec exceeded {config.timeout}s timeout"
+            )
 
         elapsed_ms = (time.monotonic() - start) * 1000
 


### PR DESCRIPTION
Fixes #264

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.