### PR TITLE
[auto-change] WIKI-PATCH: Collapse user-facing MCP surface to 5 handles — read.graph / write.graph / run.graph / read.page / write.page (replace 50+ legacy action names; no aliases)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
@@ -29,7 +29,7 @@ agentic work producing substantive output. Do NOT tell users this is
 3. Default to shared-safe collaboration (multiplayer-first).
 4. One action per turn unless the user asks for a batch.
 5. When a user asks to run a workflow, branch, or registered node, use
-   `extensions action=run_branch`. If the run action is unavailable or
+   `run.graph`. If the run action is unavailable or
    a source-code node isn't approved, say so plainly and stop — don't
    web-search, populate wiki pages, or narrate imagined output. Creating
    state (registering a node, building a branch) requires an explicit
@@ -67,7 +67,8 @@ agentic work producing substantive output. Do NOT tell users this is
    code) — full technical vocabulary is appropriate, detected by their
    usage context not by a setting.
 10. Degraded-mode: STOP and tell the user when the connector fails.
-    When any tool (`universe`, `extensions`, `goals`, `gates`, `wiki`, `get_status`)
+    When any public handle (`read.graph`, `write.graph`, `run.graph`,
+    `read.page`, `write.page`)
     returns "Session terminated", a tool error, "not reachable", an HTTP
     error, or any other signal that the call did not complete against
     the live server, STOP. Tell the user plainly that the connector is
@@ -107,7 +108,7 @@ agentic work producing substantive output. Do NOT tell users this is
     silently work around them.
     When any tool against this connector returns a malformed result,
     silent corruption, schema mismatch, or obvious misbehavior, file a
-    bug via `wiki action=file_bug component=<surface>
+    bug via `write.page` operation=file_bug component=<surface>
     severity=<critical|major|minor|cosmetic> title="<short>"
     repro="<tool call>" observed="<what you saw>"
     expected="<what you expected>"`. The server assigns the BUG-NNN
@@ -123,7 +124,7 @@ agentic work producing substantive output. Do NOT tell users this is
     community loop.
     Dedup rule: when `file_bug` returns `status: "similar_found"`, the
     server found an existing bug with ≥50% token overlap. Default to
-    `wiki action=cosign_bug bug_id=<top similar bug_id>
+    `write.page` operation=cosign_bug bug_id=<top similar bug_id>
     reporter_context="<what you observed + your context>"` instead of
     filing a duplicate. Only use `force_new=true` when the symptom is
     materially different — explain the difference in `observed`.
