### PR TITLE
[auto-change] BUG-011: Undocumented / missing durable execution across daemon restart

### DIFF
--- a/fantasy_daemon/__main__.py
+++ b/fantasy_daemon/__main__.py
@@ -773,7 +773,11 @@ def _try_execute_claimed_branch_task(
         from workflow.api.branches import _resolve_branch_id
         from workflow.branches import BranchDefinition
         from workflow.daemon_server import get_branch_definition
-        from workflow.runs import RUN_STATUS_COMPLETED, execute_branch
+        from workflow.runs import (
+            RUN_STATUS_COMPLETED,
+            execute_branch,
+            latest_run_by_name,
+        )
         from workflow.storage import data_dir
 
         base_path = data_dir()
@@ -797,6 +801,37 @@ def _try_execute_claimed_branch_task(
                 "validation_errors": errors,
             }
 
+        run_name = f"branch-task-{claimed_task.branch_task_id}"
+        existing_run = latest_run_by_name(
+            base_path,
+            run_name=run_name,
+            branch_def_id=branch_def_id,
+        )
+        if existing_run and existing_run.get("status") == RUN_STATUS_COMPLETED:
+            output = existing_run.get("output", {})
+            metadata = {
+                "branch_def_id": branch_def_id,
+                "run_id": existing_run["run_id"],
+                "run_status": existing_run["status"],
+                "actor": existing_run.get("actor") or "",
+                "reused_existing_run": True,
+            }
+            attach_result = _maybe_attach_bug_investigation_patch_packet(
+                claimed_task,
+                existing_run["status"],
+                output if isinstance(output, dict) else {},
+            )
+            if attach_result.get("status") != "skipped":
+                metadata["wiki_patch_packet"] = attach_result
+            logger.info(
+                "dispatcher_pick: reused completed branch task run %s "
+                "branch=%s run=%s",
+                claimed_task.branch_task_id,
+                branch_def_id,
+                existing_run["run_id"],
+            )
+            return True, "", metadata
+
         provider_call: Any = None
         try:
             from domains.fantasy_daemon.phases._provider_stub import (
@@ -810,7 +845,7 @@ def _try_execute_claimed_branch_task(
             base_path,
             branch=branch,
             inputs=_branch_task_inputs_for_execution(claimed_task),
-            run_name=f"branch-task-{claimed_task.branch_task_id}",
+            run_name=run_name,
             actor=actor,
             provider_call=provider_call,
             on_node_status=on_node_status,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/runs.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/runs.py
@@ -988,6 +988,37 @@ def list_runs(
     return [_row_to_run(r) for r in rows]
 
 
+def latest_run_by_name(
+    base_path: str | Path,
+    *,
+    run_name: str,
+    branch_def_id: str = "",
+) -> dict[str, Any] | None:
+    """Return the newest run with ``run_name``.
+
+    Daemon BranchTasks use deterministic run names. Looking them up lets
+    restart recovery distinguish "task was requeued after a crash" from
+    "the branch never produced a durable run".
+    """
+    initialize_runs_db(base_path)
+    clauses = ["run_name = ?"]
+    params: list[Any] = [run_name]
+    if branch_def_id:
+        clauses.append("branch_def_id = ?")
+        params.append(branch_def_id)
+    where = " AND ".join(clauses)
+    with _connect(base_path) as conn:
+        row = conn.execute(
+            f"""
+            SELECT * FROM runs
+            WHERE {where}
+            ORDER BY started_at DESC LIMIT 1
+            """,
+            params,
+        ).fetchone()
+    return _row_to_run(row) if row is not None else None
+
+
 def record_event(
     base_path: str | Path, event: RunStepEvent,
 ) -> None:
@@ -3419,6 +3450,7 @@ __all__ = [
     "list_judgments",
     "list_node_edit_audits",
     "list_runs",
+    "latest_run_by_name",
     "list_recent_runs",
     "node_output_from_run",
     "record_event",

--- a/tests/test_branch_runner.py
+++ b/tests/test_branch_runner.py
@@ -872,6 +872,39 @@ def test_recover_in_flight_runs_leaves_terminal_rows_alone(tmp_path):
         assert get_run(tmp_path, rid)["status"] == status
 
 
+def test_latest_run_by_name_returns_newest_matching_branch_run(tmp_path):
+    from workflow.runs import (
+        RUN_STATUS_COMPLETED,
+        create_run,
+        latest_run_by_name,
+        update_run_status,
+    )
+
+    older = create_run(
+        tmp_path, branch_def_id="b1", thread_id="", inputs={},
+        run_name="branch-task-bt-1", actor="a",
+    )
+    newer = create_run(
+        tmp_path, branch_def_id="b1", thread_id="", inputs={},
+        run_name="branch-task-bt-1", actor="a",
+    )
+    other_branch = create_run(
+        tmp_path, branch_def_id="b2", thread_id="", inputs={},
+        run_name="branch-task-bt-1", actor="a",
+    )
+    for rid in (older, newer, other_branch):
+        update_run_status(tmp_path, rid, status=RUN_STATUS_COMPLETED)
+
+    match = latest_run_by_name(
+        tmp_path,
+        run_name="branch-task-bt-1",
+        branch_def_id="b1",
+    )
+
+    assert match is not None
+    assert match["run_id"] == newer
+
+
 def test_concurrent_cap_respected(tmp_path, monkeypatch):
     """Custom WORKFLOW_RUN_MAX_CONCURRENT is honored."""
     monkeypatch.setenv("WORKFLOW_RUN_MAX_CONCURRENT", "2")

--- a/tests/test_bug_investigation_dispatcher.py
+++ b/tests/test_bug_investigation_dispatcher.py
@@ -323,6 +323,74 @@ class TestBugInvestigationDirectRunRouting:
 
         assert inputs == {"bug_id": "BUG-009"}
 
+    def test_direct_run_reuses_completed_branch_task_run_after_restart(
+        self, tmp_path, monkeypatch
+    ):
+        from fantasy_daemon.__main__ import _try_execute_claimed_branch_task
+        from workflow.runs import (
+            RUN_STATUS_COMPLETED,
+            create_run,
+            update_run_status,
+        )
+
+        monkeypatch.setattr("workflow.storage.data_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "workflow.api.branches._resolve_branch_id",
+            lambda requested, base_path: "branch-1",
+        )
+        monkeypatch.setattr(
+            "workflow.daemon_server.get_branch_definition",
+            lambda base_path, branch_def_id: {"branch_def_id": branch_def_id},
+        )
+
+        class _Branch:
+            def validate(self):
+                return []
+
+        from workflow.branches import BranchDefinition
+        monkeypatch.setattr(
+            BranchDefinition,
+            "from_dict",
+            classmethod(lambda cls, data: _Branch()),
+        )
+
+        def _should_not_execute(*args, **kwargs):
+            raise AssertionError("completed durable run should be reused")
+
+        monkeypatch.setattr("workflow.runs.execute_branch", _should_not_execute)
+
+        run_id = create_run(
+            tmp_path,
+            branch_def_id="branch-1",
+            thread_id="",
+            inputs={"bug_id": "BUG-011"},
+            run_name="branch-task-bt-restart",
+            actor="daemon-a",
+        )
+        update_run_status(
+            tmp_path,
+            run_id,
+            status=RUN_STATUS_COMPLETED,
+            output={"result": "already completed"},
+        )
+        task = BranchTask(
+            branch_task_id="bt-restart",
+            branch_def_id="branch-1",
+            universe_id="u",
+            inputs={"bug_id": "BUG-011"},
+            request_type=REQUEST_TYPE_BUG_INVESTIGATION,
+        )
+
+        success, error, metadata = _try_execute_claimed_branch_task(
+            tmp_path, task, "daemon-a",
+        )
+
+        assert success is True
+        assert error == ""
+        assert metadata["run_id"] == run_id
+        assert metadata["run_status"] == RUN_STATUS_COMPLETED
+        assert metadata["reused_existing_run"] is True
+
 
 class TestBugInvestigationPatchPacketWriteBack:
     def _make_bug_page(self, tmp_path):

--- a/workflow/runs.py
+++ b/workflow/runs.py
@@ -988,6 +988,37 @@ def list_runs(
     return [_row_to_run(r) for r in rows]
 
 
+def latest_run_by_name(
+    base_path: str | Path,
+    *,
+    run_name: str,
+    branch_def_id: str = "",
+) -> dict[str, Any] | None:
+    """Return the newest run with ``run_name``.
+
+    Daemon BranchTasks use deterministic run names. Looking them up lets
+    restart recovery distinguish "task was requeued after a crash" from
+    "the branch never produced a durable run".
+    """
+    initialize_runs_db(base_path)
+    clauses = ["run_name = ?"]
+    params: list[Any] = [run_name]
+    if branch_def_id:
+        clauses.append("branch_def_id = ?")
+        params.append(branch_def_id)
+    where = " AND ".join(clauses)
+    with _connect(base_path) as conn:
+        row = conn.execute(
+            f"""
+            SELECT * FROM runs
+            WHERE {where}
+            ORDER BY started_at DESC LIMIT 1
+            """,
+            params,
+        ).fetchone()
+    return _row_to_run(row) if row is not None else None
+
+
 def record_event(
     base_path: str | Path, event: RunStepEvent,
 ) -> None:
@@ -3419,6 +3450,7 @@ __all__ = [
     "list_judgments",
     "list_node_edit_audits",
     "list_runs",
+    "latest_run_by_name",
     "list_recent_runs",
     "node_output_from_run",
     "record_event",


### PR DESCRIPTION
Fixes #37

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.