### PR TITLE
[auto-change] WIKI-PATCH: Dispatcher should detect filing-shape (mechanical vs architectural) and route architectural filings to design-note drafts instead of auto-change branches

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -31,7 +31,9 @@ name: Auto-fix change
 # Variables -> Actions -> New repository variable). Flip to false to re-enable.
 # Variable-based toggle preserves the secrets; no data loss.
 #
-# Branch naming: auto-change/issue-<N>
+# Branch naming:
+#   mechanical filings:    auto-change/issue-<N>
+#   architectural filings: design-note-draft/issue-<N>
 # PR title/body are requested in the prompt because claude-code-action@v1 no
 # longer accepts the v0 `pr_title` / `pr_body` inputs.
 
@@ -534,6 +536,10 @@ jobs:
             const labels = (issue.labels || []).map(labelName);
             const requestKindLabel = labels.find((name) => name?.startsWith('request:'));
             const requestKind = requestKindLabel ? requestKindLabel.replace('request:', '') : 'change';
+            const architecturalKinds = new Set(['project-design']);
+            const filingShape = architecturalKinds.has(requestKind) ? 'architectural' : 'mechanical';
+            const branchPrefix = filingShape === 'architectural' ? 'design-note-draft/' : 'auto-change/';
+            const prTitlePrefix = filingShape === 'architectural' ? '[design-note]' : '[auto-change]';
 
             // Pull request id from titles like "[BUG-003] ..." or "[WIKI-FEATURE] ...".
             const bugMatch = title.match(/\[?(BUG-\d+)\]?/i);
@@ -550,8 +556,10 @@ jobs:
             core.setOutput('issue_number', String(issue.issue_number));
             core.setOutput('request_id', requestId);
             core.setOutput('request_kind', requestKind);
+            core.setOutput('filing_shape', filingShape);
+            core.setOutput('branch_prefix', branchPrefix);
             core.setOutput('short_title', shortTitle);
-            core.setOutput('pr_title', `[auto-change] ${requestId}: ${shortTitle}`);
+            core.setOutput('pr_title', `${prTitlePrefix} ${requestId}: ${shortTitle}`);
             core.setOutput('issue_body', body);
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -593,13 +601,14 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           base_branch: main
-          branch_prefix: auto-change/
+          branch_prefix: ${{ steps.meta.outputs.branch_prefix }}
           branch_name_template: issue-${{ steps.meta.outputs.issue_number }}
           prompt: |
             You are handling a community change request in the Workflow repository.
 
             Request ID: ${{ steps.meta.outputs.request_id }}
             Request kind: ${{ steps.meta.outputs.request_kind }}
+            Filing shape: ${{ steps.meta.outputs.filing_shape }}
             Issue #${{ steps.meta.outputs.issue_number }}: ${{ steps.meta.outputs.short_title }}
 
             Issue body:
@@ -612,6 +621,7 @@ jobs:
             1. Read AGENTS.md and STATUS.md for project context.
             2. Classify the request as bug, patch, feature, docs/ops, branch refinement, or project design.
             3. For bugs, reproduce or reason about the root cause. For non-bug requests, identify the smallest useful project change.
+            3a. For architectural/project-design filings, draft or update a design note under `docs/design-notes/proposed/`; do not make runtime code changes unless the issue explicitly asks for implementation.
             4. Implement a minimal, targeted change; no refactoring beyond what's needed.
             5. Add or update tests/docs/checks appropriate to the risk.
             6. If recent comments mention verification failures or review blockers, address those failures first.
@@ -638,9 +648,10 @@ jobs:
           WORKFLOW_CODEX_AUTH_JSON_B64: ${{ secrets.WORKFLOW_CODEX_AUTH_JSON_B64 }}
           WORKFLOW_PUSH_TOKEN: ${{ secrets.WORKFLOW_PUSH_TOKEN }}
           PR_TITLE: ${{ steps.meta.outputs.pr_title }}
+          BRANCH_PREFIX: ${{ steps.meta.outputs.branch_prefix }}
         run: |
           set -euo pipefail
-          branch="auto-change/issue-${{ steps.meta.outputs.issue_number }}-codex-${GITHUB_RUN_ID}"
+          branch="${BRANCH_PREFIX}issue-${{ steps.meta.outputs.issue_number }}-codex-${GITHUB_RUN_ID}"
           echo "branch=${branch}" >> "$GITHUB_OUTPUT"
 
           mkdir -p "$HOME/.codex"
