### PR TITLE
Recover lost skills: auto-iterate + game-prototyping (Phase B archaeology #1)

### DIFF
--- a/.agents/skills/auto-iterate/SKILL.md
+++ b/.agents/skills/auto-iterate/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: auto-iterate
+description: Ratchets prevention every time an agent (you, a teammate, a future session) makes the same behavioral mistake twice. Use when you fix a behavioral failure — a bad heuristic, a bad default, a missed convention, a recurring bug pattern, or a "you should have known better" moment. Each recurrence must add a stronger preventive layer (doc → script → hook → gate) so the failure cannot recur silently.
+---
+
+# Auto-iterate (prevention ratchet)
+
+## What this is
+
+Some failures are not one-off bugs in the code — they're patterns of agent
+behavior that will recur in future sessions if nothing changes. Two examples
+this repo has lived through:
+
+- **FUSE truncation:** Cowork's Edit/Write silently chop file overwrites.
+  An agent writes, gets a "success" response, moves on, and the file is
+  truncated mid-line. Each recurrence has produced a stronger preventive
+  layer in turn (atomic temp+rename → PostToolUse hook on Write → hook also
+  matches Edit → standing rule in CLAUDE.md/AGENTS.md/memory). See
+  `WebSite/HOOKS_FUSE_QUIRKS.md` for the documented ladder.
+
+- **Cross-provider drift:** Project-level conventions get added to
+  `CLAUDE.md` or agent memory instead of `AGENTS.md`. Future Codex/Cursor
+  sessions miss the convention. The 1st occurrence was caught by the user
+  manually; the 2nd added an explicit rule to `AGENTS.md`; the 3rd built
+  `scripts/check_cross_provider_drift.py`; the 4th wired it as a Claude
+  Code PostToolUse hook. The ladder is documented in `AGENTS.md` §
+  *Where new conventions live*.
+
+The shape is identical. **This skill formalizes the shape so we apply it
+deliberately, not after the next surprise.**
+
+## When to invoke
+
+Reach for this skill when **any** of these is true:
+
+- You just fixed a problem that you — or a previous agent — had already
+  fixed before in a different session, and might have to fix again.
+- The user redirects you on something that "feels like" you should have
+  known. ("You shouldn't have needed to be reminded of X.")
+- A guard, hook, or check fails. Even if you fix the immediate issue,
+  the failure is data — invoke this skill to decide whether to ratchet.
+- You're about to write a doc/rule that says "future sessions should…"
+  — that's a soft prevention layer; ask whether a hard one (script,
+  hook) is warranted instead.
+- Two similar incidents reach two different fixes. That divergence is
+  the signal to consolidate behind a hook.
+
+**Not for:** one-shot code bugs in a feature branch. Use
+`debugging-and-error-recovery` for those. Use `auto-iterate` only when
+the failure is about *agent behavior* — something a future session
+could repeat.
+
+## Relationship to failure protocols
+
+Some recurring failures are product/runtime patterns, not agent-behavior
+patterns. Those belong first in a living failure protocol: an error signature,
+root cause, verified fix, and optional proactive check. Promote those into
+tests, probes, validators, or specialist skill checklists.
+
+Use this skill when the recurring pattern is that agents keep making the same
+bad choice: skipping the protocol, ignoring the check, inventing APIs, loading
+the wrong context, or placing conventions in the wrong file. In that case the
+fix must make the behavior harder to repeat, not just document the bug again.
+
+## The ratchet (apply in order; each rung is stronger than the last)
+
+```
+Recurrence 1  →  Fix the symptom in place. Add a brief note in the
+                  relevant doc so the agent who reviews this PR sees it.
+Recurrence 2  →  Write the rule down explicitly in the canonical
+                  cross-provider place (AGENTS.md). Reference it from
+                  any provider-specific file that mentioned it.
+Recurrence 3  →  Build a runnable check in `scripts/`. Anyone in any
+                  provider can invoke it as a self-check. Exits non-zero
+                  on the failure pattern, with a fix prescription in
+                  the error message.
+Recurrence 4  →  Wire the check as a PostToolUse / pre-write / pre-edit
+                  hook in `.claude/hooks/` so Claude Code sessions can't
+                  miss it. Update `.claude/settings.json`. Cowork /
+                  Codex / Cursor sessions invoke the script per the
+                  AGENTS.md convention.
+Recurrence 5  →  Move the check to a pre-commit / CI gate so the
+                  failure can't even land in the repo silently.
+```
+
+If a check is too noisy or has too many false positives at any rung,
+add an explicit opt-out marker (e.g., `[harness-specific]`,
+`<!-- @harness-specific -->`, `# noqa: <rule>`) and document the
+marker in the check itself so agents who hit a false positive know
+how to silence it correctly.
+
+## Required artifacts at each rung
+
+When you ratchet, you must leave behind enough that the next session
+can extend the ladder without context. The standard kit:
+
+1. **A check script in `scripts/<name>.py`** — runnable from any provider.
+   Standalone Python, no imports outside stdlib if avoidable. Exit 0 on
+   pass, exit 2 on fail. Stderr carries the human-readable fix
+   prescription. Stdout carries `OK — …` on pass.
+
+2. **A Claude Code wrapper in `.claude/hooks/<name>_guard.py`** — reads
+   the tool-use payload from stdin (JSON), matches the relevant tool
+   (`Write` / `Edit` / `Agent` / etc.), filters to the relevant file
+   path or condition, calls the script. Exits 2 with the script's
+   stderr on failure. Wire it into the matching `PostToolUse` matcher
+   (or `PreToolUse` if blocking is appropriate) in
+   `.claude/settings.json`.
+
+3. **A paragraph in `AGENTS.md`** under the relevant section — names
+   the script, gives the runnable command, explains the failure mode
+   and the opt-out. Cross-provider visibility is the point.
+
+4. **An entry in the auto-iterate ladder of the relevant subsystem doc**
+   — for FUSE that's `WebSite/HOOKS_FUSE_QUIRKS.md`. For drift, the
+   ladder lives in `AGENTS.md` itself. Each new rung is an entry.
+
+5. **A line in `STATUS.md` or the relevant runbook** — so the next
+   session reading the standard surfaces sees the new guard.
+
+## Style of the prescription
+
+When a check fails, the error message must do three things:
+
+- **Quote the offense exactly** (file, line, the specific text).
+- **Name the convention being violated**, in plain language.
+- **Give the agent two paths forward**: (A) the canonical fix (what
+  the convention requires), (B) an explicit opt-out if the case is a
+  legitimate exception. Always show the opt-out marker syntax verbatim
+  so the agent can paste it.
+
+Example shape (from `check_cross_provider_drift.py`):
+
+```
+CROSS_PROVIDER_DRIFT — N convention(s) found …
+
+  CLAUDE.md:18  ###  Verification Implementation
+    body: AGENTS.md defines the project-wide verification invariants…
+
+Fix one of two ways:
+  (A) PROJECT-LEVEL rule: move the section into AGENTS.md, replace with a
+      one-line pointer 'Cross-provider — see AGENTS.md § …'.
+  (B) HARNESS-SPECIFIC rule: keep it where it is; add `[harness-specific]`
+      in the heading or `<!-- @harness-specific -->` on the next line.
+```
+
+This format makes the check self-documenting. An agent that hits the
+failure for the first time gets enough information to decide and fix
+without reading the script source.
+
+## What NOT to do
+
+- **Don't ratchet without recurrence.** Every guard adds friction. If
+  it's the first time the failure happens, fix it and note it; build
+  the script on recurrence 2 or 3. Premature guards become noise.
+- **Don't make the check probabilistic.** "Looks suspicious" doesn't
+  scale. Define the failure pattern precisely so opt-outs are clean.
+- **Don't lose the opt-out.** Every check needs a documented escape
+  hatch for legitimate exceptions, in the script's source AND in the
+  error message it prints.
+- **Don't bury the check.** A guard nobody runs is not a guard.
+  Document the runnable command in `AGENTS.md` and (for Claude Code)
+  wire the hook so it fires automatically.
+
+## Cross-references
+
+- `debugging-and-error-recovery` — for one-shot code bugs that don't
+  fit the recurring-behavior pattern.
+- `team-iterate` — for tuning teammate role definitions when an agent
+  underperforms (different shape: the failure is in the agent's
+  prompt, not in a check).
+- `WebSite/HOOKS_FUSE_QUIRKS.md` — full worked example of the ladder
+  for FUSE truncation.
+- `AGENTS.md` § *Where new conventions live* — full worked example of
+  the ladder for cross-provider drift.

