### PR TITLE
[auto-change] BUG-044: change_loop_v1 compile fails because node id collides with state key

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -1072,6 +1072,22 @@ def _errors_to_suggestions(
                     "target."
                 ),
             })
+        elif "collides with a graph node id" in low:
+            state_field = ""
+            match = re.search(r"State field name '([^']+)'", err)
+            if match:
+                state_field = match.group(1)
+            suggestions.append({
+                "issue": err,
+                "proposed_fix": (
+                    f"Rename state_schema field '{state_field}' or the "
+                    f"graph node ID '{state_field}' so they are distinct "
+                    "before running this branch."
+                    if state_field
+                    else "Rename the colliding state_schema field or graph "
+                    "node ID so they are distinct before running this branch."
+                ),
+            })
         elif "at least one node" in low:
             suggestions.append({
                 "issue": err,

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -524,6 +524,20 @@ class TestBranchDefinition:
         errors = b.validate()
         assert any("collides with a graph node ID" in e for e in errors)
 
+    def test_state_field_graph_node_collision_suggestion_names_both_sides(self):
+        from workflow.api.branches import _errors_to_suggestions
+
+        b = _make_sample_branch()
+        b.state_schema.append({"name": "orient", "type": "str"})
+        errors = b.validate()
+
+        suggestions = _errors_to_suggestions(b, errors)
+        fixes = " ".join(s["proposed_fix"] for s in suggestions)
+
+        assert "state_schema field 'orient'" in fixes
+        assert "graph node ID 'orient'" in fixes
+        assert "before running" in fixes
+
     def test_fork(self):
         b = _make_sample_branch()
         b.stats["run_count"] = 42

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -1072,6 +1072,22 @@ def _errors_to_suggestions(
                     "target."
                 ),
             })
+        elif "collides with a graph node id" in low:
+            state_field = ""
+            match = re.search(r"State field name '([^']+)'", err)
+            if match:
+                state_field = match.group(1)
+            suggestions.append({
+                "issue": err,
+                "proposed_fix": (
+                    f"Rename state_schema field '{state_field}' or the "
+                    f"graph node ID '{state_field}' so they are distinct "
+                    "before running this branch."
+                    if state_field
+                    else "Rename the colliding state_schema field or graph "
+                    "node ID so they are distinct before running this branch."
+                ),
+            })
         elif "at least one node" in low:
             suggestions.append({
                 "issue": err,


### PR DESCRIPTION
Fixes #89

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.