### PR TITLE
BUG-069 class absorption: structuredContent fix for mcp_server.py + directory_server.py (sibling to #493)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
@@ -112,6 +112,32 @@ def _directory_safe_status(universe_id: str = "") -> str:
     return json.dumps(_redact_directory_status(payload), default=str)
 
 
+
+def _structured_return(raw):
+    """Wrap an MCP tool result so FastMCP populates ``structured_content``.
+
+    ChatGPT (OpenAI Apps SDK) wedges on substrate-changing tool calls when
+    the response carries only ``content`` (text) without ``structuredContent``
+    (typed dict) + ``_meta`` annotations. Claude tolerates either shape.
+
+    Mirrors the helper in workflow.universe_server applied via PR #493.
+    """
+    import json as _json
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, list):
+        return {"result": raw}
+    if isinstance(raw, str):
+        try:
+            parsed = _json.loads(raw)
+        except (_json.JSONDecodeError, ValueError):
+            return {"text": raw}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"result": parsed}
+    return {"result": raw}
+
+
 @directory_mcp.tool(
     title="Get Workflow Status",
     tags={"status", "workflow", "diagnostics"},
@@ -123,16 +149,13 @@ def _directory_safe_status(universe_id: str = "") -> str:
         openWorldHint=False,
     ),
 )
-def get_workflow_status(universe_id: str = "") -> str:
+def get_workflow_status(universe_id: str = "") -> dict:
     """Use this when the user asks whether Workflow is reachable or safe to use.
 
     Args:
         universe_id: Optional universe scope. Empty uses the active universe.
     """
