### PR TITLE
[auto-change] WIKI-PATCH: PR-054: auto-fix-bug.yml top-level concurrency group is over-broad — should be per-issue, not per-workflow

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -53,9 +53,9 @@ on:
     - cron: "7,22,37,52 * * * *"
 
 concurrency:
-  # Subscription-backed writer sessions are a shared daemon lane. Queue triggers
-  # instead of overlapping writers and burning through subscription rate limits.
-  group: auto-fix-subscription-writer
+  # Queue duplicate triggers for the same issue without blocking unrelated
+  # daemon requests. Backfill triggers do not know the issue until discovery.
+  group: auto-fix-${{ github.event.issue.number || inputs.issue_number || github.run_id }}
   cancel-in-progress: false
 
 permissions:

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -77,9 +77,12 @@ def test_has_pull_requests_write(wf):
 # ---------------------------------------------------------------------------
 
 
-def test_workflow_concurrency_serializes_subscription_writer_lane(wf):
+def test_workflow_concurrency_is_issue_scoped(wf):
     conc = wf.get("concurrency", {})
-    assert conc.get("group") == "auto-fix-subscription-writer"
+    group = str(conc.get("group", ""))
+    assert "github.event.issue.number" in group
+    assert "inputs.issue_number" in group
+    assert "auto-fix-subscription-writer" not in group
     assert conc.get("cancel-in-progress") is False
 
 


### PR DESCRIPTION
Fixes #525

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.