### PR TITLE
[auto-change] WIKI-PATCH: PR-055: Render-to-shareable-artifact via read.page format= parameter (refile of #470 shape under 5-handle surface)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -339,9 +339,22 @@ def _resolve_bugs_canonical(parent: Path, slug: str) -> Path | None:
 # ---------------------------------------------------------------------------
 
 
-def _wiki_read(page: str = "", **_kwargs: Any) -> str:
+def _wiki_read(page: str = "", format: str = "", **_kwargs: Any) -> str:
     if not page:
         return json.dumps({"error": "page parameter is required."})
+
+    requested_format = (format or "json").strip().lower().replace("_", "-")
+    artifact_formats = {"artifact", "shareable-artifact", "shareable-markdown"}
+    if requested_format not in {"json", "markdown", *artifact_formats}:
+        return json.dumps({
+            "error": f"Unsupported read format: {format}",
+            "available_formats": [
+                "json",
+                "markdown",
+                "artifact",
+                "shareable-artifact",
+            ],
+        })
 
     resolved = _resolve_page(page)
     if resolved is None:
@@ -351,21 +364,36 @@ def _wiki_read(page: str = "", **_kwargs: Any) -> str:
     is_draft = _wiki_drafts_dir() in resolved.parents
     rel = _page_rel_path(resolved)
     content = _draft_read_content(text, is_draft=is_draft)
+    meta, _body = _parse_frontmatter(text)
+    title = str(meta.get("title") or resolved.stem)
 
     if len(text) > 15000:
-        return json.dumps({
+        response = {
             "path": rel,
             "is_draft": is_draft,
             "content": content[:15000],
             "truncated": True,
             "total_chars": len(text),
-        })
-    return json.dumps({
-        "path": rel,
-        "is_draft": is_draft,
-        "content": content,
-        "truncated": False,
-    })
+        }
+    else:
+        response = {
+            "path": rel,
+            "is_draft": is_draft,
+            "content": content,
+            "truncated": False,
+        }
+
+    if requested_format in {"markdown", *artifact_formats}:
+        response["format"] = "artifact" if requested_format in artifact_formats else "markdown"
+        response["artifact"] = {
+            "kind": "shareable_markdown",
+            "mime_type": "text/markdown",
+            "filename": resolved.name,
+            "title": title,
+            "content": response["content"],
+        }
+
+    return json.dumps(response)
 
 
 def _draft_read_content(text: str, *, is_draft: bool) -> str:
@@ -1764,6 +1792,7 @@ def wiki(
     bug_id: str = "",
     reporter_context: str = "",
     verbose: bool = False,
+    format: str = "",
 ) -> str:
     """Dispatch entry for the wiki MCP tool. See universe_server.py for the
     chatbot-facing docstring; this function is the implementation invoked by
@@ -1858,6 +1887,7 @@ def wiki(
         "bug_id": bug_id,
         "reporter_context": reporter_context,
         "verbose": verbose,
+        "format": format,
     }
 
     return handler(**kwargs)

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -961,6 +961,7 @@ def wiki(
     force_new: bool = False,
     bug_id: str = "",
     reporter_context: str = "",
+    format: str = "",
 ) -> str:
     """Read, write, and manage the cross-project knowledge wiki.
 
@@ -983,6 +984,8 @@ def wiki(
             sync_projects, file_bug, cosign_bug.
         old_text/new_text: For action="patch", exact text to replace server-side.
         expected_sha256: Optional full-page hash guard for action="patch".
+        format: Optional action="read" response format. Use "artifact" or
+            "shareable-artifact" to include a Markdown artifact envelope.
     """
     return _wiki_impl(
         action=action,
@@ -1015,6 +1018,7 @@ def wiki(
         force_new=force_new,
         bug_id=bug_id,
         reporter_context=reporter_context,
+        format=format,
     )
 
 

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -154,6 +154,24 @@ class TestWikiRead:
         assert "Test Project" in result["content"]
         assert result["truncated"] is False
 
+    def test_read_page_as_shareable_artifact(self, wiki_dir):
+        result = json.loads(wiki("read", page="test-project", format="artifact"))
+
+        assert result["format"] == "artifact"
+        assert result["artifact"] == {
+            "kind": "shareable_markdown",
+            "mime_type": "text/markdown",
+            "filename": "test-project.md",
+            "title": "Test Project",
+            "content": result["content"],
+        }
+
+    def test_read_rejects_unknown_format(self, wiki_dir):
+        result = json.loads(wiki("read", page="test-project", format="pdf"))
+
+        assert result["error"] == "Unsupported read format: pdf"
+        assert "artifact" in result["available_formats"]
+
     def test_read_special_index(self, wiki_dir):
         result = json.loads(wiki("read", page="index"))
         assert "Wiki Index" in result["content"]
@@ -753,3 +771,13 @@ class TestWikiMCPRegistration:
 
         assert properties["kind"] == {"default": "bug", "type": "string"}
         assert "kind" not in wiki_tool.parameters["required"]
+
+    def test_wiki_read_format_field_is_in_mcp_schema(self):
+        tools = asyncio.run(mcp.list_tools(run_middleware=False))
+        wiki_tool = next(t for t in tools if t.name == "wiki")
+        properties = wiki_tool.parameters["properties"]
+
+        assert properties["format"]["default"] == ""
+        assert properties["format"]["type"] == "string"
+        assert "artifact" in properties["format"]["description"]
+        assert "format" not in wiki_tool.parameters["required"]

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -339,9 +339,22 @@ def _resolve_bugs_canonical(parent: Path, slug: str) -> Path | None:
 # ---------------------------------------------------------------------------
 
 
-def _wiki_read(page: str = "", **_kwargs: Any) -> str:
+def _wiki_read(page: str = "", format: str = "", **_kwargs: Any) -> str:
     if not page:
         return json.dumps({"error": "page parameter is required."})
+
+    requested_format = (format or "json").strip().lower().replace("_", "-")
+    artifact_formats = {"artifact", "shareable-artifact", "shareable-markdown"}
+    if requested_format not in {"json", "markdown", *artifact_formats}:
+        return json.dumps({
+            "error": f"Unsupported read format: {format}",
+            "available_formats": [
+                "json",
+                "markdown",
+                "artifact",
+                "shareable-artifact",
+            ],
+        })
 
     resolved = _resolve_page(page)
     if resolved is None:
@@ -351,21 +364,36 @@ def _wiki_read(page: str = "", **_kwargs: Any) -> str:
     is_draft = _wiki_drafts_dir() in resolved.parents
     rel = _page_rel_path(resolved)
     content = _draft_read_content(text, is_draft=is_draft)
+    meta, _body = _parse_frontmatter(text)
+    title = str(meta.get("title") or resolved.stem)
 
     if len(text) > 15000:
-        return json.dumps({
+        response = {
             "path": rel,
             "is_draft": is_draft,
             "content": content[:15000],
             "truncated": True,
             "total_chars": len(text),
-        })
-    return json.dumps({
-        "path": rel,
-        "is_draft": is_draft,
-        "content": content,
-        "truncated": False,
-    })
+        }
+    else:
+        response = {
+            "path": rel,
+            "is_draft": is_draft,
+            "content": content,
+            "truncated": False,
+        }
+
+    if requested_format in {"markdown", *artifact_formats}:
+        response["format"] = "artifact" if requested_format in artifact_formats else "markdown"
+        response["artifact"] = {
+            "kind": "shareable_markdown",
+            "mime_type": "text/markdown",
+            "filename": resolved.name,
+            "title": title,
+            "content": response["content"],
+        }
+
+    return json.dumps(response)
 
 
 def _draft_read_content(text: str, *, is_draft: bool) -> str:
@@ -1764,6 +1792,7 @@ def wiki(
     bug_id: str = "",
     reporter_context: str = "",
     verbose: bool = False,
+    format: str = "",
 ) -> str:
     """Dispatch entry for the wiki MCP tool. See universe_server.py for the
     chatbot-facing docstring; this function is the implementation invoked by
@@ -1858,6 +1887,7 @@ def wiki(
         "bug_id": bug_id,
         "reporter_context": reporter_context,
         "verbose": verbose,
+        "format": format,
     }
 
     return handler(**kwargs)

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -961,6 +961,7 @@ def wiki(
     force_new: bool = False,
     bug_id: str = "",
     reporter_context: str = "",
+    format: str = "",
 ) -> str:
     """Read, write, and manage the cross-project knowledge wiki.
 
@@ -983,6 +984,8 @@ def wiki(
             sync_projects, file_bug, cosign_bug.
         old_text/new_text: For action="patch", exact text to replace server-side.
         expected_sha256: Optional full-page hash guard for action="patch".
+        format: Optional action="read" response format. Use "artifact" or
+            "shareable-artifact" to include a Markdown artifact envelope.
     """
     return _wiki_impl(
         action=action,
@@ -1015,6 +1018,7 @@ def wiki(
         force_new=force_new,
         bug_id=bug_id,
         reporter_context=reporter_context,
+        format=format,
     )
 
 


### PR DESCRIPTION
Fixes #526

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.