### PR TITLE
[auto-change] BUG-051: change_loop_v1 misinterprets its own successful child invocation post-#205

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -1137,9 +1137,18 @@ jobs:
                 '',
                 `Claude OAuth outcome: \`${{ steps.claude-oauth.outcome }}\``,
                 `Codex subscription outcome: \`${{ steps.codex-subscription.outcome }}\``,
+                mode === 'codex_subscription' && process.env.CODEX_OUTCOME === 'success'
+                  ? 'Writer child invocation: `succeeded`'
+                  : '',
+                mode === 'codex_subscription' && codexBranch
+                  ? 'Auto-fix branch pushed: `true`'
+                  : '',
                 codexNoChangeReason ? `Codex no-change reason: \`${codexNoChangeReason}\`` : '',
                 codexPrBlocked
                   ? `PR creation blocked: \`${codexPrBlockReason || 'unknown'}\``
+                  : '',
+                codexPrBlocked
+                  ? 'Remaining blocker: GitHub Actions PR creation policy. Do not treat this as a failed child invocation.'
                   : '',
                 codexPushBlocked
                   ? `Branch push blocked: \`${codexPushBlockReason || 'unknown'}\``

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -587,6 +587,20 @@ def test_no_pr_step_marks_review_without_failing_workflow(wf):
     assert "Pull requests write" in script
 
 
+def test_no_pr_comment_distinguishes_successful_writer_from_pr_policy_block(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    no_pr_step = next(
+        (s for s in steps if s.get("name") == "Mark needs-human if no PR opened"),
+        None,
+    )
+    assert no_pr_step is not None, "Must mark no-PR outcomes"
+    script = str(no_pr_step.get("with", {}).get("script", ""))
+    assert "Writer child invocation: `succeeded`" in script
+    assert "Auto-fix branch pushed: `true`" in script
+    assert "Remaining blocker: GitHub Actions PR creation policy" in script
+    assert "Do not treat this as a failed child invocation" in script
+
+
 def test_pr_blocked_label_is_defined(wf):
     steps = wf["jobs"]["fix"]["steps"]
     labels_step = next((s for s in steps if s.get("name") == "Ensure automation labels"), None)


### PR DESCRIPTION
Fixes #213

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.