### PR TITLE
[auto-change] WIKI-PATCH: Confidence-threshold node primitive — auto-process when sure, ask user when uncertain, learn from answers

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branches.py
@@ -386,6 +386,22 @@ class NodeDefinition:
     # }
     await_run_spec: dict[str, Any] | None = None
 
+    # confidence_threshold node kind. Deterministically routes by a numeric
+    # confidence state field: auto-process at/above threshold, ask below it,
+    # and emit an optional learning signal when a later user answer is present.
+    # Shape: {
+    #   "confidence_key": str,            # required
+    #   "threshold": float,               # default 0.8, inclusive
+    #   "route_key": str,                 # default output_keys[0] or "route"
+    #   "process_route": str,             # default "process"
+    #   "ask_route": str,                 # default "ask_user"
+    #   "answer_key": str,                # optional user answer state field
+    #   "question_key": str,              # optional output state field
+    #   "question_template": str,         # optional, state placeholders allowed
+    #   "learn_key": str,                 # optional output state field
+    # }
+    confidence_threshold_spec: dict[str, Any] | None = None
+
     # Legacy compat fields from NodeRegistration
     author: str = "anonymous"
     registered_at: str = ""
@@ -1221,6 +1237,46 @@ class BranchDefinition:
                     errors.append(
                         f"Node '{n.node_id}' has await_run_spec and also "
                         f"prompt_template/source_code — these are mutually exclusive."
+                    )
+
+            if n.confidence_threshold_spec is not None:
+                spec = n.confidence_threshold_spec
+                if not spec.get("confidence_key"):
+                    errors.append(
+                        f"Node '{n.node_id}' confidence_threshold_spec missing "
+                        f"'confidence_key'."
+                    )
+                try:
+                    threshold = float(spec.get("threshold", 0.8))
+                except (TypeError, ValueError):
+                    errors.append(
+                        f"Node '{n.node_id}' confidence_threshold_spec "
+                        "threshold must be a number between 0 and 1."
+                    )
+                else:
+                    if threshold < 0.0 or threshold > 1.0:
+                        errors.append(
+                            f"Node '{n.node_id}' confidence_threshold_spec "
+                            "threshold must be between 0 and 1."
+                        )
+                if n.prompt_template or n.source_code:
+                    errors.append(
+                        f"Node '{n.node_id}' has confidence_threshold_spec and "
+                        f"also prompt_template/source_code — these are mutually "
+                        f"exclusive."
+                    )
+                other_specs = [
+                    name for name, value in (
+                        ("invoke_branch_spec", n.invoke_branch_spec),
+                        ("invoke_branch_version_spec", n.invoke_branch_version_spec),
+                        ("await_run_spec", n.await_run_spec),
+                    )
+                    if value is not None
+                ]
+                if other_specs:
+                    errors.append(
+                        f"Node '{n.node_id}' has confidence_threshold_spec and "
+                        f"{', '.join(other_specs)} — these are mutually exclusive."
                     )
 
         return errors

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
@@ -1778,6 +1778,120 @@ def _build_await_branch_run_node(
     return _node_fn
 
 
+def _non_empty(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, dict, tuple, set)):
+        return bool(value)
+    return True
+
+
+def compile_confidence_threshold_spec(
+    state: dict[str, Any],
+    spec: dict[str, Any],
+    *,
+    output_keys: list[str] | tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Evaluate a confidence-threshold node spec against runtime state.
+
+    This is intentionally a deterministic routing primitive. It does not
+    persist memory itself; when an uncertain route later carries a user answer,
+    it emits a structured learning signal for a downstream learn/memory node.
+    """
+    confidence_key = str(spec.get("confidence_key") or "").strip()
+    if not confidence_key:
+        raise CompilerError("confidence_threshold_spec missing 'confidence_key'.")
+
+    try:
+        confidence = float(state.get(confidence_key, 0.0))
+    except (TypeError, ValueError):
+        confidence = 0.0
+
+    try:
+        threshold = float(spec.get("threshold", 0.8))
+    except (TypeError, ValueError) as exc:
+        raise CompilerError(
+            "confidence_threshold_spec threshold must be a number."
+        ) from exc
+    if threshold < 0.0 or threshold > 1.0:
+        raise CompilerError(
+            "confidence_threshold_spec threshold must be between 0 and 1."
+        )
+
+    route_key = str(
+        spec.get("route_key") or (output_keys[0] if output_keys else "route")
+    ).strip()
+    if not route_key:
+        raise CompilerError("confidence_threshold_spec route_key is empty.")
+
+    process_route = str(spec.get("process_route") or "process")
+    ask_route = str(spec.get("ask_route") or "ask_user")
+    answer_key = str(spec.get("answer_key") or "").strip()
+    has_answer = bool(answer_key and _non_empty(state.get(answer_key)))
+
+    confident = confidence >= threshold
+    result: dict[str, Any] = {
+        route_key: process_route if confident or has_answer else ask_route,
+    }
+
+    if not confident and not has_answer:
+        question_key = str(spec.get("question_key") or "").strip()
+        if question_key:
+            template = str(
+                spec.get("question_template")
+                or "Please clarify before this node continues."
+            )
+            missing = _missing_state_keys(template, state)
+            if missing:
+                raise CompilerError(
+                    "confidence_threshold_spec question_template references "
+                    f"missing state keys: {missing}"
+                )
+            result[question_key] = _render_template(template, state)
+
+    learn_key = str(spec.get("learn_key") or "").strip()
+    if learn_key and has_answer:
+        result[learn_key] = {
+            "answer": state[answer_key],
+            "confidence": confidence,
+            "threshold": threshold,
+            "confidence_key": confidence_key,
+            "route": process_route,
+        }
+
+    return result
+
+
+def _build_confidence_threshold_node(
+    node: NodeDefinition,
+    *,
+    event_sink: Callable[..., None] | None,
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    spec = node.confidence_threshold_spec or {}
+
+    def _node_fn(state: dict[str, Any]) -> dict[str, Any]:
+        result = compile_confidence_threshold_spec(
+            state, spec, output_keys=node.output_keys,
+        )
+        if event_sink is not None:
+            try:
+                event_sink(
+                    node_id=node.node_id,
+                    phase="ran",
+                    confidence_threshold=True,
+                    output=result,
+                )
+            except Exception as exc:  # noqa: BLE001
+                if _is_cancel_exception(exc):
+                    raise
+                logger.exception("event_sink raised in %s", node.node_id)
+        return result
+
+    return _node_fn
+
+
 def _build_node(
     node: NodeDefinition,
     *,
@@ -1865,6 +1979,9 @@ def _build_node(
         inner = _build_await_branch_run_node(
             node, base_path=base_path, event_sink=event_sink,
         )
+        return _wrap_with_checkpoints(inner, node, event_sink)
+    if node.confidence_threshold_spec is not None:
+        inner = _build_confidence_threshold_node(node, event_sink=event_sink)
         return _wrap_with_checkpoints(inner, node, event_sink)
     # Fallback: a genuine body-less node in a non-domain-trusted
     # context is a malformed Branch. Preserve the CompilerError

--- a/tests/test_confidence_threshold_node.py
+++ b/tests/test_confidence_threshold_node.py
@@ -1,0 +1,145 @@
+"""Tests for the confidence_threshold node primitive."""
+
+from __future__ import annotations
+
+import pytest
+
+from workflow.branches import (
+    BranchDefinition,
+    ConditionalEdge,
+    EdgeDefinition,
+    GraphNodeRef,
+    NodeDefinition,
+)
+from workflow.graph_compiler import (
+    CompilerError,
+    compile_branch,
+    compile_confidence_threshold_spec,
+)
+
+
+def _branch() -> BranchDefinition:
+    gate = NodeDefinition(
+        node_id="gate",
+        display_name="Confidence Gate",
+        output_keys=["route", "question", "learning_signal"],
+        confidence_threshold_spec={
+            "confidence_key": "confidence",
+            "threshold": 0.8,
+            "route_key": "route",
+            "process_route": "process",
+            "ask_route": "ask_user",
+            "answer_key": "user_answer",
+            "question_key": "question",
+            "question_template": "Should I process {candidate}?",
+            "learn_key": "learning_signal",
+        },
+    )
+    process = NodeDefinition(
+        node_id="process",
+        display_name="Process",
+        prompt_template="process",
+        output_keys=["processed"],
+    )
+    ask = NodeDefinition(
+        node_id="ask",
+        display_name="Ask",
+        prompt_template="ask",
+        output_keys=["asked"],
+    )
+    return BranchDefinition(
+        branch_def_id="confidence-gate-test",
+        name="Confidence Gate Test",
+        graph_nodes=[
+            GraphNodeRef(id="gate", node_def_id="gate"),
+            GraphNodeRef(id="process", node_def_id="process"),
+            GraphNodeRef(id="ask", node_def_id="ask"),
+        ],
+        node_defs=[gate, process, ask],
+        edges=[
+            EdgeDefinition(from_node="process", to_node="END"),
+            EdgeDefinition(from_node="ask", to_node="END"),
+        ],
+        conditional_edges=[
+            ConditionalEdge(
+                from_node="gate",
+                conditions={"process": "process", "ask_user": "ask"},
+            ),
+        ],
+        entry_point="gate",
+        state_schema=[
+            {"name": "confidence", "type": "float"},
+            {"name": "candidate", "type": "str"},
+            {"name": "user_answer", "type": "str"},
+            {"name": "route", "type": "str"},
+            {"name": "question", "type": "str"},
+            {"name": "learning_signal", "type": "dict"},
+            {"name": "processed", "type": "str"},
+            {"name": "asked", "type": "str"},
+        ],
+    )
+
+
+def test_confident_node_routes_to_process() -> None:
+    compiled = compile_branch(_branch())
+
+    result = compiled.graph.compile().invoke({
+        "confidence": 0.91,
+        "candidate": "the patch",
+    })
+
+    assert result["route"] == "process"
+    assert result["processed"] == "[Mock response for process]"
+    assert "asked" not in result
+    assert "question" not in result
+
+
+def test_uncertain_node_routes_to_ask_with_question() -> None:
+    compiled = compile_branch(_branch())
+
+    result = compiled.graph.compile().invoke({
+        "confidence": 0.41,
+        "candidate": "the patch",
+    })
+
+    assert result["route"] == "ask_user"
+    assert result["question"] == "Should I process the patch?"
+    assert result["asked"] == "[Mock response for ask]"
+    assert "processed" not in result
+
+
+def test_user_answer_routes_to_process_and_emits_learning_signal() -> None:
+    compiled = compile_branch(_branch())
+
+    result = compiled.graph.compile().invoke({
+        "confidence": 0.41,
+        "candidate": "the patch",
+        "user_answer": "Yes, apply it.",
+    })
+
+    assert result["route"] == "process"
+    assert result["processed"] == "[Mock response for process]"
+    assert result["learning_signal"] == {
+        "answer": "Yes, apply it.",
+        "confidence": 0.41,
+        "threshold": 0.8,
+        "confidence_key": "confidence",
+        "route": "process",
+    }
+
+
+def test_confidence_threshold_spec_validates_threshold() -> None:
+    with pytest.raises(CompilerError, match="between 0 and 1"):
+        compile_confidence_threshold_spec(
+            {"confidence": 0.5},
+            {"confidence_key": "confidence", "threshold": 1.2},
+        )
+
+
+def test_branch_validation_rejects_missing_confidence_key() -> None:
+    branch = _branch()
+    branch.node_defs[0].confidence_threshold_spec = {"threshold": 0.8}
+
+    errors = branch.validate()
+
+    assert any("confidence_threshold_spec missing 'confidence_key'" in e for e in errors)

--- a/workflow/branches.py
+++ b/workflow/branches.py
@@ -386,6 +386,22 @@ class NodeDefinition:
     # }
     await_run_spec: dict[str, Any] | None = None
 
+    # confidence_threshold node kind. Deterministically routes by a numeric
+    # confidence state field: auto-process at/above threshold, ask below it,
+    # and emit an optional learning signal when a later user answer is present.
+    # Shape: {
+    #   "confidence_key": str,            # required
+    #   "threshold": float,               # default 0.8, inclusive
+    #   "route_key": str,                 # default output_keys[0] or "route"
+    #   "process_route": str,             # default "process"
+    #   "ask_route": str,                 # default "ask_user"
+    #   "answer_key": str,                # optional user answer state field
+    #   "question_key": str,              # optional output state field
+    #   "question_template": str,         # optional, state placeholders allowed
+    #   "learn_key": str,                 # optional output state field
+    # }
+    confidence_threshold_spec: dict[str, Any] | None = None
+
     # Legacy compat fields from NodeRegistration
     author: str = "anonymous"
     registered_at: str = ""
@@ -1221,6 +1237,46 @@ class BranchDefinition:
                     errors.append(
                         f"Node '{n.node_id}' has await_run_spec and also "
                         f"prompt_template/source_code — these are mutually exclusive."
+                    )
+
+            if n.confidence_threshold_spec is not None:
+                spec = n.confidence_threshold_spec
+                if not spec.get("confidence_key"):
+                    errors.append(
+                        f"Node '{n.node_id}' confidence_threshold_spec missing "
+                        f"'confidence_key'."
+                    )
+                try:
+                    threshold = float(spec.get("threshold", 0.8))
+                except (TypeError, ValueError):
+                    errors.append(
+                        f"Node '{n.node_id}' confidence_threshold_spec "
+                        "threshold must be a number between 0 and 1."
+                    )
+                else:
+                    if threshold < 0.0 or threshold > 1.0:
+                        errors.append(
+                            f"Node '{n.node_id}' confidence_threshold_spec "
+                            "threshold must be between 0 and 1."
+                        )
+                if n.prompt_template or n.source_code:
+                    errors.append(
+                        f"Node '{n.node_id}' has confidence_threshold_spec and "
+                        f"also prompt_template/source_code — these are mutually "
+                        f"exclusive."
+                    )
+                other_specs = [
+                    name for name, value in (
+                        ("invoke_branch_spec", n.invoke_branch_spec),
+                        ("invoke_branch_version_spec", n.invoke_branch_version_spec),
+                        ("await_run_spec", n.await_run_spec),
+                    )
+                    if value is not None
+                ]
+                if other_specs:
+                    errors.append(
+                        f"Node '{n.node_id}' has confidence_threshold_spec and "
+                        f"{', '.join(other_specs)} — these are mutually exclusive."
                     )
 
         return errors

--- a/workflow/graph_compiler.py
+++ b/workflow/graph_compiler.py
@@ -1778,6 +1778,120 @@ def _build_await_branch_run_node(
     return _node_fn
 
 
+def _non_empty(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, dict, tuple, set)):
+        return bool(value)
+    return True
+
+
+def compile_confidence_threshold_spec(
+    state: dict[str, Any],
+    spec: dict[str, Any],
+    *,
+    output_keys: list[str] | tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Evaluate a confidence-threshold node spec against runtime state.
+
+    This is intentionally a deterministic routing primitive. It does not
+    persist memory itself; when an uncertain route later carries a user answer,
+    it emits a structured learning signal for a downstream learn/memory node.
+    """
+    confidence_key = str(spec.get("confidence_key") or "").strip()
+    if not confidence_key:
+        raise CompilerError("confidence_threshold_spec missing 'confidence_key'.")
+
+    try:
+        confidence = float(state.get(confidence_key, 0.0))
+    except (TypeError, ValueError):
+        confidence = 0.0
+
+    try:
+        threshold = float(spec.get("threshold", 0.8))
+    except (TypeError, ValueError) as exc:
+        raise CompilerError(
+            "confidence_threshold_spec threshold must be a number."
+        ) from exc
+    if threshold < 0.0 or threshold > 1.0:
+        raise CompilerError(
+            "confidence_threshold_spec threshold must be between 0 and 1."
+        )
+
+    route_key = str(
+        spec.get("route_key") or (output_keys[0] if output_keys else "route")
+    ).strip()
+    if not route_key:
+        raise CompilerError("confidence_threshold_spec route_key is empty.")
+
+    process_route = str(spec.get("process_route") or "process")
+    ask_route = str(spec.get("ask_route") or "ask_user")
+    answer_key = str(spec.get("answer_key") or "").strip()
+    has_answer = bool(answer_key and _non_empty(state.get(answer_key)))
+
+    confident = confidence >= threshold
+    result: dict[str, Any] = {
+        route_key: process_route if confident or has_answer else ask_route,
+    }
+
+    if not confident and not has_answer:
+        question_key = str(spec.get("question_key") or "").strip()
+        if question_key:
+            template = str(
+                spec.get("question_template")
+                or "Please clarify before this node continues."
+            )
+            missing = _missing_state_keys(template, state)
+            if missing:
+                raise CompilerError(
+                    "confidence_threshold_spec question_template references "
+                    f"missing state keys: {missing}"
+                )
+            result[question_key] = _render_template(template, state)
+
+    learn_key = str(spec.get("learn_key") or "").strip()
+    if learn_key and has_answer:
+        result[learn_key] = {
+            "answer": state[answer_key],
+            "confidence": confidence,
+            "threshold": threshold,
+            "confidence_key": confidence_key,
+            "route": process_route,
+        }
+
+    return result
+
+
+def _build_confidence_threshold_node(
+    node: NodeDefinition,
+    *,
+    event_sink: Callable[..., None] | None,
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    spec = node.confidence_threshold_spec or {}
+
+    def _node_fn(state: dict[str, Any]) -> dict[str, Any]:
+        result = compile_confidence_threshold_spec(
+            state, spec, output_keys=node.output_keys,
+        )
+        if event_sink is not None:
+            try:
+                event_sink(
+                    node_id=node.node_id,
+                    phase="ran",
+                    confidence_threshold=True,
+                    output=result,
+                )
+            except Exception as exc:  # noqa: BLE001
+                if _is_cancel_exception(exc):
+                    raise
+                logger.exception("event_sink raised in %s", node.node_id)
+        return result
+
+    return _node_fn
+
+
 def _build_node(
     node: NodeDefinition,
     *,
@@ -1865,6 +1979,9 @@ def _build_node(
         inner = _build_await_branch_run_node(
             node, base_path=base_path, event_sink=event_sink,
         )
+        return _wrap_with_checkpoints(inner, node, event_sink)
+    if node.confidence_threshold_spec is not None:
+        inner = _build_confidence_threshold_node(node, event_sink=event_sink)
         return _wrap_with_checkpoints(inner, node, event_sink)
     # Fallback: a genuine body-less node in a non-domain-trusted
     # context is a malformed Branch. Preserve the CompilerError


### PR DESCRIPTION
Fixes #441

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.