### PR TITLE
BUG-069 class absorption v2: apply #495 _register_structured_tool helper to mcp_server + directory_server

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
@@ -11,6 +11,8 @@ annotations for host review.
 from __future__ import annotations
 
 import json
+from functools import wraps
+from inspect import signature
 from typing import Any
 
 from fastmcp import FastMCP
@@ -112,17 +114,53 @@ def _directory_safe_status(universe_id: str = "") -> str:
     return json.dumps(_redact_directory_status(payload), default=str)
 
 
-@directory_mcp.tool(
-    title="Get Workflow Status",
-    tags={"status", "workflow", "diagnostics"},
-    annotations=ToolAnnotations(
-        title="Get Workflow Status",
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
+
+
+
+def _structured_return(raw):
+    """Wrap an MCP tool result so FastMCP populates ``structured_content``.
+
+    ChatGPT (OpenAI Apps SDK) wedges on substrate-changing tool calls when
+    the response carries only ``content`` (text) without ``structuredContent``
+    (typed dict) + ``_meta`` annotations. Claude tolerates either shape.
+
+    Mirrors the helpers in workflow.universe_server applied via PR #493 + #495.
+    """
+    import json as _json
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, list):
+        return {"result": raw}
+    if isinstance(raw, str):
+        try:
+            parsed = _json.loads(raw)
+        except (_json.JSONDecodeError, ValueError):
+            return {"text": raw}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"result": parsed}
+    return {"result": raw}
+
+
+def _register_structured_tool(fn, *, server, title=None, tags=None, annotations=None):
+    """Register an MCP adapter without changing the direct Python API."""
+
+    @wraps(fn)
+    def _tool(*args, **kwargs):
+        return _structured_return(fn(*args, **kwargs))
+
+    _tool.__name__ = f"_mcp_{fn.__name__}"
+    _tool.__signature__ = signature(fn).replace(return_annotation=dict)
+    kwargs = {"name": fn.__name__, "output_schema": None}
+    if title is not None:
+        kwargs["title"] = title
+    if tags is not None:
+        kwargs["tags"] = tags
+    if annotations is not None:
+        kwargs["annotations"] = annotations
+    return server.tool(**kwargs)(_tool)
+
+
 def get_workflow_status(universe_id: str = "") -> str:
     """Use this when the user asks whether Workflow is reachable or safe to use.
 
@@ -132,17 +170,21 @@ def get_workflow_status(universe_id: str = "") -> str:
     return _directory_safe_status(universe_id=universe_id)
 
 
-@directory_mcp.tool(
-    title="List Workflow Universes",
-    tags={"universes", "workflow", "browse"},
+_mcp_get_workflow_status = _register_structured_tool(
+    get_workflow_status,
+    server=directory_mcp,
+    title='Get Workflow Status',
+    tags={'status', 'workflow', 'diagnostics'},
     annotations=ToolAnnotations(
-        title="List Workflow Universes",
+        title='Get Workflow Status',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
+
 def list_workflow_universes(limit: int = 30) -> str:
     """Use this when the user wants to browse available Workflow universes.
 
@@ -152,17 +194,21 @@ def list_workflow_universes(limit: int = 30) -> str:
     return _universe_impl(action="list", limit=limit)
 
 
