### PR TITLE
[auto-change] WIKI-PATCH: As a community user I want to author small workflow units from chat without GitHub Actions YAML access

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -2669,6 +2669,10 @@ a bug (#66).
 Use `build_branch` with the whole workflow in a single `spec_json`.
 You get back a validated branch with a mermaid diagram in one call —
 no per-node chatter, no tool-call budget burn:
+This is the chat-native authoring path for small workflow units. Do NOT
+send community users to GitHub Actions YAML, repo files, or CI config
+when they ask to make or revise a workflow from chat; use `build_branch`
+for new units and `patch_branch` for edits.
 
 ```
 extensions action=build_branch spec_json='{

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
@@ -251,6 +251,10 @@ enumerate ALL FIVE. Don't list extensions actions and forget the rest.
   Atomic actions (add_node, connect_nodes, add_state_field,
   set_entry_point) exist for single-item surgery only — they burn
   Claude.ai per-turn tool-call budget. Default to `build_branch`.
+- Small workflow units are chat-native. Do NOT route community users to
+  GitHub Actions YAML, repo files, or CI configuration when they ask to
+  make a workflow from chat. Use `extensions action=build_branch` for a
+  new unit and `extensions action=patch_branch` for edits.
 - "Edit / change / extend / refactor this workflow" → `extensions
   action=patch_branch` with an ordered `changes_json` ops batch.
   Transactional (all-or-none). **When making multiple node edits, batch

--- a/tests/test_control_station_degraded_mode.py
+++ b/tests/test_control_station_degraded_mode.py
@@ -40,6 +40,19 @@ def test_prompt_body_matches_module_constant():
     assert _prompt_text() == _CONTROL_STATION_PROMPT
 
 
+def test_control_station_routes_small_workflow_authoring_to_chat_tools():
+    """Community users should be able to author small workflow units from chat.
+
+    The prompt must steer chatbots to build_branch / patch_branch and away from
+    GitHub Actions YAML as the authoring surface.
+    """
+    body = _prompt_text()
+    assert "chat-native" in body
+    assert "GitHub Actions YAML" in body
+    assert "extensions action=build_branch" in body
+    assert "extensions action=patch_branch" in body
+
+
 # ---- directive presence ---------------------------------------------------
 
 

--- a/tests/test_node_reuse_discovery.py
+++ b/tests/test_node_reuse_discovery.py
@@ -249,3 +249,11 @@ class TestReusePromptNudges:
         assert search_idx < author_idx, (
             "search-before-invent nudge must appear before the author flow"
         )
+
+    def test_branch_design_guide_names_chat_native_authoring(self, ext_env):
+        from workflow.api.branches import _BRANCH_DESIGN_GUIDE
+        text = _BRANCH_DESIGN_GUIDE
+        assert "chat-native" in text
+        assert "GitHub Actions YAML" in text
+        assert "build_branch" in text
+        assert "patch_branch" in text

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -2669,6 +2669,10 @@ a bug (#66).
 Use `build_branch` with the whole workflow in a single `spec_json`.
 You get back a validated branch with a mermaid diagram in one call —
 no per-node chatter, no tool-call budget burn:
+This is the chat-native authoring path for small workflow units. Do NOT
+send community users to GitHub Actions YAML, repo files, or CI config
+when they ask to make or revise a workflow from chat; use `build_branch`
+for new units and `patch_branch` for edits.
 
 ```
 extensions action=build_branch spec_json='{

--- a/workflow/api/prompts.py
+++ b/workflow/api/prompts.py
@@ -251,6 +251,10 @@ enumerate ALL FIVE. Don't list extensions actions and forget the rest.
   Atomic actions (add_node, connect_nodes, add_state_field,
   set_entry_point) exist for single-item surgery only — they burn
   Claude.ai per-turn tool-call budget. Default to `build_branch`.
+- Small workflow units are chat-native. Do NOT route community users to
+  GitHub Actions YAML, repo files, or CI configuration when they ask to
+  make a workflow from chat. Use `extensions action=build_branch` for a
+  new unit and `extensions action=patch_branch` for edits.
 - "Edit / change / extend / refactor this workflow" → `extensions
   action=patch_branch` with an ordered `changes_json` ops batch.
   Transactional (all-or-none). **When making multiple node edits, batch


### PR DESCRIPTION
Fixes #416

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.