### PR TITLE
[auto-change] BUG-071: Coordination notes can be synced as daemon-request project-design work and auto-dispatched to code writers

### DIFF
--- a/docs/ops/wiki-bug-sync-runbook.md
+++ b/docs/ops/wiki-bug-sync-runbook.md
@@ -62,6 +62,7 @@ commits increments back. This makes reruns idempotent.
 | `pages/plans/patch-*` | `request:patch` |
 | `pages/workflows/*` | `request:branch-refinement` |
 | builder notes under `pages/notes/*` | `request:branch-refinement` |
+| other coordination notes under `pages/notes/*` | ignored by sync |
 | strategic/roadmap/design/architecture/refactoring/attribution plans | `request:project-design` |
 | patch/feature pages whose title/path has architectural shape | `request:project-design` |
 | other promoted plans/concepts | `request:docs-ops` |
@@ -71,6 +72,10 @@ architecture, design-note, roadmap, operating-model, or substrate changes is
 filed as `request:project-design`; the auto-fix workflow then drafts under
 `docs/design-notes/proposed/` on a `design-note-draft/*` branch instead of
 opening a mechanical `auto-change/*` branch.
+
+Ordinary `pages/notes/*` coordination artifacts are not request artifacts.
+Only builder notes enter the branch-refinement lane; design or architecture
+words in coordination-note titles are not enough to create daemon requests.
 
 ## Manual trigger
 

--- a/scripts/wiki_bug_sync.py
+++ b/scripts/wiki_bug_sync.py
@@ -320,6 +320,11 @@ def _change_kind(entry: dict[str, Any]) -> str | None:
     ):
         return None
 
+    if path.startswith("pages/notes/"):
+        if "builder" in entry_type or "builder" in title:
+            return "branch-refinement"
+        return None
+
     if any(marker in design_text for marker in _ARCHITECTURAL_FILING_MARKERS):
         return "project-design"
 
@@ -346,8 +351,6 @@ def _change_kind(entry: dict[str, Any]) -> str | None:
     ):
         return "project-design"
     if path.startswith("pages/workflows/"):
-        return "branch-refinement"
-    if path.startswith("pages/notes/") and ("builder" in entry_type or "builder" in title):
         return "branch-refinement"
     if path.startswith("pages/plans/") and any(
         marker in design_text

--- a/tests/test_wiki_bug_sync.py
+++ b/tests/test_wiki_bug_sync.py
@@ -229,6 +229,35 @@ def test_architectural_patch_request_enters_project_design_lane():
     assert result[0]["request_kind"] == "project-design"
 
 
+def test_coordination_note_with_design_language_is_not_a_request():
+    wiki_list = {
+        "promoted": [
+            {
+                "path": "pages/notes/codex-architectural-coordination-2026-05-06.md",
+                "title": "Codex architectural coordination note",
+                "type": "note",
+            }
+        ]
+    }
+    result = list_new_change_requests(wiki_list, seen_paths=set())
+    assert result == []
+
+
+def test_builder_note_enters_branch_refinement_lane():
+    wiki_list = {
+        "promoted": [
+            {
+                "path": "pages/notes/builder-notes-agent-teams.md",
+                "title": "Builder notes: agent teams",
+                "type": "note",
+            }
+        ]
+    }
+    result = list_new_change_requests(wiki_list, seen_paths=set())
+    assert len(result) == 1
+    assert result[0]["request_kind"] == "branch-refinement"
+
+
 def test_legacy_bug_typed_patch_request_page_enters_patch_lane():
     wiki_list = {
         "promoted": [


### PR DESCRIPTION
Fixes #563

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.