@@ -663,6 +674,7 @@ jobs:
 
           Request ID: ${{ steps.meta.outputs.request_id }}
           Request kind: ${{ steps.meta.outputs.request_kind }}
+          Filing shape: ${{ steps.meta.outputs.filing_shape }}
           Issue #${{ steps.meta.outputs.issue_number }}: ${{ steps.meta.outputs.short_title }}
 
           Issue body:
@@ -675,6 +687,7 @@ jobs:
           1. Read AGENTS.md and STATUS.md for project context.
           2. Classify the request as bug, patch, feature, docs/ops, branch refinement, or project design.
           3. For bugs, reproduce or reason about the root cause. For non-bug requests, identify the smallest useful project change.
+          3a. For architectural/project-design filings, draft or update a design note under `docs/design-notes/proposed/`; do not make runtime code changes unless the issue explicitly asks for implementation.
           4. Implement a minimal, targeted change; no refactoring beyond what's needed.
           5. Add or update tests/docs/checks appropriate to the risk.
           6. If recent comments mention verification failures or review blockers, address those failures first.
@@ -957,9 +970,10 @@ jobs:
           script: |
             const issueNumber = Number('${{ matrix.issue.issue_number }}');
             const mode = '${{ steps.auth.outputs.mode }}';
+            const branchPrefix = '${{ steps.meta.outputs.branch_prefix }}';
             const branch = mode === 'codex_subscription'
               ? '${{ steps.codex-subscription.outputs.branch }}'
-              : `auto-change/issue-${issueNumber}`;
+              : `${branchPrefix}issue-${issueNumber}`;
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -1015,10 +1029,11 @@ jobs:
           script: |
             const issueNumber = Number('${{ matrix.issue.issue_number }}');
             const mode = '${{ steps.auth.outputs.mode }}';
+            const branchPrefix = '${{ steps.meta.outputs.branch_prefix }}';
             const codexBranch = process.env.CODEX_BRANCH || '';
             const branch = mode === 'codex_subscription' && codexBranch
               ? codexBranch
-              : `auto-change/issue-${issueNumber}`;
+              : `${branchPrefix}issue-${issueNumber}`;
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/docs/ops/wiki-bug-sync-runbook.md
+++ b/docs/ops/wiki-bug-sync-runbook.md
@@ -63,7 +63,14 @@ commits increments back. This makes reruns idempotent.
 | `pages/workflows/*` | `request:branch-refinement` |
 | builder notes under `pages/notes/*` | `request:branch-refinement` |
 | strategic/roadmap/design/architecture/refactoring/attribution plans | `request:project-design` |
+| patch/feature pages whose title/path has architectural shape | `request:project-design` |
 | other promoted plans/concepts | `request:docs-ops` |
+
+Architectural shape wins over the folder name. A patch request asking for
+architecture, design-note, roadmap, operating-model, or substrate changes is
+filed as `request:project-design`; the auto-fix workflow then drafts under
+`docs/design-notes/proposed/` on a `design-note-draft/*` branch instead of
+opening a mechanical `auto-change/*` branch.
 
 ## Manual trigger
 

--- a/scripts/wiki_bug_sync.py
+++ b/scripts/wiki_bug_sync.py
@@ -100,6 +100,19 @@ _CHANGE_KIND_PREFIX: dict[str, str] = {
     "project-design": "WIKI-DESIGN",
 }
 
+_ARCHITECTURAL_FILING_MARKERS = (
+    "architecture",
+    "architectural",
+    "design-note",
+    "design note",
+    "project design",
+    "operating-model",
+    "operating model",
+    "roadmap",
+    "strategic",
+    "substrate",
+)
+
 _INIT_PAYLOAD = {
     "jsonrpc": "2.0",
     "id": 1,
@@ -307,6 +320,9 @@ def _change_kind(entry: dict[str, Any]) -> str | None:
     ):
         return None
 