--- a/.agents/skills/game-prototyping/SKILL.md
+++ b/.agents/skills/game-prototyping/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: game-prototyping
+description: Builds playable browser games and game-like interactive prototypes with template-first, asset-aware, archetype-specific workflows. Use when creating, refactoring, or debugging games, Phaser/Canvas/Three.js interactions, arcade or puzzle prototypes, generated game assets, or game design documents.
+---
+
+# Game Prototyping
+
+## Overview
+
+Build playable browser games and game-like interactive prototypes without
+letting the agent improvise a whole engine from scratch. This skill adapts the
+useful parts of OpenGame's Game Skill into Workflow conventions: staged
+context, template-first implementation, explicit asset contracts, archetype
+packs, and systematic runtime debugging.
+
+Do not assume OpenGame-only tools such as `generate_game_assets` exist in this
+repo. Use the available project stack and harness tools. If an asset or game
+tool is unavailable, state that plainly and pick a reversible fallback.
+
+## When To Use
+
+- The user asks for a game, playable prototype, arcade interaction, puzzle, or
+  game-like demo.
+- A frontend task includes sprite animation, canvas/Phaser/Three.js mechanics,
+  levels, scoring, combat, grid logic, or wave/path systems.
+- You need generated or curated visual/audio assets for an interactive
+  experience.
+- A browser game build fails because of assets, scene wiring, config drift, or
+  runtime canvas errors.
+
+Do not use this for ordinary dashboard/product UI unless it has real game-loop
+or game-asset behavior.
+
+## Workflow
+
+### 1. Classify The Archetype
+
+Pick the dominant archetype before designing:
+
+- `platformer`: side-view gravity, jumping, platforms, melee/ranged action.
+- `top-down`: overhead movement, aiming, pathfinding, arena or tilemap worlds.
+- `grid-logic`: discrete board state, puzzles, tactics, match, roguelike turns.
+- `tower-defense`: paths, waves, economy, tower placement, target priority.
+- `ui-heavy`: dialogue, cards, quizzes, menus, battles, story choices.
+- `hybrid/custom`: combine packs deliberately and name which one owns each
+  subsystem.
+
+Use `references/archetype-packs.md` for the design constraints, asset rules,
+and verification risks.
+
+### 2. Write A Downstream-Aware Spec
+
+Before coding, write a compact GDD-style contract using
+`references/gdd-contract.md`. Each section must name the downstream consumer:
+asset plan, config, scene registration, entity/hooks, levels/content, and
+verification.
+
+No vague values. Numeric tuning, scene keys, asset keys, and control schemes
+must be concrete enough to implement and test.
+
+### 3. Choose Existing Engines And Templates
+
+Use a proven engine/library for the core loop when available:
+
+- Phaser for 2D browser games.
+- Three.js for real 3D scenes.
+- Existing project components/templates before new abstractions.
+
+Prefer hook overrides, behavior composition, config edits, and copied template
+files over rewriting base systems. Only add a new engine subsystem when no
+local template/library covers the required mechanic.
+
+### 4. Plan Assets Before Generating Or Coding
+
+Use `references/asset-protocol.md` to create an asset registry first. Keep keys
+stable across the asset manifest, animation definitions, config, and code.
+
+Generate assets in small batches with one style anchor. Verify each asset loads
+in the browser before declaring the game playable.
+
+### 5. Stage Context Loading
+
+Keep early context light:
+
+1. Read the archetype design rules and GDD contract.
+2. Read the asset protocol when planning visuals.
+3. Read template/API references when deciding implementation files.
+4. Read full source/templates only immediately before editing.
+5. Read the debug protocol only when verifying or fixing failures.
+
+This avoids filling the context with heavy implementation manuals before the
+design and asset contract are stable.
+
+### 6. Implement Thin Playable Slices
+
+Build the first playable loop before adding breadth:
+
+1. Boot screen/scene.
+2. Player/input or primary interaction.
+3. One enemy/puzzle/wave/content unit.
+4. Win/lose or completion condition.
+5. HUD feedback.
+6. Asset polish.
+
+Each slice must leave the game runnable.
+
+### 7. Verify Like A Game, Not A Static Page
+
+Follow `references/debug-protocol.md`:
+
+- Build/typecheck first.
+- Run tests if the project has them.
+- Start the dev server in the background.
+- Use browser verification for canvas pixels, console errors, input, animation,
+  layout, and asset loading.
+- Record repeated failures as protocol entries or proactive checks.
+
+For Three.js, also follow this repo's frontend instruction to verify canvas
+pixels across desktop and mobile viewports.
+
+### 8. Capture Reusable Patterns
+
+After a successful game/prototype, decide whether it produced a reusable
+template, check, asset convention, or archetype rule. If yes, update this skill
+or its references through `skill-authoring`. If the same failure recurs across
+sessions, use `auto-iterate`.
+
+## Reference Map
+
+- `references/opengame-source.md`: source audit and adaptation boundary.
+- `references/gdd-contract.md`: downstream-aware game spec format.
+- `references/asset-protocol.md`: asset planning, naming, prompts, and checks.
+- `references/archetype-packs.md`: platformer, top-down, grid, tower defense,
+  and UI-heavy packs.
+- `references/debug-protocol.md`: game-specific verification and failure
+  protocol.
+- `references/template-evolution.md`: when and how to promote reusable game
+  templates.
+
+## Handoffs
+
+- `frontend-ui-engineering`: non-game UI polish, accessibility, responsive
+  layout.
+- `browser-testing-with-devtools`: runtime browser verification.
+- `debugging-and-error-recovery`: root-cause debugging outside game-specific
+  checks.
+- `spec-driven-development`: larger product specs and acceptance criteria.
+- `skill-authoring`: updating this skill or adding reusable references.

--- a/.agents/skills/game-prototyping/references/archetype-packs.md
+++ b/.agents/skills/game-prototyping/references/archetype-packs.md
@@ -1,0 +1,227 @@
+# Archetype Packs
+
+Use these packs to constrain design, assets, and verification before coding.
+They are intentionally compact: load only the pack that matches the game.
+
+## Platformer
+
+Use for side-view gravity games with jumping, platforms, hazards, melee/ranged
+attacks, collectibles, or bosses.
+
+Design contract:
+
+- Define jump height, gravity feel, movement speed, attack range, health,
+  enemy count, checkpoints, and win/loss conditions.
+- Start with one short level and one enemy type.
+- Keep level geometry simple enough to test manually.
+- Use predefined or simple ASCII/layout plans before coding collision.
+
+Asset rules:
+
+- Side-view sprites, usually facing right.
+- Full-body player/enemy frames.
+- Background should not obscure platforms.
+- Platform/ground visual must contrast with hazards and collectibles.
+
+Implementation patterns:
+
+- Separate player, enemy, level scene, and UI/HUD.
+- Use existing physics/collision helpers.
+- Keep movement/combat behavior configurable.
+- Prefer one ultimate/special ability implemented through an existing behavior
+  pattern over several bespoke systems.
+
+Checks:
+
+- Player can move, jump, land, and cannot fall through ground.
+- Enemy collision and damage work.
+- Camera follows without hiding hazards.
+- Scene transition fires exactly once at win/loss.
+- Animation keys exist for idle/run/jump/attack/hit/death as needed.
+
+Common failures:
+
+- Tile layer name case mismatch.
+- Platform collision on the wrong layer.
+- Animation key drift between generated files and code.
+- Invulnerability or death state never reset.
+
+## Top-Down
+
+Use for overhead movement, twin-stick shooters, stealth, maze, arena survival,
+tilemap rooms, or exploration.
+
+Design contract:
+
+- Choose arena mode or tilemap mode.
+- Define movement speed, camera behavior, aiming model, enemy AI, projectile
+  rules, obstacle behavior, and level boundaries.
+- State whether directional sprites are required.
+
+Asset rules:
+
+- Top-down or three-quarter overhead.
+- Directional variants if facing direction matters.
+- Obstacles and walls must be visually distinct from walkable floor.
+- Projectiles must read at small size.
+
+Implementation patterns:
+
+- Use velocity/vector movement, not platform gravity.
+- Keep player/enemy animation direction derived from facing or velocity.
+- Register all scenes and level order explicitly.
+- Use depth sorting when sprites overlap vertically.
+
+Checks:
+
+- Movement respects world bounds and obstacles.
+- Aiming/shooting direction matches input.
+- Enemy AI can reach or intentionally fail to reach the player.
+- Projectiles spawn, collide, and clean up.
+- Camera and depth do not hide the player.
+
+Common failures:
+
+- Side-view art used in an overhead game.
+- Missing directional animation definitions.
+- Obstacles drawn but not colliding.
+- Projectiles not destroyed after collision or leaving bounds.
+
+## Grid Logic
+
+Use for discrete board games: Sokoban, sliding puzzles, tactics, roguelikes,
+match games, mines, word/number puzzles, or turn-based board interactions.
+
+Design contract:
+
+- Pick the subtype first: puzzle, tactics, match, roguelike, or arcade grid.
+- Define board dimensions, cell size, entities, turn rules, movement rules,
+  undo scope, win/loss condition, and randomization constraints.
+- Keep the first level small and solvable.
+
+Asset rules:
+
+- Readable tokens at cell size.
+- Distinct cell backgrounds, blockers, goals, hazards, and player pieces.
+- Avoid detailed art that makes state hard to scan.
+
+Implementation patterns:
+
+- Board state is the source of truth; rendering follows board state.
+- Keep turn resolution deterministic.
+- Use an animation queue when movement is visual but logic is discrete.
+- Snapshot all mutable state if undo exists.
+
+Checks:
+
+- Invalid moves do not mutate state.
+- Valid moves update board state once.
+- Undo restores board, score, cooldowns, inventory, and timers when relevant.
+- Win/loss detection happens after state settles.
+- Random boards are seeded or testable.
+
+Common failures:
+
+- UI sprite moves but board state does not.
+- Board state changes twice for one input.
+- Undo restores positions but not secondary state.
+- Generated levels are unsolvable.
+
+## Tower Defense
+
+Use for path-and-wave games with tower placement, enemy waves, economy,
+upgrades, obstacles, and a defended target.
+
+Design contract:
+
+- Define path waypoints, grid/cell system, buildable cells, blocked cells,
+  economy, wave list, tower types, enemy types, target health, and upgrade
+  rules.
+- Start with one path, two tower types, and two enemy types.
+- State target priority rules: first, nearest, strongest, weakest, or custom.
+
+Asset rules:
+
+- Top-down towers, enemies, obstacles, target, projectiles, and slot markers.
+- Distinct projectile images per tower type when projectiles are visible.
+- Path and buildable cells must be unambiguous.
+
+Implementation patterns:
+
+- Wave manager owns spawning.
+- Economy manager owns spend/reward.
+- Tower grid owns occupied cells.
+- Tower fire logic should use existing targeting/projectile helpers.
+- Obstacles should be data-driven, not hardcoded into draw calls.
+
+Checks:
+
+- Enemies follow the path in waypoint order.
+- Towers can only be placed on valid empty cells.
+- Spend/reward cannot go negative unless intentionally allowed.
+- Projectiles hit or miss according to speed/range rules.
+- Wave completion and next-level transition work.
+
+Common failures:
+
+- Buildable cells overlap the path.
+- Towers placed on already occupied cells.
+- Projectile data read after the projectile is destroyed.
+- Enemy type strings in waves do not match factory mappings.
+- Level order never advances.
+
+## UI-Heavy
+
+Use for dialogue, cards, quizzes, menus, story choices, turn battles,
+relationship systems, or interactive fiction with heavy visual UI.
+
+Design contract:
+
+- Define scene flow, dialogue data, card/deck data, quiz/question data,
+  battle rules, ending conditions, and save/progress state.
+- Start with one complete interaction loop: choose, resolve, show feedback,
+  continue/end.
+- Specify keyboard/mouse/touch controls.
+
+Asset rules:
+
+- Portraits are front or three-quarter view.
+- Use expression variants when dialogue needs emotion.
+- Cards/icons must be legible at actual UI size.
+- Avoid putting essential text inside generated images.
+
+Implementation patterns:
+
+- UI state transitions should be explicit.
+- Dialogue, cards, and questions should live in data structures.
+- Modal depth/z-index must not hide feedback that should be visible.
+- Clean up dynamic UI elements between rounds/scenes.
+
+Checks:
+
+- Dialogue character IDs match registered characters.
+- Cards/questions have all fields used by render and resolution logic.
+- Buttons are keyboard accessible when the project UI supports it.
+- Scene transitions use registered keys.
+- Round state resets before a new round starts.
+
+Common failures:
+
+- Instantiating static helper UI classes instead of using their static methods.
+- Importing invented type names.
+- Overriding hooks that do not exist.
+- Hiding HP/status changes under a modal overlay.
+- Forgetting to complete the enemy/opponent turn.
+
+## Hybrid Guidance
+
+For hybrids, assign each subsystem to one owner pack. Example:
+
+```text
+Top-down owns movement/combat.
+UI-heavy owns dialogue and card rewards.
+Grid-logic owns inventory puzzle rooms.
+```
+
+Do not merge all pack rules into one giant design. Load only the packs that
+own real subsystems, and write explicit boundaries between them.

