### PR TITLE
auto-fix: prioritize permission-blocked retries before normal queue

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -421,3 +421,14 @@ Notes:
   checks fire on loop-created PRs.
 - Ship condition: workflow static tests, actionlint, diff-check, PR opened for
   Claude/Cowork review.
+
+## Branch-Push Retry Priority - 2026-05-05
+
+- 2026-05-05 create `../wf-branch-push-terminal-retry` on
+  `codex/branch-push-terminal-retry` by codex-gpt5-desktop.
+- Source: after PR #398 landed, issue #87 stayed `branch_push_blocked` while
+  normal old pending issues were selected first.
+- Purpose: prioritize retryable `auto-fix-branch-push-blocked` issues across all
+  auto labels before normal queue discovery.
+- Ship condition: focused workflow tests, ruff, diff-check, PR opened for
+  Claude/Cowork review.

--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -161,25 +161,39 @@ jobs:
                 pushIfPending(issue, { retryAttempted: true });
               }
             } else {
-              for (const labelName of autoLabels) {
-                const { data: issues } = await github.rest.issues.listForRepo({
-                  owner,
-                  repo,
-                  state: 'open',
-                  labels: labelName,
-                  sort: 'created',
-                  direction: 'asc',
-                  per_page: 100,
-                });
-                for (const issue of issues) {
-                  pushIfPending(issue);
-                  if (rows.length >= maxIssues) {
-                    break;
+              async function scanAutoLabels(options = {}) {
+                const onlyBranchPushBlocked = options.onlyBranchPushBlocked || false;
+                for (const labelName of autoLabels) {
+                  const { data: issues } = await github.rest.issues.listForRepo({
+                    owner,
+                    repo,
+                    state: 'open',
+                    labels: labelName,
+                    sort: 'created',
+                    direction: 'asc',
+                    per_page: 100,
+                  });
+                  for (const issue of issues) {
+                    if (
+                      onlyBranchPushBlocked &&
+                      !hasLabel(issue, 'auto-fix-branch-push-blocked')
+                    ) {
+                      continue;
+                    }
+                    pushIfPending(issue);
+                    if (rows.length >= maxIssues) {
+                      return;
+                    }
                   }
                 }
-                if (rows.length >= maxIssues) {
-                  break;
-                }
+              }
+
+              await scanAutoLabels({ onlyBranchPushBlocked: true });
+              if (rows.length >= maxIssues) {
+                core.info('Prioritized retryable branch-push-blocked issue before normal queue discovery.');
+              }
+              if (rows.length < maxIssues) {
+                await scanAutoLabels();
               }
             }
 

--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -82,12 +82,22 @@ jobs:
             const repo = context.repo.repo;
             const maxIssues = 1;
             const autoLabels = ['daemon-request', 'auto-change', 'auto-bug'];
+            const priorityLabelOrder = [
+              'priority:loop-discipline',
+              'priority:primitive-layer',
+              'priority:primitive-surface',
+            ];
+            const skipLabels = ['await-primitive-layer', 'complete'];
             const hasWriterAuth = process.env.HAS_WRITER_AUTH === 'true';
             const hasWorkflowPushToken = process.env.HAS_WORKFLOW_PUSH_TOKEN === 'true';
             const autoFixDisabled = process.env.AUTO_FIX_DISABLED === 'true';
 
             function hasLabel(issue, name) {
               return (issue.labels || []).some((label) => label.name === name);
+            }
+
+            function shouldSkipIssue(issue, options = {}) {
+              return !options.ignoreSkip && skipLabels.some((name) => hasLabel(issue, name));
             }
 
             function issueRow(issue) {
@@ -113,6 +123,10 @@ jobs:
 
             function pushIfPending(issue, options = {}) {
               if (!issue || issue.pull_request || seenIssueNumbers.has(issue.number)) {
+                return;
+              }
+              if (shouldSkipIssue(issue, options)) {
+                core.info(`Skipping issue #${issue.number} because it is deferred or complete.`);
                 return;
               }
               const needsHuman = hasLabel(issue, 'needs-human');
@@ -166,12 +180,12 @@ jobs:
             } else {
               async function scanAutoLabels(options = {}) {
                 const onlyPermissionBlocked = options.onlyPermissionBlocked || false;
-                for (const labelName of autoLabels) {
+                async function scanLabelQuery(labelNames) {
                   const { data: issues } = await github.rest.issues.listForRepo({
                     owner,
                     repo,
                     state: 'open',
-                    labels: labelName,
+                    labels: labelNames.join(','),
                     sort: 'created',
                     direction: 'asc',
                     per_page: 100,
@@ -186,8 +200,22 @@ jobs:
                     }
                     pushIfPending(issue);
                     if (rows.length >= maxIssues) {
+                      return true;
+                    }
+                  }
+                  return false;
+                }
+
+                for (const priorityLabel of priorityLabelOrder) {
+                  for (const autoLabel of autoLabels) {
+                    if (await scanLabelQuery([autoLabel, priorityLabel])) {
                       return;
                     }
+                  }
+                }
+                for (const labelName of autoLabels) {
+                  if (await scanLabelQuery([labelName])) {
+                    return;
                   }
                 }
               }

--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -198,7 +198,7 @@ jobs:
                     ) {
                       continue;
                     }
-                    pushIfPending(issue);
+                    pushIfPending(issue, { ignoreSkip: onlyPermissionBlocked });
                     if (rows.length >= maxIssues) {
                       return true;
                     }

--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -118,15 +118,18 @@ jobs:
               const needsHuman = hasLabel(issue, 'needs-human');
               const attempted = hasLabel(issue, 'auto-fix-attempted');
               const reviewed = hasLabel(issue, 'auto-fix-reviewed');
-              const retryBranchPushBlocked = (
-                hasLabel(issue, 'auto-fix-branch-push-blocked') &&
+              const retryPermissionBlocked = (
+                (
+                  hasLabel(issue, 'auto-fix-branch-push-blocked') ||
+                  hasLabel(issue, 'auto-fix-pr-blocked')
+                ) &&
                 hasWriterAuth &&
                 hasWorkflowPushToken &&
                 !autoFixDisabled
               );
               const retryAttempted = options.retryAttempted || (
                 needsHuman && hasWriterAuth && !autoFixDisabled && !reviewed
-              ) || retryBranchPushBlocked;
+              ) || retryPermissionBlocked;
               if (attempted && !retryAttempted) {
                 return;
               }
@@ -137,7 +140,7 @@ jobs:
                 return;
               }
               if (needsHuman) {
-                const reason = retryBranchPushBlocked
+                const reason = retryPermissionBlocked
                   ? 'workflow push token is now visible'
                   : 'writer auth is now visible';
                 core.info(`Retrying needs-human issue #${issue.number} because ${reason}.`);
@@ -162,7 +165,7 @@ jobs:
               }
             } else {
               async function scanAutoLabels(options = {}) {
-                const onlyBranchPushBlocked = options.onlyBranchPushBlocked || false;
+                const onlyPermissionBlocked = options.onlyPermissionBlocked || false;
                 for (const labelName of autoLabels) {
                   const { data: issues } = await github.rest.issues.listForRepo({
                     owner,
@@ -175,8 +178,9 @@ jobs:
                   });
                   for (const issue of issues) {
                     if (
-                      onlyBranchPushBlocked &&
-                      !hasLabel(issue, 'auto-fix-branch-push-blocked')
+                      onlyPermissionBlocked &&
+                      !hasLabel(issue, 'auto-fix-branch-push-blocked') &&
+                      !hasLabel(issue, 'auto-fix-pr-blocked')
                     ) {
                       continue;
                     }
@@ -188,9 +192,9 @@ jobs:
                 }
               }
 
-              await scanAutoLabels({ onlyBranchPushBlocked: true });
+              await scanAutoLabels({ onlyPermissionBlocked: true });
               if (rows.length >= maxIssues) {
-                core.info('Prioritized retryable branch-push-blocked issue before normal queue discovery.');
+                core.info('Prioritized retryable permission-blocked issue before normal queue discovery.');
               }
               if (rows.length < maxIssues) {
                 await scanAutoLabels();
@@ -494,9 +498,16 @@ jobs:
             }
             if (
               '${{ steps.auth.outputs.has_workflow_push_token }}' === 'true' &&
-              issueLabels.includes('auto-fix-branch-push-blocked')
+              (
+                issueLabels.includes('auto-fix-branch-push-blocked') ||
+                issueLabels.includes('auto-fix-pr-blocked')
+              )
             ) {
-              labelsToClear.push('auto-fix-reviewed', 'auto-fix-branch-push-blocked');
+              labelsToClear.push(
+                'auto-fix-reviewed',
+                'auto-fix-branch-push-blocked',
+                'auto-fix-pr-blocked',
+              );
             }
             for (const label of labelsToClear) {
               try {

--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -354,6 +354,7 @@ def queue_stage(
     missing_codex_subscription: list[dict[str, Any]] = []
     auth_missing: list[dict[str, Any]] = []
     provider_exhausted: list[dict[str, Any]] = []
+    pr_blocked: list[dict[str, Any]] = []
     branch_push_blocked: list[dict[str, Any]] = []
     reviewed_terminal: list[dict[str, Any]] = []
     attempted: list[dict[str, Any]] = []
@@ -364,6 +365,7 @@ def queue_stage(
         labels = _labels(issue)
         if BLOCKED_LABEL in labels and (
             labels.isdisjoint(TERMINAL_REVIEW_LABELS)
+            or PR_BLOCKED_LABEL in labels
             or BRANCH_PUSH_BLOCKED_LABEL in labels
         ):
             needs_human.append(issue)
@@ -373,9 +375,11 @@ def queue_stage(
                 missing_codex_subscription.append(issue)
             if AUTH_MISSING_LABEL in labels:
                 auth_missing.append(issue)
+            if PR_BLOCKED_LABEL in labels:
+                pr_blocked.append(issue)
             if BRANCH_PUSH_BLOCKED_LABEL in labels:
                 branch_push_blocked.append(issue)
-            elif PROVIDER_EXHAUSTED_LABEL in labels:
+            if PROVIDER_EXHAUSTED_LABEL in labels:
                 provider_exhausted.append(issue)
         elif not labels.isdisjoint(TERMINAL_REVIEW_LABELS):
             reviewed_terminal.append(issue)
@@ -400,6 +404,7 @@ def queue_stage(
         "branch_push_blocked": [
             issue.get("number") for issue in branch_push_blocked
         ],
+        "pr_blocked": [issue.get("number") for issue in pr_blocked],
         "provider_exhausted": [issue.get("number") for issue in provider_exhausted],
         "pending": [issue.get("number") for issue in pending],
         "old_pending": [issue.get("number") for issue in old_pending],
@@ -411,7 +416,15 @@ def queue_stage(
     if needs_human:
         first = needs_human[0]
         root_cause = "automated writer is blocked"
-        if missing_subscription and missing_codex_subscription:
+        if branch_push_blocked and pr_blocked:
+            root_cause = (
+                "automated writer hit branch-push and PR-creation permission blocks"
+            )
+        elif branch_push_blocked:
+            root_cause = "automated writer produced a patch but branch push was blocked"
+        elif pr_blocked:
+            root_cause = "automated writer pushed a branch but PR creation was blocked"
+        elif missing_subscription and missing_codex_subscription:
             root_cause = (
                 "Claude subscription OAuth and Codex subscription auth bundle "
                 "are not visible to GitHub Actions"
@@ -426,8 +439,6 @@ def queue_stage(
             )
         elif auth_missing:
             root_cause = "approved subscription-backed writer auth is missing"
-        elif branch_push_blocked:
-            root_cause = "automated writer produced a patch but branch push was blocked"
         elif provider_exhausted:
             root_cause = "approved writer provider returned quota/capacity exhaustion"
         pending_clause = (

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -134,6 +134,27 @@ def test_discover_prioritizes_permission_blocked_before_normal_queue(wf):
     assert script.index(permission_blocked_pass) < script.index(normal_pass)
 
 
+def test_discover_respects_priority_and_skip_labels(wf):
+    discover_step = wf["jobs"]["discover"]["steps"][0]
+    script = str(discover_step.get("with", {}).get("script", ""))
+    priority_loop = "'priority:loop-discipline'"
+    priority_layer = "'priority:primitive-layer'"
+    priority_surface = "'priority:primitive-surface'"
+    normal_scan = "for (const labelName of autoLabels)"
+    assert priority_loop in script
+    assert priority_layer in script
+    assert priority_surface in script
+    assert "'await-primitive-layer'" in script
+    assert "'complete'" in script
+    assert "function shouldSkipIssue" in script
+    assert "labels: labelNames.join(',')" in script
+    assert script.index(priority_loop) < script.index(priority_layer)
+    assert script.index(priority_layer) < script.index(priority_surface)
+    assert script.index("for (const priorityLabel of priorityLabelOrder)") < (
+        script.index(normal_scan)
+    )
+
+
 def test_permission_blocked_retry_clears_terminal_labels_when_push_token_visible(wf):
     steps = wf["jobs"]["fix"]["steps"]
     clear_step = next(

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -122,6 +122,16 @@ def test_discover_retries_branch_push_blocked_when_push_token_visible(wf):
     assert "workflow push token is now visible" in script
 
 
+def test_discover_prioritizes_branch_push_blocked_before_normal_queue(wf):
+    discover_step = wf["jobs"]["discover"]["steps"][0]
+    script = str(discover_step.get("with", {}).get("script", ""))
+    branch_blocked_pass = "await scanAutoLabels({ onlyBranchPushBlocked: true });"
+    normal_pass = "await scanAutoLabels();"
+    assert "onlyBranchPushBlocked" in script
+    assert "!hasLabel(issue, 'auto-fix-branch-push-blocked')" in script
+    assert script.index(branch_blocked_pass) < script.index(normal_pass)
+
+
 def test_discover_scheduled_backfill_reads_oldest_pending_first(wf):
     discover_step = wf["jobs"]["discover"]["steps"][0]
     script = str(discover_step.get("with", {}).get("script", ""))

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -112,24 +112,40 @@ def test_discover_retries_unreviewed_attempted_needs_human_with_auth(wf):
     assert "retryAttempted" in script
 
 
-def test_discover_retries_branch_push_blocked_when_push_token_visible(wf):
+def test_discover_retries_permission_blocked_when_push_token_visible(wf):
     discover_step = wf["jobs"]["discover"]["steps"][0]
     script = str(discover_step.get("with", {}).get("script", ""))
     assert "HAS_WORKFLOW_PUSH_TOKEN" in str(discover_step.get("env", {}))
     assert "hasWorkflowPushToken" in script
     assert "auto-fix-branch-push-blocked" in script
-    assert "retryBranchPushBlocked" in script
+    assert "auto-fix-pr-blocked" in script
+    assert "retryPermissionBlocked" in script
     assert "workflow push token is now visible" in script
 
 
-def test_discover_prioritizes_branch_push_blocked_before_normal_queue(wf):
+def test_discover_prioritizes_permission_blocked_before_normal_queue(wf):
     discover_step = wf["jobs"]["discover"]["steps"][0]
     script = str(discover_step.get("with", {}).get("script", ""))
-    branch_blocked_pass = "await scanAutoLabels({ onlyBranchPushBlocked: true });"
+    permission_blocked_pass = "await scanAutoLabels({ onlyPermissionBlocked: true });"
     normal_pass = "await scanAutoLabels();"
-    assert "onlyBranchPushBlocked" in script
+    assert "onlyPermissionBlocked" in script
     assert "!hasLabel(issue, 'auto-fix-branch-push-blocked')" in script
-    assert script.index(branch_blocked_pass) < script.index(normal_pass)
+    assert "!hasLabel(issue, 'auto-fix-pr-blocked')" in script
+    assert script.index(permission_blocked_pass) < script.index(normal_pass)
+
+
+def test_permission_blocked_retry_clears_terminal_labels_when_push_token_visible(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    clear_step = next(
+        (s for s in steps if s.get("name") == "Clear auth-missing block when auth is visible"),
+        None,
+    )
+    assert clear_step is not None
+    script = str(clear_step.get("with", {}).get("script", ""))
+    assert "has_workflow_push_token" in script
+    assert "auto-fix-branch-push-blocked" in script
+    assert "auto-fix-pr-blocked" in script
+    assert "auto-fix-reviewed" in script
 
 
 def test_discover_scheduled_backfill_reads_oldest_pending_first(wf):

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -131,6 +131,7 @@ def test_discover_prioritizes_permission_blocked_before_normal_queue(wf):
     assert "onlyPermissionBlocked" in script
     assert "!hasLabel(issue, 'auto-fix-branch-push-blocked')" in script
     assert "!hasLabel(issue, 'auto-fix-pr-blocked')" in script
+    assert "ignoreSkip: onlyPermissionBlocked" in script
     assert script.index(permission_blocked_pass) < script.index(normal_pass)
 
 

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -177,3 +177,88 @@ def test_queue_stage_counts_push_blocked_issue_as_needs_human(monkeypatch):
     assert stage["status"] == "red"
     assert stage["details"]["needs_human"] == [298]
     assert stage["details"]["reviewed_terminal"] == []
+
+
+def test_queue_stage_counts_pr_blocked_issue_as_needs_human(monkeypatch):
+    now = dt.datetime(2026, 5, 5, 21, 20, tzinfo=dt.timezone.utc)
+
+    def fake_list_loop_issues(*_args, **_kwargs):
+        return [
+            {
+                "number": 70,
+                "title": "Writer pushed a branch but could not open the PR",
+                "created_at": "2026-05-01T01:00:00Z",
+                "html_url": "https://example.test/issues/70",
+                "labels": [
+                    {"name": watch.BLOCKED_LABEL},
+                    {"name": watch.ATTEMPTED_LABEL},
+                    {"name": watch.REVIEWED_LABEL},
+                    {"name": watch.CLAUDE_SUBSCRIPTION_MISSING_LABEL},
+                    {"name": watch.PR_BLOCKED_LABEL},
+                ],
+            }
+        ]
+
+    monkeypatch.setattr(watch, "list_loop_issues", fake_list_loop_issues)
+
+    stage = watch.queue_stage(
+        "owner/repo",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+        now=now,
+        max_pending_age_min=45,
+    )
+
+    assert stage["status"] == "red"
+    assert stage["details"]["needs_human"] == [70]
+    assert stage["details"]["pr_blocked"] == [70]
+    assert stage["details"]["reviewed_terminal"] == []
+    assert "PR creation was blocked" in stage["summary"]
+
+
+def test_queue_stage_summarizes_mixed_permission_blocks(monkeypatch):
+    now = dt.datetime(2026, 5, 5, 21, 20, tzinfo=dt.timezone.utc)
+
+    def fake_list_loop_issues(*_args, **_kwargs):
+        return [
+            {
+                "number": 87,
+                "title": "Writer could not push the branch",
+                "created_at": "2026-04-30T23:00:00Z",
+                "html_url": "https://example.test/issues/87",
+                "labels": [
+                    {"name": watch.BLOCKED_LABEL},
+                    {"name": watch.ATTEMPTED_LABEL},
+                    {"name": watch.REVIEWED_LABEL},
+                    {"name": watch.BRANCH_PUSH_BLOCKED_LABEL},
+                ],
+            },
+            {
+                "number": 70,
+                "title": "Writer could not open the PR",
+                "created_at": "2026-05-01T01:00:00Z",
+                "html_url": "https://example.test/issues/70",
+                "labels": [
+                    {"name": watch.BLOCKED_LABEL},
+                    {"name": watch.ATTEMPTED_LABEL},
+                    {"name": watch.REVIEWED_LABEL},
+                    {"name": watch.PR_BLOCKED_LABEL},
+                ],
+            },
+        ]
+
+    monkeypatch.setattr(watch, "list_loop_issues", fake_list_loop_issues)
+
+    stage = watch.queue_stage(
+        "owner/repo",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+        now=now,
+        max_pending_age_min=45,
+    )
+
+    assert stage["details"]["branch_push_blocked"] == [87]
+    assert stage["details"]["pr_blocked"] == [70]
+    assert "branch-push and PR-creation permission blocks" in stage["summary"]


### PR DESCRIPTION
## Summary
- add a permission-blocked pre-pass across all auto-fix label buckets before normal oldest-first discovery
- treats both `auto-fix-branch-push-blocked` and `auto-fix-pr-blocked` as retryable only when writer auth and `WORKFLOW_PUSH_TOKEN` are visible
- clears stale terminal permission labels when a token-backed retry begins, so #87 and older PR-creation-blocked issues can be retried without an operator-dispatched `issue_number`
- updates `community_loop_watch.py` so PR-blocked issues stay visible as active writer blockers instead of being hidden as reviewed-terminal
- keeps normal queue order after retryable permission-blocked issues are exhausted

## Verification
- `python -m pytest tests\\test_auto_fix_workflow.py tests\\test_community_loop_watch.py -q` (54 passed)
- `python -m ruff check tests\\test_auto_fix_workflow.py scripts\\community_loop_watch.py tests\\test_community_loop_watch.py`
- `git diff --check`
- local patched `python scripts\\community_loop_watch.py --json` now reports `pr_blocked` and the mixed branch-push/PR-creation permission-block summary

Local actionlint is unavailable in this workspace; PR CI should run actionlint. Requires Claude/Cowork checker key.