### PR TITLE
[auto-change] BUG-025: claude-code provider listed first in writer chain but never available in container image

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/router.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/router.py
@@ -119,6 +119,32 @@ class ProviderRouter:
     def available_providers(self) -> list[str]:
         return list(self._providers)
 
+    def effective_chain(
+        self,
+        chain: list[str],
+    ) -> tuple[list[str], list[ProviderAttemptDiagnostic]]:
+        """Return registered providers from *chain* plus explicit exclusions.
+
+        ``FALLBACK_CHAINS`` records preference order, but runtime routing must
+        only advertise and iterate providers that were actually registered at
+        startup. Missing CLI-backed providers, such as ``claude-code`` in the
+        cloud image, are reported as exclusions rather than silent phantom
+        entries at the front of the live chain.
+        """
+        effective: list[str] = []
+        excluded: list[ProviderAttemptDiagnostic] = []
+        for provider_name in chain:
+            if provider_name in self._providers:
+                effective.append(provider_name)
+                continue
+            excluded.append(ProviderAttemptDiagnostic(
+                provider=provider_name,
+                status="skipped",
+                skip_class="not_in_registry",
+                detail="provider name not registered with daemon",
+            ))
+        return effective, excluded
+
     # ------------------------------------------------------------------
     # Core routing
     # ------------------------------------------------------------------
@@ -253,9 +279,22 @@ class ProviderRouter:
             )
             chain = auth_filtered
 
-        # FEAT-006: collect per-provider skip/failure diagnostics so the
-        # final AllProvidersExhaustedError can carry structured detail.
+        # FEAT-006 / BUG-025: collect per-provider skip/failure diagnostics so
+        # the final AllProvidersExhaustedError can carry structured detail.
+        # For normal fallback routing, remove unregistered providers before
+        # iteration so the live chain does not advertise phantom first entries.
         attempts: list[ProviderAttemptDiagnostic] = []
+        if not is_pinned_writer:
+            effective_chain, excluded = self.effective_chain(chain)
+            if excluded:
+                logger.info(
+                    "Excluding unregistered providers from effective role=%s "
+                    "chain: %s",
+                    role,
+                    [attempt.provider for attempt in excluded],
+                )
+                attempts.extend(excluded)
+            chain = effective_chain
 
         for provider_name in chain:
             provider = self._providers.get(provider_name)

--- a/tests/test_provider_router_diagnostics.py
+++ b/tests/test_provider_router_diagnostics.py
@@ -203,7 +203,7 @@ class TestProviderRouterDiagnostics:
         assert err.chain_state is not None
         assert err.chain_state["role"] == "writer"
         assert err.chain_state["api_key_providers_enabled"] is False
-        assert err.chain_state["chain"] == ["claude-code", "codex", "ollama-local"]
+        assert err.chain_state["chain"] == ["codex", "ollama-local"]
         attempts = {attempt.provider: attempt for attempt in err.attempts}
         assert attempts["claude-code"].skip_class == "not_in_registry"
         assert attempts["codex"].skip_class == "auth_invalid"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -481,6 +481,26 @@ class TestProviderRegistration:
         with patch("shutil.which", return_value="/usr/local/bin/codex"):
             assert CodexProvider.is_available()
 
+    def test_effective_chain_excludes_unregistered_providers(self):
+        """Runtime chain skips absent CLI providers instead of advertising them first."""
+        router = ProviderRouter(
+            providers={
+                "codex": FakeProvider("codex", "openai"),
+                "ollama-local": FakeProvider("ollama-local", "local"),
+            },
+        )
+
+        chain, excluded = router.effective_chain(FALLBACK_CHAINS["writer"])
+
+        assert chain == ["codex", "ollama-local"]
+        assert [attempt.provider for attempt in excluded] == [
+            "claude-code",
+            "gemini-free",
+            "groq-free",
+            "grok-free",
+        ]
+        assert {attempt.skip_class for attempt in excluded} == {"not_in_registry"}
+
 
 # =====================================================================
 # ClaudeProvider (subprocess mock)
@@ -887,7 +907,8 @@ class TestGrokProvider:
 
 
 class TestFallbackChainDefinitions:
-    def test_writer_chain_starts_with_claude(self):
+    def test_writer_preference_chain_starts_with_claude(self):
+        """Static preference may name Claude; runtime effective_chain probes it."""
         assert FALLBACK_CHAINS["writer"][0] == "claude-code"
         assert FALLBACK_CHAINS["writer"][-1] == "ollama-local"
 

--- a/workflow/providers/router.py
+++ b/workflow/providers/router.py
@@ -119,6 +119,32 @@ class ProviderRouter:
     def available_providers(self) -> list[str]:
         return list(self._providers)
 
+    def effective_chain(
+        self,
+        chain: list[str],
+    ) -> tuple[list[str], list[ProviderAttemptDiagnostic]]:
+        """Return registered providers from *chain* plus explicit exclusions.
+
+        ``FALLBACK_CHAINS`` records preference order, but runtime routing must
+        only advertise and iterate providers that were actually registered at
+        startup. Missing CLI-backed providers, such as ``claude-code`` in the
+        cloud image, are reported as exclusions rather than silent phantom
+        entries at the front of the live chain.
+        """
+        effective: list[str] = []
+        excluded: list[ProviderAttemptDiagnostic] = []
+        for provider_name in chain:
+            if provider_name in self._providers:
+                effective.append(provider_name)
+                continue
+            excluded.append(ProviderAttemptDiagnostic(
+                provider=provider_name,
+                status="skipped",
+                skip_class="not_in_registry",
+                detail="provider name not registered with daemon",
+            ))
+        return effective, excluded
+
     # ------------------------------------------------------------------
     # Core routing
     # ------------------------------------------------------------------
@@ -253,9 +279,22 @@ class ProviderRouter:
             )
             chain = auth_filtered
 
-        # FEAT-006: collect per-provider skip/failure diagnostics so the
-        # final AllProvidersExhaustedError can carry structured detail.
+        # FEAT-006 / BUG-025: collect per-provider skip/failure diagnostics so
+        # the final AllProvidersExhaustedError can carry structured detail.
+        # For normal fallback routing, remove unregistered providers before
+        # iteration so the live chain does not advertise phantom first entries.
         attempts: list[ProviderAttemptDiagnostic] = []
+        if not is_pinned_writer:
+            effective_chain, excluded = self.effective_chain(chain)
+            if excluded:
+                logger.info(
+                    "Excluding unregistered providers from effective role=%s "
+                    "chain: %s",
+                    role,
+                    [attempt.provider for attempt in excluded],
+                )
+                attempts.extend(excluded)
+            chain = effective_chain
 
         for provider_name in chain:
             provider = self._providers.get(provider_name)


### PR DESCRIPTION
Fixes #55

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.