### PR TITLE
[auto-change] WIKI-PATCH: Dispatcher should detect filing-shape (mechanical vs architectural) and route architectural filings to design-note drafts instead of auto-change branches

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -115,6 +115,10 @@ jobs:
               if (!issue || issue.pull_request || seenIssueNumbers.has(issue.number)) {
                 return;
               }
+              if (hasLabel(issue, 'request:project-design')) {
+                core.info(`Skipping project-design issue #${issue.number}; design-note drafting does not use auto-change branches.`);
+                return;
+              }
               const needsHuman = hasLabel(issue, 'needs-human');
               const attempted = hasLabel(issue, 'auto-fix-attempted');
               const reviewed = hasLabel(issue, 'auto-fix-reviewed');

--- a/docs/ops/wiki-bug-sync-runbook.md
+++ b/docs/ops/wiki-bug-sync-runbook.md
@@ -60,6 +60,7 @@ commits increments back. This makes reruns idempotent.
 | BUG page | `request:bug` |
 | `pages/plans/feature-*` | `request:feature` |
 | `pages/plans/patch-*` | `request:patch` |
+| architectural/design-shaped patch filings | `request:project-design` + `design-note-draft` |
 | `pages/workflows/*` | `request:branch-refinement` |
 | builder notes under `pages/notes/*` | `request:branch-refinement` |
 | strategic/roadmap/design/architecture/refactoring/attribution plans | `request:project-design` |

--- a/scripts/wiki_bug_sync.py
+++ b/scripts/wiki_bug_sync.py
@@ -72,6 +72,7 @@ _PAYMENT_FREE_OK_LABEL = "payment:free-ok"
 _WRITER_POOL_LABEL = "writer-pool:claude-codex"
 _CHECKER_POLICY_LABEL = "checker:cross-family"
 _GATE_REQUIRED_LABEL = "gate-required"