+    if any(marker in design_text for marker in _ARCHITECTURAL_FILING_MARKERS):
+        return "project-design"
+
     if (
         entry_type in {"feature", "feature_request"}
         or path.startswith("pages/feature-requests/")
@@ -336,15 +352,10 @@ def _change_kind(entry: dict[str, Any]) -> str | None:
     if path.startswith("pages/plans/") and any(
         marker in design_text
         for marker in (
-            "architecture",
+            *_ARCHITECTURAL_FILING_MARKERS,
             "attribution",
             "design",
-            "operating-model",
-            "operating model",
             "refactoring",
-            "roadmap",
-            "strategic",
-            "substrate",
             "synthesis",
         )
     ):

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -399,23 +399,49 @@ def test_codex_pr_creation_policy_block_is_classified(wf):
 
 def test_branch_naming_convention(wf):
     steps = wf["jobs"]["fix"]["steps"]
+    meta_step = next((s for s in steps if s.get("id") == "meta"), None)
     oauth_step = next((s for s in steps if s.get("id") == "claude-oauth"), None)
+    assert meta_step is not None, "Must have request metadata step"
     assert oauth_step is not None, "Must have a Claude OAuth step"
+    meta_script = str(meta_step.get("with", {}).get("script", ""))
+    assert "const branchPrefix" in meta_script
+    assert "design-note-draft/" in meta_script
+    assert "auto-change/" in meta_script
+    assert "core.setOutput('branch_prefix', branchPrefix)" in meta_script
     with_block = oauth_step.get("with", {})
-    assert with_block.get("branch_prefix") == "auto-change/"
+    assert with_block.get("branch_prefix") == "${{ steps.meta.outputs.branch_prefix }}"
     assert "issue-${{ steps.meta.outputs.issue_number }}" == with_block.get(
         "branch_name_template"
     ), (
-        "Branch must follow auto-change/issue-<N> naming convention"
+        "Branch must follow the filing-shape branch prefix plus issue-<N>"
     )
 
 
-def test_pr_title_includes_auto_fix_prefix(wf):
+def test_pr_title_prefix_uses_filing_shape(wf):
     steps = wf["jobs"]["fix"]["steps"]
     meta_step = next((s for s in steps if s.get("id") == "meta"), None)
     assert meta_step is not None
     script = str(meta_step.get("with", {}).get("script", ""))
-    assert "[auto-change]" in script, "PR title must start with [auto-change]"
+    assert "const filingShape" in script
+    assert "'[design-note]'" in script
+    assert "'[auto-change]'" in script
+    assert "core.setOutput('filing_shape', filingShape)" in script
+    assert "prTitlePrefix" in script
+
+
+def test_architectural_prompt_routes_to_design_note_draft(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    oauth_step = next((s for s in steps if s.get("id") == "claude-oauth"), None)
+    codex_step = next((s for s in steps if s.get("id") == "codex-subscription"), None)
+    assert oauth_step is not None, "Must have a Claude OAuth step"
+    assert codex_step is not None, "Must have a Codex subscription step"
+    oauth_prompt = str(oauth_step.get("with", {}).get("prompt", ""))
+    codex_prompt = str(codex_step.get("run", ""))
+    for prompt in (oauth_prompt, codex_prompt):
+        assert "Filing shape:" in prompt
+        assert "architectural/project-design filings" in prompt
+        assert "docs/design-notes/proposed/" in prompt
+        assert "do not make runtime code changes" in prompt
 
 
 def test_meta_step_fetches_recent_issue_comments_for_feedback(wf):

--- a/tests/test_wiki_bug_sync.py
+++ b/tests/test_wiki_bug_sync.py
@@ -208,6 +208,27 @@ def test_patch_request_page_enters_patch_lane():
     assert result[0]["request_kind"] == "patch"
 
 
+def test_architectural_patch_request_enters_project_design_lane():
+    wiki_list = {
+        "promoted": [
+            {
+                "path": (
+                    "pages/patch-requests/"
+                    "pr-004-dispatcher-should-detect-filing-shape.md"
+                ),
+                "title": (
+                    "Dispatcher should detect filing-shape mechanical vs "
+                    "architectural and route to design-note drafts"
+                ),
+                "type": "patch_request",
+            }
+        ]
+    }
+    result = list_new_change_requests(wiki_list, seen_paths=set())
+    assert len(result) == 1
+    assert result[0]["request_kind"] == "project-design"
+
+
 def test_legacy_bug_typed_patch_request_page_enters_patch_lane():
     wiki_list = {
         "promoted": [


### PR DESCRIPTION
Fixes #295

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.