### PR TITLE
BUG-069 fix: wrap MCP tool responses for ChatGPT Apps SDK alignment

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -52,6 +52,34 @@ logger = logging.getLogger("universe_server")
 # Server
 # ---------------------------------------------------------------------------
 
+def _structured_return(raw):
+    """Wrap an MCP tool result so FastMCP populates ``structured_content``.
+
+    ChatGPT (OpenAI Apps SDK) wedges on substrate-changing tool calls when
+    the response carries only ``content`` (text) without ``structuredContent``
+    (typed dict) + ``_meta`` annotations. Claude tolerates either shape.
+
+    The internal ``*_impl`` functions return JSON strings for back-compat.
+    Wrapping their output in a dict (parsing JSON when possible, else
+    embedding the raw text) lets FastMCP's response builder populate
+    ``structured_content`` automatically — Apps SDK then renders cleanly.
+    """
+    import json as _json
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, list):
+        return {"result": raw}
+    if isinstance(raw, str):
+        try:
+            parsed = _json.loads(raw)
+        except (_json.JSONDecodeError, ValueError):
+            return {"text": raw}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"result": parsed}
+    return {"result": raw}
+
+
 mcp = FastMCP(
     "workflow",
     instructions=(
@@ -300,7 +328,7 @@ def universe(
     enabled: bool = False,
     tag: str = "",
     anchor_json: str = "",
-) -> str:
+) -> dict:
     """Inspect and steer a workflow's universe.
 
     Self-contained workspace for a multi-step workflow. New workflows
@@ -335,7 +363,7 @@ def universe(
         filename/provenance_tag/limit/tag: Optional read/write filters.
         anchor_json: Optional JSON object for `give_direction` line/span notes.
     """
-    return _universe_impl(
+    return _structured_return(_universe_impl(
         action=action,
         universe_id=universe_id,
         text=text,
@@ -364,7 +392,7 @@ def universe(
         enabled=enabled,
         tag=tag,
         anchor_json=anchor_json,
-    )
+    ))
 
 
 # ---------------------------------------------------------------------------
@@ -389,7 +417,7 @@ def universe(
 def community_change_context(
     filter_text: str = "",
     limit: int = 10,
-) -> str:
+) -> dict:
     """Review PR metadata, changed files, reviews, and project plan context.
 
     Use this when the user asks to review, approve, reject, send back,
@@ -404,11 +432,11 @@ def community_change_context(
             reviews; or "issue:NUMBER" for the request thread.
         limit: Max PRs/issues/files/comments to return, capped server-side.
     """
-    return _universe_impl(
+    return _structured_return(_universe_impl(
         action="community_change_context",
         filter_text=filter_text,
         limit=limit,
-    )
+    ))
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -545,7 +573,7 @@ def extensions(
     ship_class: str = "",
     changed_paths_json: str = "",
     stable_evidence_handle: str = "",
-) -> str:
+) -> dict:
     """Workflow-builder surface: design, edit, run, judge custom AI graphs.
 
     Behavioral rules live in `control_station`, `extension_guide`, and
@@ -580,7 +608,7 @@ def extensions(
 
     Args: pass `action` plus the matching ids or JSON payload fields.
     """
-    return _extensions_impl(
+    return _structured_return(_extensions_impl(
         action=action,
         node_id=node_id,
         display_name=display_name,
@@ -698,7 +726,7 @@ def extensions(
         ship_class=ship_class,
         changed_paths_json=changed_paths_json,
         stable_evidence_handle=stable_evidence_handle,
-    )
+    ))
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -733,7 +761,7 @@ def goals(
     limit: int = 50,
     scope: str = "",
     force: bool = False,
-) -> str:
+) -> dict:
     """Goals — first-class shared primitives above workflow Branches.
 
     A Goal captures the intent a workflow serves ("produce a research
@@ -756,7 +784,7 @@ def goals(
       common_nodes Nodes appearing in >=`min_branches` Branches.
 
     """
-    return _goals_impl(
+    return _structured_return(_goals_impl(
         action=action,
         goal_id=goal_id,
         branch_def_id=branch_def_id,
@@ -772,7 +800,7 @@ def goals(
         limit=limit,
         scope=scope,
         force=force,
-    )
+    ))
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -809,7 +837,7 @@ def gates(
     eval_verdict: str = "",
     node_last_claimer: str = "",
     node_id: str = "",
-) -> str:
+) -> dict:
     """Outcome Gates — real-world impact claims per Branch.
 
     Each Goal declares a ladder of rungs (draft -> peer-reviewed -> published
@@ -841,7 +869,7 @@ def gates(
       release_bonus Resolve a bonus payout via evaluator verdict.
 
     """
-    return _gates_impl(
+    return _structured_return(_gates_impl(
         action=action,
         goal_id=goal_id,
         branch_def_id=branch_def_id,
@@ -859,7 +887,7 @@ def gates(
         eval_verdict=eval_verdict,
         node_last_claimer=node_last_claimer,
         node_id=node_id,
-    )
+    ))
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -909,7 +937,7 @@ def wiki(
     force_new: bool = False,
     bug_id: str = "",
     reporter_context: str = "",
-) -> str:
+) -> dict:
     """Read, write, and manage the cross-project knowledge wiki.
 
     Persistent prose knowledge shared across sessions. It is not for
@@ -932,7 +960,7 @@ def wiki(
         old_text/new_text: For action="patch", exact text to replace server-side.
         expected_sha256: Optional full-page hash guard for action="patch".
     """
-    return _wiki_impl(
+    return _structured_return(_wiki_impl(
         action=action,
         page=page,
         query=query,
@@ -963,7 +991,7 @@ def wiki(
         force_new=force_new,
         bug_id=bug_id,
         reporter_context=reporter_context,
-    )
+    ))
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -985,7 +1013,7 @@ def wiki(
         openWorldHint=False,
     ),
 )
-def get_status(universe_id: str = "") -> str:
+def get_status(universe_id: str = "") -> dict:
     """Factual snapshot of the daemon's identity + routing config.
 
     Chatbots call this whenever they need ground-truth daemon facts.
@@ -1004,7 +1032,7 @@ def get_status(universe_id: str = "") -> str:
     Args:
         universe_id: Optional universe scope. Defaults to active universe.
     """
-    return _get_status_impl(universe_id=universe_id)
+    return _structured_return(_get_status_impl(universe_id=universe_id))
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -52,6 +52,34 @@ logger = logging.getLogger("universe_server")
 # Server
 # ---------------------------------------------------------------------------
 
+def _structured_return(raw):
+    """Wrap an MCP tool result so FastMCP populates ``structured_content``.
+
+    ChatGPT (OpenAI Apps SDK) wedges on substrate-changing tool calls when
+    the response carries only ``content`` (text) without ``structuredContent``
+    (typed dict) + ``_meta`` annotations. Claude tolerates either shape.
+
+    The internal ``*_impl`` functions return JSON strings for back-compat.
+    Wrapping their output in a dict (parsing JSON when possible, else
+    embedding the raw text) lets FastMCP's response builder populate
+    ``structured_content`` automatically — Apps SDK then renders cleanly.
+    """
+    import json as _json
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, list):
+        return {"result": raw}
+    if isinstance(raw, str):
+        try:
+            parsed = _json.loads(raw)
+        except (_json.JSONDecodeError, ValueError):
+            return {"text": raw}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"result": parsed}
+    return {"result": raw}
+
+
 mcp = FastMCP(
     "workflow",
     instructions=(
@@ -300,7 +328,7 @@ def universe(
     enabled: bool = False,
     tag: str = "",
     anchor_json: str = "",
-) -> str:
+) -> dict:
     """Inspect and steer a workflow's universe.
 
     Self-contained workspace for a multi-step workflow. New workflows
@@ -335,7 +363,7 @@ def universe(
         filename/provenance_tag/limit/tag: Optional read/write filters.
         anchor_json: Optional JSON object for `give_direction` line/span notes.
     """
-    return _universe_impl(
+    return _structured_return(_universe_impl(
         action=action,
         universe_id=universe_id,
         text=text,
@@ -364,7 +392,7 @@ def universe(
         enabled=enabled,
         tag=tag,
         anchor_json=anchor_json,
-    )
+    ))
 
 
 # ---------------------------------------------------------------------------
@@ -389,7 +417,7 @@ def universe(
 def community_change_context(
     filter_text: str = "",
     limit: int = 10,
-) -> str:
+) -> dict:
     """Review PR metadata, changed files, reviews, and project plan context.
 
     Use this when the user asks to review, approve, reject, send back,
@@ -404,11 +432,11 @@ def community_change_context(
             reviews; or "issue:NUMBER" for the request thread.
         limit: Max PRs/issues/files/comments to return, capped server-side.
     """
-    return _universe_impl(
+    return _structured_return(_universe_impl(
         action="community_change_context",
         filter_text=filter_text,
         limit=limit,
-    )
+    ))
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -545,7 +573,7 @@ def extensions(
     ship_class: str = "",
     changed_paths_json: str = "",
     stable_evidence_handle: str = "",
-) -> str:
+) -> dict:
     """Workflow-builder surface: design, edit, run, judge custom AI graphs.
 
     Behavioral rules live in `control_station`, `extension_guide`, and
@@ -580,7 +608,7 @@ def extensions(
 
     Args: pass `action` plus the matching ids or JSON payload fields.
     """
-    return _extensions_impl(
+    return _structured_return(_extensions_impl(
         action=action,
         node_id=node_id,
         display_name=display_name,
@@ -698,7 +726,7 @@ def extensions(
         ship_class=ship_class,
         changed_paths_json=changed_paths_json,
         stable_evidence_handle=stable_evidence_handle,
-    )
+    ))
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -733,7 +761,7 @@ def goals(
     limit: int = 50,
     scope: str = "",
     force: bool = False,
-) -> str:
+) -> dict:
     """Goals — first-class shared primitives above workflow Branches.
 
     A Goal captures the intent a workflow serves ("produce a research
@@ -756,7 +784,7 @@ def goals(
       common_nodes Nodes appearing in >=`min_branches` Branches.
 
     """
-    return _goals_impl(
+    return _structured_return(_goals_impl(
         action=action,
         goal_id=goal_id,
         branch_def_id=branch_def_id,
@@ -772,7 +800,7 @@ def goals(
         limit=limit,
         scope=scope,
         force=force,
-    )
+    ))
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -809,7 +837,7 @@ def gates(
     eval_verdict: str = "",
     node_last_claimer: str = "",
     node_id: str = "",
-) -> str:
+) -> dict:
     """Outcome Gates — real-world impact claims per Branch.
 
     Each Goal declares a ladder of rungs (draft -> peer-reviewed -> published
@@ -841,7 +869,7 @@ def gates(
       release_bonus Resolve a bonus payout via evaluator verdict.
 
     """
-    return _gates_impl(
+    return _structured_return(_gates_impl(
         action=action,
         goal_id=goal_id,
         branch_def_id=branch_def_id,
@@ -859,7 +887,7 @@ def gates(
         eval_verdict=eval_verdict,
         node_last_claimer=node_last_claimer,
         node_id=node_id,
-    )
+    ))
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -909,7 +937,7 @@ def wiki(
     force_new: bool = False,
     bug_id: str = "",
     reporter_context: str = "",
-) -> str:
+) -> dict:
     """Read, write, and manage the cross-project knowledge wiki.
 
     Persistent prose knowledge shared across sessions. It is not for
@@ -932,7 +960,7 @@ def wiki(
         old_text/new_text: For action="patch", exact text to replace server-side.
         expected_sha256: Optional full-page hash guard for action="patch".
     """
-    return _wiki_impl(
+    return _structured_return(_wiki_impl(
         action=action,
         page=page,
         query=query,
@@ -963,7 +991,7 @@ def wiki(
         force_new=force_new,
         bug_id=bug_id,
         reporter_context=reporter_context,
-    )
+    ))
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -985,7 +1013,7 @@ def wiki(
         openWorldHint=False,
     ),
 )
-def get_status(universe_id: str = "") -> str:
+def get_status(universe_id: str = "") -> dict:
     """Factual snapshot of the daemon's identity + routing config.
 
     Chatbots call this whenever they need ground-truth daemon facts.
@@ -1004,7 +1032,7 @@ def get_status(universe_id: str = "") -> str:
     Args:
         universe_id: Optional universe scope. Defaults to active universe.
     """
-    return _get_status_impl(universe_id=universe_id)
+    return _structured_return(_get_status_impl(universe_id=universe_id))
 
 
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Fixes BUG-069 (chatbot Thinking-wedge after access granted on substrate-changing tool calls — ChatGPT-only).

## Root cause

ChatGPT (OpenAI Apps SDK) wedges on substrate-changing MCP calls when the response carries only `content` (text) without `structuredContent` (typed dict) + `_meta` annotations. Claude tolerates either shape — confirmed by cross-family probe (PR-052 filed cleanly via Claude.ai, same MCP, no wedge).

## Fix

Adds `_structured_return()` helper + wraps all 7 `@mcp.tool` wrappers (universe, community_change_context, extensions, goals, gates, wiki, get_status) so FastMCP populates `structured_content` automatically. Internal `*_impl` functions still return JSON strings — back-compat preserved.

## Cross-client alignment principle

Claude and ChatGPT MCP expectations are **project prerequisites**. Substrate must satisfy both — divergent client tolerance is a substrate bug, not a client bug.

## Triple-key gate

- Cowork checker-key: YES (this PR)
- Codex review: pending dual-key concur
- Host approval: required as third key for merge

## Cross-refs

- BUG-069 (chatbot Thinking-wedge after access granted, ChatGPT-only)
- BUG-067 (read-side wedge, fixed by #419)
- PR-052 (cross-family Claude.ai reproducer — proves substrate-side bug)
- pages/notes/cowork-bug-069-cross-family-claude-ai-clean-chatgpt-specific-2026-05-06
- pages/notes/cowork-codex-bug-069-parallel-investigation-2026-05-06