### PR TITLE
[auto-change] BUG-067: ChatGPT Workflow response can stop after source reads before requested create/readback is visible

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -3762,6 +3762,7 @@ def _action_list_sources(
 def _action_read_source(
     universe_id: str = "",
     filename: str = "",
+    limit: int = 30,
     **_kwargs: Any,
 ) -> str:
     """Read one uploaded source document verbatim with checksum metadata."""
@@ -3800,15 +3801,30 @@ def _action_read_source(
     except OSError as exc:
         return json.dumps({"error": f"Failed to read source file: {exc}"})
 
-    truncated = len(content) > 10000
+    # ChatGPT's connector wrapper can stop rendering downstream writes after
+    # several large source reads. Keep the default preview compact, while still
+    # allowing an explicit larger preview through the existing MCP `limit` arg.
+    preview_chars = 4000
+    if limit and limit > 100:
+        preview_chars = min(limit, 10000)
+
+    truncated = len(content) > preview_chars
     entry.update({
         "universe_id": uid,
-        "content": content[:10000] if truncated else content,
+        "content": content[:preview_chars] if truncated else content,
         "truncated": truncated,
+        "content_preview_chars": preview_chars,
+        "next_action_hint": (
+            "If the user requested a create or update, continue with that write "
+            "action now; do not stop after reading sources."
+        ),
     })
     if truncated:
         entry["total_chars"] = len(content)
-        entry["note"] = "Source file truncated to 10K chars."
+        entry["note"] = (
+            f"Source file preview truncated to {preview_chars} chars. "
+            "Pass limit=10000 for the largest supported preview."
+        )
     return json.dumps(entry)
 
 

--- a/tests/test_universe_server_add_canon.py
+++ b/tests/test_universe_server_add_canon.py
@@ -275,8 +275,47 @@ class TestSourceInspection:
         assert out["filename"] == "lore.md"
         assert out["content"] == content
         assert out["truncated"] is False
+        assert out["content_preview_chars"] == 4000
+        assert "continue with that write action" in out["next_action_hint"]
         assert out["provenance"] == "source pack"
         assert out["sha256"] == hashlib.sha256(source_bytes).hexdigest()
+
+    def test_read_source_default_preview_preserves_chatgpt_continuation_budget(
+        self, universe: str, tmp_path: Path,
+    ) -> None:
+        src = tmp_path / "long-source.md"
+        content = "A" * 6000
+        src.write_text(content, encoding="utf-8")
+        _call("add_canon_from_path", path=str(src), provenance_tag="long source")
+
+        out = json.loads(us._universe_impl(
+            action="read_source",
+            filename="long-source.md",
+        ))
+
+        assert out["content"] == content[:4000]
+        assert out["truncated"] is True
+        assert out["content_preview_chars"] == 4000
+        assert out["total_chars"] == 6000
+        assert "do not stop after reading sources" in out["next_action_hint"]
+
+    def test_read_source_explicit_limit_allows_larger_preview(
+        self, universe: str, tmp_path: Path,
+    ) -> None:
+        src = tmp_path / "longer-source.md"
+        content = "B" * 6000
+        src.write_text(content, encoding="utf-8")
+        _call("add_canon_from_path", path=str(src), provenance_tag="longer source")
+
+        out = json.loads(us._universe_impl(
+            action="read_source",
+            filename="longer-source.md",
+            limit=10000,
+        ))
+
+        assert out["content"] == content
+        assert out["truncated"] is False
+        assert out["content_preview_chars"] == 10000
 
     def test_read_source_rejects_path_segments(self, universe: str) -> None:
         out = json.loads(us._universe_impl(

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -3762,6 +3762,7 @@ def _action_list_sources(
 def _action_read_source(
     universe_id: str = "",
     filename: str = "",
+    limit: int = 30,
     **_kwargs: Any,
 ) -> str:
     """Read one uploaded source document verbatim with checksum metadata."""
@@ -3800,15 +3801,30 @@ def _action_read_source(
     except OSError as exc:
         return json.dumps({"error": f"Failed to read source file: {exc}"})
 
-    truncated = len(content) > 10000
+    # ChatGPT's connector wrapper can stop rendering downstream writes after
+    # several large source reads. Keep the default preview compact, while still
+    # allowing an explicit larger preview through the existing MCP `limit` arg.
+    preview_chars = 4000
+    if limit and limit > 100:
+        preview_chars = min(limit, 10000)
+
+    truncated = len(content) > preview_chars
     entry.update({
         "universe_id": uid,
-        "content": content[:10000] if truncated else content,
+        "content": content[:preview_chars] if truncated else content,
         "truncated": truncated,
+        "content_preview_chars": preview_chars,
+        "next_action_hint": (
+            "If the user requested a create or update, continue with that write "
+            "action now; do not stop after reading sources."
+        ),
     })
     if truncated:
         entry["total_chars"] = len(content)
-        entry["note"] = "Source file truncated to 10K chars."
+        entry["note"] = (
+            f"Source file preview truncated to {preview_chars} chars. "
+            "Pass limit=10000 for the largest supported preview."
+        )
     return json.dumps(entry)
 
 


### PR DESCRIPTION
Fixes #367

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.