--- a/.agents/skills/game-prototyping/references/asset-protocol.md
+++ b/.agents/skills/game-prototyping/references/asset-protocol.md
@@ -1,0 +1,197 @@
+# Asset Protocol
+
+Plan game assets as a contract before generating or coding them. The most
+common game-agent failures are key drift and missing assets, not a lack of
+visual imagination.
+
+## Asset Registry
+
+Create an asset table before generation:
+
+| type | key | file/output | used by | style/prompt | checks |
+|---|---|---|---|---|---|
+
+Rules:
+
+- One stable `key` per loadable asset.
+- The same key must appear in the asset manifest, animation definitions,
+  config, and code.
+- Prefix keys by role when useful: `player_`, `enemy_`, `bg_`, `tile_`,
+  `icon_`, `sfx_`, `bgm_`.
+- Record whether an asset is final, placeholder, generated, searched, or hand
+  drawn.
+
+## Asset Types
+
+### Background
+
+Use for full-screen or level backdrops. Prefer 16:9 or the actual viewport
+aspect. Do not request transparency unless the background is a layer.
+
+Checks:
+
+- Fills the viewport without unintended stretching.
+- Does not hide gameplay entities.
+- Loads before gameplay starts or has a clear loading state.
+
+### Tileset Or Tile Pattern
+
+Use only when the engine actually consumes tiles. If the game uses code-defined
+grids, do not create a tileset just because the archetype is grid-like.
+
+Checks:
+
+- Tiles align to the configured tile size.
+- Tile edges are clean and repeat without visible seams.
+- Legend or tile IDs match the map data.
+
+### Animation Or Sprite Frames
+
+Use for moving characters, enemies, effects, and projectiles. Prefer fewer,
+consistent frames over many inconsistent frames.
+
+Checks:
+
+- Frame keys exist in the manifest.
+- Animation keys exist in the animation definition file.
+- Code references animation keys, not raw frame filenames.
+- Side-view sprites face the same default direction; use flipping in code.
+
+### Image, Sprite, Icon, Or Portrait
+
+Use for static game objects, UI, portraits, cards, towers, projectiles, and
+inventory items.
+
+Checks:
+
+- One object/character per image unless the asset is intentionally a group.
+- Transparent or plain background when the object should be composited.
+- Clear silhouette at final display size.
+
+### Audio
+
+Use for primary feedback only at first: action, hit, collect, win, lose, menu,
+and one background loop.
+
+Checks:
+
+- File format is supported by the target browser.
+- Duration is short enough for the interaction.
+- Volume is balanced against other sounds.
+- Playback is gated by user interaction when the browser requires it.
+
+## Map And Tilemap Protocol
+
+Use map data when level layout matters. Do not bury level geometry in scene
+code unless the game is a tiny prototype.
+
+### ASCII Layouts
+
+ASCII maps are useful for platformers, top-down tilemaps, grid puzzles, and
+tower-defense paths. Each symbol needs a legend:
+
+```text
+########
+#P..E..#
+#..##..#
+#....G.#
+########
+```
+
+Example legend:
+
+```yaml
+"#": wall_or_ground
+".": empty_or_floor
+"P": player_spawn
+"E": enemy_spawn
+"G": goal
+```
+
+Rules:
+
+- All rows must have the same width.
+- Object markers such as player/enemy/goal should not become solid tiles by
+  accident.
+- Keep collision layers and visual layers separate when the engine supports
+  it.
+- Name tilemap layers exactly; layer names are usually case-sensitive.
+
+### Dual Tilesets
+
+Top-down tilemaps often need separate floor and wall visuals. Treat these as
+two asset keys and two layers unless the engine template expects otherwise.
+
+Checks:
+
+- Walkable floor is visually calm.
+- Walls/blocked cells have stronger contrast.
+- Collision applies to the wall/blocked layer, not decorative floor.
+
+### 3x3 To 7x7 Expansion
+
+OpenGame's tooling expands a simple 3x3 tileset into a fuller blob tileset for
+auto-tiling. If Workflow later builds local game tooling, this is a good
+candidate to implement as a deterministic helper:
+
+- Input: 3x3 tiles for corners, edges, and center.
+- Output: 7x7 blobset with repeated edges, center fills, and inner corners.
+- Pair with an 8-neighbor bitmask auto-tiler.
+
+## Prompting Rules
+
+Use one style anchor for a batch:
+
+```text
+Style anchor: 16-bit pixel art, high-contrast silhouettes, readable at 64px,
+consistent palette, no text baked into the image.
+```
+
+Character prompts should specify:
+
+- View angle: side, top-down, front, or three-quarter.
+- Facing direction.
+- Full body vs bust.
+- Action pose and limb/body position.
+- Props that must stay consistent.
+- Background treatment: transparent, plain white, or full environment.
+
+Generate in small batches. If the batch is large, split by role:
+
+1. Core player/enemy/UI assets.
+2. Environment/background/tile assets.
+3. Effects/audio/polish assets.
+
+## Archetype View Rules
+
+- Platformer: side view, usually facing right, full body.
+- Top-down: overhead or three-quarter overhead; include directional variants
+  when movement direction matters.
+- Grid logic: readable tokens from top-down or orthographic view.
+- Tower defense: top-down towers, enemies, projectiles, obstacles, path/slot
+  markers.
+- UI-heavy: front or three-quarter portraits, static expressions, cards and
+  panels optimized for readability.
+
+## Verification Checklist
+
+Before coding:
+
+- [ ] Every planned asset has a unique key.
+- [ ] Style anchor is consistent across the batch.
+- [ ] Character orientation matches the archetype.
+- [ ] Placeholder assets are labeled as placeholders.
+
+Before final verification:
+
+- [ ] Every key referenced in code/config exists in the manifest.
+- [ ] Every animation key referenced in code exists in animation definitions.
+- [ ] Browser console has no missing texture, failed image, or failed audio
+      errors.
+- [ ] The game renders nonblank visuals on desktop and mobile viewports.
+- [ ] The user can distinguish player, obstacles, enemies, interactive items,
+      and feedback effects at actual game size.
+
+If no asset-generation tool is available, do not invent one. Use existing
+assets, create simple local placeholders with clear labels, or record the asset
+gap as an explicit follow-up.

--- a/.agents/skills/game-prototyping/references/debug-protocol.md
+++ b/.agents/skills/game-prototyping/references/debug-protocol.md
@@ -1,0 +1,108 @@
+# Game Debug Protocol
+
+Use this when verifying or repairing a browser game/prototype.
+
+## Pre-Build Checks
+
+### Asset Keys
+
+- [ ] Every image/audio key referenced in code exists in the asset manifest.
+- [ ] Every physical file referenced by the manifest exists.
+- [ ] Placeholder keys are not mixed with final keys by accident.
+
+### Animation Keys
+
+- [ ] Frame keys exist in the manifest.
+- [ ] Animation definitions reference valid frame keys.
+- [ ] Code references animation keys that exist.
+- [ ] Static UI-heavy portraits are not accidentally treated as animations.
+
+### Config Keys
+
+- [ ] Every config path referenced in code exists.
+- [ ] Every required entity stat exists for player/enemy/tower/card/question.
+- [ ] Numeric values use the intended unit: pixels, seconds, milliseconds,
+      frames, grid cells, or percentages.
+
+### Scene And Level Registration
+
+- [ ] Every `start`, `launch`, route, or transition target is registered.
+- [ ] Level order references real scene keys.
+- [ ] First scene/level is not still a template default.
+
+### Hook And Type Integrity
+
+- [ ] Every override/hook name exists in the base class/component.
+- [ ] Overrides do not narrow visibility or change required signatures.
+- [ ] Imported types/classes actually exist in the source file.
+- [ ] Type-only imports are marked correctly when the project requires it.
+
+### State Cleanup
+
+- [ ] Event listeners added on scene creation are removed or scoped to scene
+      shutdown.
+- [ ] Dynamic UI elements are destroyed before recreation.
+- [ ] Per-round/per-level mutable state resets at the start of the next round.
+- [ ] Projectiles, timers, tweens, and physics bodies clean up.
+
+## Execution Order
+
+1. Build/typecheck.
+2. Run tests.
+3. Start the dev server in the background.
+4. Open the game in a browser.
+5. Check console and network errors.
+6. Verify a visible, nonblank canvas or UI.
+7. Exercise the first playable loop.
+8. Check desktop and mobile viewport framing.
+
+Do not run long-lived dev servers in the foreground. Keep terminal control.
+
+## Failure Record
+
+When a failure is fixed, capture a record if it is likely to recur:
+
+```yaml
+signature:
+  stage: build | test | browser | visual | gameplay
+  error_code: string-or-null
+  message_pattern: short regex or exact text
+  file_context: path/glob if useful
+root_cause: one sentence
+verified_fix: what changed and how it was verified
+proactive_check: optional future validation
+first_seen: YYYY-MM-DD
+last_seen: YYYY-MM-DD
+occurrences: 1
+```
+
+If the same signature appears three times, promote it into a proactive check,
+test, lint rule, or skill instruction. If the recurring failure is agent
+behavior rather than game code, use `auto-iterate`.
+
+## Common Signatures
+
+| Signature | Likely cause | First place to inspect |
+|---|---|---|
+| Missing import/module | Wrong relative path or export name | Import line and target file |
+| Property does not exist | Config/type drift or invented API | Type/interface and caller |
+| Texture/image not found | Key mismatch or missing manifest entry | Asset manifest and code key |
+| Animation not found | Animation definition missing or wrong key | Animation JSON and anim map |
+| Scene not found | Transition target not registered | Engine scene config/level order |
+| Cannot read property of undefined | Initialization order or missing data | Constructor/create lifecycle |
+| Blank canvas | Boot failure, hidden canvas, missing assets | Console, network, canvas pixels |
+| Input ignored | Focus, event binding, scene pause, overlay | Browser events and scene state |
+| State repeats/duplicates | Event listener leak or missing cleanup | Scene restart and shutdown hooks |
+
+## Browser Acceptance
+
+A game is not verified just because it builds. Acceptance needs browser
+evidence:
+
+- Canvas/UI is nonblank.
+- Primary controls work.
+- One win/loss or completion path works.
+- Console has no relevant errors.
+- Assets visibly match the intended archetype.
+- Text fits on desktop and mobile.
+- Animation or movement is visible when expected.

