### PR TITLE
[auto-change] BUG-031: describe_branch marks source-code branches valid without warning that unapproved nodes cannot run

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -950,14 +950,16 @@ def _ext_branch_describe(kwargs: dict[str, Any]) -> str:
     if approval_warning_lines:
         summary_parts += ["", "Approval warnings (branch NOT runnable):"]
         summary_parts += approval_warning_lines
-    summary_parts += [
-        "",
-        "Graph:",
-        mermaid,
-        "",
-        "Note: run this branch with action='run_branch' once validated. "
-        "Pass state field values via inputs_json.",
-    ]
+    run_note = (
+        "Note: this branch has unapproved source_code nodes and must be "
+        "approved before it can run."
+        if unapproved_sc
+        else (
+            "Note: run this branch with action='run_branch' once validated. "
+            "Pass state field values via inputs_json."
+        )
+    )
+    summary_parts += ["", "Graph:", mermaid, "", run_note]
     summary = "\n".join(summary_parts)
     related = _related_wiki_pages(source_dict)
 
@@ -2750,9 +2752,12 @@ per-turn tool-call budget is not at risk:
 
 ## Hard rule
 
-After `describe_branch`, tell the user their branch is ready to run. Use
-`run_branch` with a JSON `inputs_json` that fills the state_schema fields.
-The runner returns a `run_id`, final status, and per-node trace.
+After `describe_branch`, check `runnable` before telling the user their
+branch is ready to run. If `runnable=false`, surface
+`unapproved_source_code_nodes` or validation errors and stop. If
+`runnable=true`, use `run_branch` with a JSON `inputs_json` that fills the
+state_schema fields. The runner returns a `run_id`, final status, and
+per-node trace.
 
 ## Power users
 

--- a/tests/test_describe_branch_approval.py
+++ b/tests/test_describe_branch_approval.py
@@ -141,6 +141,8 @@ class TestDescribeBranchApproval:
         assert unapp["display_name"] == "Custom Runner"
         assert "APPROVAL REQUIRED" in result["summary"]
         assert "approve_source_code" in result["summary"]
+        assert "must be approved before it can run" in result["summary"]
+        assert "once validated" not in result["summary"]
 
     def test_unapproved_node_still_valid_structurally(self):
         """valid reflects structural errors only; approval is separate via runnable."""

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -950,14 +950,16 @@ def _ext_branch_describe(kwargs: dict[str, Any]) -> str:
     if approval_warning_lines:
         summary_parts += ["", "Approval warnings (branch NOT runnable):"]
         summary_parts += approval_warning_lines
-    summary_parts += [
-        "",
-        "Graph:",
-        mermaid,
-        "",
-        "Note: run this branch with action='run_branch' once validated. "
-        "Pass state field values via inputs_json.",
-    ]
+    run_note = (
+        "Note: this branch has unapproved source_code nodes and must be "
+        "approved before it can run."
+        if unapproved_sc
+        else (
+            "Note: run this branch with action='run_branch' once validated. "
+            "Pass state field values via inputs_json."
+        )
+    )
+    summary_parts += ["", "Graph:", mermaid, "", run_note]
     summary = "\n".join(summary_parts)
     related = _related_wiki_pages(source_dict)
 
@@ -2750,9 +2752,12 @@ per-turn tool-call budget is not at risk:
 
 ## Hard rule
 
-After `describe_branch`, tell the user their branch is ready to run. Use
-`run_branch` with a JSON `inputs_json` that fills the state_schema fields.
-The runner returns a `run_id`, final status, and per-node trace.
+After `describe_branch`, check `runnable` before telling the user their
+branch is ready to run. If `runnable=false`, surface
+`unapproved_source_code_nodes` or validation errors and stop. If
+`runnable=true`, use `run_branch` with a JSON `inputs_json` that fills the
+state_schema fields. The runner returns a `run_id`, final status, and
+per-node trace.
 
 ## Power users
 


### PR DESCRIPTION
Fixes #66

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.