-@directory_mcp.tool(
-    title="Inspect Workflow Universe",
-    tags={"universes", "workflow", "inspect"},
+_mcp_list_workflow_universes = _register_structured_tool(
+    list_workflow_universes,
+    server=directory_mcp,
+    title='List Workflow Universes',
+    tags={'universes', 'workflow', 'browse'},
     annotations=ToolAnnotations(
-        title="Inspect Workflow Universe",
+        title='List Workflow Universes',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
+
 def inspect_workflow_universe(universe_id: str = "") -> str:
     """Use this when the user wants a summary of one Workflow universe.
 
@@ -172,17 +218,21 @@ def inspect_workflow_universe(universe_id: str = "") -> str:
     return _universe_impl(action="inspect", universe_id=universe_id)
 
 
-@directory_mcp.tool(
-    title="List Workflow Goals",
-    tags={"goals", "workflow", "browse"},
+_mcp_inspect_workflow_universe = _register_structured_tool(
+    inspect_workflow_universe,
+    server=directory_mcp,
+    title='Inspect Workflow Universe',
+    tags={'universes', 'workflow', 'inspect'},
     annotations=ToolAnnotations(
-        title="List Workflow Goals",
+        title='Inspect Workflow Universe',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
+
 def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> str:
     """Use this when the user wants to browse existing shared Workflow goals.
 
@@ -194,17 +244,21 @@ def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> st
     return _goals_impl(action="list", tags=tags, author=author, limit=limit)
 
 
-@directory_mcp.tool(
-    title="Search Workflow Goals",
-    tags={"goals", "workflow", "search"},
+_mcp_list_workflow_goals = _register_structured_tool(
+    list_workflow_goals,
+    server=directory_mcp,
+    title='List Workflow Goals',
+    tags={'goals', 'workflow', 'browse'},
     annotations=ToolAnnotations(
-        title="Search Workflow Goals",
+        title='List Workflow Goals',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
+
 def search_workflow_goals(query: str, limit: int = 20) -> str:
     """Use this when the user wants to find Workflow goals by text or tag.
 
@@ -215,17 +269,21 @@ def search_workflow_goals(query: str, limit: int = 20) -> str:
     return _goals_impl(action="search", query=query, limit=limit)
 
 
-@directory_mcp.tool(
-    title="Get Workflow Goal",
-    tags={"goals", "workflow", "inspect"},
+_mcp_search_workflow_goals = _register_structured_tool(
+    search_workflow_goals,
+    server=directory_mcp,
+    title='Search Workflow Goals',
+    tags={'goals', 'workflow', 'search'},
     annotations=ToolAnnotations(
-        title="Get Workflow Goal",
+        title='Search Workflow Goals',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
+
 def get_workflow_goal(goal_id: str) -> str:
     """Use this when the user wants details for a specific Workflow goal.
 
@@ -235,17 +293,21 @@ def get_workflow_goal(goal_id: str) -> str:
     return _goals_impl(action="get", goal_id=goal_id)
 
 
-@directory_mcp.tool(
-    title="Search Workflow Wiki",
-    tags={"wiki", "knowledge", "workflow", "search"},
+_mcp_get_workflow_goal = _register_structured_tool(
+    get_workflow_goal,
+    server=directory_mcp,
+    title='Get Workflow Goal',
+    tags={'goals', 'workflow', 'inspect'},
     annotations=ToolAnnotations(
-        title="Search Workflow Wiki",
+        title='Get Workflow Goal',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
+
 def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) -> str:
     """Use this when the user wants to search Workflow project knowledge.
 
@@ -261,17 +323,21 @@ def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) 
         max_results=max_results,
     )
 
-@directory_mcp.tool(
-    title="Read Workflow Wiki Page",
-    tags={"wiki", "knowledge", "workflow", "read"},
+
+_mcp_search_workflow_wiki = _register_structured_tool(
+    search_workflow_wiki,
+    server=directory_mcp,
+    title='Search Workflow Wiki',
+    tags={'wiki', 'knowledge', 'workflow', 'search'},
     annotations=ToolAnnotations(
-        title="Read Workflow Wiki Page",
+        title='Search Workflow Wiki',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
 def read_workflow_wiki_page(page: str) -> str:
     """Use this when the user wants to read one Workflow wiki page.
 
@@ -281,17 +347,21 @@ def read_workflow_wiki_page(page: str) -> str:
     return _wiki_impl(action="read", page=page)
 
 
-@directory_mcp.tool(
-    title="List Workflow Runs",
-    tags={"runs", "workflow", "browse"},
+_mcp_read_workflow_wiki_page = _register_structured_tool(
+    read_workflow_wiki_page,
+    server=directory_mcp,
+    title='Read Workflow Wiki Page',
+    tags={'wiki', 'knowledge', 'workflow', 'read'},
     annotations=ToolAnnotations(
-        title="List Workflow Runs",
+        title='Read Workflow Wiki Page',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
+
 def list_workflow_runs(status: str = "", limit: int = 20) -> str:
     """Use this when the user wants recent Workflow run history.
 
@@ -302,17 +372,21 @@ def list_workflow_runs(status: str = "", limit: int = 20) -> str:
     return _extensions_impl(action="list_runs", status=status, limit=limit)
 
 
-@directory_mcp.tool(
-    title="Propose Workflow Goal",
-    tags={"goals", "workflow", "create"},
+_mcp_list_workflow_runs = _register_structured_tool(
+    list_workflow_runs,
+    server=directory_mcp,
+    title='List Workflow Runs',
+    tags={'runs', 'workflow', 'browse'},
     annotations=ToolAnnotations(
-        title="Propose Workflow Goal",
-        readOnlyHint=False,
+        title='List Workflow Runs',
+        readOnlyHint=True,
         destructiveHint=False,
-        idempotentHint=False,
-        openWorldHint=True,
+        idempotentHint=True,
+        openWorldHint=False,
     ),
 )
+
+
 def propose_workflow_goal(
     name: str,
     description: str = "",
@@ -336,17 +410,21 @@ def propose_workflow_goal(
     )
 
 
-@directory_mcp.tool(
-    title="Submit Workflow Request",
-    tags={"requests", "workflow", "queue"},
+_mcp_propose_workflow_goal = _register_structured_tool(
+    propose_workflow_goal,
+    server=directory_mcp,
+    title='Propose Workflow Goal',
+    tags={'goals', 'workflow', 'create'},
     annotations=ToolAnnotations(
-        title="Submit Workflow Request",
+        title='Propose Workflow Goal',
         readOnlyHint=False,
         destructiveHint=False,
         idempotentHint=False,
-        openWorldHint=False,
+        openWorldHint=True,
     ),
 )
+
+
 def submit_workflow_request(
     text: str,
     universe_id: str = "",
@@ -368,3 +446,18 @@ def submit_workflow_request(
         request_type=request_type,
         branch_id=branch_id,
     )
+
+
+_mcp_submit_workflow_request = _register_structured_tool(
+    submit_workflow_request,
+    server=directory_mcp,
+    title='Submit Workflow Request',
+    tags={'requests', 'workflow', 'queue'},
+    annotations=ToolAnnotations(
+        title='Submit Workflow Request',
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=False,
+    ),
+)

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/mcp_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/mcp_server.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timezone
+from functools import wraps
+from inspect import signature
 from pathlib import Path
 
 from fastmcp import FastMCP
@@ -64,10 +66,53 @@ def _universe_dir() -> Path:
     return data_dir() / "default-universe"
 
 
-@mcp.tool(
-    tags={"status", "monitoring"},
-    annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True, openWorldHint=False),
-)
+
+
+
+def _structured_return(raw):
+    """Wrap an MCP tool result so FastMCP populates ``structured_content``.
+
+    ChatGPT (OpenAI Apps SDK) wedges on substrate-changing tool calls when
+    the response carries only ``content`` (text) without ``structuredContent``
+    (typed dict) + ``_meta`` annotations. Claude tolerates either shape.
+
+    Mirrors the helpers in workflow.universe_server applied via PR #493 + #495.
+    """
+    import json as _json
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, list):
+        return {"result": raw}
+    if isinstance(raw, str):
+        try:
+            parsed = _json.loads(raw)
+        except (_json.JSONDecodeError, ValueError):
+            return {"text": raw}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"result": parsed}
+    return {"result": raw}
+
+
+def _register_structured_tool(fn, *, server, title=None, tags=None, annotations=None):
+    """Register an MCP adapter without changing the direct Python API."""
+
+    @wraps(fn)
+    def _tool(*args, **kwargs):
+        return _structured_return(fn(*args, **kwargs))
+
+    _tool.__name__ = f"_mcp_{fn.__name__}"
+    _tool.__signature__ = signature(fn).replace(return_annotation=dict)
+    kwargs = {"name": fn.__name__, "output_schema": None}
+    if title is not None:
+        kwargs["title"] = title
+    if tags is not None:
+        kwargs["tags"] = tags
+    if annotations is not None:
+        kwargs["annotations"] = annotations
+    return server.tool(**kwargs)(_tool)
+
+
 def get_status() -> str:
     """Read the daemon's current status including phase, word count, and accept rate.
 
@@ -82,10 +127,14 @@ def get_status() -> str:
         return f"Error reading status.json: {e}"
 
 
-@mcp.tool(
-    tags={"notes", "steering", "direction"},
-    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False),
+_mcp_get_status = _register_structured_tool(
+    get_status,
+    server=mcp,
+    tags={'status', 'monitoring'},
+    annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True, openWorldHint=False),
 )
+
+
 def add_note(text: str, category: str = "direction") -> str:
     """Add a note that the daemon reads at each scene boundary.
 
@@ -113,15 +162,19 @@ def add_note(text: str, category: str = "direction") -> str:
         return f"Error adding note: {e}"
 
 
+_mcp_add_note = _register_structured_tool(
+    add_note,
+    server=mcp,
+    tags={'notes', 'steering', 'direction'},
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False),
+)
+
+
 def steer(directive: str, category: str = "direction") -> str:
     """Backward-compatible alias for ``add_note``."""
     return add_note(directive, category)
 
 
-@mcp.tool(
-    tags={"premise", "story"},
-    annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
-)
 def get_premise() -> str:
     """Read the current story premise from PROGRAM.md.
 
@@ -136,10 +189,14 @@ def get_premise() -> str:
         return f"Error reading PROGRAM.md: {e}"
 
 
-@mcp.tool(
-    tags={"premise", "story"},
-    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True),
+_mcp_get_premise = _register_structured_tool(
+    get_premise,
+    server=mcp,
+    tags={'premise', 'story'},
+    annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
+
+
 def set_premise(text: str) -> str:
     """Write or overwrite the story premise in PROGRAM.md.
 
@@ -156,10 +213,14 @@ def set_premise(text: str) -> str:
         return f"Error writing PROGRAM.md: {e}"
 
 
-@mcp.tool(
-    tags={"progress", "monitoring"},
-    annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+_mcp_set_premise = _register_structured_tool(
+    set_premise,
+    server=mcp,
+    tags={'premise', 'story'},
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True),
 )
+
+
 def get_progress() -> str:
     """Read the human-readable progress summary.
 
@@ -174,10 +235,14 @@ def get_progress() -> str:
         return f"Error reading progress.md: {e}"
 
 
-@mcp.tool(
-    tags={"work-targets", "planning"},
+_mcp_get_progress = _register_structured_tool(
+    get_progress,
+    server=mcp,
+    tags={'progress', 'monitoring'},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
+
+
 def get_work_targets() -> str:
     """Read the durable work target registry.
 
@@ -192,10 +257,14 @@ def get_work_targets() -> str:
         return f"Error reading work_targets.json: {e}"
 
 
-@mcp.tool(
-    tags={"review", "monitoring"},
+_mcp_get_work_targets = _register_structured_tool(
+    get_work_targets,
+    server=mcp,
+    tags={'work-targets', 'planning'},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
+
+
 def get_review_state() -> str:
     """Read the latest review-state snapshot including daemon phase, word count, and accept rate."""
     status_path = _universe_dir() / "status.json"
@@ -207,10 +276,14 @@ def get_review_state() -> str:
         return f"Error reading status.json: {e}"
 
 
-@mcp.tool(
-    tags={"output", "reading"},
+_mcp_get_review_state = _register_structured_tool(
+    get_review_state,
+    server=mcp,
+    tags={'review', 'monitoring'},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
+
+
 def get_chapter(book: int, chapter: int) -> str:
     """Read a completed chapter from the daemon's output.
 
@@ -227,10 +300,14 @@ def get_chapter(book: int, chapter: int) -> str:
         return f"Error reading chapter file: {e}"
 
 
-@mcp.tool(
-    tags={"activity", "monitoring"},
+_mcp_get_chapter = _register_structured_tool(
+    get_chapter,
+    server=mcp,
+    tags={'output', 'reading'},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
+
+
 def get_activity(lines: int = 20) -> str:
     """Read the most recent lines from the daemon's activity log.
 
@@ -251,10 +328,14 @@ def get_activity(lines: int = 20) -> str:
         return f"Error reading activity.log: {e}"
 
 
-@mcp.tool(
-    tags={"control", "daemon"},
-    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
+_mcp_get_activity = _register_structured_tool(
+    get_activity,
+    server=mcp,
+    tags={'activity', 'monitoring'},
+    annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
+
+
 def pause() -> str:
     """Pause the daemon at the next scene boundary.
 
@@ -271,10 +352,14 @@ def pause() -> str:
         return f"Error writing pause signal: {e}"
 
 
-@mcp.tool(
-    tags={"control", "daemon"},
+_mcp_pause = _register_structured_tool(
+    pause,
+    server=mcp,
+    tags={'control', 'daemon'},
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
 )
+
+
 def resume() -> str:
     """Resume a paused daemon by removing the pause signal."""
     pause_path = _universe_dir() / ".pause"
@@ -287,10 +372,14 @@ def resume() -> str:
         return f"Error removing pause signal: {e}"
 
 
-@mcp.tool(
-    tags={"canon", "worldbuilding"},
+_mcp_resume = _register_structured_tool(
+    resume,
+    server=mcp,
+    tags={'control', 'daemon'},
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
 )
+
+
 def add_canon(filename: str, content: str) -> str:
     """Add a reference document to the canon/ directory for the daemon to ingest.
 
@@ -314,6 +403,14 @@ def add_canon(filename: str, content: str) -> str:
         return f"Written {safe_name} to canon/."
     except OSError as e:
         return f"Error writing to canon/: {e}"
+
+
+_mcp_add_canon = _register_structured_tool(
+    add_canon,
+    server=mcp,
+    tags={'canon', 'worldbuilding'},
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
+)
 
 
 def main() -> None:

--- a/workflow/directory_server.py
+++ b/workflow/directory_server.py
@@ -11,6 +11,8 @@ annotations for host review.
 from __future__ import annotations
 
 import json
+from functools import wraps
+from inspect import signature
 from typing import Any
 
 from fastmcp import FastMCP
@@ -112,17 +114,53 @@ def _directory_safe_status(universe_id: str = "") -> str:
     return json.dumps(_redact_directory_status(payload), default=str)
 
 
-@directory_mcp.tool(
-    title="Get Workflow Status",
-    tags={"status", "workflow", "diagnostics"},
-    annotations=ToolAnnotations(
-        title="Get Workflow Status",
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
+
+
+
+def _structured_return(raw):
+    """Wrap an MCP tool result so FastMCP populates ``structured_content``.
+
+    ChatGPT (OpenAI Apps SDK) wedges on substrate-changing tool calls when
+    the response carries only ``content`` (text) without ``structuredContent``
+    (typed dict) + ``_meta`` annotations. Claude tolerates either shape.
+
+    Mirrors the helpers in workflow.universe_server applied via PR #493 + #495.
+    """
+    import json as _json
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, list):
+        return {"result": raw}
+    if isinstance(raw, str):
+        try:
+            parsed = _json.loads(raw)
+        except (_json.JSONDecodeError, ValueError):
+            return {"text": raw}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"result": parsed}
+    return {"result": raw}
+
+
+def _register_structured_tool(fn, *, server, title=None, tags=None, annotations=None):
+    """Register an MCP adapter without changing the direct Python API."""
+
+    @wraps(fn)
+    def _tool(*args, **kwargs):
+        return _structured_return(fn(*args, **kwargs))
+
+    _tool.__name__ = f"_mcp_{fn.__name__}"
+    _tool.__signature__ = signature(fn).replace(return_annotation=dict)
+    kwargs = {"name": fn.__name__, "output_schema": None}
+    if title is not None:
+        kwargs["title"] = title
+    if tags is not None:
+        kwargs["tags"] = tags
+    if annotations is not None:
+        kwargs["annotations"] = annotations
+    return server.tool(**kwargs)(_tool)
+
+
 def get_workflow_status(universe_id: str = "") -> str:
     """Use this when the user asks whether Workflow is reachable or safe to use.
 
@@ -132,17 +170,21 @@ def get_workflow_status(universe_id: str = "") -> str:
     return _directory_safe_status(universe_id=universe_id)
 
 
-@directory_mcp.tool(
-    title="List Workflow Universes",
-    tags={"universes", "workflow", "browse"},
+_mcp_get_workflow_status = _register_structured_tool(
+    get_workflow_status,
+    server=directory_mcp,
+    title='Get Workflow Status',
+    tags={'status', 'workflow', 'diagnostics'},
     annotations=ToolAnnotations(
-        title="List Workflow Universes",
+        title='Get Workflow Status',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
+
 def list_workflow_universes(limit: int = 30) -> str:
     """Use this when the user wants to browse available Workflow universes.
 
@@ -152,17 +194,21 @@ def list_workflow_universes(limit: int = 30) -> str:
     return _universe_impl(action="list", limit=limit)
 
 
-@directory_mcp.tool(
-    title="Inspect Workflow Universe",
-    tags={"universes", "workflow", "inspect"},
+_mcp_list_workflow_universes = _register_structured_tool(
+    list_workflow_universes,
+    server=directory_mcp,
+    title='List Workflow Universes',
+    tags={'universes', 'workflow', 'browse'},
     annotations=ToolAnnotations(
-        title="Inspect Workflow Universe",
+        title='List Workflow Universes',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
+
 def inspect_workflow_universe(universe_id: str = "") -> str:
     """Use this when the user wants a summary of one Workflow universe.
 
@@ -172,17 +218,21 @@ def inspect_workflow_universe(universe_id: str = "") -> str:
     return _universe_impl(action="inspect", universe_id=universe_id)
 
 
-@directory_mcp.tool(
-    title="List Workflow Goals",
-    tags={"goals", "workflow", "browse"},
+_mcp_inspect_workflow_universe = _register_structured_tool(
+    inspect_workflow_universe,
+    server=directory_mcp,
+    title='Inspect Workflow Universe',
+    tags={'universes', 'workflow', 'inspect'},
     annotations=ToolAnnotations(
-        title="List Workflow Goals",
+        title='Inspect Workflow Universe',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
+
 def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> str:
     """Use this when the user wants to browse existing shared Workflow goals.
 
@@ -194,17 +244,21 @@ def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> st
     return _goals_impl(action="list", tags=tags, author=author, limit=limit)
 
 
-@directory_mcp.tool(
-    title="Search Workflow Goals",
-    tags={"goals", "workflow", "search"},
+_mcp_list_workflow_goals = _register_structured_tool(
+    list_workflow_goals,
+    server=directory_mcp,
+    title='List Workflow Goals',
+    tags={'goals', 'workflow', 'browse'},
     annotations=ToolAnnotations(
-        title="Search Workflow Goals",
+        title='List Workflow Goals',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
+
 def search_workflow_goals(query: str, limit: int = 20) -> str:
     """Use this when the user wants to find Workflow goals by text or tag.
 
@@ -215,17 +269,21 @@ def search_workflow_goals(query: str, limit: int = 20) -> str:
     return _goals_impl(action="search", query=query, limit=limit)
 
 
-@directory_mcp.tool(
-    title="Get Workflow Goal",
-    tags={"goals", "workflow", "inspect"},
+_mcp_search_workflow_goals = _register_structured_tool(
+    search_workflow_goals,
+    server=directory_mcp,
+    title='Search Workflow Goals',
+    tags={'goals', 'workflow', 'search'},
     annotations=ToolAnnotations(
-        title="Get Workflow Goal",
+        title='Search Workflow Goals',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
+
 def get_workflow_goal(goal_id: str) -> str:
     """Use this when the user wants details for a specific Workflow goal.
 
@@ -235,17 +293,21 @@ def get_workflow_goal(goal_id: str) -> str:
     return _goals_impl(action="get", goal_id=goal_id)
 
 
-@directory_mcp.tool(
-    title="Search Workflow Wiki",
-    tags={"wiki", "knowledge", "workflow", "search"},
+_mcp_get_workflow_goal = _register_structured_tool(
+    get_workflow_goal,
+    server=directory_mcp,
+    title='Get Workflow Goal',
+    tags={'goals', 'workflow', 'inspect'},
     annotations=ToolAnnotations(
-        title="Search Workflow Wiki",
+        title='Get Workflow Goal',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
+
 def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) -> str:
     """Use this when the user wants to search Workflow project knowledge.
 
@@ -261,17 +323,21 @@ def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) 
         max_results=max_results,
     )
 
-@directory_mcp.tool(
-    title="Read Workflow Wiki Page",
-    tags={"wiki", "knowledge", "workflow", "read"},
+
+_mcp_search_workflow_wiki = _register_structured_tool(
+    search_workflow_wiki,
+    server=directory_mcp,
+    title='Search Workflow Wiki',
+    tags={'wiki', 'knowledge', 'workflow', 'search'},
     annotations=ToolAnnotations(
-        title="Read Workflow Wiki Page",
+        title='Search Workflow Wiki',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
 def read_workflow_wiki_page(page: str) -> str:
     """Use this when the user wants to read one Workflow wiki page.
 
@@ -281,17 +347,21 @@ def read_workflow_wiki_page(page: str) -> str:
     return _wiki_impl(action="read", page=page)
 
 
-@directory_mcp.tool(
-    title="List Workflow Runs",
-    tags={"runs", "workflow", "browse"},
+_mcp_read_workflow_wiki_page = _register_structured_tool(
+    read_workflow_wiki_page,
+    server=directory_mcp,
+    title='Read Workflow Wiki Page',
+    tags={'wiki', 'knowledge', 'workflow', 'read'},
     annotations=ToolAnnotations(
-        title="List Workflow Runs",
+        title='Read Workflow Wiki Page',
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
         openWorldHint=False,
     ),
 )
+
+
 def list_workflow_runs(status: str = "", limit: int = 20) -> str:
     """Use this when the user wants recent Workflow run history.
 
@@ -302,17 +372,21 @@ def list_workflow_runs(status: str = "", limit: int = 20) -> str:
     return _extensions_impl(action="list_runs", status=status, limit=limit)
 
 
-@directory_mcp.tool(
-    title="Propose Workflow Goal",
-    tags={"goals", "workflow", "create"},
+_mcp_list_workflow_runs = _register_structured_tool(
+    list_workflow_runs,
+    server=directory_mcp,
+    title='List Workflow Runs',
+    tags={'runs', 'workflow', 'browse'},
     annotations=ToolAnnotations(
-        title="Propose Workflow Goal",
-        readOnlyHint=False,
+        title='List Workflow Runs',
+        readOnlyHint=True,
         destructiveHint=False,
-        idempotentHint=False,
-        openWorldHint=True,
+        idempotentHint=True,
+        openWorldHint=False,
     ),
 )
+
+
 def propose_workflow_goal(
     name: str,
     description: str = "",
@@ -336,17 +410,21 @@ def propose_workflow_goal(
     )
 
 
-@directory_mcp.tool(
-    title="Submit Workflow Request",
-    tags={"requests", "workflow", "queue"},
+_mcp_propose_workflow_goal = _register_structured_tool(
+    propose_workflow_goal,
+    server=directory_mcp,
+    title='Propose Workflow Goal',
+    tags={'goals', 'workflow', 'create'},
     annotations=ToolAnnotations(
-        title="Submit Workflow Request",
+        title='Propose Workflow Goal',
         readOnlyHint=False,
         destructiveHint=False,
         idempotentHint=False,
-        openWorldHint=False,
+        openWorldHint=True,
     ),
 )
+
+
 def submit_workflow_request(
     text: str,
     universe_id: str = "",
@@ -368,3 +446,18 @@ def submit_workflow_request(
         request_type=request_type,
         branch_id=branch_id,
     )
+
+
+_mcp_submit_workflow_request = _register_structured_tool(
+    submit_workflow_request,
+    server=directory_mcp,
+    title='Submit Workflow Request',
+    tags={'requests', 'workflow', 'queue'},
+    annotations=ToolAnnotations(
+        title='Submit Workflow Request',
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=False,
+    ),
+)

--- a/workflow/mcp_server.py
+++ b/workflow/mcp_server.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timezone
+from functools import wraps
+from inspect import signature
 from pathlib import Path
 
 from fastmcp import FastMCP
@@ -64,10 +66,53 @@ def _universe_dir() -> Path:
     return data_dir() / "default-universe"
 
 
-@mcp.tool(
-    tags={"status", "monitoring"},
-    annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True, openWorldHint=False),
-)
+
+
+
+def _structured_return(raw):
+    """Wrap an MCP tool result so FastMCP populates ``structured_content``.
+
+    ChatGPT (OpenAI Apps SDK) wedges on substrate-changing tool calls when
+    the response carries only ``content`` (text) without ``structuredContent``
+    (typed dict) + ``_meta`` annotations. Claude tolerates either shape.
+
+    Mirrors the helpers in workflow.universe_server applied via PR #493 + #495.
+    """
+    import json as _json
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, list):
+        return {"result": raw}
+    if isinstance(raw, str):
+        try:
+            parsed = _json.loads(raw)
+        except (_json.JSONDecodeError, ValueError):
+            return {"text": raw}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"result": parsed}
+    return {"result": raw}
+
+
+def _register_structured_tool(fn, *, server, title=None, tags=None, annotations=None):
+    """Register an MCP adapter without changing the direct Python API."""
+
+    @wraps(fn)
+    def _tool(*args, **kwargs):
+        return _structured_return(fn(*args, **kwargs))
+
+    _tool.__name__ = f"_mcp_{fn.__name__}"
+    _tool.__signature__ = signature(fn).replace(return_annotation=dict)
+    kwargs = {"name": fn.__name__, "output_schema": None}
+    if title is not None:
+        kwargs["title"] = title
+    if tags is not None:
+        kwargs["tags"] = tags
+    if annotations is not None:
+        kwargs["annotations"] = annotations
+    return server.tool(**kwargs)(_tool)
+
+
 def get_status() -> str:
     """Read the daemon's current status including phase, word count, and accept rate.
 
@@ -82,10 +127,14 @@ def get_status() -> str:
         return f"Error reading status.json: {e}"
 
 
-@mcp.tool(
-    tags={"notes", "steering", "direction"},
-    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False),
+_mcp_get_status = _register_structured_tool(
+    get_status,
+    server=mcp,
+    tags={'status', 'monitoring'},
+    annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True, openWorldHint=False),
 )
+
+
 def add_note(text: str, category: str = "direction") -> str:
     """Add a note that the daemon reads at each scene boundary.
 
@@ -113,15 +162,19 @@ def add_note(text: str, category: str = "direction") -> str:
         return f"Error adding note: {e}"
 
 
+_mcp_add_note = _register_structured_tool(
+    add_note,
+    server=mcp,
+    tags={'notes', 'steering', 'direction'},
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False),
+)
+
+
 def steer(directive: str, category: str = "direction") -> str:
     """Backward-compatible alias for ``add_note``."""
     return add_note(directive, category)
 
 
-@mcp.tool(
-    tags={"premise", "story"},
-    annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
-)
 def get_premise() -> str:
     """Read the current story premise from PROGRAM.md.
 
@@ -136,10 +189,14 @@ def get_premise() -> str:
         return f"Error reading PROGRAM.md: {e}"
 
 
-@mcp.tool(
-    tags={"premise", "story"},
-    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True),
+_mcp_get_premise = _register_structured_tool(
+    get_premise,
+    server=mcp,
+    tags={'premise', 'story'},
+    annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
+
+
 def set_premise(text: str) -> str:
     """Write or overwrite the story premise in PROGRAM.md.
 
@@ -156,10 +213,14 @@ def set_premise(text: str) -> str:
         return f"Error writing PROGRAM.md: {e}"
 
 
-@mcp.tool(
-    tags={"progress", "monitoring"},
-    annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+_mcp_set_premise = _register_structured_tool(
+    set_premise,
+    server=mcp,
+    tags={'premise', 'story'},
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True),
 )
+
+
 def get_progress() -> str:
     """Read the human-readable progress summary.
 
@@ -174,10 +235,14 @@ def get_progress() -> str:
         return f"Error reading progress.md: {e}"
 
 
-@mcp.tool(
-    tags={"work-targets", "planning"},
+_mcp_get_progress = _register_structured_tool(
+    get_progress,
+    server=mcp,
+    tags={'progress', 'monitoring'},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
+
+
 def get_work_targets() -> str:
     """Read the durable work target registry.
 
@@ -192,10 +257,14 @@ def get_work_targets() -> str:
         return f"Error reading work_targets.json: {e}"
 
 
-@mcp.tool(
-    tags={"review", "monitoring"},
+_mcp_get_work_targets = _register_structured_tool(
+    get_work_targets,
+    server=mcp,
+    tags={'work-targets', 'planning'},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
+
+
 def get_review_state() -> str:
     """Read the latest review-state snapshot including daemon phase, word count, and accept rate."""
     status_path = _universe_dir() / "status.json"
@@ -207,10 +276,14 @@ def get_review_state() -> str:
         return f"Error reading status.json: {e}"
 
 
-@mcp.tool(
-    tags={"output", "reading"},
+_mcp_get_review_state = _register_structured_tool(
+    get_review_state,
+    server=mcp,
+    tags={'review', 'monitoring'},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
+
+
 def get_chapter(book: int, chapter: int) -> str:
     """Read a completed chapter from the daemon's output.
 
@@ -227,10 +300,14 @@ def get_chapter(book: int, chapter: int) -> str:
         return f"Error reading chapter file: {e}"
 
 
-@mcp.tool(
-    tags={"activity", "monitoring"},
+_mcp_get_chapter = _register_structured_tool(
+    get_chapter,
+    server=mcp,
+    tags={'output', 'reading'},
     annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
+
+
 def get_activity(lines: int = 20) -> str:
     """Read the most recent lines from the daemon's activity log.
 
@@ -251,10 +328,14 @@ def get_activity(lines: int = 20) -> str:
         return f"Error reading activity.log: {e}"
 
 
-@mcp.tool(
-    tags={"control", "daemon"},
-    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
+_mcp_get_activity = _register_structured_tool(
+    get_activity,
+    server=mcp,
+    tags={'activity', 'monitoring'},
+    annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
 )
+
+
 def pause() -> str:
     """Pause the daemon at the next scene boundary.
 
@@ -271,10 +352,14 @@ def pause() -> str:
         return f"Error writing pause signal: {e}"
 
 
-@mcp.tool(
-    tags={"control", "daemon"},
+_mcp_pause = _register_structured_tool(
+    pause,
+    server=mcp,
+    tags={'control', 'daemon'},
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
 )
+
+
 def resume() -> str:
     """Resume a paused daemon by removing the pause signal."""
     pause_path = _universe_dir() / ".pause"
@@ -287,10 +372,14 @@ def resume() -> str:
         return f"Error removing pause signal: {e}"
 
 
-@mcp.tool(
-    tags={"canon", "worldbuilding"},
+_mcp_resume = _register_structured_tool(
+    resume,
+    server=mcp,
+    tags={'control', 'daemon'},
     annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
 )
+
+
 def add_canon(filename: str, content: str) -> str:
     """Add a reference document to the canon/ directory for the daemon to ingest.
 
@@ -314,6 +403,14 @@ def add_canon(filename: str, content: str) -> str:
         return f"Written {safe_name} to canon/."
     except OSError as e:
         return f"Error writing to canon/: {e}"
+
+
+_mcp_add_canon = _register_structured_tool(
+    add_canon,
+    server=mcp,
+    tags={'canon', 'worldbuilding'},
+    annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
+)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

Mirrors Codex's `_register_structured_tool` pattern from PR #495 (now in main) onto the remaining two MCP servers. Closes the cross-client alignment audit Codex asked for in [[codex-response-loop-escalation-discipline-2026-05-06]]. Supersedes my closed #517 which used the direct-edit approach (same back-compat regression that #493 originally had — repaired by #495).

## Pattern (from #495, applied here)

- Direct Python functions keep `-> str` + JSON string returns — back-compat for legacy callers/tests preserved
- MCP-registered adapters wrap via `_register_structured_tool()` helper that invokes `_structured_return()` and re-registers via `server.tool(...)` with dict return type
- ChatGPT (Apps SDK) sees `structuredContent`; Claude tolerates either shape; direct Python callers unchanged

## Files changed

- `workflow/mcp_server.py` + packaging mirror — 12 tools (`get_status`, `add_note`, `get_premise`, `set_premise`, `get_progress`, `get_work_targets`, `get_review_state`, `get_chapter`, `get_activity`, `pause`, `resume`, `add_canon`)
- `workflow/directory_server.py` + packaging mirror — 11 tools (`get_workflow_status`, `list_workflow_universes`, `inspect_workflow_universe`, `list_workflow_goals`, `search_workflow_goals`, `get_workflow_goal`, `search_workflow_wiki`, `read_workflow_wiki_page`, `list_workflow_runs`, `propose_workflow_goal`, `submit_workflow_request`)

## Local verification

- All 4 files parse OK (Python AST)
- `_structured_return` + `_register_structured_tool` smoke tests pass
- `get_status()` direct call returns `str` (back-compat preserved)

## Risk

Low. Same shape as #495 which is now in main with no regressions. Direct callers unaffected.

## Triple-key gate

- Cowork checker-key: YES (this PR)
- Codex review: pending dual-key concur
- Host approval: required as third key for merge

## Cross-refs

- PR #495 (introduced `_register_structured_tool` for universe_server.py)
- PR #493 (the original BUG-069 fix that needed regression repair)
- BUG-069 family (chatbot Thinking-wedge after access granted, ChatGPT-only)
- pages/notes/cowork-bug-069-fix-shipped-pr493-cross-client-alignment-2026-05-06
- pages/notes/codex-opened-pr495-bug069-direct-wrapper-regression-repair-2026-05-06