--- a/.agents/skills/game-prototyping/references/gdd-contract.md
+++ b/.agents/skills/game-prototyping/references/gdd-contract.md
@@ -1,0 +1,116 @@
+# Game Design Contract
+
+Use this compact GDD format before coding a game or game-like prototype. The
+point is not a long design document; it is a downstream contract that prevents
+asset, config, scene, and implementation drift.
+
+## Core Principles
+
+- Config-first: numeric tuning belongs in config or constants, not scattered
+  through gameplay code.
+- Template-first: use existing engines, templates, hooks, and components before
+  inventing custom systems.
+- Behavior-first: compose movement, combat, interaction, and UI behaviors when
+  the archetype already has a pattern.
+- Concrete values: no "some enemies", "appropriate speed", or "nice effect".
+- Exact keys: scene IDs, asset keys, animation keys, config paths, and route
+  names must be spelled exactly once and reused consistently.
+
+## Required Sections
+
+### 0. Technical Architecture
+
+Consumer: scene registration, engine boot, routing, build setup.
+
+Must include:
+
+- Engine/library choice.
+- Archetype and any hybrid split.
+- Resolution/aspect ratio.
+- Scene flow, with exact scene key strings.
+- First playable slice.
+- Files likely touched.
+
+### 1. Visual Style And Asset Registry
+
+Consumer: asset creation, asset manifest, animation definitions, preloader.
+
+Must include an asset table:
+
+| type | key | use | prompt/style note | verification |
+|---|---|---|---|---|
+
+Use stable keys. Every asset key planned here must later exist in the manifest
+or be removed from code/config before verification.
+
+### 2. Game Configuration
+
+Consumer: config files, constants, balancing.
+
+Must include complete values for:
+
+- Screen/camera settings.
+- Player/input stats.
+- Enemy/puzzle/wave/content stats.
+- Economy, score, timers, cooldowns, or win/loss thresholds.
+- Feature flags or debug settings.
+
+### 3. Entity And Scene Architecture
+
+Consumer: source files, templates, hooks, class/component boundaries.
+
+Must include:
+
+- Base class/component to extend.
+- Existing behavior/system to reuse.
+- Hooks to override, with exact names if known.
+- Event names and ownership.
+- Data ownership: scene state, entity state, global state, URL state.
+
+### 4. Level And Content Design
+
+Consumer: levels, maps, puzzle data, dialogue, waves, encounters.
+
+Must include:
+
+- Level order.
+- Spawn points or board layout.
+- Content data structures.
+- Difficulty progression.
+- Minimum content needed for the first playable slice.
+
+### 5. Implementation Roadmap
+
+Consumer: task list and code edits.
+
+Write file-level operations:
+
+```text
+1. UPDATE src/gameConfig.* with the Section 2 values.
+2. UPDATE scene registration with [ExactSceneKey].
+3. COPY/CREATE scene/entity files from [template/source].
+4. IMPLEMENT hooks [hook names].
+5. ADD tests/browser checks for [specific behavior].
+```
+
+### 6. Verification Plan
+
+Consumer: tests, browser checks, debug protocol.
+
+Must include:
+
+- Build/typecheck command.
+- Test command, if available.
+- Dev server command and URL.
+- Browser interactions to perform.
+- Asset/animation/scene/config consistency checks.
+- Canvas-pixel or screenshot checks for nonblank rendering.
+
+## Forbidden In The GDD
+
+- "Implement from scratch" when an existing template/library covers it.
+- Unspecified numbers.
+- Asset keys that are not listed in the registry.
+- Scene transitions to unregistered scene keys.
+- Custom engine systems for mechanics already handled by a library.
+- Copying external code without adapting it to the project conventions.

--- a/.agents/skills/game-prototyping/references/opengame-source.md
+++ b/.agents/skills/game-prototyping/references/opengame-source.md
@@ -1,0 +1,63 @@
+# OpenGame Source Notes
+
+Source audited: `https://github.com/leigest519/OpenGame`
+
+Commit audited: `c54307e` (`2026-04-22T12:50:54+08:00`)
+
+Audit date: `2026-05-01`
+
+License observed in the source checkout: Apache License 2.0.
+
+## What Was Imported
+
+This skill adapts concepts from OpenGame's Game Skill stack rather than
+vendoring its files raw:
+
+- Template-first game creation.
+- Debug protocol with reusable signatures and proactive checks.
+- GDD-style downstream contract.
+- Asset planning and key-consistency checks.
+- Archetype packs for platformer, top-down, grid logic, tower defense, and
+  UI-heavy games.
+- Context staging: light design/capability docs first, heavy implementation
+  docs only when coding.
+
+## What Was Not Imported
+
+- OpenGame's Qwen runtime assumptions.
+- `generate_game_assets`, `generate_tilemap`, or other OpenGame-specific tool
+  names as required commands.
+- Phaser template source files.
+- Provider-specific environment variables.
+- Large raw archetype manuals.
+
+## Additional Candidates Found
+
+These were found in the broader repo scan and are worth considering only when
+Workflow has a concrete need:
+
+- Physics-first classifier: `packages/core/src/tools/game-type-classifier.ts`.
+  The decision tree is already reflected in `archetype-packs.md`; a tool is
+  only worth building if we repeatedly classify game requests.
+- GDD generator: `packages/core/src/tools/generate-gdd.ts`. The useful pattern
+  is auto-loading core rules plus design rules plus template capability docs.
+  That pattern is now reflected in `gdd-contract.md` and `context-engineering`.
+- Asset pipeline: `generate-assets.ts`, `assetImageService.ts`,
+  `assetAudioService.ts`, `assetVideoService.ts`, background removal, and frame
+  extraction. Worth revisiting if we need repeatable local game-asset output
+  instead of ad hoc image generation.
+- Tilemap pipeline: `generate-tilemap.ts`, `auto-tiler.ts`, and
+  `tileset-processor.ts`. Worth copying as a deterministic helper if we build
+  several tile-based games.
+- Copy-template tool: `copy-template.ts`. The key idea is safe scaffold copying
+  that does not overwrite existing files.
+- Skill manager: `packages/core/src/skills/skill-manager.ts`. Mostly overlaps
+  our existing `validate_skills.py`; no import needed now.
+- OpenGame-Bench: README describes dynamic playability evaluation across build
+  health, visual usability, and intent alignment, but the pipeline is not
+  released in this checkout. Good future inspiration for browser-game
+  acceptance probes.
+
+Future sessions should treat these references as Workflow-local guidance. If
+we later vendor source templates, preserve Apache-2.0 notices and document the
+source commit next to the copied files.

--- a/.agents/skills/game-prototyping/references/template-evolution.md
+++ b/.agents/skills/game-prototyping/references/template-evolution.md
@@ -1,0 +1,62 @@
+# Template Evolution
+
+Use this when a completed game/prototype reveals reusable structure. The goal
+is to accumulate useful templates without bloating the skill with one-off
+project details.
+
+## Promotion Criteria
+
+Promote a pattern only when at least one is true:
+
+- It has been useful in two or more projects.
+- It prevents a repeated failure.
+- It captures a stable engine/archetype boundary.
+- It reduces future implementation steps without hiding important decisions.
+- It can be verified with a checklist, test, or browser probe.
+
+Do not promote one-off game content, licensed art, generated story text, or
+theme-specific names.
+
+## Evolution Pipeline
+
+1. Collect: list files, commands, assets, config, and tests from the completed
+   project.
+2. Classify: identify the archetype and any hybrid boundaries.
+3. Extract: find reusable base classes, hooks, config schema, assets patterns,
+   directory structure, and verification checks.
+4. Abstract: replace game-specific names and numbers with placeholders or
+   config fields.
+5. Merge: update the relevant reference pack or template with minimal new text.
+6. Verify: run skill validation and, if code/templates were added, run the
+   project's build/test/browser checks.
+
+## What To Store
+
+Good template material:
+
+- Directory skeletons.
+- Config schemas.
+- Hook lists.
+- Event contracts.
+- Asset key conventions.
+- Verification checklists.
+- Small starter files that are clearly placeholders.
+
+Bad template material:
+
+- Full generated games.
+- Brand/IP-specific assets.
+- Huge implementation manuals no one will load.
+- Untested snippets.
+- Commands that assume unavailable tools.
+
+## Where It Goes
+
+- Reusable game workflow: `game-prototyping/SKILL.md`.
+- Archetype-specific design/capability guidance:
+  `game-prototyping/references/archetype-packs.md`.
+- Asset rules: `game-prototyping/references/asset-protocol.md`.
+- Debug signatures/checks: `game-prototyping/references/debug-protocol.md` or
+  the broader `debugging-and-error-recovery` skill if not game-specific.
+- Cross-provider process rules: `AGENTS.md`, only when every provider needs to
+  know the convention outside this skill.

