### PR TITLE
[auto-change] BUG-027: No startup file-probe for required data files — missing artifacts degrade silently instead of failing loud

### DIFF
--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -96,8 +96,22 @@ fi
 
 _workflow_bash_path() {
     local _path="${1:-}"
-    if [[ "${_path}" =~ ^[A-Za-z]:[\\/].* ]] && command -v cygpath >/dev/null 2>&1; then
-        cygpath -u "${_path}"
+    if [[ "${_path}" =~ ^([A-Za-z]):([\\/].*)$ ]]; then
+        if command -v cygpath >/dev/null 2>&1; then
+            cygpath -u "${_path}"
+        else
+            local _drive
+            local _prefix
+            local _rest
+            _drive="$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]')"
+            _rest="${BASH_REMATCH[2]//\\//}"
+            _rest="${_rest#/}"
+            _prefix="/${_drive}"
+            if [[ -d "/mnt/${_drive}" ]]; then
+                _prefix="/mnt/${_drive}"
+            fi
+            printf '%s/%s\n' "${_prefix}" "${_rest}"
+        fi
     else
         printf '%s\n' "${_path}"
     fi

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -9,7 +9,8 @@
 # 3. Optionally install a subscription-backed Codex auth bundle from
 #    WORKFLOW_CODEX_AUTH_JSON_B64. Legacy `codex login --with-api-key`
 #    from OPENAI_API_KEY is intentionally not run.
-# 4. exec the passed CMD (preserves tini PID-1 signal forwarding).
+# 4. Fail loud if required static data files are missing from the image.
+# 5. exec the passed CMD (preserves tini PID-1 signal forwarding).
 #
 # Placed before CMD so operators can override CMD freely.
 
@@ -92,5 +93,27 @@ if [[ -n "${WORKFLOW_CODEX_AUTH_JSON_B64:-}" ]]; then
     fi
     unset WORKFLOW_CODEX_AUTH_JSON_B64
 fi
+
+_workflow_bash_path() {
+    local _path="${1:-}"
+    if [[ "${_path}" =~ ^[A-Za-z]:[\\/].* ]] && command -v cygpath >/dev/null 2>&1; then
+        cygpath -u "${_path}"
+    else
+        printf '%s\n' "${_path}"
+    fi
+}
+
+_workflow_package_root="$(_workflow_bash_path "${WORKFLOW_PACKAGE_ROOT:-/app}")"
+_required_data_files=(
+    data/world_rules.lp
+)
+
+for _rel in "${_required_data_files[@]}"; do
+    _expected="${_workflow_package_root}/${_rel}"
+    if [[ ! -f "${_expected}" ]]; then
+        echo "DATA-FILE-MISSING: ${_rel} (expected at ${_expected})" >&2
+        exit 1
+    fi
+done
 
 exec "$@"

--- a/tests/test_env_unreadable_marker.py
+++ b/tests/test_env_unreadable_marker.py
@@ -41,6 +41,7 @@ def _run_entrypoint_via_stdin(
     *,
     exec_replacement: str,
     extra_env: dict[str, str] | None = None,
+    raw_preamble_lines: list[str] | None = None,
 ) -> subprocess.CompletedProcess:
     """Run docker-entrypoint.sh with a harnessed exec line, fed via stdin.
 
@@ -57,7 +58,9 @@ def _run_entrypoint_via_stdin(
     preamble_lines = [
         # Clear sentinels first so ambient-shell values don't leak through.
         "unset CLOUDFLARE_TUNNEL_TOKEN SUPABASE_DB_URL WORKFLOW_IMAGE",
+        f"export WORKFLOW_PACKAGE_ROOT={str(_REPO)!r}",
     ]
+    preamble_lines.extend(raw_preamble_lines or [])
     for key, value in (extra_env or {}).items():
         preamble_lines.append(f"export {key}={value!r}")
     combined = "\n".join(preamble_lines) + "\n" + script
@@ -109,6 +112,73 @@ def test_entrypoint_passes_through_when_one_sentinel_set():
         "marker should NOT fire when a sentinel is set"
     )
     assert "would-exec" in result.stdout
+
+
+@pytest.mark.skipif(not _have_bash(), reason="bash not on PATH")
+def test_entrypoint_fails_loud_when_required_data_file_missing(tmp_path: Path):
+    """Required static data absent -> entrypoint emits DATA-FILE-MISSING."""
+    result = _run_entrypoint_via_stdin(
+        exec_replacement='echo "[harness] would-exec: $@"',
+        extra_env={
+            "WORKFLOW_IMAGE": "ghcr.io/jonnyton/workflow-daemon:abc123",
+            "WORKFLOW_PACKAGE_ROOT": str(tmp_path),
+        },
+    )
+
+    assert result.returncode == 1, (
+        f"expected missing data-file exit 1; got {result.returncode}. "
+        f"stderr={result.stderr!r} stdout={result.stdout!r}"
+    )
+    assert "DATA-FILE-MISSING: data/world_rules.lp" in result.stderr
+    assert "would-exec" not in result.stdout
+
+
+@pytest.mark.skipif(not _have_bash(), reason="bash not on PATH")
+def test_entrypoint_data_file_probe_accepts_git_bash_windows_package_root(
+    tmp_path: Path,
+):
+    """Git Bash gets WORKFLOW_PACKAGE_ROOT as C:\\...; normalize before -f."""
+    package_root = tmp_path / "package-root"
+    (package_root / "data").mkdir(parents=True)
+    (package_root / "data" / "world_rules.lp").write_text("% rules\n")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_cygpath = fake_bin / "cygpath"
+    fake_cygpath.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf '%s\\n' \"$WORKFLOW_FAKE_POSIX_ROOT\"\n",
+        encoding="utf-8",
+    )
+    fake_cygpath.chmod(0o755)
+
+    result = _run_entrypoint_via_stdin(
+        exec_replacement='echo "[harness] would-exec: $@"',
+        extra_env={
+            "WORKFLOW_IMAGE": "ghcr.io/jonnyton/workflow-daemon:abc123",
+            "WORKFLOW_PACKAGE_ROOT": r"C:\Users\Jonathan\Projects\wf-review-108",
+            "WORKFLOW_FAKE_POSIX_ROOT": str(package_root),
+        },
+        raw_preamble_lines=[f"export PATH={str(fake_bin)!r}:$PATH"],
+    )
+
+    assert result.returncode == 0, (
+        f"expected normalized Windows root to pass; got {result.returncode}. "
+        f"stderr={result.stderr!r} stdout={result.stdout!r}"
+    )
+    assert "DATA-FILE-MISSING" not in result.stderr
+    assert "would-exec" in result.stdout
+
+
+def test_entrypoint_data_file_probe_does_not_require_python_alias():
+    """The startup data-file probe must stay shell-only for Git Bash hosts."""
+    text = _ENTRYPOINT.read_text(encoding="utf-8")
+    probe_start = text.index("_workflow_bash_path()")
+    probe_text = text[probe_start:text.index('exec "$@"', probe_start)]
+
+    assert "python" not in probe_text.lower()
+    assert "cygpath" in probe_text
+    assert "DATA-FILE-MISSING" in probe_text
 
 
 @pytest.mark.skipif(not _have_bash(), reason="bash not on PATH")

--- a/tests/test_env_unreadable_marker.py
+++ b/tests/test_env_unreadable_marker.py
@@ -34,6 +34,23 @@ def _have_bash() -> bool:
     return shutil.which("bash") is not None
 
 
+def _bash_readable_path(path: Path) -> str:
+    text = str(path)
+    if sys.platform.startswith("win") and len(text) > 2 and text[1] == ":":
+        drive = text[0].lower()
+        rest = text[2:].replace("\\", "/").lstrip("/")
+        if shutil.which("bash"):
+            probe = subprocess.run(
+                ["bash", "-lc", f"test -d /mnt/{drive}"],
+                capture_output=True,
+                timeout=5,
+            )
+            if probe.returncode == 0:
+                return f"/mnt/{drive}/{rest}"
+        return f"/{drive}/{rest}"
+    return text
+
+
 # ---- entrypoint behavior --------------------------------------------------
 
 
@@ -58,7 +75,7 @@ def _run_entrypoint_via_stdin(
     preamble_lines = [
         # Clear sentinels first so ambient-shell values don't leak through.
         "unset CLOUDFLARE_TUNNEL_TOKEN SUPABASE_DB_URL WORKFLOW_IMAGE",
-        f"export WORKFLOW_PACKAGE_ROOT={str(_REPO)!r}",
+        f"export WORKFLOW_PACKAGE_ROOT={_bash_readable_path(_REPO)!r}",
     ]
     preamble_lines.extend(raw_preamble_lines or [])
     for key, value in (extra_env or {}).items():
@@ -149,6 +166,7 @@ def test_entrypoint_data_file_probe_accepts_git_bash_windows_package_root(
         "#!/usr/bin/env bash\n"
         "printf '%s\\n' \"$WORKFLOW_FAKE_POSIX_ROOT\"\n",
         encoding="utf-8",
+        newline="\n",
     )
     fake_cygpath.chmod(0o755)
 
@@ -157,9 +175,9 @@ def test_entrypoint_data_file_probe_accepts_git_bash_windows_package_root(
         extra_env={
             "WORKFLOW_IMAGE": "ghcr.io/jonnyton/workflow-daemon:abc123",
             "WORKFLOW_PACKAGE_ROOT": r"C:\Users\Jonathan\Projects\wf-review-108",
-            "WORKFLOW_FAKE_POSIX_ROOT": str(package_root),
+            "WORKFLOW_FAKE_POSIX_ROOT": _bash_readable_path(package_root),
         },
-        raw_preamble_lines=[f"export PATH={str(fake_bin)!r}:$PATH"],
+        raw_preamble_lines=[f"export PATH={_bash_readable_path(fake_bin)!r}:$PATH"],
     )
 
     assert result.returncode == 0, (


### PR DESCRIPTION
Fixes #57

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.