### PR TITLE
[auto-change] WIKI-PATCH: Dispatcher should prioritize claimable priority:loop-discipline requests before lower-priority work

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -89,6 +89,7 @@ jobs:
               'priority:primitive-layer',
               'priority:primitive-surface',
             ];
+            const triggerLabels = [...autoLabels, ...priorityLabelOrder];
             const skipLabels = ['await-primitive-layer', 'complete'];
             const hasWriterAuth = process.env.HAS_WRITER_AUTH === 'true';
             const hasWorkflowPushToken = process.env.HAS_WORKFLOW_PUSH_TOKEN === 'true';
@@ -165,14 +166,59 @@ jobs:
               seenIssueNumbers.add(issue.number);
             }
 
+            async function scanAutoLabels(options = {}) {
+              const onlyPermissionBlocked = options.onlyPermissionBlocked || false;
+              async function scanLabelQuery(labelNames) {
+                const { data: issues } = await github.rest.issues.listForRepo({
+                  owner,
+                  repo,
+                  state: 'open',
+                  labels: labelNames.join(','),
+                  sort: 'created',
+                  direction: 'asc',
+                  per_page: 100,
+                });
+                for (const issue of issues) {
+                  if (
+                    onlyPermissionBlocked &&
+                    !hasLabel(issue, 'auto-fix-branch-push-blocked') &&
+                    !hasLabel(issue, 'auto-fix-pr-blocked')
+                  ) {
+                    continue;
+                  }
+                  pushIfPending(issue, { ignoreSkip: onlyPermissionBlocked });
+                  if (rows.length >= maxIssues) {
+                    return true;
+                  }
+                }
+                return false;
+              }
+
+              for (const priorityLabel of priorityLabelOrder) {
+                for (const autoLabel of autoLabels) {
+                  if (await scanLabelQuery([autoLabel, priorityLabel])) {
+                    return;
+                  }
+                }
+              }
+              for (const labelName of autoLabels) {
+                if (await scanLabelQuery([labelName])) {
+                  return;
+                }
+              }
+            }
+
             if (context.eventName === 'issues') {
               const issue = context.payload.issue;
               const label = context.payload.label;
               if (
-                autoLabels.includes(label?.name) &&
+                triggerLabels.includes(label?.name) &&
                 !issue.pull_request
               ) {
-                pushIfPending(issue, { retryAttempted: true });
+                await scanAutoLabels();
+                if (rows.length < maxIssues) {
+                  pushIfPending(issue, { retryAttempted: true });
+                }
               }
             } else if (context.eventName === 'workflow_dispatch' && core.getInput('issue_number')) {
               const issue = await issueFromNumber(core.getInput('issue_number'));
@@ -180,48 +226,6 @@ jobs:
                 pushIfPending(issue, { retryAttempted: true });
               }
             } else {
-              async function scanAutoLabels(options = {}) {
-                const onlyPermissionBlocked = options.onlyPermissionBlocked || false;
-                async function scanLabelQuery(labelNames) {
-                  const { data: issues } = await github.rest.issues.listForRepo({
-                    owner,
-                    repo,
-                    state: 'open',
-                    labels: labelNames.join(','),
-                    sort: 'created',
-                    direction: 'asc',
-                    per_page: 100,
-                  });
-                  for (const issue of issues) {
-                    if (
-                      onlyPermissionBlocked &&
-                      !hasLabel(issue, 'auto-fix-branch-push-blocked') &&
-                      !hasLabel(issue, 'auto-fix-pr-blocked')
-                    ) {
-                      continue;
-                    }
-                    pushIfPending(issue, { ignoreSkip: onlyPermissionBlocked });
-                    if (rows.length >= maxIssues) {
-                      return true;
-                    }
-                  }
-                  return false;
-                }
-
-                for (const priorityLabel of priorityLabelOrder) {
-                  for (const autoLabel of autoLabels) {
-                    if (await scanLabelQuery([autoLabel, priorityLabel])) {
-                      return;
-                    }
-                  }
-                }
-                for (const labelName of autoLabels) {
-                  if (await scanLabelQuery([labelName])) {
-                    return;
-                  }
-                }
-              }
-
               await scanAutoLabels({ onlyPermissionBlocked: true });
               if (rows.length >= maxIssues) {
                 core.info('Prioritized retryable permission-blocked issue before normal queue discovery.');

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -126,13 +126,18 @@ def test_discover_retries_permission_blocked_when_push_token_visible(wf):
 def test_discover_prioritizes_permission_blocked_before_normal_queue(wf):
     discover_step = wf["jobs"]["discover"]["steps"][0]
     script = str(discover_step.get("with", {}).get("script", ""))
+    backfill_branch = script[
+        script.index("} else {\n  await scanAutoLabels({ onlyPermissionBlocked: true });"):
+    ]
     permission_blocked_pass = "await scanAutoLabels({ onlyPermissionBlocked: true });"
     normal_pass = "await scanAutoLabels();"
     assert "onlyPermissionBlocked" in script
     assert "!hasLabel(issue, 'auto-fix-branch-push-blocked')" in script
     assert "!hasLabel(issue, 'auto-fix-pr-blocked')" in script
     assert "ignoreSkip: onlyPermissionBlocked" in script
-    assert script.index(permission_blocked_pass) < script.index(normal_pass)
+    assert backfill_branch.index(permission_blocked_pass) < backfill_branch.index(
+        normal_pass
+    )
 
 
 def test_discover_respects_priority_and_skip_labels(wf):
@@ -153,6 +158,22 @@ def test_discover_respects_priority_and_skip_labels(wf):
     assert script.index(priority_layer) < script.index(priority_surface)
     assert script.index("for (const priorityLabel of priorityLabelOrder)") < (
         script.index(normal_scan)
+    )
+
+
+def test_labeled_event_prioritizes_claimable_priority_before_trigger_issue(wf):
+    discover_step = wf["jobs"]["discover"]["steps"][0]
+    script = str(discover_step.get("with", {}).get("script", ""))
+    assert "const triggerLabels = [...autoLabels, ...priorityLabelOrder];" in script
+    assert "triggerLabels.includes(label?.name)" in script
+    event_branch = script[
+        script.index("if (context.eventName === 'issues')"):
+        script.index("} else if (context.eventName === 'workflow_dispatch'")
+    ]
+    assert "await scanAutoLabels();" in event_branch
+    assert "if (rows.length < maxIssues)" in event_branch
+    assert event_branch.index("await scanAutoLabels();") < event_branch.index(
+        "pushIfPending(issue, { retryAttempted: true });"
     )
 
 


### PR DESCRIPTION
Fixes #453

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.