### PR TITLE
[auto-change] BUG-070: workflow-live wiki and community_change_context tools return JSON-RPC deserialize error while get_status works

### DIFF
--- a/tests/test_universe_server_mcp_structured_results.py
+++ b/tests/test_universe_server_mcp_structured_results.py
@@ -19,7 +19,7 @@ def test_direct_wrappers_keep_json_string_contract() -> None:
     assert "promoted" in json.loads(wiki_raw)
 
 
-def test_mcp_tool_result_has_structured_content_and_text_content() -> None:
+def test_mcp_status_tool_result_has_structured_content_and_text_content() -> None:
     """ChatGPT/Apps SDK needs structuredContent without losing text content."""
     from workflow import universe_server as us
 
@@ -33,3 +33,78 @@ def test_mcp_tool_result_has_structured_content_and_text_content() -> None:
     assert result.content
     assert result.content[0].type == "text"
     assert json.loads(result.content[0].text)["schema_version"] == 1
+
+
+def test_mcp_wiki_tool_result_has_structured_content_and_text_content(
+    monkeypatch,
+) -> None:
+    """BUG-070 guard: `wiki` stays JSON-RPC deserializable through MCP."""
+    from workflow import universe_server as us
+
+    monkeypatch.setattr(
+        us,
+        "_wiki_impl",
+        lambda **kwargs: json.dumps(
+            {
+                "promoted": [{"page": "pages/bugs/bug-070.md"}],
+                "promoted_count": 1,
+                "drafts": [],
+                "drafts_count": 0,
+                "action": kwargs["action"],
+            }
+        ),
+    )
+
+    async def _call_wiki():
+        return await us.mcp.call_tool("wiki", {"action": "list"})
+
+    result = asyncio.run(_call_wiki())
+
+    assert result.structured_content == {
+        "promoted": [{"page": "pages/bugs/bug-070.md"}],
+        "promoted_count": 1,
+        "drafts": [],
+        "drafts_count": 0,
+        "action": "list",
+    }
+    assert result.content
+    assert result.content[0].type == "text"
+    assert json.loads(result.content[0].text) == result.structured_content
+
+
+def test_mcp_community_change_context_tool_result_has_structured_content_and_text_content(
+    monkeypatch,
+) -> None:
+    """BUG-070 guard: review-context alias stays deserializable through MCP."""
+    from workflow import universe_server as us
+
+    monkeypatch.setattr(
+        us,
+        "_universe_impl",
+        lambda **kwargs: json.dumps(
+            {
+                "kind": "community_change_context",
+                "selector": kwargs["filter_text"],
+                "limit": kwargs["limit"],
+                "open_prs": [],
+            }
+        ),
+    )
+
+    async def _call_context():
+        return await us.mcp.call_tool(
+            "community_change_context",
+            {"filter_text": "queue", "limit": 1},
+        )
+
+    result = asyncio.run(_call_context())
+
+    assert result.structured_content == {
+        "kind": "community_change_context",
+        "selector": "queue",
+        "limit": 1,
+        "open_prs": [],
+    }
+    assert result.content
+    assert result.content[0].type == "text"
+    assert json.loads(result.content[0].text) == result.structured_content


### PR DESCRIPTION
Fixes #553

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.