### PR TITLE
[auto-change] WIKI-PATCH: wiki-change-sync fails red at sync-state push when main advances during run, despite successful issue creation

### DIFF
--- a/.github/workflows/wiki-bug-sync.yml
+++ b/.github/workflows/wiki-bug-sync.yml
@@ -61,5 +61,17 @@ jobs:
           else
             git add .agents/.wiki_bug_sync_cursor .agents/.wiki_change_sync_seen.json
             git commit -m "chore: wiki change sync state update [skip ci]"
-            git push
+            branch="${GITHUB_REF_NAME:-main}"
+            for attempt in 1 2 3; do
+              if git push origin "HEAD:${branch}"; then
+                exit 0
+              fi
+              if [ "$attempt" -eq 3 ]; then
+                echo "Sync state push failed after ${attempt} attempts."
+                exit 1
+              fi
+              echo "Sync state push rejected; rebasing on origin/${branch} and retrying."
+              git fetch origin "$branch"
+              git rebase "origin/${branch}"
+            done
           fi

--- a/tests/test_wiki_bug_sync_workflow.py
+++ b/tests/test_wiki_bug_sync_workflow.py
@@ -1,0 +1,22 @@
+"""Regression checks for the wiki bug sync GitHub Actions workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parent.parent
+    / ".github"
+    / "workflows"
+    / "wiki-bug-sync.yml"
+)
+
+
+def test_sync_state_push_rebases_and_retries_when_main_advances():
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "for attempt in 1 2 3; do" in workflow
+    assert 'git push origin "HEAD:${branch}"' in workflow
+    assert 'git fetch origin "$branch"' in workflow
+    assert 'git rebase "origin/${branch}"' in workflow
+    assert "Sync state push rejected; rebasing" in workflow


### PR DESCRIPTION
Fixes #305

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.