--- a/.claude/skills/auto-iterate/SKILL.md
+++ b/.claude/skills/auto-iterate/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: auto-iterate
+description: Ratchets prevention every time an agent (you, a teammate, a future session) makes the same behavioral mistake twice. Use when you fix a behavioral failure — a bad heuristic, a bad default, a missed convention, a recurring bug pattern, or a "you should have known better" moment. Each recurrence must add a stronger preventive layer (doc → script → hook → gate) so the failure cannot recur silently.
+---
+
+# Auto-iterate (prevention ratchet)
+
+## What this is
+
+Some failures are not one-off bugs in the code — they're patterns of agent
+behavior that will recur in future sessions if nothing changes. Two examples
+this repo has lived through:
+
+- **FUSE truncation:** Cowork's Edit/Write silently chop file overwrites.
+  An agent writes, gets a "success" response, moves on, and the file is
+  truncated mid-line. Each recurrence has produced a stronger preventive
+  layer in turn (atomic temp+rename → PostToolUse hook on Write → hook also
+  matches Edit → standing rule in CLAUDE.md/AGENTS.md/memory). See
+  `WebSite/HOOKS_FUSE_QUIRKS.md` for the documented ladder.
+
+- **Cross-provider drift:** Project-level conventions get added to
+  `CLAUDE.md` or agent memory instead of `AGENTS.md`. Future Codex/Cursor
+  sessions miss the convention. The 1st occurrence was caught by the user
+  manually; the 2nd added an explicit rule to `AGENTS.md`; the 3rd built
+  `scripts/check_cross_provider_drift.py`; the 4th wired it as a Claude
+  Code PostToolUse hook. The ladder is documented in `AGENTS.md` §
+  *Where new conventions live*.
+
+The shape is identical. **This skill formalizes the shape so we apply it
+deliberately, not after the next surprise.**
+
+## When to invoke
+
+Reach for this skill when **any** of these is true:
+
+- You just fixed a problem that you — or a previous agent — had already
+  fixed before in a different session, and might have to fix again.
+- The user redirects you on something that "feels like" you should have
+  known. ("You shouldn't have needed to be reminded of X.")
+- A guard, hook, or check fails. Even if you fix the immediate issue,
+  the failure is data — invoke this skill to decide whether to ratchet.
+- You're about to write a doc/rule that says "future sessions should…"
+  — that's a soft prevention layer; ask whether a hard one (script,
+  hook) is warranted instead.
+- Two similar incidents reach two different fixes. That divergence is
+  the signal to consolidate behind a hook.
+
+**Not for:** one-shot code bugs in a feature branch. Use
+`debugging-and-error-recovery` for those. Use `auto-iterate` only when
+the failure is about *agent behavior* — something a future session
+could repeat.
+
+## Relationship to failure protocols
+
+Some recurring failures are product/runtime patterns, not agent-behavior
+patterns. Those belong first in a living failure protocol: an error signature,
+root cause, verified fix, and optional proactive check. Promote those into
+tests, probes, validators, or specialist skill checklists.
+
+Use this skill when the recurring pattern is that agents keep making the same
+bad choice: skipping the protocol, ignoring the check, inventing APIs, loading
+the wrong context, or placing conventions in the wrong file. In that case the
+fix must make the behavior harder to repeat, not just document the bug again.
+
+## The ratchet (apply in order; each rung is stronger than the last)
+
+```
+Recurrence 1  →  Fix the symptom in place. Add a brief note in the
+                  relevant doc so the agent who reviews this PR sees it.
+Recurrence 2  →  Write the rule down explicitly in the canonical
+                  cross-provider place (AGENTS.md). Reference it from
+                  any provider-specific file that mentioned it.
+Recurrence 3  →  Build a runnable check in `scripts/`. Anyone in any
+                  provider can invoke it as a self-check. Exits non-zero
+                  on the failure pattern, with a fix prescription in
+                  the error message.
+Recurrence 4  →  Wire the check as a PostToolUse / pre-write / pre-edit
+                  hook in `.claude/hooks/` so Claude Code sessions can't
+                  miss it. Update `.claude/settings.json`. Cowork /
+                  Codex / Cursor sessions invoke the script per the
+                  AGENTS.md convention.
+Recurrence 5  →  Move the check to a pre-commit / CI gate so the
+                  failure can't even land in the repo silently.
+```
+
+If a check is too noisy or has too many false positives at any rung,
+add an explicit opt-out marker (e.g., `[harness-specific]`,
+`<!-- @harness-specific -->`, `# noqa: <rule>`) and document the
+marker in the check itself so agents who hit a false positive know
+how to silence it correctly.
+
+## Required artifacts at each rung
+
+When you ratchet, you must leave behind enough that the next session
+can extend the ladder without context. The standard kit:
+
+1. **A check script in `scripts/<name>.py`** — runnable from any provider.
+   Standalone Python, no imports outside stdlib if avoidable. Exit 0 on
+   pass, exit 2 on fail. Stderr carries the human-readable fix
+   prescription. Stdout carries `OK — …` on pass.
+
+2. **A Claude Code wrapper in `.claude/hooks/<name>_guard.py`** — reads
+   the tool-use payload from stdin (JSON), matches the relevant tool
+   (`Write` / `Edit` / `Agent` / etc.), filters to the relevant file
+   path or condition, calls the script. Exits 2 with the script's
+   stderr on failure. Wire it into the matching `PostToolUse` matcher
+   (or `PreToolUse` if blocking is appropriate) in
+   `.claude/settings.json`.
+
+3. **A paragraph in `AGENTS.md`** under the relevant section — names
+   the script, gives the runnable command, explains the failure mode
+   and the opt-out. Cross-provider visibility is the point.
+
+4. **An entry in the auto-iterate ladder of the relevant subsystem doc**
+   — for FUSE that's `WebSite/HOOKS_FUSE_QUIRKS.md`. For drift, the
+   ladder lives in `AGENTS.md` itself. Each new rung is an entry.
+
+5. **A line in `STATUS.md` or the relevant runbook** — so the next
+   session reading the standard surfaces sees the new guard.
+
+## Style of the prescription
+
+When a check fails, the error message must do three things:
+
+- **Quote the offense exactly** (file, line, the specific text).
+- **Name the convention being violated**, in plain language.
+- **Give the agent two paths forward**: (A) the canonical fix (what
+  the convention requires), (B) an explicit opt-out if the case is a
+  legitimate exception. Always show the opt-out marker syntax verbatim
+  so the agent can paste it.
+
+Example shape (from `check_cross_provider_drift.py`):
+
+```
+CROSS_PROVIDER_DRIFT — N convention(s) found …
+
+  CLAUDE.md:18  ###  Verification Implementation
+    body: AGENTS.md defines the project-wide verification invariants…
+
+Fix one of two ways:
+  (A) PROJECT-LEVEL rule: move the section into AGENTS.md, replace with a
+      one-line pointer 'Cross-provider — see AGENTS.md § …'.
+  (B) HARNESS-SPECIFIC rule: keep it where it is; add `[harness-specific]`
+      in the heading or `<!-- @harness-specific -->` on the next line.
+```
+
+This format makes the check self-documenting. An agent that hits the
+failure for the first time gets enough information to decide and fix
+without reading the script source.
+
+## What NOT to do
+
+- **Don't ratchet without recurrence.** Every guard adds friction. If
+  it's the first time the failure happens, fix it and note it; build
+  the script on recurrence 2 or 3. Premature guards become noise.
+- **Don't make the check probabilistic.** "Looks suspicious" doesn't
+  scale. Define the failure pattern precisely so opt-outs are clean.
+- **Don't lose the opt-out.** Every check needs a documented escape
+  hatch for legitimate exceptions, in the script's source AND in the
+  error message it prints.
+- **Don't bury the check.** A guard nobody runs is not a guard.
+  Document the runnable command in `AGENTS.md` and (for Claude Code)
+  wire the hook so it fires automatically.
+
+## Cross-references
+
+- `debugging-and-error-recovery` — for one-shot code bugs that don't
+  fit the recurring-behavior pattern.
+- `team-iterate` — for tuning teammate role definitions when an agent
+  underperforms (different shape: the failure is in the agent's
+  prompt, not in a check).
+- `WebSite/HOOKS_FUSE_QUIRKS.md` — full worked example of the ladder
+  for FUSE truncation.
+- `AGENTS.md` § *Where new conventions live* — full worked example of
+  the ladder for cross-provider drift.

--- a/.claude/skills/game-prototyping/SKILL.md
+++ b/.claude/skills/game-prototyping/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: game-prototyping
+description: Builds playable browser games and game-like interactive prototypes with template-first, asset-aware, archetype-specific workflows. Use when creating, refactoring, or debugging games, Phaser/Canvas/Three.js interactions, arcade or puzzle prototypes, generated game assets, or game design documents.
+---
+
+# Game Prototyping
+
+## Overview
+
+Build playable browser games and game-like interactive prototypes without
+letting the agent improvise a whole engine from scratch. This skill adapts the
+useful parts of OpenGame's Game Skill into Workflow conventions: staged
+context, template-first implementation, explicit asset contracts, archetype
+packs, and systematic runtime debugging.
+
+Do not assume OpenGame-only tools such as `generate_game_assets` exist in this
+repo. Use the available project stack and harness tools. If an asset or game
+tool is unavailable, state that plainly and pick a reversible fallback.
+
+## When To Use
+
+- The user asks for a game, playable prototype, arcade interaction, puzzle, or
+  game-like demo.
+- A frontend task includes sprite animation, canvas/Phaser/Three.js mechanics,
+  levels, scoring, combat, grid logic, or wave/path systems.
+- You need generated or curated visual/audio assets for an interactive
+  experience.
+- A browser game build fails because of assets, scene wiring, config drift, or
+  runtime canvas errors.
+
+Do not use this for ordinary dashboard/product UI unless it has real game-loop
+or game-asset behavior.
+
+## Workflow
+
+### 1. Classify The Archetype
+
+Pick the dominant archetype before designing:
+
+- `platformer`: side-view gravity, jumping, platforms, melee/ranged action.
+- `top-down`: overhead movement, aiming, pathfinding, arena or tilemap worlds.
+- `grid-logic`: discrete board state, puzzles, tactics, match, roguelike turns.
+- `tower-defense`: paths, waves, economy, tower placement, target priority.
+- `ui-heavy`: dialogue, cards, quizzes, menus, battles, story choices.
+- `hybrid/custom`: combine packs deliberately and name which one owns each
+  subsystem.
+
+Use `references/archetype-packs.md` for the design constraints, asset rules,
+and verification risks.
+
+### 2. Write A Downstream-Aware Spec
+
+Before coding, write a compact GDD-style contract using
+`references/gdd-contract.md`. Each section must name the downstream consumer:
+asset plan, config, scene registration, entity/hooks, levels/content, and
+verification.
+
+No vague values. Numeric tuning, scene keys, asset keys, and control schemes
+must be concrete enough to implement and test.
+
+### 3. Choose Existing Engines And Templates
+
+Use a proven engine/library for the core loop when available:
+
+- Phaser for 2D browser games.
+- Three.js for real 3D scenes.
+- Existing project components/templates before new abstractions.
+
+Prefer hook overrides, behavior composition, config edits, and copied template
+files over rewriting base systems. Only add a new engine subsystem when no
+local template/library covers the required mechanic.
+
+### 4. Plan Assets Before Generating Or Coding
+
+Use `references/asset-protocol.md` to create an asset registry first. Keep keys
+stable across the asset manifest, animation definitions, config, and code.
+
+Generate assets in small batches with one style anchor. Verify each asset loads
+in the browser before declaring the game playable.
+
+### 5. Stage Context Loading
+
+Keep early context light:
+
+1. Read the archetype design rules and GDD contract.
+2. Read the asset protocol when planning visuals.
+3. Read template/API references when deciding implementation files.
+4. Read full source/templates only immediately before editing.
+5. Read the debug protocol only when verifying or fixing failures.
+
+This avoids filling the context with heavy implementation manuals before the
+design and asset contract are stable.
+
+### 6. Implement Thin Playable Slices
+
+Build the first playable loop before adding breadth:
+
+1. Boot screen/scene.
+2. Player/input or primary interaction.
+3. One enemy/puzzle/wave/content unit.
+4. Win/lose or completion condition.
+5. HUD feedback.
+6. Asset polish.
+
+Each slice must leave the game runnable.
+
+### 7. Verify Like A Game, Not A Static Page
+
+Follow `references/debug-protocol.md`:
+
+- Build/typecheck first.
+- Run tests if the project has them.
+- Start the dev server in the background.
+- Use browser verification for canvas pixels, console errors, input, animation,
+  layout, and asset loading.
+- Record repeated failures as protocol entries or proactive checks.
+
+For Three.js, also follow this repo's frontend instruction to verify canvas
+pixels across desktop and mobile viewports.
+
+### 8. Capture Reusable Patterns
+
+After a successful game/prototype, decide whether it produced a reusable
+template, check, asset convention, or archetype rule. If yes, update this skill
+or its references through `skill-authoring`. If the same failure recurs across
+sessions, use `auto-iterate`.
+
+## Reference Map
+
+- `references/opengame-source.md`: source audit and adaptation boundary.
+- `references/gdd-contract.md`: downstream-aware game spec format.
+- `references/asset-protocol.md`: asset planning, naming, prompts, and checks.
+- `references/archetype-packs.md`: platformer, top-down, grid, tower defense,
+  and UI-heavy packs.
+- `references/debug-protocol.md`: game-specific verification and failure
+  protocol.
+- `references/template-evolution.md`: when and how to promote reusable game
+  templates.
+
+## Handoffs
+
+- `frontend-ui-engineering`: non-game UI polish, accessibility, responsive
+  layout.
+- `browser-testing-with-devtools`: runtime browser verification.
+- `debugging-and-error-recovery`: root-cause debugging outside game-specific
+  checks.
+- `spec-driven-development`: larger product specs and acceptance criteria.
+- `skill-authoring`: updating this skill or adding reusable references.