+_DESIGN_NOTE_DRAFT_LABEL = "design-note-draft"
 _DAEMON_REQUEST_LABELS = [
     _DAEMON_REQUEST_LABEL,
     _AUTO_CHANGE_LABEL,
@@ -99,6 +100,21 @@ _CHANGE_KIND_PREFIX: dict[str, str] = {
     "branch-refinement": "WIKI-BRANCH",
     "project-design": "WIKI-DESIGN",
 }
+
+_ARCHITECTURAL_FILING_MARKERS = (
+    "architecture",
+    "architectural",
+    "design",
+    "design-note",
+    "design note",
+    "operating-model",
+    "operating model",
+    "refactoring",
+    "roadmap",
+    "strategic",
+    "substrate",
+    "synthesis",
+)
 
 _INIT_PAYLOAD = {
     "jsonrpc": "2.0",
@@ -307,6 +323,18 @@ def _change_kind(entry: dict[str, Any]) -> str | None:
     ):
         return None
 
+    is_patch_request = (
+        entry_type in {"patch", "patch_request"}
+        or path.startswith("pages/patch-requests/")
+        or path.startswith("patch-requests/")
+        or path.startswith("pages/plans/patch-")
+        or title.startswith("patch ")
+    )
+    if is_patch_request and any(
+        marker in design_text for marker in _ARCHITECTURAL_FILING_MARKERS
+    ):
+        return "project-design"
+
     if (
         entry_type in {"feature", "feature_request"}
         or path.startswith("pages/feature-requests/")
@@ -315,13 +343,7 @@ def _change_kind(entry: dict[str, Any]) -> str | None:
         or title.startswith("feature ")
     ):
         return "feature"
-    if (
-        entry_type in {"patch", "patch_request"}
-        or path.startswith("pages/patch-requests/")
-        or path.startswith("patch-requests/")
-        or path.startswith("pages/plans/patch-")
-        or title.startswith("patch ")
-    ):
+    if is_patch_request:
         return "patch"
     if (
         entry_type in {"design", "design_proposal", "project-design"}
@@ -336,16 +358,8 @@ def _change_kind(entry: dict[str, Any]) -> str | None:
     if path.startswith("pages/plans/") and any(
         marker in design_text
         for marker in (
-            "architecture",
+            *_ARCHITECTURAL_FILING_MARKERS,
             "attribution",
-            "design",
-            "operating-model",
-            "operating model",
-            "refactoring",
-            "roadmap",
-            "strategic",
-            "substrate",
-            "synthesis",
         )
     ):
         return "project-design"
@@ -461,6 +475,8 @@ def _label_color(label: str) -> str:
         return "b60205"
     if label == _GATE_REQUIRED_LABEL:
         return "fbca04"
+    if label == _DESIGN_NOTE_DRAFT_LABEL:
+        return "c5def5"
     if label.startswith("severity:"):
         return "d93f0b"
     if label.startswith("request:"):
@@ -550,16 +566,34 @@ def create_gh_change_issue(
 ) -> str:
     """Create a non-bug community change Issue."""
     kind_label = _REQUEST_KIND_LABELS.get(request_kind, "request:change")
-    labels = [*_DAEMON_REQUEST_LABELS, kind_label]
+    if request_kind == "project-design":
+        labels = [
+            _DAEMON_REQUEST_LABEL,
+            _PAYMENT_FREE_OK_LABEL,
+            _GATE_REQUIRED_LABEL,
+            _DESIGN_NOTE_DRAFT_LABEL,
+            kind_label,
+        ]
+        request_contract = (
+            "**Daemon request contract:** claimable by paid or free design-note "
+            "drafting daemons that meet the declared gate requirements. "
+            "Architectural filings must produce reviewable design-note drafts, "
+            "not auto-change code branches.\n"
+        )
+    else:
+        labels = [*_DAEMON_REQUEST_LABELS, kind_label]
+        request_contract = (
+            "**Daemon request contract:** claimable by paid or free daemons that meet "
+            "the declared gate requirements. Code-change writers are Claude/Codex "
+            "only and require an opposite-family checker.\n"
+        )
     prefix = _CHANGE_KIND_PREFIX.get(request_kind, "WIKI-CHANGE")
     title_str = f"[{prefix}] {title}"
     issue_body = (
         f"**Request kind:** {request_kind}\n"
         f"**Wiki path:** `{path}`\n\n"
-        "**Daemon request contract:** claimable by paid or free daemons that meet "
-        "the declared gate requirements. Code-change writers are Claude/Codex "
-        "only and require an opposite-family checker.\n"
-        "**Bounty terms:** no paid bounty is attached by default; if one is "
+        + request_contract
+        + "**Bounty terms:** no paid bounty is attached by default; if one is "
         "added, settlement follows the gate ladder's `bounty_requirements`.\n\n"
         f"{body_md}\n\n"
         f"_Auto-filed by wiki-change-sync from wiki page `{path}`._"

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -122,6 +122,13 @@ def test_discover_retries_branch_push_blocked_when_push_token_visible(wf):
     assert "workflow push token is now visible" in script
 
 
+def test_discover_skips_project_design_issues(wf):
+    discover_step = wf["jobs"]["discover"]["steps"][0]
+    script = str(discover_step.get("with", {}).get("script", ""))
+    assert "request:project-design" in script
+    assert "design-note drafting does not use auto-change branches" in script
+
+
 def test_discover_scheduled_backfill_reads_oldest_pending_first(wf):
     discover_step = wf["jobs"]["discover"]["steps"][0]
     script = str(discover_step.get("with", {}).get("script", ""))

--- a/tests/test_wiki_bug_sync.py
+++ b/tests/test_wiki_bug_sync.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 from wiki_bug_sync import (  # noqa: E402
     SyncError,
     _bug_number,
+    create_gh_change_issue,
     create_gh_issue,
     fetch_bug_detail,
     list_new_bugs,
@@ -208,6 +209,24 @@ def test_patch_request_page_enters_patch_lane():
     assert result[0]["request_kind"] == "patch"
 
 
+def test_architectural_patch_request_enters_project_design_lane():
+    wiki_list = {
+        "promoted": [
+            {
+                "path": "pages/patch-requests/pr-004-dispatcher-filing-shape.md",
+                "title": (
+                    "Dispatcher should detect filing-shape mechanical vs "
+                    "architectural"
+                ),
+                "type": "patch_request",
+            }
+        ]
+    }
+    result = list_new_change_requests(wiki_list, seen_paths=set())
+    assert len(result) == 1
+    assert result[0]["request_kind"] == "project-design"
+
+
 def test_legacy_bug_typed_patch_request_page_enters_patch_lane():
     wiki_list = {
         "promoted": [
@@ -296,6 +315,24 @@ def test_create_gh_issue_no_token_raises():
             body_md="desc", dry_run=False,
         )
     assert exc_info.value.code == 3
+
+
+def test_project_design_issue_routes_to_design_note_draft_not_auto_change(capsys):
+    url = create_gh_change_issue(
+        token="",
+        repo="owner/repo",
+        request_kind="project-design",
+        title="Dispatcher filing shape",
+        path="pages/patch-requests/pr-004-dispatcher-filing-shape.md",
+        body_md="desc",
+        dry_run=True,
+    )
+    out = capsys.readouterr().out
+    assert url == "[dry-run]"
+    assert "request:project-design" in out
+    assert "design-note-draft" in out
+    assert "auto-change" not in out
+    assert "writer-pool:claude-codex" not in out
 
 
 def test_fetch_bug_detail_reads_with_page_not_path():


### PR DESCRIPTION
Fixes #303

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.