### PR TITLE
[auto-change] BUG-007: input_keys is not enforced as context isolation; prompt_template can read any state field

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branches.py
@@ -287,15 +287,12 @@ class NodeDefinition:
     output_keys: list[str] = field(default_factory=list)
     # When true, prompt_template rendering sees ONLY the state keys
     # declared in ``input_keys`` — references to any other state key
-    # raise CompilerError at runtime. Symmetry-restore vs code-node
-    # sandbox (node_sandbox.py:279-282 already filters code-node state
-    # views). Default false to preserve back-compat with branches that
-    # rely on implicit cross-key reads; flip to true for new branches
-    # that want strict isolation. Regardless of this flag,
-    # ``collect_build_warnings`` surfaces a warning per out-of-input_keys
-    # placeholder at build time so authors see the leak even without
-    # opting into strict mode.
-    strict_input_isolation: bool = False
+    # raise CompilerError at runtime. This restores symmetry with the
+    # code-node sandbox (node_sandbox.py:279-282 already filters
+    # code-node state views). Branch authors can explicitly set false
+    # as a legacy escape hatch for prompt templates that intentionally
+    # read beyond their declared input_keys.
+    strict_input_isolation: bool = True
 
     # Source and execution — one of source_code or prompt_template
     source_code: str = ""

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/catalog/serializer.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/catalog/serializer.py
@@ -219,6 +219,8 @@ def node_to_yaml_payload(node: NodeDefinition) -> dict[str, Any]:
         payload["input_keys"] = list(node.input_keys)
     if node.output_keys:
         payload["output_keys"] = list(node.output_keys)
+    if node.strict_input_isolation is False:
+        payload["strict_input_isolation"] = False
     if node.tools_allowed:
         payload["tools_allowed"] = list(node.tools_allowed)
     if node.dependencies:
@@ -256,6 +258,9 @@ def node_from_yaml_payload(payload: dict[str, Any]) -> NodeDefinition:
         output_keys=payload.get("output_keys") or [],
         source_code=payload.get("source_code", ""),
         prompt_template=payload.get("prompt_template", ""),
+        strict_input_isolation=bool(
+            payload.get("strict_input_isolation", True)
+        ),
         model_hint=payload.get("model_hint", ""),
         tools_allowed=list(payload.get("tools_allowed", []) or []),
         dependencies=list(payload.get("dependencies", []) or []),

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
@@ -455,8 +455,8 @@ def collect_build_warnings(branch: BranchDefinition) -> list[dict[str, Any]]:
                     f"input_keys {sorted(node.input_keys)!r}. This is "
                     f"an implicit cross-node dependency that reduces "
                     f"branch portability. Add '{placeholder}' to "
-                    f"input_keys, or set strict_input_isolation=true "
-                    f"to reject such references at runtime."
+                    f"input_keys, or set strict_input_isolation=false "
+                    f"only when the cross-key read is intentional."
                 ),
             })
     return warnings