--- a/.claude/skills/game-prototyping/references/archetype-packs.md
+++ b/.claude/skills/game-prototyping/references/archetype-packs.md
@@ -1,0 +1,227 @@
+# Archetype Packs
+
+Use these packs to constrain design, assets, and verification before coding.
+They are intentionally compact: load only the pack that matches the game.
+
+## Platformer
+
+Use for side-view gravity games with jumping, platforms, hazards, melee/ranged
+attacks, collectibles, or bosses.
+
+Design contract:
+
+- Define jump height, gravity feel, movement speed, attack range, health,
+  enemy count, checkpoints, and win/loss conditions.
+- Start with one short level and one enemy type.
+- Keep level geometry simple enough to test manually.
+- Use predefined or simple ASCII/layout plans before coding collision.
+
+Asset rules:
+
+- Side-view sprites, usually facing right.
+- Full-body player/enemy frames.
+- Background should not obscure platforms.
+- Platform/ground visual must contrast with hazards and collectibles.
+
+Implementation patterns:
+
+- Separate player, enemy, level scene, and UI/HUD.
+- Use existing physics/collision helpers.
+- Keep movement/combat behavior configurable.
+- Prefer one ultimate/special ability implemented through an existing behavior
+  pattern over several bespoke systems.
+
+Checks:
+
+- Player can move, jump, land, and cannot fall through ground.
+- Enemy collision and damage work.
+- Camera follows without hiding hazards.
+- Scene transition fires exactly once at win/loss.
+- Animation keys exist for idle/run/jump/attack/hit/death as needed.
+
+Common failures:
+
+- Tile layer name case mismatch.
+- Platform collision on the wrong layer.
+- Animation key drift between generated files and code.
+- Invulnerability or death state never reset.
+
+## Top-Down
+
+Use for overhead movement, twin-stick shooters, stealth, maze, arena survival,
+tilemap rooms, or exploration.
+
+Design contract:
+
+- Choose arena mode or tilemap mode.
+- Define movement speed, camera behavior, aiming model, enemy AI, projectile
+  rules, obstacle behavior, and level boundaries.
+- State whether directional sprites are required.
+
+Asset rules:
+
+- Top-down or three-quarter overhead.
+- Directional variants if facing direction matters.
+- Obstacles and walls must be visually distinct from walkable floor.
+- Projectiles must read at small size.
+
+Implementation patterns:
+
+- Use velocity/vector movement, not platform gravity.
+- Keep player/enemy animation direction derived from facing or velocity.
+- Register all scenes and level order explicitly.
+- Use depth sorting when sprites overlap vertically.
+
+Checks:
+
+- Movement respects world bounds and obstacles.
+- Aiming/shooting direction matches input.
+- Enemy AI can reach or intentionally fail to reach the player.
+- Projectiles spawn, collide, and clean up.
+- Camera and depth do not hide the player.
+
+Common failures:
+
+- Side-view art used in an overhead game.
+- Missing directional animation definitions.
+- Obstacles drawn but not colliding.
+- Projectiles not destroyed after collision or leaving bounds.
+
+## Grid Logic
+
+Use for discrete board games: Sokoban, sliding puzzles, tactics, roguelikes,
+match games, mines, word/number puzzles, or turn-based board interactions.
+
+Design contract:
+
+- Pick the subtype first: puzzle, tactics, match, roguelike, or arcade grid.
+- Define board dimensions, cell size, entities, turn rules, movement rules,
+  undo scope, win/loss condition, and randomization constraints.
+- Keep the first level small and solvable.
+
+Asset rules:
+
+- Readable tokens at cell size.
+- Distinct cell backgrounds, blockers, goals, hazards, and player pieces.
+- Avoid detailed art that makes state hard to scan.
+
+Implementation patterns:
+
+- Board state is the source of truth; rendering follows board state.
+- Keep turn resolution deterministic.
+- Use an animation queue when movement is visual but logic is discrete.
+- Snapshot all mutable state if undo exists.
+
+Checks:
+
+- Invalid moves do not mutate state.
+- Valid moves update board state once.
+- Undo restores board, score, cooldowns, inventory, and timers when relevant.
+- Win/loss detection happens after state settles.
+- Random boards are seeded or testable.
+
+Common failures:
+
+- UI sprite moves but board state does not.
+- Board state changes twice for one input.
+- Undo restores positions but not secondary state.
+- Generated levels are unsolvable.
+
+## Tower Defense
+
+Use for path-and-wave games with tower placement, enemy waves, economy,
+upgrades, obstacles, and a defended target.
+
+Design contract:
+
+- Define path waypoints, grid/cell system, buildable cells, blocked cells,
+  economy, wave list, tower types, enemy types, target health, and upgrade
+  rules.
+- Start with one path, two tower types, and two enemy types.
+- State target priority rules: first, nearest, strongest, weakest, or custom.
+
+Asset rules:
+
+- Top-down towers, enemies, obstacles, target, projectiles, and slot markers.
+- Distinct projectile images per tower type when projectiles are visible.
+- Path and buildable cells must be unambiguous.
+
+Implementation patterns:
+
+- Wave manager owns spawning.
+- Economy manager owns spend/reward.
+- Tower grid owns occupied cells.
+- Tower fire logic should use existing targeting/projectile helpers.
+- Obstacles should be data-driven, not hardcoded into draw calls.
+
+Checks:
+
+- Enemies follow the path in waypoint order.
+- Towers can only be placed on valid empty cells.
+- Spend/reward cannot go negative unless intentionally allowed.
+- Projectiles hit or miss according to speed/range rules.
+- Wave completion and next-level transition work.
+
+Common failures:
+
+- Buildable cells overlap the path.
+- Towers placed on already occupied cells.
+- Projectile data read after the projectile is destroyed.
+- Enemy type strings in waves do not match factory mappings.
+- Level order never advances.
+
+## UI-Heavy
+
+Use for dialogue, cards, quizzes, menus, story choices, turn battles,
+relationship systems, or interactive fiction with heavy visual UI.
+
+Design contract:
+
+- Define scene flow, dialogue data, card/deck data, quiz/question data,
+  battle rules, ending conditions, and save/progress state.
+- Start with one complete interaction loop: choose, resolve, show feedback,
+  continue/end.
+- Specify keyboard/mouse/touch controls.
+
+Asset rules:
+
+- Portraits are front or three-quarter view.
+- Use expression variants when dialogue needs emotion.
+- Cards/icons must be legible at actual UI size.
+- Avoid putting essential text inside generated images.
+
+Implementation patterns:
+
+- UI state transitions should be explicit.
+- Dialogue, cards, and questions should live in data structures.
+- Modal depth/z-index must not hide feedback that should be visible.
+- Clean up dynamic UI elements between rounds/scenes.
+
+Checks:
+
+- Dialogue character IDs match registered characters.
+- Cards/questions have all fields used by render and resolution logic.
+- Buttons are keyboard accessible when the project UI supports it.
+- Scene transitions use registered keys.
+- Round state resets before a new round starts.
+
+Common failures:
+
+- Instantiating static helper UI classes instead of using their static methods.
+- Importing invented type names.
+- Overriding hooks that do not exist.
+- Hiding HP/status changes under a modal overlay.
+- Forgetting to complete the enemy/opponent turn.
+
+## Hybrid Guidance
+
+For hybrids, assign each subsystem to one owner pack. Example:
+
+```text
+Top-down owns movement/combat.
+UI-heavy owns dialogue and card rewards.
+Grid-logic owns inventory puzzle rooms.
+```
+
+Do not merge all pack rules into one giant design. Load only the packs that
+own real subsystems, and write explicit boundaries between them.