-    return _directory_safe_status(universe_id=universe_id)
-
-
-@directory_mcp.tool(
+    return _structured_return(_directory_safe_status(universe_id=universe_id))@directory_mcp.tool(
     title="List Workflow Universes",
     tags={"universes", "workflow", "browse"},
     annotations=ToolAnnotations(
@@ -143,16 +166,13 @@ def get_workflow_status(universe_id: str = "") -> str:
         openWorldHint=False,
     ),
 )
-def list_workflow_universes(limit: int = 30) -> str:
+def list_workflow_universes(limit: int = 30) -> dict:
     """Use this when the user wants to browse available Workflow universes.
 
     Args:
         limit: Maximum number of universes to return.
     """
-    return _universe_impl(action="list", limit=limit)
-
-
-@directory_mcp.tool(
+    return _structured_return(_universe_impl(action="list", limit=limit))@directory_mcp.tool(
     title="Inspect Workflow Universe",
     tags={"universes", "workflow", "inspect"},
     annotations=ToolAnnotations(
@@ -163,16 +183,13 @@ def list_workflow_universes(limit: int = 30) -> str:
         openWorldHint=False,
     ),
 )
-def inspect_workflow_universe(universe_id: str = "") -> str:
+def inspect_workflow_universe(universe_id: str = "") -> dict:
     """Use this when the user wants a summary of one Workflow universe.
 
     Args:
         universe_id: Optional universe scope. Empty uses the active universe.
     """
-    return _universe_impl(action="inspect", universe_id=universe_id)
-
-
-@directory_mcp.tool(
+    return _structured_return(_universe_impl(action="inspect", universe_id=universe_id))@directory_mcp.tool(
     title="List Workflow Goals",
     tags={"goals", "workflow", "browse"},
     annotations=ToolAnnotations(
@@ -183,7 +200,7 @@ def inspect_workflow_universe(universe_id: str = "") -> str:
         openWorldHint=False,
     ),
 )
-def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> str:
+def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> dict:
     """Use this when the user wants to browse existing shared Workflow goals.
 
     Args:
@@ -191,10 +208,7 @@ def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> st
         author: Optional author filter.
         limit: Maximum number of goals to return.
     """
-    return _goals_impl(action="list", tags=tags, author=author, limit=limit)
-
-
-@directory_mcp.tool(
+    return _structured_return(_goals_impl(action="list", tags=tags, author=author, limit=limit))@directory_mcp.tool(
     title="Search Workflow Goals",
     tags={"goals", "workflow", "search"},
     annotations=ToolAnnotations(
@@ -205,17 +219,14 @@ def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> st
         openWorldHint=False,
     ),
 )
-def search_workflow_goals(query: str, limit: int = 20) -> str:
+def search_workflow_goals(query: str, limit: int = 20) -> dict:
     """Use this when the user wants to find Workflow goals by text or tag.
 
     Args:
         query: Search text.
         limit: Maximum number of goals to return.
     """
-    return _goals_impl(action="search", query=query, limit=limit)
-
-
-@directory_mcp.tool(
+    return _structured_return(_goals_impl(action="search", query=query, limit=limit))@directory_mcp.tool(
     title="Get Workflow Goal",
     tags={"goals", "workflow", "inspect"},
     annotations=ToolAnnotations(
@@ -226,16 +237,13 @@ def search_workflow_goals(query: str, limit: int = 20) -> str:
         openWorldHint=False,
     ),
 )
-def get_workflow_goal(goal_id: str) -> str:
+def get_workflow_goal(goal_id: str) -> dict:
     """Use this when the user wants details for a specific Workflow goal.
 
     Args:
         goal_id: Goal identifier to inspect.
     """
-    return _goals_impl(action="get", goal_id=goal_id)
-
-
-@directory_mcp.tool(
+    return _structured_return(_goals_impl(action="get", goal_id=goal_id))@directory_mcp.tool(
     title="Search Workflow Wiki",
     tags={"wiki", "knowledge", "workflow", "search"},
     annotations=ToolAnnotations(
@@ -246,7 +254,7 @@ def get_workflow_goal(goal_id: str) -> str:
         openWorldHint=False,
     ),
 )
-def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) -> str:
+def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) -> dict:
     """Use this when the user wants to search Workflow project knowledge.
 
     Args:
@@ -254,12 +262,12 @@ def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) 
         category: Optional wiki category filter.
         max_results: Maximum number of wiki hits to return.
     """
-    return _wiki_impl(
+    return _structured_return(_wiki_impl(
         action="search",
         query=query,
         category=category,
         max_results=max_results,
-    )
+    ))
 
 @directory_mcp.tool(
     title="Read Workflow Wiki Page",
@@ -272,16 +280,13 @@ def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) 
         openWorldHint=False,
     ),
 )
-def read_workflow_wiki_page(page: str) -> str:
+def read_workflow_wiki_page(page: str) -> dict:
     """Use this when the user wants to read one Workflow wiki page.
 
     Args:
         page: Wiki page slug or path.
     """
-    return _wiki_impl(action="read", page=page)
-
-
-@directory_mcp.tool(
+    return _structured_return(_wiki_impl(action="read", page=page))@directory_mcp.tool(
     title="List Workflow Runs",
     tags={"runs", "workflow", "browse"},
     annotations=ToolAnnotations(
@@ -292,17 +297,14 @@ def read_workflow_wiki_page(page: str) -> str:
         openWorldHint=False,
     ),
 )
-def list_workflow_runs(status: str = "", limit: int = 20) -> str:
+def list_workflow_runs(status: str = "", limit: int = 20) -> dict:
     """Use this when the user wants recent Workflow run history.
 
     Args:
         status: Optional run status filter.
         limit: Maximum number of runs to return.
     """
-    return _extensions_impl(action="list_runs", status=status, limit=limit)
-
-
-@directory_mcp.tool(
+    return _structured_return(_extensions_impl(action="list_runs", status=status, limit=limit))@directory_mcp.tool(
     title="Propose Workflow Goal",
     tags={"goals", "workflow", "create"},
     annotations=ToolAnnotations(
@@ -318,7 +320,7 @@ def propose_workflow_goal(
     description: str = "",
     tags: str = "",
     visibility: str = "public",
-) -> str:
+) -> dict:
     """Use this when the user asks to create a shared Workflow goal proposal.
 
     Args:
@@ -327,13 +329,13 @@ def propose_workflow_goal(
         tags: Optional comma-separated tags.
         visibility: Visibility value accepted by Workflow, usually public.
     """
-    return _goals_impl(
+    return _structured_return(_goals_impl(
         action="propose",
         name=name,
         description=description,
         tags=tags,
         visibility=visibility,
-    )
+    ))
 
 
 @directory_mcp.tool(
@@ -352,7 +354,7 @@ def submit_workflow_request(
     universe_id: str = "",
     request_type: str = "scene_direction",
     branch_id: str = "",
-) -> str:
+) -> dict:
     """Use this when the user wants the Workflow daemon to handle a bounded request.
 
     Args:
@@ -361,10 +363,10 @@ def submit_workflow_request(
         request_type: Workflow request type.
         branch_id: Optional target branch identifier.
     """
-    return _universe_impl(
+    return _structured_return(_universe_impl(
         action="submit_request",
         universe_id=universe_id,
         text=text,
         request_type=request_type,
         branch_id=branch_id,
-    )
+    ))

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/mcp_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/mcp_server.py
@@ -64,11 +64,37 @@ def _universe_dir() -> Path:
     return data_dir() / "default-universe"
 
 
+
+def _structured_return(raw):
+    """Wrap an MCP tool result so FastMCP populates ``structured_content``.
+
+    ChatGPT (OpenAI Apps SDK) wedges on substrate-changing tool calls when
+    the response carries only ``content`` (text) without ``structuredContent``
+    (typed dict) + ``_meta`` annotations. Claude tolerates either shape.
+
+    Mirrors the helper in workflow.universe_server applied via PR #493.
+    """
+    import json as _json
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, list):
+        return {"result": raw}
+    if isinstance(raw, str):
+        try:
+            parsed = _json.loads(raw)
+        except (_json.JSONDecodeError, ValueError):
+            return {"text": raw}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"result": parsed}
+    return {"result": raw}
+
+
 @mcp.tool(
     tags={"status", "monitoring"},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True, openWorldHint=False),
 )
-def get_status() -> str:
+def get_status() -> dict:
     """Read the daemon's current status including phase, word count, and accept rate.
 
     Call this first to orient yourself.
@@ -77,7 +103,7 @@ def get_status() -> str:
     if not status_path.exists():
         return "No status.json found. The daemon may not be running."
     try:
-        return status_path.read_text(encoding="utf-8")
+        return _structured_return(status_path.read_text(encoding="utf-8"))
     except OSError as e:
         return f"Error reading status.json: {e}"
 
@@ -86,7 +112,7 @@ def get_status() -> str:
     tags={"notes", "steering", "direction"},
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False),
 )
-def add_note(text: str, category: str = "direction") -> str:
+def add_note(text: str, category: str = "direction") -> dict:
     """Add a note that the daemon reads at each scene boundary.
 
     Notes are the primary feedback mechanism — use them to steer the story,
@@ -115,14 +141,11 @@ def add_note(text: str, category: str = "direction") -> str:
 
 def steer(directive: str, category: str = "direction") -> str:
     """Backward-compatible alias for ``add_note``."""
-    return add_note(directive, category)
-
-
-@mcp.tool(
+    return _structured_return(add_note(directive, category))@mcp.tool(
     tags={"premise", "story"},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
-def get_premise() -> str:
+def get_premise() -> dict:
     """Read the current story premise from PROGRAM.md.
 
     The premise seeds the daemon's creative direction.
@@ -131,7 +154,7 @@ def get_premise() -> str:
     if not program_path.exists():
         return "No PROGRAM.md found. Use set_premise() to create one."
     try:
-        return program_path.read_text(encoding="utf-8")
+        return _structured_return(program_path.read_text(encoding="utf-8"))
     except OSError as e:
         return f"Error reading PROGRAM.md: {e}"
 
@@ -140,7 +163,7 @@ def get_premise() -> str:
     tags={"premise", "story"},
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True),
 )
-def set_premise(text: str) -> str:
+def set_premise(text: str) -> dict:
     """Write or overwrite the story premise in PROGRAM.md.
 
     The daemon reads this at startup to seed the story direction.
@@ -151,16 +174,16 @@ def set_premise(text: str) -> str:
     try:
         _universe_dir().mkdir(parents=True, exist_ok=True)
         program_path.write_text(text, encoding="utf-8")
-        return "PROGRAM.md updated."
+        return _structured_return("PROGRAM.md updated.")
     except OSError as e:
-        return f"Error writing PROGRAM.md: {e}"
+        return _structured_return(f"Error writing PROGRAM.md: {e}")
 
 
 @mcp.tool(
     tags={"progress", "monitoring"},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
-def get_progress() -> str:
+def get_progress() -> dict:
     """Read the human-readable progress summary.
 
     Includes story outline, word counts, and current chapter status.
@@ -169,7 +192,7 @@ def get_progress() -> str:
     if not progress_path.exists():
         return "No progress.md found. The daemon may not have started writing yet."
     try:
-        return progress_path.read_text(encoding="utf-8")
+        return _structured_return(progress_path.read_text(encoding="utf-8"))
     except OSError as e:
         return f"Error reading progress.md: {e}"
 
@@ -178,7 +201,7 @@ def get_progress() -> str:
     tags={"work-targets", "planning"},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
-def get_work_targets() -> str:
+def get_work_targets() -> dict:
     """Read the durable work target registry.
 
     Shows what the daemon is working on, what's queued, and lifecycle state.
@@ -187,7 +210,7 @@ def get_work_targets() -> str:
     if not path.exists():
         return "No work_targets.json found."
     try:
-        return path.read_text(encoding="utf-8")
+        return _structured_return(path.read_text(encoding="utf-8"))
     except OSError as e:
         return f"Error reading work_targets.json: {e}"
 
@@ -196,13 +219,13 @@ def get_work_targets() -> str:
     tags={"review", "monitoring"},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
-def get_review_state() -> str:
+def get_review_state() -> dict:
     """Read the latest review-state snapshot including daemon phase, word count, and accept rate."""
     status_path = _universe_dir() / "status.json"
     if not status_path.exists():
         return "No status.json found."
     try:
-        return status_path.read_text(encoding="utf-8")
+        return _structured_return(status_path.read_text(encoding="utf-8"))
     except OSError as e:
         return f"Error reading status.json: {e}"
 
@@ -211,7 +234,7 @@ def get_review_state() -> str:
     tags={"output", "reading"},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
-def get_chapter(book: int, chapter: int) -> str:
+def get_chapter(book: int, chapter: int) -> dict:
     """Read a completed chapter from the daemon's output.
 
     Args:
@@ -222,7 +245,7 @@ def get_chapter(book: int, chapter: int) -> str:
     if not chapter_path.exists():
         return f"Chapter file not found: book-{book}/chapter-{chapter:02d}.md"
     try:
-        return chapter_path.read_text(encoding="utf-8")
+        return _structured_return(chapter_path.read_text(encoding="utf-8"))
     except OSError as e:
         return f"Error reading chapter file: {e}"
 
@@ -231,7 +254,7 @@ def get_chapter(book: int, chapter: int) -> str:
     tags={"activity", "monitoring"},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
-def get_activity(lines: int = 20) -> str:
+def get_activity(lines: int = 20) -> dict:
     """Read the most recent lines from the daemon's activity log.
 
     Shows scene completions, reviews, and errors.
@@ -241,21 +264,21 @@ def get_activity(lines: int = 20) -> str:
     """
     log_path = _universe_dir() / "activity.log"
     if not log_path.exists():
-        return "No activity.log found."
+        return _structured_return("No activity.log found.")
     try:
         content = log_path.read_text(encoding="utf-8")
         all_lines = content.strip().splitlines()
         tail = all_lines[-lines:] if len(all_lines) > lines else all_lines
-        return "\n".join(tail)
+        return _structured_return("\n".join(tail))
     except OSError as e:
-        return f"Error reading activity.log: {e}"
+        return _structured_return(f"Error reading activity.log: {e}")
 
 
 @mcp.tool(
     tags={"control", "daemon"},
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
 )
-def pause() -> str:
+def pause() -> dict:
     """Pause the daemon at the next scene boundary.
 
     The daemon checks for a pause signal between scenes.
@@ -266,32 +289,32 @@ def pause() -> str:
         pause_path.write_text(
             datetime.now(timezone.utc).isoformat(), encoding="utf-8",
         )
-        return "Pause signal written. The daemon will pause at the next scene boundary."
+        return _structured_return("Pause signal written. The daemon will pause at the next scene boundary.")
     except OSError as e:
-        return f"Error writing pause signal: {e}"
+        return _structured_return(f"Error writing pause signal: {e}")
 
 
 @mcp.tool(
     tags={"control", "daemon"},
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
 )
-def resume() -> str:
+def resume() -> dict:
     """Resume a paused daemon by removing the pause signal."""
     pause_path = _universe_dir() / ".pause"
     if not pause_path.exists():
-        return "Daemon is not paused (no .pause file found)."
+        return _structured_return("Daemon is not paused (no .pause file found).")
     try:
         pause_path.unlink()
-        return "Pause signal removed. The daemon will resume."
+        return _structured_return("Pause signal removed. The daemon will resume.")
     except OSError as e:
-        return f"Error removing pause signal: {e}"
+        return _structured_return(f"Error removing pause signal: {e}")
 
 
 @mcp.tool(
     tags={"canon", "worldbuilding"},
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
 )
-def add_canon(filename: str, content: str) -> str:
+def add_canon(filename: str, content: str) -> dict:
     """Add a reference document to the canon/ directory for the daemon to ingest.
 
     Canon files provide worldbuilding context — character sheets, maps, lore
@@ -306,14 +329,14 @@ def add_canon(filename: str, content: str) -> str:
     # Sanitize filename to prevent path traversal
     safe_name = Path(filename).name
     if not safe_name:
-        return "Invalid filename."
+        return _structured_return("Invalid filename.")
     try:
         canon_dir.mkdir(parents=True, exist_ok=True)
         target = canon_dir / safe_name
         target.write_text(content, encoding="utf-8")
-        return f"Written {safe_name} to canon/."
+        return _structured_return(f"Written {safe_name} to canon/.")
     except OSError as e:
-        return f"Error writing to canon/: {e}"
+        return _structured_return(f"Error writing to canon/: {e}")
 
 
 def main() -> None:

--- a/workflow/directory_server.py
+++ b/workflow/directory_server.py
@@ -112,6 +112,32 @@ def _directory_safe_status(universe_id: str = "") -> str:
     return json.dumps(_redact_directory_status(payload), default=str)
 
 
+
+def _structured_return(raw):
+    """Wrap an MCP tool result so FastMCP populates ``structured_content``.
+
+    ChatGPT (OpenAI Apps SDK) wedges on substrate-changing tool calls when
+    the response carries only ``content`` (text) without ``structuredContent``
+    (typed dict) + ``_meta`` annotations. Claude tolerates either shape.
+
+    Mirrors the helper in workflow.universe_server applied via PR #493.
+    """
+    import json as _json
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, list):
+        return {"result": raw}
+    if isinstance(raw, str):
+        try:
+            parsed = _json.loads(raw)
+        except (_json.JSONDecodeError, ValueError):
+            return {"text": raw}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"result": parsed}
+    return {"result": raw}
+
+
 @directory_mcp.tool(
     title="Get Workflow Status",
     tags={"status", "workflow", "diagnostics"},
@@ -123,16 +149,13 @@ def _directory_safe_status(universe_id: str = "") -> str:
         openWorldHint=False,
     ),
 )
-def get_workflow_status(universe_id: str = "") -> str:
+def get_workflow_status(universe_id: str = "") -> dict:
     """Use this when the user asks whether Workflow is reachable or safe to use.
 
     Args:
         universe_id: Optional universe scope. Empty uses the active universe.
     """
-    return _directory_safe_status(universe_id=universe_id)
-
-
-@directory_mcp.tool(
+    return _structured_return(_directory_safe_status(universe_id=universe_id))@directory_mcp.tool(
     title="List Workflow Universes",
     tags={"universes", "workflow", "browse"},
     annotations=ToolAnnotations(
@@ -143,16 +166,13 @@ def get_workflow_status(universe_id: str = "") -> str:
         openWorldHint=False,
     ),
 )
-def list_workflow_universes(limit: int = 30) -> str:
+def list_workflow_universes(limit: int = 30) -> dict:
     """Use this when the user wants to browse available Workflow universes.
 
     Args:
         limit: Maximum number of universes to return.
     """
-    return _universe_impl(action="list", limit=limit)
-
-
-@directory_mcp.tool(
+    return _structured_return(_universe_impl(action="list", limit=limit))@directory_mcp.tool(
     title="Inspect Workflow Universe",
     tags={"universes", "workflow", "inspect"},
     annotations=ToolAnnotations(
@@ -163,16 +183,13 @@ def list_workflow_universes(limit: int = 30) -> str:
         openWorldHint=False,
     ),
 )
-def inspect_workflow_universe(universe_id: str = "") -> str:
+def inspect_workflow_universe(universe_id: str = "") -> dict:
     """Use this when the user wants a summary of one Workflow universe.
 
     Args:
         universe_id: Optional universe scope. Empty uses the active universe.
     """
-    return _universe_impl(action="inspect", universe_id=universe_id)
-
-
-@directory_mcp.tool(
+    return _structured_return(_universe_impl(action="inspect", universe_id=universe_id))@directory_mcp.tool(
     title="List Workflow Goals",
     tags={"goals", "workflow", "browse"},
     annotations=ToolAnnotations(
@@ -183,7 +200,7 @@ def inspect_workflow_universe(universe_id: str = "") -> str:
         openWorldHint=False,
     ),
 )
-def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> str:
+def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> dict:
     """Use this when the user wants to browse existing shared Workflow goals.
 
     Args:
@@ -191,10 +208,7 @@ def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> st
         author: Optional author filter.
         limit: Maximum number of goals to return.
     """
-    return _goals_impl(action="list", tags=tags, author=author, limit=limit)
-
-
-@directory_mcp.tool(
+    return _structured_return(_goals_impl(action="list", tags=tags, author=author, limit=limit))@directory_mcp.tool(
     title="Search Workflow Goals",
     tags={"goals", "workflow", "search"},
     annotations=ToolAnnotations(
@@ -205,17 +219,14 @@ def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> st
         openWorldHint=False,
     ),
 )
-def search_workflow_goals(query: str, limit: int = 20) -> str:
+def search_workflow_goals(query: str, limit: int = 20) -> dict:
     """Use this when the user wants to find Workflow goals by text or tag.
 
     Args:
         query: Search text.
         limit: Maximum number of goals to return.
     """
-    return _goals_impl(action="search", query=query, limit=limit)
-
-
-@directory_mcp.tool(
+    return _structured_return(_goals_impl(action="search", query=query, limit=limit))@directory_mcp.tool(
     title="Get Workflow Goal",
     tags={"goals", "workflow", "inspect"},
     annotations=ToolAnnotations(
@@ -226,16 +237,13 @@ def search_workflow_goals(query: str, limit: int = 20) -> str:
         openWorldHint=False,
     ),
 )
-def get_workflow_goal(goal_id: str) -> str:
+def get_workflow_goal(goal_id: str) -> dict:
     """Use this when the user wants details for a specific Workflow goal.
 
     Args:
         goal_id: Goal identifier to inspect.
     """
-    return _goals_impl(action="get", goal_id=goal_id)
-
-
-@directory_mcp.tool(
+    return _structured_return(_goals_impl(action="get", goal_id=goal_id))@directory_mcp.tool(
     title="Search Workflow Wiki",
     tags={"wiki", "knowledge", "workflow", "search"},
     annotations=ToolAnnotations(
@@ -246,7 +254,7 @@ def get_workflow_goal(goal_id: str) -> str:
         openWorldHint=False,
     ),
 )
-def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) -> str:
+def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) -> dict:
     """Use this when the user wants to search Workflow project knowledge.
 
     Args:
@@ -254,12 +262,12 @@ def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) 
         category: Optional wiki category filter.
         max_results: Maximum number of wiki hits to return.
     """
-    return _wiki_impl(
+    return _structured_return(_wiki_impl(
         action="search",
         query=query,
         category=category,
         max_results=max_results,
-    )
+    ))
 
 @directory_mcp.tool(
     title="Read Workflow Wiki Page",
@@ -272,16 +280,13 @@ def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) 
         openWorldHint=False,
     ),
 )
-def read_workflow_wiki_page(page: str) -> str:
+def read_workflow_wiki_page(page: str) -> dict:
     """Use this when the user wants to read one Workflow wiki page.
 
     Args:
         page: Wiki page slug or path.
     """
-    return _wiki_impl(action="read", page=page)
-
-
-@directory_mcp.tool(
+    return _structured_return(_wiki_impl(action="read", page=page))@directory_mcp.tool(
     title="List Workflow Runs",
     tags={"runs", "workflow", "browse"},
     annotations=ToolAnnotations(
@@ -292,17 +297,14 @@ def read_workflow_wiki_page(page: str) -> str:
         openWorldHint=False,
     ),
 )
-def list_workflow_runs(status: str = "", limit: int = 20) -> str:
+def list_workflow_runs(status: str = "", limit: int = 20) -> dict:
     """Use this when the user wants recent Workflow run history.
 
     Args:
         status: Optional run status filter.
         limit: Maximum number of runs to return.
     """
-    return _extensions_impl(action="list_runs", status=status, limit=limit)
-
-
-@directory_mcp.tool(
+    return _structured_return(_extensions_impl(action="list_runs", status=status, limit=limit))@directory_mcp.tool(
     title="Propose Workflow Goal",
     tags={"goals", "workflow", "create"},
     annotations=ToolAnnotations(
@@ -318,7 +320,7 @@ def propose_workflow_goal(
     description: str = "",
     tags: str = "",
     visibility: str = "public",
-) -> str:
+) -> dict:
     """Use this when the user asks to create a shared Workflow goal proposal.
 
     Args:
@@ -327,13 +329,13 @@ def propose_workflow_goal(
         tags: Optional comma-separated tags.
         visibility: Visibility value accepted by Workflow, usually public.
     """
-    return _goals_impl(
+    return _structured_return(_goals_impl(
         action="propose",
         name=name,
         description=description,
         tags=tags,
         visibility=visibility,
-    )
+    ))
 
 
 @directory_mcp.tool(
@@ -352,7 +354,7 @@ def submit_workflow_request(
     universe_id: str = "",
     request_type: str = "scene_direction",
     branch_id: str = "",
-) -> str:
+) -> dict:
     """Use this when the user wants the Workflow daemon to handle a bounded request.
 
     Args:
@@ -361,10 +363,10 @@ def submit_workflow_request(
         request_type: Workflow request type.
         branch_id: Optional target branch identifier.
     """
-    return _universe_impl(
+    return _structured_return(_universe_impl(
         action="submit_request",
         universe_id=universe_id,
         text=text,
         request_type=request_type,
         branch_id=branch_id,
-    )
+    ))

--- a/workflow/mcp_server.py
+++ b/workflow/mcp_server.py
@@ -64,11 +64,37 @@ def _universe_dir() -> Path:
     return data_dir() / "default-universe"
 
 
+
+def _structured_return(raw):
+    """Wrap an MCP tool result so FastMCP populates ``structured_content``.
+
+    ChatGPT (OpenAI Apps SDK) wedges on substrate-changing tool calls when
+    the response carries only ``content`` (text) without ``structuredContent``
+    (typed dict) + ``_meta`` annotations. Claude tolerates either shape.
+
+    Mirrors the helper in workflow.universe_server applied via PR #493.
+    """
+    import json as _json
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, list):
+        return {"result": raw}
+    if isinstance(raw, str):
+        try:
+            parsed = _json.loads(raw)
+        except (_json.JSONDecodeError, ValueError):
+            return {"text": raw}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"result": parsed}
+    return {"result": raw}
+
+
 @mcp.tool(
     tags={"status", "monitoring"},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True, openWorldHint=False),
 )
-def get_status() -> str:
+def get_status() -> dict:
     """Read the daemon's current status including phase, word count, and accept rate.
 
     Call this first to orient yourself.
@@ -77,7 +103,7 @@ def get_status() -> str:
     if not status_path.exists():
         return "No status.json found. The daemon may not be running."
     try:
-        return status_path.read_text(encoding="utf-8")
+        return _structured_return(status_path.read_text(encoding="utf-8"))
     except OSError as e:
         return f"Error reading status.json: {e}"
 
@@ -86,7 +112,7 @@ def get_status() -> str:
     tags={"notes", "steering", "direction"},
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False),
 )
-def add_note(text: str, category: str = "direction") -> str:
+def add_note(text: str, category: str = "direction") -> dict:
     """Add a note that the daemon reads at each scene boundary.
 
     Notes are the primary feedback mechanism — use them to steer the story,
@@ -115,14 +141,11 @@ def add_note(text: str, category: str = "direction") -> str:
 
 def steer(directive: str, category: str = "direction") -> str:
     """Backward-compatible alias for ``add_note``."""
-    return add_note(directive, category)
-
-
-@mcp.tool(
+    return _structured_return(add_note(directive, category))@mcp.tool(
     tags={"premise", "story"},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
-def get_premise() -> str:
+def get_premise() -> dict:
     """Read the current story premise from PROGRAM.md.
 
     The premise seeds the daemon's creative direction.
@@ -131,7 +154,7 @@ def get_premise() -> str:
     if not program_path.exists():
         return "No PROGRAM.md found. Use set_premise() to create one."
     try:
-        return program_path.read_text(encoding="utf-8")
+        return _structured_return(program_path.read_text(encoding="utf-8"))
     except OSError as e:
         return f"Error reading PROGRAM.md: {e}"
 
@@ -140,7 +163,7 @@ def get_premise() -> str:
     tags={"premise", "story"},
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True),
 )
-def set_premise(text: str) -> str:
+def set_premise(text: str) -> dict:
     """Write or overwrite the story premise in PROGRAM.md.
 
     The daemon reads this at startup to seed the story direction.
@@ -151,16 +174,16 @@ def set_premise(text: str) -> str:
     try:
         _universe_dir().mkdir(parents=True, exist_ok=True)
         program_path.write_text(text, encoding="utf-8")
-        return "PROGRAM.md updated."
+        return _structured_return("PROGRAM.md updated.")
     except OSError as e:
-        return f"Error writing PROGRAM.md: {e}"
+        return _structured_return(f"Error writing PROGRAM.md: {e}")
 
 
 @mcp.tool(
     tags={"progress", "monitoring"},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
-def get_progress() -> str:
+def get_progress() -> dict:
     """Read the human-readable progress summary.
 
     Includes story outline, word counts, and current chapter status.
@@ -169,7 +192,7 @@ def get_progress() -> str:
     if not progress_path.exists():
         return "No progress.md found. The daemon may not have started writing yet."
     try:
-        return progress_path.read_text(encoding="utf-8")
+        return _structured_return(progress_path.read_text(encoding="utf-8"))
     except OSError as e:
         return f"Error reading progress.md: {e}"
 
@@ -178,7 +201,7 @@ def get_progress() -> str:
     tags={"work-targets", "planning"},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
-def get_work_targets() -> str:
+def get_work_targets() -> dict:
     """Read the durable work target registry.
 
     Shows what the daemon is working on, what's queued, and lifecycle state.
@@ -187,7 +210,7 @@ def get_work_targets() -> str:
     if not path.exists():
         return "No work_targets.json found."
     try:
-        return path.read_text(encoding="utf-8")
+        return _structured_return(path.read_text(encoding="utf-8"))
     except OSError as e:
         return f"Error reading work_targets.json: {e}"
 
@@ -196,13 +219,13 @@ def get_work_targets() -> str:
     tags={"review", "monitoring"},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
-def get_review_state() -> str:
+def get_review_state() -> dict:
     """Read the latest review-state snapshot including daemon phase, word count, and accept rate."""
     status_path = _universe_dir() / "status.json"
     if not status_path.exists():
         return "No status.json found."
     try:
-        return status_path.read_text(encoding="utf-8")
+        return _structured_return(status_path.read_text(encoding="utf-8"))
     except OSError as e:
         return f"Error reading status.json: {e}"
 
@@ -211,7 +234,7 @@ def get_review_state() -> str:
     tags={"output", "reading"},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
-def get_chapter(book: int, chapter: int) -> str:
+def get_chapter(book: int, chapter: int) -> dict:
     """Read a completed chapter from the daemon's output.
 
     Args:
@@ -222,7 +245,7 @@ def get_chapter(book: int, chapter: int) -> str:
     if not chapter_path.exists():
         return f"Chapter file not found: book-{book}/chapter-{chapter:02d}.md"
     try:
-        return chapter_path.read_text(encoding="utf-8")
+        return _structured_return(chapter_path.read_text(encoding="utf-8"))
     except OSError as e:
         return f"Error reading chapter file: {e}"
 
@@ -231,7 +254,7 @@ def get_chapter(book: int, chapter: int) -> str:
     tags={"activity", "monitoring"},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
-def get_activity(lines: int = 20) -> str:
+def get_activity(lines: int = 20) -> dict:
     """Read the most recent lines from the daemon's activity log.
 
     Shows scene completions, reviews, and errors.
@@ -241,21 +264,21 @@ def get_activity(lines: int = 20) -> str:
     """
     log_path = _universe_dir() / "activity.log"
     if not log_path.exists():
-        return "No activity.log found."
+        return _structured_return("No activity.log found.")
     try:
         content = log_path.read_text(encoding="utf-8")
         all_lines = content.strip().splitlines()
         tail = all_lines[-lines:] if len(all_lines) > lines else all_lines
-        return "\n".join(tail)
+        return _structured_return("\n".join(tail))
     except OSError as e:
-        return f"Error reading activity.log: {e}"
+        return _structured_return(f"Error reading activity.log: {e}")
 
 
 @mcp.tool(
     tags={"control", "daemon"},
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
 )
-def pause() -> str:
+def pause() -> dict:
     """Pause the daemon at the next scene boundary.
 
     The daemon checks for a pause signal between scenes.
@@ -266,32 +289,32 @@ def pause() -> str:
         pause_path.write_text(
             datetime.now(timezone.utc).isoformat(), encoding="utf-8",
         )
-        return "Pause signal written. The daemon will pause at the next scene boundary."
+        return _structured_return("Pause signal written. The daemon will pause at the next scene boundary.")
     except OSError as e:
-        return f"Error writing pause signal: {e}"
+        return _structured_return(f"Error writing pause signal: {e}")
 
 
 @mcp.tool(
     tags={"control", "daemon"},
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
 )
-def resume() -> str:
+def resume() -> dict:
     """Resume a paused daemon by removing the pause signal."""
     pause_path = _universe_dir() / ".pause"
     if not pause_path.exists():
-        return "Daemon is not paused (no .pause file found)."
+        return _structured_return("Daemon is not paused (no .pause file found).")
     try:
         pause_path.unlink()
-        return "Pause signal removed. The daemon will resume."
+        return _structured_return("Pause signal removed. The daemon will resume.")
     except OSError as e:
-        return f"Error removing pause signal: {e}"
+        return _structured_return(f"Error removing pause signal: {e}")
 
 
 @mcp.tool(
     tags={"canon", "worldbuilding"},
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
 )
-def add_canon(filename: str, content: str) -> str:
+def add_canon(filename: str, content: str) -> dict:
     """Add a reference document to the canon/ directory for the daemon to ingest.
 
     Canon files provide worldbuilding context — character sheets, maps, lore
@@ -306,14 +329,14 @@ def add_canon(filename: str, content: str) -> str:
     # Sanitize filename to prevent path traversal
     safe_name = Path(filename).name
     if not safe_name:
-        return "Invalid filename."
+        return _structured_return("Invalid filename.")
     try:
         canon_dir.mkdir(parents=True, exist_ok=True)
         target = canon_dir / safe_name
         target.write_text(content, encoding="utf-8")
-        return f"Written {safe_name} to canon/."
+        return _structured_return(f"Written {safe_name} to canon/.")
     except OSError as e:
-        return f"Error writing to canon/: {e}"
+        return _structured_return(f"Error writing to canon/: {e}")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

Mirrors PR #493 fix on the remaining two MCP servers. Closes the cross-client alignment audit Codex asked for in [[codex-response-loop-escalation-discipline-2026-05-06]].

## What this fixes

ChatGPT (OpenAI Apps SDK) wedges on substrate-changing tool calls when responses carry only `content` (text) without `structuredContent` (typed dict). Claude tolerates either shape. PR #493 fixed `universe_server.py` (7 tools). This PR fixes the sibling servers:

- `workflow/mcp_server.py` — 12 tools (`get_status`, `add_note`, `get_premise`, `set_premise`, `get_progress`, `get_work_targets`, `get_review_state`, `get_chapter`, `get_activity`, `pause`, `resume`, `add_canon`)
- `workflow/directory_server.py` — 11 tools (`get_workflow_status`, `list_workflow_universes`, `inspect_workflow_universe`, `list_workflow_goals`, `search_workflow_goals`, `get_workflow_goal`, `search_workflow_wiki`, `read_workflow_wiki_page`, `list_workflow_runs`, `propose_workflow_goal`, `submit_workflow_request`)

## Fix shape

Adds `_structured_return()` helper to each file + wraps every tool wrapper return + changes annotations from `-> str` to `-> dict`. Internal logic unchanged — back-compat preserved via the helper that JSON-parses-or-wraps.

## Cross-client alignment principle

Claude and ChatGPT MCP expectations are project prerequisites (per host directive 2026-05-06 ~07:30Z and Cowork memory `feedback_mcp_cross_client_alignment`). Substrate must satisfy both.

## Risk

Low. Same shape as #493 which has been live for ~3h with no regressions. `_structured_return` JSON-parses dict-shaped strings cleanly; falls back to `{"text": raw}` on parse failure.

## Triple-key gate

- Cowork checker-key: YES
- Codex review: pending dual-key concur
- Host approval: required as third key for merge

## Cross-refs

- PR #493 (the original fix, merged earlier today)
- BUG-069 (chatbot Thinking-wedge after access granted, ChatGPT-only)
- pages/notes/cowork-bug-069-fix-shipped-pr493-cross-client-alignment-2026-05-06