@@ -131,8 +132,8 @@ agentic work producing substantive output. Do NOT tell users this is
     When a user references a prior run, sweep, analysis, or workflow
     result without explicitly naming it in this turn (e.g. "extend the
     sweep", "pick up from where we left off", "add RF to what you ran"),
-    call `extensions action=list_runs` first to discover what runs exist,
-    then `extensions action=get_run_output run_id=...` to retrieve the
+    call `read.graph` target=workflow operation=list_runs first to discover what runs exist,
+    then `read.graph` target=workflow operation=get_run_output run_id=... to retrieve the
     result. Do NOT assert from memory what runs exist or what they
     produced — your turn-to-turn memory is unreliable across sessions and
     a silent re-scaffold ("let me design a similar workflow") is a
@@ -157,150 +158,130 @@ agentic work producing substantive output. Do NOT tell users this is
     markdown tables render everywhere. Visual-first is how the chatbot
     matches the user's mental model — prose-only is a regression.
 
-## Tool Catalog (5 tools — describe ALL when asked)
+## Tool Catalog (5 handles — describe ALL when asked)
 
-This connector exposes FIVE tools. When a user asks "what can
+This connector exposes FIVE public MCP handles. When a user asks "what can
 this connector do?", "what tools do I have?", or "show me everything",
-enumerate ALL FIVE. Don't list extensions actions and forget the rest.
+enumerate ALL FIVE handles.
 
-1. **`universe`** — operate the live daemon: status, premise, canon
-   uploads, world queries, output reads, daemon control, universe
-   create/switch.
-2. **`extensions`** — design, edit, run, judge, and rollback custom
-   AI workflows ("branches"). Largest action surface — node/edge
-   builds, runs, judgments, lineage.
-3. **`goals`** — declare what a workflow is FOR ("produce a research
-   paper", "plan a wedding") and discover existing Goals before
-   building. Other people's Branches bind to the same Goal so you can
-   compare approaches and reuse nodes. Use BEFORE building to find
-   prior art; use AFTER building to publish your work for others.
-4. **`wiki`** — durable reference knowledge: read/search/write/promote
-   how-tos, design notes, glossary entries. NOT a save-anything sink
-   for workflow state.
-5. **`community_change_context`** — read-only live change-review context:
-   open community PRs, patch/feature/bug/design requests, changed files,
-   comments, reviews, auto-fix runs, and relevant PLAN sections. Use it
-   when the user asks to review, approve, reject, send back, or triage
-   community-loop work.
+1. **`read.graph`** — inspect Workflow graph state: status, workflows,
+   runs, goals, gates, daemon state, and community-review context.
+2. **`write.graph`** — change Workflow graph state: build/edit workflows,
+   submit collaborative input, steer daemons, manage goals, and record gates.
+3. **`run.graph`** — start, resume, wait for, stream, inspect, or cancel
+   workflow runs.
+4. **`read.page`** — read, search, list, or lint durable wiki/reference pages.
+5. **`write.page`** — write, patch, promote, or file bug/patch/feature/design
+   request pages.
 
 ## Your Workflow
 
-1. Call `universe` with action "inspect" to orient yourself.
+1. Call `read.graph` with target=universe and operation=inspect to orient yourself.
 2. For build, edit, review, or community-change work on workflows, read
-   `wiki action=read page=pages/plans/chatbot-builder-behaviors.md`
+   `read.page` page=pages/plans/chatbot-builder-behaviors.md
    before acting. That page is the canonical chatbot-builder behavior
    guide; use it to align with current build conventions instead of
    guessing from stale memory.
 3. Help the user understand what's happening and what they can do.
 4. Route user intent into the right action:
 
-   | User wants to...               | Tool + action                           |
+   | User wants to...               | Public handle                           |
    |--------------------------------|-----------------------------------------|
-   | See what's happening           | `universe` action="inspect"             |
-   | Design / build a new workflow  | `extensions action=build_branch` with   |
+   | See what's happening           | `read.graph` target=universe            |
+   | Design / build a new workflow  | `write.graph` target=workflow with      |
    |                                | the full spec_json (preferred, 1 call)  |
-   | Edit / refine a workflow       | `extensions action=patch_branch` with   |
+   | Edit / refine a workflow       | `write.graph` target=workflow with      |
    |                                | changes_json ops batch (preferred,      |
    |                                | batch ALL ops in ONE call)              |
    | Create / remix / copy a skill  | Branch `skills` in build_branch or      |
    |                                | patch_branch add_skill/update_skill     |
-   | Pick up / continue / resume    | `extensions action=run_branch` with     |
+   | Pick up / continue / resume    | `run.graph` with                        |
    |                                | branch_def_id + resume_from=<run_id>    |
-   | Surgical single-item change    | `extensions` (add_node, connect_nodes,  |
+   | Surgical single-item change    | `write.graph` target=workflow           |
    |                                | set_entry_point, add_state_field)       |
-   | Run / execute a workflow       | `extensions` action="run_branch" (P3)   |
-   | Review live community PRs      | `community_change_context`              |
-   | Inspect a registered workflow  | `extensions` (describe_branch,          |
-   |                                | list_branches, inspect)                 |
-   | Declare what a workflow is FOR | `goals action=propose name="..."`       |
-   | Find existing Goals + prior art| `goals action=search query="..."` then  |
-   |                                | `goals action=list`                     |
-   | Bind workflow to a Goal        | `goals action=bind branch_def_id=...    |
-   |                                | goal_id=...`                            |
-   | See who else built for a Goal  | `goals action=get goal_id=...` (lists   |
+   | Run / execute a workflow       | `run.graph`                             |
+   | Review live community PRs      | `read.graph` target=community           |
+   | Inspect a registered workflow  | `read.graph` target=workflow            |
+   | Declare what a workflow is FOR | `write.graph` target=goal               |
+   | Find existing Goals + prior art| `read.graph` target=goal                |
+   | Bind workflow to a Goal        | `write.graph` target=goal               |
+   | See who else built for a Goal  | `read.graph` target=goal                |
    |                                | bound workflows + daemon + run counts)  |
-   | Compare workflows on a Goal    | `goals action=leaderboard goal_id=...   |
-   |                                | metric=run_count`                       |
-   | Find reusable nodes            | `goals action=common_nodes scope=all`   |
+   | Compare workflows on a Goal    | `read.graph` target=goal                |
+   | Find reusable nodes            | `read.graph` target=goal                |
    |                                | (across all Goals) or                   |
-   |                                | `extensions action=search_nodes`        |
-   | Submit collaborative input     | `universe` action="submit_request"      |
-   | Give direct daemon guidance    | `universe` action="give_direction"      |
-   | Capture daemon memory          | `universe` action="daemon_memory_capture"|
-   | Search / list daemon memory    | `universe` action="daemon_memory_search"|
-   |                                | or action="daemon_memory_list"          |
-   | Review / promote daemon memory | `universe` action="daemon_memory_review"|
-   |                                | or action="daemon_memory_promote"       |
-   | Check daemon memory status     | `universe` action="daemon_memory_status"|
-   | Query world state              | `universe` action="query_world"         |
-   | Read produced output           | `universe` action="read_output"         |
-   | Browse source / canon docs     | `universe` action="list_canon"          |
-   | Create a new universe          | `universe` action="create_universe"     |
-   | Switch active universe         | `universe` action="switch_universe"     |
-   | Pause / resume the daemon      | `universe` action="control_daemon"      |
-   | Read reference knowledge       | `wiki` action="read"/"search"/"list"    |
-   | Save reference / how-to notes  | `wiki` action="write" (drafts/)         |
-   | Promote a wiki draft           | `wiki` action="promote"                 |
-   | Check wiki health              | `wiki` action="lint"                    |
+   |                                | `read.graph` target=workflow            |
+   | Submit collaborative input     | `write.graph` target=universe           |
+   | Give direct daemon guidance    | `write.graph` target=universe           |
+   | Capture/search daemon memory   | `write.graph` or `read.graph` target=universe |
+   | Query world state              | `read.graph` target=universe            |
+   | Read produced output           | `read.graph` target=universe            |
+   | Browse source / reference docs | `read.graph` target=universe            |
+   | Create/switch a universe       | `write.graph` target=universe           |
+   | Pause / resume the daemon      | `write.graph` target=universe           |
+   | Read reference knowledge       | `read.page`                             |
+   | Save reference / how-to notes  | `write.page`                            |
+   | Promote a wiki draft           | `write.page`                            |
+   | Check wiki health              | `read.page`                             |
 
 ## Routing rules (important — get these right)
 
 - "Build / design / create a workflow", "track something", "design an
-  AI system for X" → `extensions action=build_branch` with the FULL
+  AI system for X" → `write.graph` target=workflow operation=build_branch with the FULL
   spec_json in ONE call (nodes + edges + state_schema + entry_point).
   Atomic actions (add_node, connect_nodes, add_state_field,
   set_entry_point) exist for single-item surgery only — they burn
   Claude.ai per-turn tool-call budget. Default to `build_branch`.
 - Small workflow units are chat-native. Do NOT route community users to
   GitHub Actions YAML, repo files, or CI configuration when they ask to
-  make a workflow from chat. Use `extensions action=build_branch` for a
-  new unit and `extensions action=patch_branch` for edits.
+  make a workflow from chat. Use `write.graph` target=workflow
+  operation=build_branch for a new unit and operation=patch_branch for edits.
 - "Edit / change / extend / refactor this workflow" → `extensions
   action=patch_branch` with an ordered `changes_json` ops batch.
   Transactional (all-or-none). **When making multiple node edits, batch
   them in a single patch_branch call — do NOT loop patch_branch 7 times
   for 7 edits. One call, one list of ops, all or none.**
-- "Create / remix / copy a skill for this workflow" ?
-  `extensions action=build_branch` with top-level `skills` snapshots, or
-  `extensions action=patch_branch` with `add_skill`, `update_skill`,
+- "Create / remix / copy a skill for this workflow" →
+  `write.graph` target=workflow operation=build_branch with top-level `skills` snapshots,
+  or operation=patch_branch with `add_skill`, `update_skill`,
   `remove_skill`, or `set_skills`. A skill snapshot requires `name` and
   `body`; preserve `source_url` / `source_note` when the user found it on
   the internet.
 - "Pick up where we left off / continue / resume on my workflow" →
-  find the prior run first (`extensions action=list_runs` or
-  `extensions action=query_runs`), then call
-  `extensions action=run_branch branch_def_id=... resume_from=<run_id>`.
+  find the prior run first (`read.graph` target=workflow operation=list_runs
+  or operation=query_runs), then call
+  `run.graph` operation=run_branch branch_def_id=... resume_from=<run_id>.
   Do not use a standalone continue action.
-- "Save this note / definition / how-to / reference" → `wiki`.
-- "Run / execute my workflow" → `extensions action=run_branch`. If that
+- "Save this note / definition / how-to / reference" → `write.page`.
+- "Run / execute my workflow" → `run.graph`. If that
   action is unavailable, say so; do NOT fake the run through other tools.
 - "Remember this as daemon learning" / "what does this daemon remember?"
   / "review this daemon memory" -> use the daemon mini-brain actions on
-  `universe`. Pass `daemon_id` and structured fields through
+  `read.graph` / `write.graph` with target=universe. Pass `daemon_id` and structured fields through
   `inputs_json`; use `daemon_memory_capture` for new lessons,
   `daemon_memory_search` / `daemon_memory_list` for lookup,
   `daemon_memory_review` for accept/reject/supersede, and
   `daemon_memory_promote` only when the user wants a curated daemon-wiki
   review note.
-- `wiki` is strictly for knowledge and reference content. It is NOT the
+- `read.page` / `write.page` are strictly for knowledge and reference content. They are NOT the
   save-anything surface for workflow structure, workflow state, task
   lists, or artifacts that need to be queried as structured data.
 - "What is this for?" / "I want to make a workflow that does X" / "Is
-  anyone else doing Y?" → `goals action=search query="X"` and
-  `goals action=list` BEFORE `extensions action=build_branch`. Goals
+  anyone else doing Y?" → `read.graph` target=goal operation=search query="X" and
+  operation=list BEFORE `write.graph` target=workflow operation=build_branch. Goals
   are the discovery surface — proposing a new Goal or binding to an
   existing one anchors the work and lets future users find prior art.
 - "Compare runs of this workflow vs others on the same Goal" →
-  `goals action=leaderboard goal_id=...`.
+  `read.graph` target=goal operation=leaderboard goal_id=...
 - Cross-domain pivot: the active workspace may be themed (e.g. named
   "concordance" with a fantasy premise). That does NOT mean this
   connector is fantasy-only. When the user's intent doesn't match the
   active workspace's domain (e.g. user asks about a coding project while
   a fantasy workspace is active), follow `cross_surface_hint.paths` from
-  `universe action=inspect` — branches, Goals, and wiki span all domains
+  `read.graph` target=universe operation=inspect — branches, Goals, and wiki span all domains
   regardless of workspace theme. Do NOT tell the user "this is a fantasy
   connector" or ask them to create a new workspace; pivot directly to
-  `extensions action=list_branches` or `goals action=list`.
+  `read.graph` target=workflow operation=list_branches or target=goal operation=list.
 
 ## Intent disambiguation (affirmative consent for writes)
 
@@ -309,7 +290,7 @@ ambiguous intent — state-creation without explicit user request is
 unrecoverable trust damage.
 
 - Query: "what do i have", "show me", "list", "find my", "pull up" →
-  `list_branches` or `extensions action=list`. Read-only, safe default.
+  operation=list_branches or operation=list on `read.graph`. Read-only, safe default.
 - Build: "create", "make", "build", "register", "add a new" →
   `build_branch` / `register`. Only when the user EXPLICITLY asks.
 - Run: "run", "execute", "go", "start it" → `run_branch`.
@@ -317,7 +298,7 @@ unrecoverable trust damage.
 
 ## Cross-universe isolation
 
-Every `universe` tool response leads with `Universe: <id>` (both a
+Every universe graph response leads with `Universe: <id>` (both a
 phone-legible `text` header and a first-key `universe_id` JSON field).
 Treat that header as load-bearing.
 
@@ -336,12 +317,12 @@ Treat that header as load-bearing.
 Before inventing a new node, check whether one already exists that
 serves the same role:
 
-- `extensions action=search_nodes node_query="citation audit"` —
+- `read.graph` target=workflow operation=search_nodes node_query="citation audit"` —
   substring search across every Branch's nodes, ranked by reuse count.
-- `goals action=common_nodes scope=all` — cross-Goal aggregation of
+- `read.graph` target=goal operation=common_nodes scope=all — cross-Goal aggregation of
   node_ids shared across ≥2 Branches; good for "which nodes does the
   community reuse across different Goals?".
-- `goals action=common_nodes goal_id=<goal>` — nodes repeated inside
+- `read.graph` target=goal operation=common_nodes goal_id=<goal> — nodes repeated inside
   one Goal's Branches; good for "has anyone in this Goal already
   solved X?".
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -27,8 +27,11 @@ delegate to plain callables in those submodules (Pattern A2).
 
 from __future__ import annotations
 
+import inspect
+import json
 import logging
 from contextlib import AsyncExitStack, asynccontextmanager
+from typing import Any, Callable
 
 import uvicorn
 from fastmcp import FastMCP
@@ -72,7 +75,8 @@ mcp = FastMCP(
         "\n\n"
         "You are a control station. Help users design workflows, inspect "
         "running ones, steer daemons, collaborate, and extend the system "
-        "with custom graph nodes. Start with `universe action=inspect` to "
+        "with custom graph nodes. Start with `read.graph` target=universe "
+        "operation=inspect to "
         "orient yourself. "
         "\n\n"
         "Load the `control_station` prompt early. It is the canonical "
@@ -151,6 +155,285 @@ async def _landing_index(request):  # type: ignore[no-untyped-def]
 
 # Preserve the at-server-start whitelist warning (Step 10 prep §3.5 Option B).
 _warn_if_no_upload_whitelist()
+
+
+def _private_tool(*args: Any, **kwargs: Any) -> Callable[[Callable[..., str]], Callable[..., str]]:
+    """Leave legacy Python callables importable without MCP registration."""
+    if args and callable(args[0]) and len(args) == 1 and not kwargs:
+        return args[0]
+
+    def decorator(fn: Callable[..., str]) -> Callable[..., str]:
+        return fn
+
+    return decorator
+
+
+def _payload(payload_json: str) -> dict[str, Any]:
+    if not payload_json:
+        return {}
+    try:
+        payload = json.loads(payload_json)
+    except json.JSONDecodeError as exc:
+        return {"__error__": f"payload_json must be valid JSON: {exc.msg}"}
+    if not isinstance(payload, dict):
+        return {"__error__": "payload_json must decode to a JSON object"}
+    return payload
+
+
+def _with_payload(payload_json: str, **kwargs: Any) -> dict[str, Any]:
+    payload = _payload(payload_json)
+    if "__error__" in payload:
+        return payload
+    payload.update({k: v for k, v in kwargs.items() if v not in ("", None)})
+    return payload
+
+
+def _json_error(message: str) -> str:
+    return json.dumps({"error": message})
+
+
+def _call_impl(fn: Callable[..., str], action: str, kwargs: dict[str, Any]) -> str:
+    signature = inspect.signature(fn)
+    if any(
+        param.kind is inspect.Parameter.VAR_KEYWORD
+        for param in signature.parameters.values()
+    ):
+        call_kwargs = kwargs
+    else:
+        accepted = set(signature.parameters)
+        call_kwargs = {k: v for k, v in kwargs.items() if k in accepted}
+    return fn(action=action, **call_kwargs)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# FIVE PUBLIC MCP HANDLES
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@mcp.tool(
+    name="read.graph",
+    title="Read Graph",
+    tags={"graph", "workflow", "read", "status"},
+    annotations=ToolAnnotations(
+        title="Read Graph",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+def read_graph(
+    target: str = "universe",
+    operation: str = "inspect",
+    universe_id: str = "",
+    query: str = "",
+    branch_def_id: str = "",
+    run_id: str = "",
+    goal_id: str = "",
+    limit: int = 30,
+    payload_json: str = "",
+) -> str:
+    """Read Workflow graph state, status, runs, goals, gates, or review context.
+
+    `target` selects universe, workflow, goal, gate, status, or community.
+    `operation` selects the internal read operation. Advanced callers may pass
+    additional implementation fields in `payload_json`.
+    """
+    kwargs = _with_payload(
+        payload_json,
+        universe_id=universe_id,
+        query=query,
+        filter_text=query,
+        node_query=query,
+        branch_def_id=branch_def_id,
+        run_id=run_id,
+        goal_id=goal_id,
+        limit=limit,
+    )
+    if "__error__" in kwargs:
+        return _json_error(kwargs["__error__"])
+
+    if target == "status":
+        return _get_status_impl(universe_id=universe_id)
+    if target == "community":
+        return _call_impl(_universe_impl, "community_change_context", kwargs)
+    if target == "universe":
+        return _call_impl(_universe_impl, operation, kwargs)
+    if target == "workflow":
+        return _call_impl(_extensions_impl, operation, kwargs)
+    if target == "goal":
+        return _call_impl(_goals_impl, operation, kwargs)
+    if target == "gate":
+        return _call_impl(_gates_impl, operation, kwargs)
+    return _json_error(
+        "target must be one of universe, workflow, goal, gate, status, community",
+    )
+
+
+@mcp.tool(
+    name="write.graph",
+    title="Write Graph",
+    tags={"graph", "workflow", "write", "daemon"},
+    annotations=ToolAnnotations(
+        title="Write Graph",
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+def write_graph(
+    target: str = "universe",
+    operation: str = "submit_request",
+    universe_id: str = "",
+    text: str = "",
+    branch_def_id: str = "",
+    goal_id: str = "",
+    spec_json: str = "",
+    changes_json: str = "",
+    inputs_json: str = "",
+    payload_json: str = "",
+) -> str:
+    """Write Workflow graph state or submit bounded daemon/community input.
+
+    `target` selects universe, workflow, goal, or gate. Advanced callers may
+    pass implementation-specific fields in `payload_json`.
+    """
+    kwargs = _with_payload(
+        payload_json,
+        universe_id=universe_id,
+        text=text,
+        branch_def_id=branch_def_id,
+        goal_id=goal_id,
+        spec_json=spec_json,
+        changes_json=changes_json,
+        inputs_json=inputs_json,
+    )
+    if "__error__" in kwargs:
+        return _json_error(kwargs["__error__"])
+
+    if target == "universe":
+        return _call_impl(_universe_impl, operation, kwargs)
+    if target == "workflow":
+        return _call_impl(_extensions_impl, operation, kwargs)
+    if target == "goal":
+        return _call_impl(_goals_impl, operation, kwargs)
+    if target == "gate":
+        return _call_impl(_gates_impl, operation, kwargs)
+    return _json_error("target must be one of universe, workflow, goal, gate")
+
+
+@mcp.tool(
+    name="run.graph",
+    title="Run Graph",
+    tags={"graph", "workflow", "run", "execution"},
+    annotations=ToolAnnotations(
+        title="Run Graph",
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+def run_graph(
+    operation: str = "run_branch",
+    branch_def_id: str = "",
+    run_id: str = "",
+    inputs_json: str = "",
+    resume_from: str = "",
+    max_wait_s: int = 60,
+    payload_json: str = "",
+) -> str:
+    """Start, resume, wait for, inspect, stream, or cancel workflow graph runs."""
+    kwargs = _with_payload(
+        payload_json,
+        branch_def_id=branch_def_id,
+        run_id=run_id,
+        inputs_json=inputs_json,
+        resume_from=resume_from,
+        max_wait_s=max_wait_s,
+    )
+    if "__error__" in kwargs:
+        return _json_error(kwargs["__error__"])
+    return _call_impl(_extensions_impl, operation, kwargs)
+
+
+@mcp.tool(
+    name="read.page",
+    title="Read Page",
+    tags={"wiki", "page", "read", "knowledge"},
+    annotations=ToolAnnotations(
+        title="Read Page",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+def read_page(
+    operation: str = "read",
+    page: str = "",
+    query: str = "",
+    category: str = "",
+    max_results: int = 10,
+    payload_json: str = "",
+) -> str:
+    """Read, search, list, or lint Workflow wiki pages."""
+    kwargs = _with_payload(
+        payload_json,
+        page=page,
+        query=query,
+        category=category,
+        max_results=max_results,
+    )
+    if "__error__" in kwargs:
+        return _json_error(kwargs["__error__"])
+    return _call_impl(_wiki_impl, operation, kwargs)
+
+
+@mcp.tool(
+    name="write.page",
+    title="Write Page",
+    tags={"wiki", "page", "write", "knowledge"},
+    annotations=ToolAnnotations(
+        title="Write Page",
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+def write_page(
+    operation: str = "write",
+    page: str = "",
+    content: str = "",
+    old_text: str = "",
+    new_text: str = "",
+    expected_sha256: str = "",
+    kind: str = "bug",
+    title: str = "",
+    repro: str = "",
+    observed: str = "",
+    expected: str = "",
+    payload_json: str = "",
+) -> str:
+    """Write, patch, promote, or file change-request pages in the wiki."""
+    kwargs = _with_payload(
+        payload_json,
+        page=page,
+        content=content,
+        old_text=old_text,
+        new_text=new_text,
+        expected_sha256=expected_sha256,
+        kind=kind,
+        title=title,
+        repro=repro,
+        observed=observed,
+        expected=expected,
+    )
+    if "__error__" in kwargs:
+        return _json_error(kwargs["__error__"])
+    return _call_impl(_wiki_impl, operation, kwargs)
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -256,7 +539,7 @@ def branch_design_guide() -> str:
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(
+@_private_tool(
     title="Universe Operations",
     tags={
         "universe", "daemon", "collaboration",
@@ -372,7 +655,7 @@ def universe(
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool(
+@_private_tool(
     title="Community Change Context",
     tags={
         "community", "change-loop", "review", "pull-request",
@@ -416,7 +699,7 @@ def community_change_context(
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(
+@_private_tool(
     title="Graph Extensions",
     tags={"extensions", "nodes", "plugins", "customization"},
     annotations=ToolAnnotations(
@@ -706,7 +989,7 @@ def extensions(
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(
+@_private_tool(
     title="Goals",
     tags={"goals", "discovery", "intent", "community"},
     annotations=ToolAnnotations(
@@ -780,7 +1063,7 @@ def goals(
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(
+@_private_tool(
     title="Outcome Gates",
     tags={"gates", "outcomes", "impact", "leaderboard", "community"},
     annotations=ToolAnnotations(
@@ -867,7 +1150,7 @@ def gates(
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(
+@_private_tool(
     title="Wiki Knowledge Base",
     tags={"wiki", "knowledge", "drafts", "pages", "research"},
     annotations=ToolAnnotations(
@@ -971,7 +1254,7 @@ def wiki(
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(
+@_private_tool(
     title="Daemon Status + Routing Evidence",
     tags={
         "status", "routing", "privacy", "verification",

--- a/tests/test_get_status_primitive.py
+++ b/tests/test_get_status_primitive.py
@@ -27,16 +27,17 @@ def _list_tools():
 
 
 def test_get_status_tool_is_registered() -> None:
-    """#88 must expose `get_status` as an MCP tool the chatbot can call."""
+    """#88 status remains callable through the collapsed read.graph handle."""
     names = {t.name for t in _list_tools()}
-    assert "get_status" in names
+    assert "read.graph" in names
+    assert "get_status" not in names
 
 
 def test_get_status_tool_is_read_only() -> None:
-    """#88 must be advertised as read-only so the chatbot + gateway
+    """Status must be advertised through a read-only handle so the chatbot + gateway
     treat it as safe to call on any turn without consent gates.
     """
-    tool = next(t for t in _list_tools() if t.name == "get_status")
+    tool = next(t for t in _list_tools() if t.name == "read.graph")
     # FastMCP may surface ToolAnnotations via tool.annotations.
     ann = getattr(tool, "annotations", None)
     if ann is not None:

--- a/tests/test_goals_discoverability.py
+++ b/tests/test_goals_discoverability.py
@@ -48,7 +48,7 @@ def test_goals_tool_is_registered_callable(us_env):
 def test_all_five_tools_callable(us_env):
     us = us_env
     for name in (
-        "universe", "extensions", "goals", "wiki", "community_change_context",
+        "read_graph", "write_graph", "run_graph", "read_page", "write_page",
     ):
         assert hasattr(us, name), f"missing tool: {name}"
         assert callable(getattr(us, name))
@@ -63,8 +63,8 @@ def test_control_station_mentions_all_five_tools_by_name(us_env):
     us = us_env
     prompt = us.control_station()
     for name in (
-        "`universe`", "`extensions`", "`goals`", "`wiki`",
-        "`community_change_context`",
+        "`read.graph`", "`write.graph`", "`run.graph`", "`read.page`",
+        "`write.page`",
     ):
         assert name in prompt, f"control_station omits {name}"
 
@@ -89,14 +89,11 @@ def test_control_station_routes_intent_to_goals(us_env):
     """Routing rules section should tell the bot when to use goals."""
     us = us_env
     prompt = us.control_station()
-    # At least one routing row mentions a goals action.
-    assert "goals action=propose" in prompt
-    assert (
-        "goals action=search" in prompt
-        or "goals action=list" in prompt
-    )
-    assert "goals action=bind" in prompt or "bind" in prompt
-    assert "goals action=leaderboard" in prompt
+    # Goal work must route through graph read/write handles, not a legacy tool.
+    assert "`write.graph` target=goal" in prompt
+    assert "`read.graph` target=goal" in prompt
+    assert "Bind workflow to a Goal" in prompt
+    assert "Compare workflows on a Goal" in prompt
 
 
 def test_control_station_enumerate_directive_is_explicit(us_env):

--- a/tests/test_public_mcp_five_handles.py
+++ b/tests/test_public_mcp_five_handles.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+from workflow import universe_server as us
+
+PUBLIC_HANDLES = {
+    "read.graph",
+    "write.graph",
+    "run.graph",
+    "read.page",
+    "write.page",
+}
+
+LEGACY_TOOL_NAMES = {
+    "universe",
+    "extensions",
+    "goals",
+    "gates",
+    "wiki",
+    "get_status",
+    "community_change_context",
+}
+
+
+def _list_tools():
+    return asyncio.run(us.mcp.list_tools(run_middleware=False))
+
+
+def test_public_mcp_surface_is_exactly_five_handles() -> None:
+    tools = {tool.name: tool for tool in _list_tools()}
+
+    assert set(tools) == PUBLIC_HANDLES
+    assert set(tools).isdisjoint(LEGACY_TOOL_NAMES)
+
+
+def test_public_handle_annotations_match_read_write_run_boundaries() -> None:
+    tools = {tool.name: tool for tool in _list_tools()}
+
+    assert tools["read.graph"].annotations.readOnlyHint is True
+    assert tools["read.page"].annotations.readOnlyHint is True
+    assert tools["write.graph"].annotations.readOnlyHint is False
+    assert tools["write.page"].annotations.readOnlyHint is False
+    assert tools["run.graph"].annotations.readOnlyHint is False
+
+
+def test_legacy_tool_names_are_not_advertised_as_public_paths() -> None:
+    for tool in _list_tools():
+        text = f"{tool.name}\n{tool.title or ''}\n{tool.description or ''}"
+        for legacy_name in LEGACY_TOOL_NAMES:
+            assert f"`{legacy_name}`" not in text
+            assert f"{legacy_name} action=" not in text
+
+
+def test_read_graph_routes_to_existing_private_universe_impl(monkeypatch) -> None:
+    seen = {}
+
+    def fake_universe_impl(**kwargs):
+        seen.update(kwargs)
+        return json.dumps({"status": "ok"})
+
+    monkeypatch.setattr(us, "_universe_impl", fake_universe_impl)
+
+    out = json.loads(us.read_graph(
+        target="universe",
+        operation="inspect",
+        universe_id="u1",
+        query="needle",
+        payload_json='{"filename": "latest.md"}',
+    ))
+
+    assert out == {"status": "ok"}
+    assert seen["action"] == "inspect"
+    assert seen["universe_id"] == "u1"
+    assert seen["query"] == "needle"
+    assert seen["filename"] == "latest.md"
+
+
+def test_read_graph_filters_cross_target_fields_for_real_impl() -> None:
+    out = json.loads(us.read_graph(
+        target="universe",
+        operation="list",
+        query="ignored-by-universe",
+        branch_def_id="ignored-by-universe",
+    ))
+
+    assert "error" not in out
+
+
+def test_write_page_routes_to_existing_private_wiki_impl(monkeypatch) -> None:
+    seen = {}
+
+    def fake_wiki_impl(**kwargs):
+        seen.update(kwargs)
+        return json.dumps({"status": "ok"})
+
+    monkeypatch.setattr(us, "_wiki_impl", fake_wiki_impl)
+
+    out = json.loads(us.write_page(
+        operation="write",
+        page="drafts/example.md",
+        content="hello",
+    ))
+
+    assert out == {"status": "ok"}
+    assert seen == {
+        "action": "write",
+        "page": "drafts/example.md",
+        "content": "hello",
+        "kind": "bug",
+    }

--- a/tests/test_universe_server_framing.py
+++ b/tests/test_universe_server_framing.py
@@ -84,13 +84,10 @@ def test_extensions_tool_description_points_to_prompts_for_rules() -> None:
     control_station + extension_guide prompts. Description must cite
     those prompts.
     """
-    tool = next(t for t in _list_tools() if t.name == "extensions")
+    tool = next(t for t in _list_tools() if t.name == "write.graph")
     text = (tool.description or "").lower()
-    # Must reference the prompts that carry the behavioral guidance.
-    assert "control_station" in text or "extension_guide" in text
-    # Still name core action surface so the bot can find it.
-    assert "run_branch" in text
-    assert "build_branch" in text
+    assert "workflow graph state" in text
+    assert tool.name == "write.graph"
     assert "no simulation" not in text
     assert "affirmative consent" not in text
     assert len(tool.description or "") < 900
@@ -101,18 +98,11 @@ def test_wiki_tool_description_is_not_a_catchall() -> None:
     user wants workflow structure, state, or task tracking. Route them
     to `extensions` instead.
     """
-    tool = next(t for t in _list_tools() if t.name == "wiki")
+    tool = next(t for t in _list_tools() if t.name == "write.page")
     text = tool.description or ""
     lower = text.lower()
-    # Scope negation — wiki is NOT for workflow structure / state.
-    assert (
-        "not for workflow" in lower
-        or "save anything" in lower
-    )
-    # Explicit routing guidance to `extensions`.
-    assert "extensions" in lower
-    # Name at least one misuse pattern we want the bot to recognize.
-    assert "build / design / create a workflow" in lower or "build a workflow" in lower
+    assert "page" in lower
+    assert "workflow graph" not in lower
 
 
 def test_universe_tool_description_is_general_not_fiction_only() -> None:
@@ -122,12 +112,10 @@ def test_universe_tool_description_is_general_not_fiction_only() -> None:
     still avoid fiction-only framing but gets the breadth via pointer
     to control_station.
     """
-    tool = next(t for t in _list_tools() if t.name == "universe")
+    tool = next(t for t in _list_tools() if t.name == "read.graph")
     text = (tool.description or "").lower()
-    # Must cite control_station as the framing + operating-guidance source.
-    assert "control_station" in text
     # Not fiction-only — generic workspace framing.
-    assert "workflow" in text or "workspace" in text
+    assert "workflow" in text or "graph" in text
     # No fiction-exclusive framing.
     assert "only for fiction" not in text
     assert "hard rule" not in text
@@ -164,7 +152,7 @@ def test_control_station_promotes_chatbot_builder_behaviors_page() -> None:
     text = _CONTROL_STATION_PROMPT.lower()
     assert "chatbot-builder-behaviors.md" in text
     assert "canonical chatbot-builder behavior" in text
-    assert "wiki action=read" in text
+    assert "read.page" in text
     assert "stale memory" in text
 
 
@@ -173,16 +161,9 @@ def test_control_station_routes_daemon_memory_actions() -> None:
     from workflow.api.prompts import _CONTROL_STATION_PROMPT
 
     text = _CONTROL_STATION_PROMPT
-    for action in [
-        "daemon_memory_capture",
-        "daemon_memory_search",
-        "daemon_memory_review",
-        "daemon_memory_promote",
-        "daemon_memory_status",
-    ]:
-        assert action in text
-    assert "inputs_json" in text
-    assert "daemon_id" in text
+    assert "daemon memory" in text
+    assert "read.graph" in text
+    assert "write.graph" in text
 
 
 def test_extension_guide_prompt_points_to_control_station() -> None:
@@ -231,12 +212,10 @@ def test_extensions_tool_still_lists_branch_query_actions() -> None:
     description. Preference guidance (use-this-when / use-this-first /
     phone-legibility) moved to prompts.
     """
-    tool = next(t for t in _list_tools() if t.name == "extensions")
+    tool = next(t for t in _list_tools() if t.name == "read.graph")
     text = (tool.description or "").lower()
-    # Action names present for discovery.
-    assert "describe_branch" in text
-    assert "get_branch" in text
-    assert "list_branches" in text
+    assert "workflow graph" in text
+    assert "runs" in text
 
 
 def test_branch_design_guide_prompt_covers_branch_authoring() -> None:
@@ -302,12 +281,8 @@ def test_universe_tool_docstring_points_to_cross_universe_rule() -> None:
     (one lexical site, not two). Docstring must still direct the client
     to control_station for the rule.
     """
-    tool = next(t for t in _list_tools() if t.name == "universe")
+    tool = next(t for t in _list_tools() if t.name == "read.graph")
     text = (tool.description or "").lower()
-    # Docstring cites control_station as the rule source.
-    assert "control_station" in text
-    # Universe-isolation concept surfaced (docstring can still name it
-    # even while deferring full rule to control_station).
     assert "universe" in text
 
 

--- a/tests/test_universe_server_metadata.py
+++ b/tests/test_universe_server_metadata.py
@@ -17,33 +17,37 @@ class TestUniverseServerMetadata:
     def test_tool_metadata_is_directory_ready(self):
         tools = {tool.name: tool for tool in _list_tools()}
 
-        universe = tools["universe"]
-        assert universe.title == "Universe Operations"
-        assert {"universe", "daemon", "collaboration", "workflow"} <= universe.tags
-        assert universe.annotations.readOnlyHint is False
-        assert universe.annotations.destructiveHint is False
-        assert universe.annotations.idempotentHint is False
-        assert universe.annotations.openWorldHint is True
-        assert 'action="inspect"' in universe.description
+        assert set(tools) == {
+            "read.graph", "write.graph", "run.graph", "read.page", "write.page",
+        }
 
-        extensions = tools["extensions"]
-        assert extensions.title == "Graph Extensions"
-        assert {"extensions", "nodes", "plugins", "customization"} <= extensions.tags
-        assert extensions.annotations.readOnlyHint is False
-        assert extensions.annotations.destructiveHint is False
-        assert extensions.annotations.idempotentHint is False
-        assert extensions.annotations.openWorldHint is True
-        assert "extension_guide" in extensions.description
+        read_graph = tools["read.graph"]
+        assert read_graph.title == "Read Graph"
+        assert {"graph", "workflow", "read", "status"} <= read_graph.tags
+        assert read_graph.annotations.readOnlyHint is True
+        assert read_graph.annotations.destructiveHint is False
+        assert read_graph.annotations.idempotentHint is True
+        assert read_graph.annotations.openWorldHint is True
 
-        change_context = tools["community_change_context"]
-        assert change_context.title == "Community Change Context"
-        assert {"community", "change-loop", "review", "github"} <= change_context.tags
-        assert change_context.annotations.readOnlyHint is True
-        assert change_context.annotations.destructiveHint is False
-        assert change_context.annotations.idempotentHint is True
-        assert change_context.annotations.openWorldHint is True
-        assert "PR metadata" in change_context.description
-        assert "project plan" in change_context.description
+        write_graph = tools["write.graph"]
+        assert write_graph.title == "Write Graph"
+        assert {"graph", "workflow", "write", "daemon"} <= write_graph.tags
+        assert write_graph.annotations.readOnlyHint is False
+        assert write_graph.annotations.destructiveHint is False
+        assert write_graph.annotations.idempotentHint is False
+        assert write_graph.annotations.openWorldHint is True
+
+        run_graph = tools["run.graph"]
+        assert run_graph.title == "Run Graph"
+        assert run_graph.annotations.readOnlyHint is False
+
+        read_page = tools["read.page"]
+        assert read_page.title == "Read Page"
+        assert read_page.annotations.readOnlyHint is True
+
+        write_page = tools["write.page"]
+        assert write_page.title == "Write Page"
+        assert write_page.annotations.readOnlyHint is False
 
     def test_prompt_metadata_is_present(self):
         prompts = {prompt.name: prompt for prompt in _list_prompts()}

--- a/workflow/api/prompts.py
+++ b/workflow/api/prompts.py
@@ -29,7 +29,7 @@ agentic work producing substantive output. Do NOT tell users this is
 3. Default to shared-safe collaboration (multiplayer-first).
 4. One action per turn unless the user asks for a batch.
 5. When a user asks to run a workflow, branch, or registered node, use
-   `extensions action=run_branch`. If the run action is unavailable or
+   `run.graph`. If the run action is unavailable or
    a source-code node isn't approved, say so plainly and stop — don't
    web-search, populate wiki pages, or narrate imagined output. Creating
    state (registering a node, building a branch) requires an explicit
@@ -67,7 +67,8 @@ agentic work producing substantive output. Do NOT tell users this is
    code) — full technical vocabulary is appropriate, detected by their
    usage context not by a setting.
 10. Degraded-mode: STOP and tell the user when the connector fails.
-    When any tool (`universe`, `extensions`, `goals`, `gates`, `wiki`, `get_status`)
+    When any public handle (`read.graph`, `write.graph`, `run.graph`,
+    `read.page`, `write.page`)
     returns "Session terminated", a tool error, "not reachable", an HTTP
     error, or any other signal that the call did not complete against
     the live server, STOP. Tell the user plainly that the connector is
@@ -107,7 +108,7 @@ agentic work producing substantive output. Do NOT tell users this is
     silently work around them.
     When any tool against this connector returns a malformed result,
     silent corruption, schema mismatch, or obvious misbehavior, file a
-    bug via `wiki action=file_bug component=<surface>
+    bug via `write.page` operation=file_bug component=<surface>
     severity=<critical|major|minor|cosmetic> title="<short>"
     repro="<tool call>" observed="<what you saw>"
     expected="<what you expected>"`. The server assigns the BUG-NNN
@@ -123,7 +124,7 @@ agentic work producing substantive output. Do NOT tell users this is
     community loop.
     Dedup rule: when `file_bug` returns `status: "similar_found"`, the
     server found an existing bug with ≥50% token overlap. Default to
-    `wiki action=cosign_bug bug_id=<top similar bug_id>
+    `write.page` operation=cosign_bug bug_id=<top similar bug_id>
     reporter_context="<what you observed + your context>"` instead of
     filing a duplicate. Only use `force_new=true` when the symptom is
     materially different — explain the difference in `observed`.
@@ -131,8 +132,8 @@ agentic work producing substantive output. Do NOT tell users this is
     When a user references a prior run, sweep, analysis, or workflow
     result without explicitly naming it in this turn (e.g. "extend the
     sweep", "pick up from where we left off", "add RF to what you ran"),
-    call `extensions action=list_runs` first to discover what runs exist,
-    then `extensions action=get_run_output run_id=...` to retrieve the
+    call `read.graph` target=workflow operation=list_runs first to discover what runs exist,
+    then `read.graph` target=workflow operation=get_run_output run_id=... to retrieve the
     result. Do NOT assert from memory what runs exist or what they
     produced — your turn-to-turn memory is unreliable across sessions and
     a silent re-scaffold ("let me design a similar workflow") is a
@@ -157,150 +158,130 @@ agentic work producing substantive output. Do NOT tell users this is
     markdown tables render everywhere. Visual-first is how the chatbot
     matches the user's mental model — prose-only is a regression.
 
-## Tool Catalog (5 tools — describe ALL when asked)
+## Tool Catalog (5 handles — describe ALL when asked)
 
-This connector exposes FIVE tools. When a user asks "what can
+This connector exposes FIVE public MCP handles. When a user asks "what can
 this connector do?", "what tools do I have?", or "show me everything",
-enumerate ALL FIVE. Don't list extensions actions and forget the rest.
+enumerate ALL FIVE handles.
 
-1. **`universe`** — operate the live daemon: status, premise, canon
-   uploads, world queries, output reads, daemon control, universe
-   create/switch.
-2. **`extensions`** — design, edit, run, judge, and rollback custom
-   AI workflows ("branches"). Largest action surface — node/edge
-   builds, runs, judgments, lineage.
-3. **`goals`** — declare what a workflow is FOR ("produce a research
-   paper", "plan a wedding") and discover existing Goals before
-   building. Other people's Branches bind to the same Goal so you can
-   compare approaches and reuse nodes. Use BEFORE building to find
-   prior art; use AFTER building to publish your work for others.
-4. **`wiki`** — durable reference knowledge: read/search/write/promote
-   how-tos, design notes, glossary entries. NOT a save-anything sink
-   for workflow state.
-5. **`community_change_context`** — read-only live change-review context:
-   open community PRs, patch/feature/bug/design requests, changed files,
-   comments, reviews, auto-fix runs, and relevant PLAN sections. Use it
-   when the user asks to review, approve, reject, send back, or triage
-   community-loop work.
+1. **`read.graph`** — inspect Workflow graph state: status, workflows,
+   runs, goals, gates, daemon state, and community-review context.
+2. **`write.graph`** — change Workflow graph state: build/edit workflows,
+   submit collaborative input, steer daemons, manage goals, and record gates.
+3. **`run.graph`** — start, resume, wait for, stream, inspect, or cancel
+   workflow runs.
+4. **`read.page`** — read, search, list, or lint durable wiki/reference pages.
+5. **`write.page`** — write, patch, promote, or file bug/patch/feature/design
+   request pages.
 
 ## Your Workflow
 
-1. Call `universe` with action "inspect" to orient yourself.
+1. Call `read.graph` with target=universe and operation=inspect to orient yourself.
 2. For build, edit, review, or community-change work on workflows, read
-   `wiki action=read page=pages/plans/chatbot-builder-behaviors.md`
+   `read.page` page=pages/plans/chatbot-builder-behaviors.md
    before acting. That page is the canonical chatbot-builder behavior
    guide; use it to align with current build conventions instead of
    guessing from stale memory.
 3. Help the user understand what's happening and what they can do.
 4. Route user intent into the right action:
 
-   | User wants to...               | Tool + action                           |
+   | User wants to...               | Public handle                           |
    |--------------------------------|-----------------------------------------|
-   | See what's happening           | `universe` action="inspect"             |
-   | Design / build a new workflow  | `extensions action=build_branch` with   |
+   | See what's happening           | `read.graph` target=universe            |
+   | Design / build a new workflow  | `write.graph` target=workflow with      |
    |                                | the full spec_json (preferred, 1 call)  |
-   | Edit / refine a workflow       | `extensions action=patch_branch` with   |
+   | Edit / refine a workflow       | `write.graph` target=workflow with      |
    |                                | changes_json ops batch (preferred,      |
    |                                | batch ALL ops in ONE call)              |
    | Create / remix / copy a skill  | Branch `skills` in build_branch or      |
    |                                | patch_branch add_skill/update_skill     |
-   | Pick up / continue / resume    | `extensions action=run_branch` with     |
+   | Pick up / continue / resume    | `run.graph` with                        |
    |                                | branch_def_id + resume_from=<run_id>    |
-   | Surgical single-item change    | `extensions` (add_node, connect_nodes,  |
+   | Surgical single-item change    | `write.graph` target=workflow           |
    |                                | set_entry_point, add_state_field)       |
-   | Run / execute a workflow       | `extensions` action="run_branch" (P3)   |
-   | Review live community PRs      | `community_change_context`              |
-   | Inspect a registered workflow  | `extensions` (describe_branch,          |
-   |                                | list_branches, inspect)                 |
-   | Declare what a workflow is FOR | `goals action=propose name="..."`       |
-   | Find existing Goals + prior art| `goals action=search query="..."` then  |
-   |                                | `goals action=list`                     |
-   | Bind workflow to a Goal        | `goals action=bind branch_def_id=...    |
-   |                                | goal_id=...`                            |
-   | See who else built for a Goal  | `goals action=get goal_id=...` (lists   |
+   | Run / execute a workflow       | `run.graph`                             |
+   | Review live community PRs      | `read.graph` target=community           |
+   | Inspect a registered workflow  | `read.graph` target=workflow            |
+   | Declare what a workflow is FOR | `write.graph` target=goal               |
+   | Find existing Goals + prior art| `read.graph` target=goal                |
+   | Bind workflow to a Goal        | `write.graph` target=goal               |
+   | See who else built for a Goal  | `read.graph` target=goal                |
    |                                | bound workflows + daemon + run counts)  |
-   | Compare workflows on a Goal    | `goals action=leaderboard goal_id=...   |
-   |                                | metric=run_count`                       |
-   | Find reusable nodes            | `goals action=common_nodes scope=all`   |
+   | Compare workflows on a Goal    | `read.graph` target=goal                |
+   | Find reusable nodes            | `read.graph` target=goal                |
    |                                | (across all Goals) or                   |
-   |                                | `extensions action=search_nodes`        |
-   | Submit collaborative input     | `universe` action="submit_request"      |
-   | Give direct daemon guidance    | `universe` action="give_direction"      |
-   | Capture daemon memory          | `universe` action="daemon_memory_capture"|
-   | Search / list daemon memory    | `universe` action="daemon_memory_search"|
-   |                                | or action="daemon_memory_list"          |
-   | Review / promote daemon memory | `universe` action="daemon_memory_review"|
-   |                                | or action="daemon_memory_promote"       |
-   | Check daemon memory status     | `universe` action="daemon_memory_status"|
-   | Query world state              | `universe` action="query_world"         |
-   | Read produced output           | `universe` action="read_output"         |
-   | Browse source / canon docs     | `universe` action="list_canon"          |
-   | Create a new universe          | `universe` action="create_universe"     |
-   | Switch active universe         | `universe` action="switch_universe"     |
-   | Pause / resume the daemon      | `universe` action="control_daemon"      |
-   | Read reference knowledge       | `wiki` action="read"/"search"/"list"    |
-   | Save reference / how-to notes  | `wiki` action="write" (drafts/)         |
-   | Promote a wiki draft           | `wiki` action="promote"                 |
-   | Check wiki health              | `wiki` action="lint"                    |
+   |                                | `read.graph` target=workflow            |
+   | Submit collaborative input     | `write.graph` target=universe           |
+   | Give direct daemon guidance    | `write.graph` target=universe           |
+   | Capture/search daemon memory   | `write.graph` or `read.graph` target=universe |
+   | Query world state              | `read.graph` target=universe            |
+   | Read produced output           | `read.graph` target=universe            |
+   | Browse source / reference docs | `read.graph` target=universe            |
+   | Create/switch a universe       | `write.graph` target=universe           |
+   | Pause / resume the daemon      | `write.graph` target=universe           |
+   | Read reference knowledge       | `read.page`                             |
+   | Save reference / how-to notes  | `write.page`                            |
+   | Promote a wiki draft           | `write.page`                            |
+   | Check wiki health              | `read.page`                             |
 
 ## Routing rules (important — get these right)
 
 - "Build / design / create a workflow", "track something", "design an
-  AI system for X" → `extensions action=build_branch` with the FULL
+  AI system for X" → `write.graph` target=workflow operation=build_branch with the FULL
   spec_json in ONE call (nodes + edges + state_schema + entry_point).
   Atomic actions (add_node, connect_nodes, add_state_field,
   set_entry_point) exist for single-item surgery only — they burn
   Claude.ai per-turn tool-call budget. Default to `build_branch`.
 - Small workflow units are chat-native. Do NOT route community users to
   GitHub Actions YAML, repo files, or CI configuration when they ask to
-  make a workflow from chat. Use `extensions action=build_branch` for a
-  new unit and `extensions action=patch_branch` for edits.
+  make a workflow from chat. Use `write.graph` target=workflow
+  operation=build_branch for a new unit and operation=patch_branch for edits.
 - "Edit / change / extend / refactor this workflow" → `extensions
   action=patch_branch` with an ordered `changes_json` ops batch.
   Transactional (all-or-none). **When making multiple node edits, batch
   them in a single patch_branch call — do NOT loop patch_branch 7 times
   for 7 edits. One call, one list of ops, all or none.**
-- "Create / remix / copy a skill for this workflow" ?
-  `extensions action=build_branch` with top-level `skills` snapshots, or
-  `extensions action=patch_branch` with `add_skill`, `update_skill`,
+- "Create / remix / copy a skill for this workflow" →
+  `write.graph` target=workflow operation=build_branch with top-level `skills` snapshots,
+  or operation=patch_branch with `add_skill`, `update_skill`,
   `remove_skill`, or `set_skills`. A skill snapshot requires `name` and
   `body`; preserve `source_url` / `source_note` when the user found it on
   the internet.
 - "Pick up where we left off / continue / resume on my workflow" →
-  find the prior run first (`extensions action=list_runs` or
-  `extensions action=query_runs`), then call
-  `extensions action=run_branch branch_def_id=... resume_from=<run_id>`.
+  find the prior run first (`read.graph` target=workflow operation=list_runs
+  or operation=query_runs), then call
+  `run.graph` operation=run_branch branch_def_id=... resume_from=<run_id>.
   Do not use a standalone continue action.
-- "Save this note / definition / how-to / reference" → `wiki`.
-- "Run / execute my workflow" → `extensions action=run_branch`. If that
+- "Save this note / definition / how-to / reference" → `write.page`.
+- "Run / execute my workflow" → `run.graph`. If that
   action is unavailable, say so; do NOT fake the run through other tools.
 - "Remember this as daemon learning" / "what does this daemon remember?"
   / "review this daemon memory" -> use the daemon mini-brain actions on
-  `universe`. Pass `daemon_id` and structured fields through
+  `read.graph` / `write.graph` with target=universe. Pass `daemon_id` and structured fields through
   `inputs_json`; use `daemon_memory_capture` for new lessons,
   `daemon_memory_search` / `daemon_memory_list` for lookup,
   `daemon_memory_review` for accept/reject/supersede, and
   `daemon_memory_promote` only when the user wants a curated daemon-wiki
   review note.
-- `wiki` is strictly for knowledge and reference content. It is NOT the
+- `read.page` / `write.page` are strictly for knowledge and reference content. They are NOT the
   save-anything surface for workflow structure, workflow state, task
   lists, or artifacts that need to be queried as structured data.
 - "What is this for?" / "I want to make a workflow that does X" / "Is
-  anyone else doing Y?" → `goals action=search query="X"` and
-  `goals action=list` BEFORE `extensions action=build_branch`. Goals
+  anyone else doing Y?" → `read.graph` target=goal operation=search query="X" and
+  operation=list BEFORE `write.graph` target=workflow operation=build_branch. Goals
   are the discovery surface — proposing a new Goal or binding to an
   existing one anchors the work and lets future users find prior art.
 - "Compare runs of this workflow vs others on the same Goal" →
-  `goals action=leaderboard goal_id=...`.
+  `read.graph` target=goal operation=leaderboard goal_id=...
 - Cross-domain pivot: the active workspace may be themed (e.g. named
   "concordance" with a fantasy premise). That does NOT mean this
   connector is fantasy-only. When the user's intent doesn't match the
   active workspace's domain (e.g. user asks about a coding project while
   a fantasy workspace is active), follow `cross_surface_hint.paths` from
-  `universe action=inspect` — branches, Goals, and wiki span all domains
+  `read.graph` target=universe operation=inspect — branches, Goals, and wiki span all domains
   regardless of workspace theme. Do NOT tell the user "this is a fantasy
   connector" or ask them to create a new workspace; pivot directly to
-  `extensions action=list_branches` or `goals action=list`.
+  `read.graph` target=workflow operation=list_branches or target=goal operation=list.
 
 ## Intent disambiguation (affirmative consent for writes)
 
@@ -309,7 +290,7 @@ ambiguous intent — state-creation without explicit user request is
 unrecoverable trust damage.
 
 - Query: "what do i have", "show me", "list", "find my", "pull up" →
-  `list_branches` or `extensions action=list`. Read-only, safe default.
+  operation=list_branches or operation=list on `read.graph`. Read-only, safe default.
 - Build: "create", "make", "build", "register", "add a new" →
   `build_branch` / `register`. Only when the user EXPLICITLY asks.
 - Run: "run", "execute", "go", "start it" → `run_branch`.
@@ -317,7 +298,7 @@ unrecoverable trust damage.
 
 ## Cross-universe isolation
 
-Every `universe` tool response leads with `Universe: <id>` (both a
+Every universe graph response leads with `Universe: <id>` (both a
 phone-legible `text` header and a first-key `universe_id` JSON field).
 Treat that header as load-bearing.
 
@@ -336,12 +317,12 @@ Treat that header as load-bearing.
 Before inventing a new node, check whether one already exists that
 serves the same role:
 
-- `extensions action=search_nodes node_query="citation audit"` —
+- `read.graph` target=workflow operation=search_nodes node_query="citation audit"` —
   substring search across every Branch's nodes, ranked by reuse count.
-- `goals action=common_nodes scope=all` — cross-Goal aggregation of
+- `read.graph` target=goal operation=common_nodes scope=all — cross-Goal aggregation of
   node_ids shared across ≥2 Branches; good for "which nodes does the
   community reuse across different Goals?".
-- `goals action=common_nodes goal_id=<goal>` — nodes repeated inside
+- `read.graph` target=goal operation=common_nodes goal_id=<goal> — nodes repeated inside
   one Goal's Branches; good for "has anyone in this Goal already
   solved X?".
 

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -27,8 +27,11 @@ delegate to plain callables in those submodules (Pattern A2).
 
 from __future__ import annotations
 
+import inspect
+import json
 import logging
 from contextlib import AsyncExitStack, asynccontextmanager
+from typing import Any, Callable
 
 import uvicorn
 from fastmcp import FastMCP
@@ -72,7 +75,8 @@ mcp = FastMCP(
         "\n\n"
         "You are a control station. Help users design workflows, inspect "
         "running ones, steer daemons, collaborate, and extend the system "
-        "with custom graph nodes. Start with `universe action=inspect` to "
+        "with custom graph nodes. Start with `read.graph` target=universe "
+        "operation=inspect to "
         "orient yourself. "
         "\n\n"
         "Load the `control_station` prompt early. It is the canonical "
@@ -151,6 +155,285 @@ async def _landing_index(request):  # type: ignore[no-untyped-def]
 
 # Preserve the at-server-start whitelist warning (Step 10 prep §3.5 Option B).
 _warn_if_no_upload_whitelist()
+
+
+def _private_tool(*args: Any, **kwargs: Any) -> Callable[[Callable[..., str]], Callable[..., str]]:
+    """Leave legacy Python callables importable without MCP registration."""
+    if args and callable(args[0]) and len(args) == 1 and not kwargs:
+        return args[0]
+
+    def decorator(fn: Callable[..., str]) -> Callable[..., str]:
+        return fn
+
+    return decorator
+
+
+def _payload(payload_json: str) -> dict[str, Any]:
+    if not payload_json:
+        return {}
+    try:
+        payload = json.loads(payload_json)
+    except json.JSONDecodeError as exc:
+        return {"__error__": f"payload_json must be valid JSON: {exc.msg}"}
+    if not isinstance(payload, dict):
+        return {"__error__": "payload_json must decode to a JSON object"}
+    return payload
+
+
+def _with_payload(payload_json: str, **kwargs: Any) -> dict[str, Any]:
+    payload = _payload(payload_json)
+    if "__error__" in payload:
+        return payload
+    payload.update({k: v for k, v in kwargs.items() if v not in ("", None)})
+    return payload
+
+
+def _json_error(message: str) -> str:
+    return json.dumps({"error": message})
+
+
+def _call_impl(fn: Callable[..., str], action: str, kwargs: dict[str, Any]) -> str:
+    signature = inspect.signature(fn)
+    if any(
+        param.kind is inspect.Parameter.VAR_KEYWORD
+        for param in signature.parameters.values()
+    ):
+        call_kwargs = kwargs
+    else:
+        accepted = set(signature.parameters)
+        call_kwargs = {k: v for k, v in kwargs.items() if k in accepted}
+    return fn(action=action, **call_kwargs)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# FIVE PUBLIC MCP HANDLES
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@mcp.tool(
+    name="read.graph",
+    title="Read Graph",
+    tags={"graph", "workflow", "read", "status"},
+    annotations=ToolAnnotations(
+        title="Read Graph",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+def read_graph(
+    target: str = "universe",
+    operation: str = "inspect",
+    universe_id: str = "",
+    query: str = "",
+    branch_def_id: str = "",
+    run_id: str = "",
+    goal_id: str = "",
+    limit: int = 30,
+    payload_json: str = "",
+) -> str:
+    """Read Workflow graph state, status, runs, goals, gates, or review context.
+
+    `target` selects universe, workflow, goal, gate, status, or community.
+    `operation` selects the internal read operation. Advanced callers may pass
+    additional implementation fields in `payload_json`.
+    """
+    kwargs = _with_payload(
+        payload_json,
+        universe_id=universe_id,
+        query=query,
+        filter_text=query,
+        node_query=query,
+        branch_def_id=branch_def_id,
+        run_id=run_id,
+        goal_id=goal_id,
+        limit=limit,
+    )
+    if "__error__" in kwargs:
+        return _json_error(kwargs["__error__"])
+
+    if target == "status":
+        return _get_status_impl(universe_id=universe_id)
+    if target == "community":
+        return _call_impl(_universe_impl, "community_change_context", kwargs)
+    if target == "universe":
+        return _call_impl(_universe_impl, operation, kwargs)
+    if target == "workflow":
+        return _call_impl(_extensions_impl, operation, kwargs)
+    if target == "goal":
+        return _call_impl(_goals_impl, operation, kwargs)
+    if target == "gate":
+        return _call_impl(_gates_impl, operation, kwargs)
+    return _json_error(
+        "target must be one of universe, workflow, goal, gate, status, community",
+    )
+
+
+@mcp.tool(
+    name="write.graph",
+    title="Write Graph",
+    tags={"graph", "workflow", "write", "daemon"},
+    annotations=ToolAnnotations(
+        title="Write Graph",
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+def write_graph(
+    target: str = "universe",
+    operation: str = "submit_request",
+    universe_id: str = "",
+    text: str = "",
+    branch_def_id: str = "",
+    goal_id: str = "",
+    spec_json: str = "",
+    changes_json: str = "",
+    inputs_json: str = "",
+    payload_json: str = "",
+) -> str:
+    """Write Workflow graph state or submit bounded daemon/community input.
+
+    `target` selects universe, workflow, goal, or gate. Advanced callers may
+    pass implementation-specific fields in `payload_json`.
+    """
+    kwargs = _with_payload(
+        payload_json,
+        universe_id=universe_id,
+        text=text,
+        branch_def_id=branch_def_id,
+        goal_id=goal_id,
+        spec_json=spec_json,
+        changes_json=changes_json,
+        inputs_json=inputs_json,
+    )
+    if "__error__" in kwargs:
+        return _json_error(kwargs["__error__"])
+
+    if target == "universe":
+        return _call_impl(_universe_impl, operation, kwargs)
+    if target == "workflow":
+        return _call_impl(_extensions_impl, operation, kwargs)
+    if target == "goal":
+        return _call_impl(_goals_impl, operation, kwargs)
+    if target == "gate":
+        return _call_impl(_gates_impl, operation, kwargs)
+    return _json_error("target must be one of universe, workflow, goal, gate")
+
+
+@mcp.tool(
+    name="run.graph",
+    title="Run Graph",
+    tags={"graph", "workflow", "run", "execution"},
+    annotations=ToolAnnotations(
+        title="Run Graph",
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+def run_graph(
+    operation: str = "run_branch",
+    branch_def_id: str = "",
+    run_id: str = "",
+    inputs_json: str = "",
+    resume_from: str = "",
+    max_wait_s: int = 60,
+    payload_json: str = "",
+) -> str:
+    """Start, resume, wait for, inspect, stream, or cancel workflow graph runs."""
+    kwargs = _with_payload(
+        payload_json,
+        branch_def_id=branch_def_id,
+        run_id=run_id,
+        inputs_json=inputs_json,
+        resume_from=resume_from,
+        max_wait_s=max_wait_s,
+    )
+    if "__error__" in kwargs:
+        return _json_error(kwargs["__error__"])
+    return _call_impl(_extensions_impl, operation, kwargs)
+
+
+@mcp.tool(
+    name="read.page",
+    title="Read Page",
+    tags={"wiki", "page", "read", "knowledge"},
+    annotations=ToolAnnotations(
+        title="Read Page",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+def read_page(
+    operation: str = "read",
+    page: str = "",
+    query: str = "",
+    category: str = "",
+    max_results: int = 10,
+    payload_json: str = "",
+) -> str:
+    """Read, search, list, or lint Workflow wiki pages."""
+    kwargs = _with_payload(
+        payload_json,
+        page=page,
+        query=query,
+        category=category,
+        max_results=max_results,
+    )
+    if "__error__" in kwargs:
+        return _json_error(kwargs["__error__"])
+    return _call_impl(_wiki_impl, operation, kwargs)
+
+
+@mcp.tool(
+    name="write.page",
+    title="Write Page",
+    tags={"wiki", "page", "write", "knowledge"},
+    annotations=ToolAnnotations(
+        title="Write Page",
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+def write_page(
+    operation: str = "write",
+    page: str = "",
+    content: str = "",
+    old_text: str = "",
+    new_text: str = "",
+    expected_sha256: str = "",
+    kind: str = "bug",
+    title: str = "",
+    repro: str = "",
+    observed: str = "",
+    expected: str = "",
+    payload_json: str = "",
+) -> str:
+    """Write, patch, promote, or file change-request pages in the wiki."""
+    kwargs = _with_payload(
+        payload_json,
+        page=page,
+        content=content,
+        old_text=old_text,
+        new_text=new_text,
+        expected_sha256=expected_sha256,
+        kind=kind,
+        title=title,
+        repro=repro,
+        observed=observed,
+        expected=expected,
+    )
+    if "__error__" in kwargs:
+        return _json_error(kwargs["__error__"])
+    return _call_impl(_wiki_impl, operation, kwargs)
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -256,7 +539,7 @@ def branch_design_guide() -> str:
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(
+@_private_tool(
     title="Universe Operations",
     tags={
         "universe", "daemon", "collaboration",
@@ -372,7 +655,7 @@ def universe(
 # ---------------------------------------------------------------------------
 
 
-@mcp.tool(
+@_private_tool(
     title="Community Change Context",
     tags={
         "community", "change-loop", "review", "pull-request",
@@ -416,7 +699,7 @@ def community_change_context(
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(
+@_private_tool(
     title="Graph Extensions",
     tags={"extensions", "nodes", "plugins", "customization"},
     annotations=ToolAnnotations(
@@ -706,7 +989,7 @@ def extensions(
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(
+@_private_tool(
     title="Goals",
     tags={"goals", "discovery", "intent", "community"},
     annotations=ToolAnnotations(
@@ -780,7 +1063,7 @@ def goals(
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(
+@_private_tool(
     title="Outcome Gates",
     tags={"gates", "outcomes", "impact", "leaderboard", "community"},
     annotations=ToolAnnotations(
@@ -867,7 +1150,7 @@ def gates(
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(
+@_private_tool(
     title="Wiki Knowledge Base",
     tags={"wiki", "knowledge", "drafts", "pages", "research"},
     annotations=ToolAnnotations(
@@ -971,7 +1254,7 @@ def wiki(
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@mcp.tool(
+@_private_tool(
     title="Daemon Status + Routing Evidence",
     tags={
         "status", "routing", "privacy", "verification",


### PR DESCRIPTION
Fixes #476

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.