--- a/.claude/skills/game-prototyping/references/asset-protocol.md
+++ b/.claude/skills/game-prototyping/references/asset-protocol.md
@@ -1,0 +1,197 @@
+# Asset Protocol
+
+Plan game assets as a contract before generating or coding them. The most
+common game-agent failures are key drift and missing assets, not a lack of
+visual imagination.
+
+## Asset Registry
+
+Create an asset table before generation:
+
+| type | key | file/output | used by | style/prompt | checks |
+|---|---|---|---|---|---|
+
+Rules:
+
+- One stable `key` per loadable asset.
+- The same key must appear in the asset manifest, animation definitions,
+  config, and code.
+- Prefix keys by role when useful: `player_`, `enemy_`, `bg_`, `tile_`,
+  `icon_`, `sfx_`, `bgm_`.
+- Record whether an asset is final, placeholder, generated, searched, or hand
+  drawn.
+
+## Asset Types
+
+### Background
+
+Use for full-screen or level backdrops. Prefer 16:9 or the actual viewport
+aspect. Do not request transparency unless the background is a layer.
+
+Checks:
+
+- Fills the viewport without unintended stretching.
+- Does not hide gameplay entities.
+- Loads before gameplay starts or has a clear loading state.
+
+### Tileset Or Tile Pattern
+
+Use only when the engine actually consumes tiles. If the game uses code-defined
+grids, do not create a tileset just because the archetype is grid-like.
+
+Checks:
+
+- Tiles align to the configured tile size.
+- Tile edges are clean and repeat without visible seams.
+- Legend or tile IDs match the map data.
+
+### Animation Or Sprite Frames
+
+Use for moving characters, enemies, effects, and projectiles. Prefer fewer,
+consistent frames over many inconsistent frames.
+
+Checks:
+
+- Frame keys exist in the manifest.
+- Animation keys exist in the animation definition file.
+- Code references animation keys, not raw frame filenames.
+- Side-view sprites face the same default direction; use flipping in code.
+
+### Image, Sprite, Icon, Or Portrait
+
+Use for static game objects, UI, portraits, cards, towers, projectiles, and
+inventory items.
+
+Checks:
+
+- One object/character per image unless the asset is intentionally a group.
+- Transparent or plain background when the object should be composited.
+- Clear silhouette at final display size.
+
+### Audio
+
+Use for primary feedback only at first: action, hit, collect, win, lose, menu,
+and one background loop.
+
+Checks:
+
+- File format is supported by the target browser.
+- Duration is short enough for the interaction.
+- Volume is balanced against other sounds.
+- Playback is gated by user interaction when the browser requires it.
+
+## Map And Tilemap Protocol
+
+Use map data when level layout matters. Do not bury level geometry in scene
+code unless the game is a tiny prototype.
+
+### ASCII Layouts
+
+ASCII maps are useful for platformers, top-down tilemaps, grid puzzles, and
+tower-defense paths. Each symbol needs a legend:
+
+```text
+########
+#P..E..#
+#..##..#
+#....G.#
+########
+```
+
+Example legend:
+
+```yaml
+"#": wall_or_ground
+".": empty_or_floor
+"P": player_spawn
+"E": enemy_spawn
+"G": goal
+```
+
+Rules:
+
+- All rows must have the same width.
+- Object markers such as player/enemy/goal should not become solid tiles by
+  accident.
+- Keep collision layers and visual layers separate when the engine supports
+  it.
+- Name tilemap layers exactly; layer names are usually case-sensitive.
+
+### Dual Tilesets
+
+Top-down tilemaps often need separate floor and wall visuals. Treat these as
+two asset keys and two layers unless the engine template expects otherwise.
+
+Checks:
+
+- Walkable floor is visually calm.
+- Walls/blocked cells have stronger contrast.
+- Collision applies to the wall/blocked layer, not decorative floor.
+
+### 3x3 To 7x7 Expansion
+
+OpenGame's tooling expands a simple 3x3 tileset into a fuller blob tileset for
+auto-tiling. If Workflow later builds local game tooling, this is a good
+candidate to implement as a deterministic helper:
+
+- Input: 3x3 tiles for corners, edges, and center.
+- Output: 7x7 blobset with repeated edges, center fills, and inner corners.
+- Pair with an 8-neighbor bitmask auto-tiler.
+
+## Prompting Rules
+
+Use one style anchor for a batch:
+
+```text
+Style anchor: 16-bit pixel art, high-contrast silhouettes, readable at 64px,
+consistent palette, no text baked into the image.
+```
+
+Character prompts should specify:
+
+- View angle: side, top-down, front, or three-quarter.
+- Facing direction.
+- Full body vs bust.
+- Action pose and limb/body position.
+- Props that must stay consistent.
+- Background treatment: transparent, plain white, or full environment.
+
+Generate in small batches. If the batch is large, split by role:
+
+1. Core player/enemy/UI assets.
+2. Environment/background/tile assets.
+3. Effects/audio/polish assets.
+
+## Archetype View Rules
+
+- Platformer: side view, usually facing right, full body.
+- Top-down: overhead or three-quarter overhead; include directional variants
+  when movement direction matters.
+- Grid logic: readable tokens from top-down or orthographic view.
+- Tower defense: top-down towers, enemies, projectiles, obstacles, path/slot
+  markers.
+- UI-heavy: front or three-quarter portraits, static expressions, cards and
+  panels optimized for readability.
+
+## Verification Checklist
+
+Before coding:
+
+- [ ] Every planned asset has a unique key.
+- [ ] Style anchor is consistent across the batch.
+- [ ] Character orientation matches the archetype.
+- [ ] Placeholder assets are labeled as placeholders.
+
+Before final verification:
+
+- [ ] Every key referenced in code/config exists in the manifest.
+- [ ] Every animation key referenced in code exists in animation definitions.
+- [ ] Browser console has no missing texture, failed image, or failed audio
+      errors.
+- [ ] The game renders nonblank visuals on desktop and mobile viewports.
+- [ ] The user can distinguish player, obstacles, enemies, interactive items,
+      and feedback effects at actual game size.
+
+If no asset-generation tool is available, do not invent one. Use existing
+assets, create simple local placeholders with clear labels, or record the asset
+gap as an explicit follow-up.

--- a/.claude/skills/game-prototyping/references/debug-protocol.md
+++ b/.claude/skills/game-prototyping/references/debug-protocol.md
@@ -1,0 +1,108 @@
+# Game Debug Protocol
+
+Use this when verifying or repairing a browser game/prototype.
+
+## Pre-Build Checks
+
+### Asset Keys
+
+- [ ] Every image/audio key referenced in code exists in the asset manifest.
+- [ ] Every physical file referenced by the manifest exists.
+- [ ] Placeholder keys are not mixed with final keys by accident.
+
+### Animation Keys
+
+- [ ] Frame keys exist in the manifest.
+- [ ] Animation definitions reference valid frame keys.
+- [ ] Code references animation keys that exist.
+- [ ] Static UI-heavy portraits are not accidentally treated as animations.
+
+### Config Keys
+
+- [ ] Every config path referenced in code exists.
+- [ ] Every required entity stat exists for player/enemy/tower/card/question.
+- [ ] Numeric values use the intended unit: pixels, seconds, milliseconds,
+      frames, grid cells, or percentages.
+
+### Scene And Level Registration
+
+- [ ] Every `start`, `launch`, route, or transition target is registered.
+- [ ] Level order references real scene keys.
+- [ ] First scene/level is not still a template default.
+
+### Hook And Type Integrity
+
+- [ ] Every override/hook name exists in the base class/component.
+- [ ] Overrides do not narrow visibility or change required signatures.
+- [ ] Imported types/classes actually exist in the source file.
+- [ ] Type-only imports are marked correctly when the project requires it.
+
+### State Cleanup
+
+- [ ] Event listeners added on scene creation are removed or scoped to scene
+      shutdown.
+- [ ] Dynamic UI elements are destroyed before recreation.
+- [ ] Per-round/per-level mutable state resets at the start of the next round.
+- [ ] Projectiles, timers, tweens, and physics bodies clean up.
+
+## Execution Order
+
+1. Build/typecheck.
+2. Run tests.
+3. Start the dev server in the background.
+4. Open the game in a browser.
+5. Check console and network errors.
+6. Verify a visible, nonblank canvas or UI.
+7. Exercise the first playable loop.
+8. Check desktop and mobile viewport framing.
+
+Do not run long-lived dev servers in the foreground. Keep terminal control.
+
+## Failure Record
+
+When a failure is fixed, capture a record if it is likely to recur:
+
+```yaml
+signature:
+  stage: build | test | browser | visual | gameplay
+  error_code: string-or-null
+  message_pattern: short regex or exact text
+  file_context: path/glob if useful
+root_cause: one sentence
+verified_fix: what changed and how it was verified
+proactive_check: optional future validation
+first_seen: YYYY-MM-DD
+last_seen: YYYY-MM-DD
+occurrences: 1
+```
+
+If the same signature appears three times, promote it into a proactive check,
+test, lint rule, or skill instruction. If the recurring failure is agent
+behavior rather than game code, use `auto-iterate`.
+
+## Common Signatures
+
+| Signature | Likely cause | First place to inspect |
+|---|---|---|
+| Missing import/module | Wrong relative path or export name | Import line and target file |
+| Property does not exist | Config/type drift or invented API | Type/interface and caller |
+| Texture/image not found | Key mismatch or missing manifest entry | Asset manifest and code key |
+| Animation not found | Animation definition missing or wrong key | Animation JSON and anim map |
+| Scene not found | Transition target not registered | Engine scene config/level order |
+| Cannot read property of undefined | Initialization order or missing data | Constructor/create lifecycle |
+| Blank canvas | Boot failure, hidden canvas, missing assets | Console, network, canvas pixels |
+| Input ignored | Focus, event binding, scene pause, overlay | Browser events and scene state |
+| State repeats/duplicates | Event listener leak or missing cleanup | Scene restart and shutdown hooks |
+
+## Browser Acceptance
+
+A game is not verified just because it builds. Acceptance needs browser
+evidence:
+
+- Canvas/UI is nonblank.
+- Primary controls work.
+- One win/loss or completion path works.
+- Console has no relevant errors.
+- Assets visibly match the intended archetype.
+- Text fits on desktop and mobile.
+- Animation or movement is visible when expected.

