### PR TITLE
[auto-change] WIKI-PATCH: Community loop watch should classify tier3-broken clone-smoke failures as Forever Rule red, not hidden non-P0 issues

### DIFF
--- a/.github/workflows/community-loop-watch.yml
+++ b/.github/workflows/community-loop-watch.yml
@@ -12,7 +12,7 @@ on:
     - cron: "*/15 * * * *"
   workflow_dispatch:
   workflow_run:
-    workflows: ["Wiki bug sync", "Auto-fix change", "Uptime canary", "deploy-site", "Deploy prod"]
+    workflows: ["Wiki bug sync", "Auto-fix change", "Uptime canary", "tier3-oss-clone-nightly", "deploy-site", "Deploy prod"]
     types: [completed]
   push:
     branches: [main]

--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -46,6 +46,7 @@ BLOCKED_LABEL = "needs-human"
 AWAIT_PRIMITIVE_LAYER_LABEL = "await-primitive-layer"
 ATTEMPTED_LABEL = "auto-fix-attempted"
 P0_OUTAGE_LABEL = "p0-outage"
+TIER3_BROKEN_LABEL = "tier3-broken"
 AUTH_MISSING_LABEL = "auto-fix-auth-missing"
 CLAUDE_SUBSCRIPTION_MISSING_LABEL = "auto-fix-claude-subscription-missing"
 CODEX_SUBSCRIPTION_MISSING_LABEL = "auto-fix-codex-subscription-missing"
@@ -663,6 +664,37 @@ def incident_stage(
     )
 
 
+def tier3_clone_smoke_stage(
+    repo: str,
+    *,
+    api: str,
+    token: str | None,
+    timeout: float,
+) -> dict[str, Any]:
+    issues = list_open_issues_by_label(
+        repo, TIER3_BROKEN_LABEL, api=api, token=token, timeout=timeout
+    )
+    if issues:
+        issue = issues[0]
+        return _stage(
+            "Tier-3 clone smoke",
+            "red",
+            (
+                f"{len(issues)} open {TIER3_BROKEN_LABEL} issue(s); "
+                "Forever Rule tier-3 clone/run surface is red"
+            ),
+            evidence=f"#{issue.get('number')}: {issue.get('title')}",
+            url=issue.get("html_url"),
+            details={"open_tier3_broken": [i.get("number") for i in issues]},
+        )
+    return _stage(
+        "Tier-3 clone smoke",
+        "green",
+        f"no open {TIER3_BROKEN_LABEL} issues",
+        details={"open_tier3_broken": []},
+    )
+
+
 def classify(stages: list[dict[str, Any]]) -> str:
     return max((stage["status"] for stage in stages), key=lambda s: STATUS_RANK[s])
 
@@ -717,6 +749,7 @@ def build_status(args: argparse.Namespace, now: dt.datetime | None = None) -> di
             max_age_min=args.max_observation_age_min,
         ),
         incident_stage(repo, api=api, token=token, timeout=timeout),
+        tier3_clone_smoke_stage(repo, api=api, token=token, timeout=timeout),
         workflow_stage(
             "Production deploy",
             repo,

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -517,3 +517,89 @@ def test_queue_stage_maps_legacy_priority_labels_before_pending_stuck(monkeypatc
         }
     ]
     assert "legacy unprefixed priority label" in stage["summary"]
+
+
+def test_tier3_broken_issue_marks_clone_smoke_stage_red(monkeypatch):
+    def fake_list_open_issues_by_label(repo, label, **kwargs):
+        assert repo == "owner/repo"
+        assert label == watch.TIER3_BROKEN_LABEL
+        return [
+            {
+                "number": 521,
+                "title": "Tier-3 OSS clone smoke failed",
+                "html_url": "https://example.test/issues/521",
+            }
+        ]
+
+    monkeypatch.setattr(
+        watch, "list_open_issues_by_label", fake_list_open_issues_by_label
+    )
+
+    stage = watch.tier3_clone_smoke_stage(
+        "owner/repo",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+    )
+
+    assert stage["status"] == "red"
+    assert stage["details"]["open_tier3_broken"] == [521]
+    assert "Forever Rule" in stage["summary"]
+
+
+def test_build_status_is_red_when_tier3_broken_issue_is_open(monkeypatch):
+    now = dt.datetime(2026, 5, 6, 12, 0, tzinfo=dt.timezone.utc)
+
+    def fake_recent_workflow_runs(*_args, **_kwargs):
+        return [
+            {
+                "id": 1,
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": "2026-05-06T11:50:00Z",
+                "updated_at": "2026-05-06T11:51:00Z",
+                "event": "schedule",
+                "html_url": "https://example.test/runs/1",
+            }
+        ]
+
+    def fake_list_loop_issues(*_args, **_kwargs):
+        return []
+
+    def fake_list_open_issues_by_label(_repo, label, **_kwargs):
+        if label == watch.TIER3_BROKEN_LABEL:
+            return [
+                {
+                    "number": 521,
+                    "title": "Tier-3 OSS clone smoke failed",
+                    "html_url": "https://example.test/issues/521",
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(watch, "_recent_workflow_runs", fake_recent_workflow_runs)
+    monkeypatch.setattr(watch, "list_loop_issues", fake_list_loop_issues)
+    monkeypatch.setattr(
+        watch, "list_open_issues_by_label", fake_list_open_issues_by_label
+    )
+    monkeypatch.setattr(watch, "_github_token", lambda _args: None)
+
+    status = watch.build_status(
+        argparse.Namespace(
+            repo="owner/repo",
+            api="https://api.github.test",
+            token=None,
+            timeout=1,
+            max_sync_age_min=90,
+            max_writer_age_min=90,
+            max_observation_age_min=90,
+            max_pending_age_min=45,
+        ),
+        now=now,
+    )
+
+    assert status["overall"] == "red"
+    assert status["exit_code"] == 2
+    assert [
+        stage for stage in status["stages"] if stage["name"] == "Tier-3 clone smoke"
+    ][0]["status"] == "red"


### PR DESCRIPTION
Fixes #521

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.