@@ -731,7 +731,7 @@ def _build_prompt_template_node(
     role = (node.model_hint or "writer").strip().lower() or "writer"
     template = node.prompt_template or ""
     timeout_s = float(node.timeout_seconds or 300.0)
-    strict_isolation = bool(getattr(node, "strict_input_isolation", False))
+    strict_isolation = bool(getattr(node, "strict_input_isolation", True))
     declared_inputs = list(node.input_keys)
     state_types = _state_type_map(state_schema or [])
     needs_json = _needs_json_contract(node, state_types)

--- a/tests/test_input_keys_isolation.py
+++ b/tests/test_input_keys_isolation.py
@@ -7,13 +7,15 @@ silently succeeded even when ``other_node_output`` wasn't in
 ``input_keys``. That's an implicit cross-node dependency which reduces
 branch portability and hides unintentional coupling.
 
-Contract (per STATUS.md "Approved bugs" entry 2026-04-22):
+Contract:
 
-- ``NodeDefinition.strict_input_isolation: bool = False`` — default
-  preserves back-compat.
+- ``NodeDefinition.strict_input_isolation: bool = True`` — declaring
+  ``input_keys`` isolates prompt-template rendering by default.
 - When strict=true, ``_build_prompt_template_node`` renders against a
   state view filtered to ``input_keys`` only. Out-of-keys placeholders
   raise ``CompilerError`` at runtime.
+- Branch authors may set ``strict_input_isolation=False`` as an explicit
+  legacy escape hatch.
 - Regardless of flag, ``collect_build_warnings(branch)`` emits one
   warning per out-of-input_keys placeholder so authors see the leak.
 - When ``event_sink`` is provided and strict=false, the runtime emits
@@ -275,6 +277,27 @@ def test_strict_isolation_rejects_even_when_state_has_key():
         fn({"topic": "whales", "leaked_key": "present but filtered out"})
 
 
+def test_default_input_keys_isolation_rejects_out_of_input_keys():
+    """BUG-007: declaring input_keys must isolate prompt_template reads.
+
+    The author should not have to opt into strict mode; if a template
+    references a state key outside input_keys, rendering must fail even
+    when the broader branch state contains that key.
+    """
+    node = NodeDefinition(
+        node_id="n1",
+        display_name="n1",
+        input_keys=["topic"],
+        output_keys=["draft"],
+        prompt_template="Write {topic} with {leaked_key}.",
+    )
+    fn = _make_prompt_fn(node)
+    with pytest.raises(CompilerError) as exc:
+        fn({"topic": "whales", "leaked_key": "should not be readable"})
+    assert "strict_input_isolation=true" in str(exc.value)
+    assert "leaked_key" in str(exc.value)
+
+
 def test_non_strict_mode_renders_with_leaked_state():
     """Back-compat: strict=false preserves the pre-BUG-007 behavior
     where templates freely read non-input_keys state."""
@@ -392,11 +415,10 @@ def test_strict_input_isolation_roundtrips_through_to_dict():
     assert restored.strict_input_isolation is True
 
 
-def test_strict_input_isolation_default_false():
-    """Back-compat: default must be False so existing branches work
-    unchanged after the schema update."""
+def test_strict_input_isolation_default_true():
+    """input_keys is an isolation contract by default."""
     node = NodeDefinition(node_id="n1", display_name="n1")
-    assert node.strict_input_isolation is False
+    assert node.strict_input_isolation is True
 
 
 def test_node_registration_shape_excludes_strict_flag():

--- a/tests/test_storage_phase7_serializer.py
+++ b/tests/test_storage_phase7_serializer.py
@@ -252,6 +252,19 @@ def test_node_payload_omits_defaults_for_small_files():
     assert payload["prompt_template"] == "hi"
 
 
+def test_node_payload_preserves_explicit_non_strict_input_isolation():
+    node = NodeDefinition(
+        node_id="n1",
+        display_name="N1",
+        input_keys=["topic"],
+        prompt_template="{topic} {legacy_global}",
+        strict_input_isolation=False,
+    )
+    payload = node_to_yaml_payload(node)
+    assert payload["strict_input_isolation"] is False
+    assert node_from_yaml_payload(payload).strict_input_isolation is False
+
+
 def test_node_payload_always_includes_timeout_seconds():
     """#61 raised the default; the YAML records intent explicitly so
     operators can see the current contract without remembering it."""

--- a/workflow/branches.py
+++ b/workflow/branches.py
@@ -287,15 +287,12 @@ class NodeDefinition:
     output_keys: list[str] = field(default_factory=list)
     # When true, prompt_template rendering sees ONLY the state keys
     # declared in ``input_keys`` — references to any other state key
-    # raise CompilerError at runtime. Symmetry-restore vs code-node
-    # sandbox (node_sandbox.py:279-282 already filters code-node state
-    # views). Default false to preserve back-compat with branches that
-    # rely on implicit cross-key reads; flip to true for new branches
-    # that want strict isolation. Regardless of this flag,
-    # ``collect_build_warnings`` surfaces a warning per out-of-input_keys
-    # placeholder at build time so authors see the leak even without
-    # opting into strict mode.
-    strict_input_isolation: bool = False
+    # raise CompilerError at runtime. This restores symmetry with the
+    # code-node sandbox (node_sandbox.py:279-282 already filters
+    # code-node state views). Branch authors can explicitly set false
+    # as a legacy escape hatch for prompt templates that intentionally
+    # read beyond their declared input_keys.
+    strict_input_isolation: bool = True
 
     # Source and execution — one of source_code or prompt_template
     source_code: str = ""

--- a/workflow/catalog/serializer.py
+++ b/workflow/catalog/serializer.py
@@ -219,6 +219,8 @@ def node_to_yaml_payload(node: NodeDefinition) -> dict[str, Any]:
         payload["input_keys"] = list(node.input_keys)
     if node.output_keys:
         payload["output_keys"] = list(node.output_keys)
+    if node.strict_input_isolation is False:
+        payload["strict_input_isolation"] = False
     if node.tools_allowed:
         payload["tools_allowed"] = list(node.tools_allowed)
     if node.dependencies:
@@ -256,6 +258,9 @@ def node_from_yaml_payload(payload: dict[str, Any]) -> NodeDefinition:
         output_keys=payload.get("output_keys") or [],
         source_code=payload.get("source_code", ""),
         prompt_template=payload.get("prompt_template", ""),
+        strict_input_isolation=bool(
+            payload.get("strict_input_isolation", True)
+        ),
         model_hint=payload.get("model_hint", ""),
         tools_allowed=list(payload.get("tools_allowed", []) or []),
         dependencies=list(payload.get("dependencies", []) or []),

--- a/workflow/graph_compiler.py
+++ b/workflow/graph_compiler.py
@@ -455,8 +455,8 @@ def collect_build_warnings(branch: BranchDefinition) -> list[dict[str, Any]]:
                     f"input_keys {sorted(node.input_keys)!r}. This is "
                     f"an implicit cross-node dependency that reduces "
                     f"branch portability. Add '{placeholder}' to "
-                    f"input_keys, or set strict_input_isolation=true "
-                    f"to reject such references at runtime."
+                    f"input_keys, or set strict_input_isolation=false "
+                    f"only when the cross-key read is intentional."
                 ),
             })
     return warnings
@@ -731,7 +731,7 @@ def _build_prompt_template_node(
     role = (node.model_hint or "writer").strip().lower() or "writer"
     template = node.prompt_template or ""
     timeout_s = float(node.timeout_seconds or 300.0)
-    strict_isolation = bool(getattr(node, "strict_input_isolation", False))
+    strict_isolation = bool(getattr(node, "strict_input_isolation", True))
     declared_inputs = list(node.input_keys)
     state_types = _state_type_map(state_schema or [])
     needs_json = _needs_json_contract(node, state_types)


### PR DESCRIPTION
Fixes #33

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.