### PR TITLE
[auto-change] BUG-034: All extensions actions return 'No approval received' while goals/wiki/universe/get_status work normally

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -424,7 +424,7 @@ def community_change_context(
         readOnlyHint=False,
         destructiveHint=False,
         idempotentHint=False,
-        openWorldHint=False,
+        openWorldHint=True,
     ),
 )
 def extensions(

--- a/tests/test_universe_server_metadata.py
+++ b/tests/test_universe_server_metadata.py
@@ -32,7 +32,7 @@ class TestUniverseServerMetadata:
         assert extensions.annotations.readOnlyHint is False
         assert extensions.annotations.destructiveHint is False
         assert extensions.annotations.idempotentHint is False
-        assert extensions.annotations.openWorldHint is False
+        assert extensions.annotations.openWorldHint is True
         assert "extension_guide" in extensions.description
 
         change_context = tools["community_change_context"]

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -424,7 +424,7 @@ def community_change_context(
         readOnlyHint=False,
         destructiveHint=False,
         idempotentHint=False,
-        openWorldHint=False,
+        openWorldHint=True,
     ),
 )
 def extensions(


### PR DESCRIPTION
Fixes #70

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.