--- a/.claude/skills/game-prototyping/references/gdd-contract.md
+++ b/.claude/skills/game-prototyping/references/gdd-contract.md
@@ -1,0 +1,116 @@
+# Game Design Contract
+
+Use this compact GDD format before coding a game or game-like prototype. The
+point is not a long design document; it is a downstream contract that prevents
+asset, config, scene, and implementation drift.
+
+## Core Principles
+
+- Config-first: numeric tuning belongs in config or constants, not scattered
+  through gameplay code.
+- Template-first: use existing engines, templates, hooks, and components before
+  inventing custom systems.
+- Behavior-first: compose movement, combat, interaction, and UI behaviors when
+  the archetype already has a pattern.
+- Concrete values: no "some enemies", "appropriate speed", or "nice effect".
+- Exact keys: scene IDs, asset keys, animation keys, config paths, and route
+  names must be spelled exactly once and reused consistently.
+
+## Required Sections
+
+### 0. Technical Architecture
+
+Consumer: scene registration, engine boot, routing, build setup.
+
+Must include:
+
+- Engine/library choice.
+- Archetype and any hybrid split.
+- Resolution/aspect ratio.
+- Scene flow, with exact scene key strings.
+- First playable slice.
+- Files likely touched.
+
+### 1. Visual Style And Asset Registry
+
+Consumer: asset creation, asset manifest, animation definitions, preloader.
+
+Must include an asset table:
+
+| type | key | use | prompt/style note | verification |
+|---|---|---|---|---|
+
+Use stable keys. Every asset key planned here must later exist in the manifest
+or be removed from code/config before verification.
+
+### 2. Game Configuration
+
+Consumer: config files, constants, balancing.
+
+Must include complete values for:
+
+- Screen/camera settings.
+- Player/input stats.
+- Enemy/puzzle/wave/content stats.
+- Economy, score, timers, cooldowns, or win/loss thresholds.
+- Feature flags or debug settings.
+
+### 3. Entity And Scene Architecture
+
+Consumer: source files, templates, hooks, class/component boundaries.
+
+Must include:
+
+- Base class/component to extend.
+- Existing behavior/system to reuse.
+- Hooks to override, with exact names if known.
+- Event names and ownership.
+- Data ownership: scene state, entity state, global state, URL state.
+
+### 4. Level And Content Design
+
+Consumer: levels, maps, puzzle data, dialogue, waves, encounters.
+
+Must include:
+
+- Level order.
+- Spawn points or board layout.
+- Content data structures.
+- Difficulty progression.
+- Minimum content needed for the first playable slice.
+
+### 5. Implementation Roadmap
+
+Consumer: task list and code edits.
+
+Write file-level operations:
+
+```text
+1. UPDATE src/gameConfig.* with the Section 2 values.
+2. UPDATE scene registration with [ExactSceneKey].
+3. COPY/CREATE scene/entity files from [template/source].
+4. IMPLEMENT hooks [hook names].
+5. ADD tests/browser checks for [specific behavior].
+```
+
+### 6. Verification Plan
+
+Consumer: tests, browser checks, debug protocol.
+
+Must include:
+
+- Build/typecheck command.
+- Test command, if available.
+- Dev server command and URL.
+- Browser interactions to perform.
+- Asset/animation/scene/config consistency checks.
+- Canvas-pixel or screenshot checks for nonblank rendering.
+
+## Forbidden In The GDD
+
+- "Implement from scratch" when an existing template/library covers it.
+- Unspecified numbers.
+- Asset keys that are not listed in the registry.
+- Scene transitions to unregistered scene keys.
+- Custom engine systems for mechanics already handled by a library.
+- Copying external code without adapting it to the project conventions.

--- a/.claude/skills/game-prototyping/references/opengame-source.md
+++ b/.claude/skills/game-prototyping/references/opengame-source.md
@@ -1,0 +1,63 @@
+# OpenGame Source Notes
+
+Source audited: `https://github.com/leigest519/OpenGame`
+
+Commit audited: `c54307e` (`2026-04-22T12:50:54+08:00`)
+
+Audit date: `2026-05-01`
+
+License observed in the source checkout: Apache License 2.0.
+
+## What Was Imported
+
+This skill adapts concepts from OpenGame's Game Skill stack rather than
+vendoring its files raw:
+
+- Template-first game creation.
+- Debug protocol with reusable signatures and proactive checks.
+- GDD-style downstream contract.
+- Asset planning and key-consistency checks.
+- Archetype packs for platformer, top-down, grid logic, tower defense, and
+  UI-heavy games.
+- Context staging: light design/capability docs first, heavy implementation
+  docs only when coding.
+
+## What Was Not Imported
+
+- OpenGame's Qwen runtime assumptions.
+- `generate_game_assets`, `generate_tilemap`, or other OpenGame-specific tool
+  names as required commands.
+- Phaser template source files.
+- Provider-specific environment variables.
+- Large raw archetype manuals.
+
+## Additional Candidates Found
+
+These were found in the broader repo scan and are worth considering only when
+Workflow has a concrete need:
+
+- Physics-first classifier: `packages/core/src/tools/game-type-classifier.ts`.
+  The decision tree is already reflected in `archetype-packs.md`; a tool is
+  only worth building if we repeatedly classify game requests.
+- GDD generator: `packages/core/src/tools/generate-gdd.ts`. The useful pattern
+  is auto-loading core rules plus design rules plus template capability docs.
+  That pattern is now reflected in `gdd-contract.md` and `context-engineering`.
+- Asset pipeline: `generate-assets.ts`, `assetImageService.ts`,
+  `assetAudioService.ts`, `assetVideoService.ts`, background removal, and frame
+  extraction. Worth revisiting if we need repeatable local game-asset output
+  instead of ad hoc image generation.
+- Tilemap pipeline: `generate-tilemap.ts`, `auto-tiler.ts`, and
+  `tileset-processor.ts`. Worth copying as a deterministic helper if we build
+  several tile-based games.
+- Copy-template tool: `copy-template.ts`. The key idea is safe scaffold copying
+  that does not overwrite existing files.
+- Skill manager: `packages/core/src/skills/skill-manager.ts`. Mostly overlaps
+  our existing `validate_skills.py`; no import needed now.
+- OpenGame-Bench: README describes dynamic playability evaluation across build
+  health, visual usability, and intent alignment, but the pipeline is not
+  released in this checkout. Good future inspiration for browser-game
+  acceptance probes.
+
+Future sessions should treat these references as Workflow-local guidance. If
+we later vendor source templates, preserve Apache-2.0 notices and document the
+source commit next to the copied files.

--- a/.claude/skills/game-prototyping/references/template-evolution.md
+++ b/.claude/skills/game-prototyping/references/template-evolution.md
@@ -1,0 +1,62 @@
+# Template Evolution
+
+Use this when a completed game/prototype reveals reusable structure. The goal
+is to accumulate useful templates without bloating the skill with one-off
+project details.
+
+## Promotion Criteria
+
+Promote a pattern only when at least one is true:
+
+- It has been useful in two or more projects.
+- It prevents a repeated failure.
+- It captures a stable engine/archetype boundary.
+- It reduces future implementation steps without hiding important decisions.
+- It can be verified with a checklist, test, or browser probe.
+
+Do not promote one-off game content, licensed art, generated story text, or
+theme-specific names.
+
+## Evolution Pipeline
+
+1. Collect: list files, commands, assets, config, and tests from the completed
+   project.
+2. Classify: identify the archetype and any hybrid boundaries.
+3. Extract: find reusable base classes, hooks, config schema, assets patterns,
+   directory structure, and verification checks.
+4. Abstract: replace game-specific names and numbers with placeholders or
+   config fields.
+5. Merge: update the relevant reference pack or template with minimal new text.
+6. Verify: run skill validation and, if code/templates were added, run the
+   project's build/test/browser checks.
+
+## What To Store
+
+Good template material:
+
+- Directory skeletons.
+- Config schemas.
+- Hook lists.
+- Event contracts.
+- Asset key conventions.
+- Verification checklists.
+- Small starter files that are clearly placeholders.
+
+Bad template material:
+
+- Full generated games.
+- Brand/IP-specific assets.
+- Huge implementation manuals no one will load.
+- Untested snippets.
+- Commands that assume unavailable tools.
+
+## Where It Goes
+
+- Reusable game workflow: `game-prototyping/SKILL.md`.
+- Archetype-specific design/capability guidance:
+  `game-prototyping/references/archetype-packs.md`.
+- Asset rules: `game-prototyping/references/asset-protocol.md`.
+- Debug signatures/checks: `game-prototyping/references/debug-protocol.md` or
+  the broader `debugging-and-error-recovery` skill if not game-specific.
+- Cross-provider process rules: `AGENTS.md`, only when every provider needs to
+  know the convention outside this skill.


### PR DESCRIPTION
## Summary

Phase B recovery from dirty-worktree audit ([[cowork-dirty-worktree-audit-lost-framings-2026-05-06]]). The `cursor/claim-check-session-d` branch from 4.9d ago contained 2580 lines of new skill curriculum that never got PR'd. This PR recovers the 2 NEW skill folders that have no conflict risk with current main.

## auto-iterate skill (175 lines, mirrored to .agents/ + .claude/)

Formalizes the prevention-ratchet shape. Each recurrence of a behavioral failure must add a stronger preventive layer (doc → script → hook → gate) so the failure cannot recur silently. Two canonical exemplars: FUSE truncation ratchet + cross-provider-drift ratchet. This is a high-value framing that captures the discipline we've been operating under without naming.

## game-prototyping skill (148 + 921 lines references, mirrored)

Template-first browser game prototyping with archetype packs, asset protocol, debug protocol, GDD contract, opengame-source guidance, and template-evolution patterns. 6 reference files covering the full prototype lifecycle. Adapts useful parts of OpenGame's Game Skill into Workflow conventions.

## Total recovered

- 16 files (8 in `.agents/skills/`, 8 mirrored in `.claude/skills/`)
- 2192 lines of skill curriculum content

## What this PR does NOT include

The cursor branch also had 6 modifications to **existing** skill files (context-engineering, debugging-and-error-recovery, skill-authoring, spec-driven-development, using-agent-skills, website-editing) — those need careful merge review against current main since main has evolved over the past 4.9d. Filing those as a separate follow-up PR after diff inspection.

## Triple-key gate

- Cowork checker-key: YES (this PR)
- Codex review: pending dual-key concur
- Host approval: required as third key for merge

## Cross-refs

- [[cowork-dirty-worktree-audit-lost-framings-2026-05-06]]
- Original orphaned branch: `cursor/claim-check-session-d` @ `79baa96c`