### PR TITLE
[auto-change] WIKI-PATCH: Live brain ambient relevance feed for cross-session insight propagation

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -235,6 +235,122 @@ def _wiki_similarity_score(
     return jaccard * 0.4 + link_score * 0.3 + title_bonus
 
 
+def _parse_wiki_timestamp(value: str) -> datetime | None:
+    raw = value.strip()
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        try:
+            parsed = datetime.fromisoformat(f"{raw}T00:00:00+00:00")
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _page_updated_at(path: Path, meta: dict[str, str]) -> datetime:
+    parsed = _parse_wiki_timestamp(meta.get("updated", ""))
+    if parsed is not None:
+        return parsed
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+
+
+def _wiki_read_terms(
+    *,
+    page: str,
+    query: str,
+    meta: dict[str, str],
+    body: str,
+) -> set[str]:
+    text = query.strip()
+    if not text:
+        text = " ".join(
+            part for part in (
+                page,
+                meta.get("title", ""),
+                meta.get("tags", ""),
+                meta.get("type", ""),
+                body[:1200],
+            ) if part
+        )
+    return _extract_keywords(text)
+
+
+def _coerce_feed_limit(value: Any) -> int:
+    try:
+        raw = int(value or 0)
+    except (TypeError, ValueError):
+        raw = 10
+    return max(0, min(raw, 20))
+
+
+def _ambient_relevance_feed(
+    *,
+    source: Path,
+    page: str,
+    query: str,
+    changed_since: str,
+    max_results: int,
+    source_meta: dict[str, str],
+    source_body: str,
+) -> dict[str, Any]:
+    terms = _wiki_read_terms(
+        page=page,
+        query=query,
+        meta=source_meta,
+        body=source_body,
+    )
+    since = _parse_wiki_timestamp(changed_since)
+    limit = _coerce_feed_limit(max_results)
+    candidates: list[dict[str, Any]] = []
+    for candidate in (
+        _find_all_pages(_wiki_pages_dir()) + _find_all_pages(_wiki_drafts_dir())
+    ):
+        if candidate == source:
+            continue
+        raw = _read_text(candidate)
+        if not raw:
+            continue
+        meta, body = _parse_frontmatter(raw)
+        updated_at = _page_updated_at(candidate, meta)
+        if since is not None and updated_at <= since:
+            continue
+        haystack = " ".join(
+            part for part in (
+                meta.get("title", ""),
+                meta.get("tags", ""),
+                meta.get("type", ""),
+                body,
+            ) if part
+        ).lower()
+        matched_terms = sorted(term for term in terms if term in haystack)
+        if not matched_terms:
+            continue
+        title = meta.get("title") or candidate.stem
+        excerpt = body.replace("\n", " ").strip()[:220]
+        candidates.append({
+            "path": _page_rel_path(candidate),
+            "title": title,
+            "updated": updated_at.isoformat().replace("+00:00", "Z"),
+            "matched_terms": matched_terms[:8],
+            "score": len(matched_terms),
+            "excerpt": excerpt,
+        })
+
+    candidates.sort(key=lambda item: (-item["score"], item["path"]))
+    items = candidates[:limit]
+    return {
+        "source_path": _page_rel_path(source),
+        "query_terms": sorted(terms)[:20],
+        "changed_since": changed_since.strip(),
+        "items": items,
+        "truncated_count": max(0, len(candidates) - len(items)),
+    }
+
+
 def _add_to_index(category: str, slug: str, title: str) -> None:
     """Add an entry to the wiki index.md under the right section."""
     idx_path = _wiki_index_path()
@@ -339,7 +455,13 @@ def _resolve_bugs_canonical(parent: Path, slug: str) -> Path | None:
 # ---------------------------------------------------------------------------
 
 
-def _wiki_read(page: str = "", **_kwargs: Any) -> str:
+def _wiki_read(
+    page: str = "",
+    query: str = "",
+    changed_since: str = "",
+    max_results: int = 10,
+    **_kwargs: Any,
+) -> str:
     if not page:
         return json.dumps({"error": "page parameter is required."})
 
@@ -350,7 +472,25 @@ def _wiki_read(page: str = "", **_kwargs: Any) -> str:
     text = _read_text(resolved)
     is_draft = _wiki_drafts_dir() in resolved.parents
     rel = _page_rel_path(resolved)
+    meta, body = _parse_frontmatter(text)
+    updated_at = _page_updated_at(resolved, meta)
     content = _draft_read_content(text, is_draft=is_draft)
+    source_read_proof = {
+        "path": rel,
+        "title": meta.get("title") or resolved.stem,
+        "updated": updated_at.isoformat().replace("+00:00", "Z"),
+        "sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "is_draft": is_draft,
+    }
+    ambient_feed = _ambient_relevance_feed(
+        source=resolved,
+        page=page,
+        query=query,
+        changed_since=changed_since,
+        max_results=max_results,
+        source_meta=meta,
+        source_body=body,
+    )
 
     if len(text) > 15000:
         return json.dumps({
@@ -359,12 +499,16 @@ def _wiki_read(page: str = "", **_kwargs: Any) -> str:
             "content": content[:15000],
             "truncated": True,
             "total_chars": len(text),
+            "source_read_proof": source_read_proof,
+            "ambient_relevance_feed": ambient_feed,
         })
     return json.dumps({
         "path": rel,
         "is_draft": is_draft,
         "content": content,
         "truncated": False,
+        "source_read_proof": source_read_proof,
+        "ambient_relevance_feed": ambient_feed,
     })
 
 
@@ -1764,6 +1908,7 @@ def wiki(
     bug_id: str = "",
     reporter_context: str = "",
     verbose: bool = False,
+    changed_since: str = "",
 ) -> str:
     """Dispatch entry for the wiki MCP tool. See universe_server.py for the
     chatbot-facing docstring; this function is the implementation invoked by
@@ -1858,6 +2003,7 @@ def wiki(
         "bug_id": bug_id,
         "reporter_context": reporter_context,
         "verbose": verbose,
+        "changed_since": changed_since,
     }
 
     return handler(**kwargs)

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
@@ -338,13 +338,27 @@ _mcp_search_workflow_wiki = _register_structured_tool(
     ),
 )
 
-def read_workflow_wiki_page(page: str) -> str:
+def read_workflow_wiki_page(
+    page: str,
+    query: str = "",
+    changed_since: str = "",
+    max_results: int = 10,
+) -> str:
     """Use this when the user wants to read one Workflow wiki page.
 
     Args:
         page: Wiki page slug or path.
+        query: Optional topic terms for the ambient relevance feed.
+        changed_since: Optional ISO timestamp for feed freshness filtering.
+        max_results: Maximum ambient feed items to return.
     """
-    return _wiki_impl(action="read", page=page)
+    return _wiki_impl(
+        action="read",
+        page=page,
+        query=query,
+        changed_since=changed_since,
+        max_results=max_results,
+    )
 
 
 _mcp_read_workflow_wiki_page = _register_structured_tool(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -961,6 +961,7 @@ def wiki(
     force_new: bool = False,
     bug_id: str = "",
     reporter_context: str = "",
+    changed_since: str = "",
 ) -> str:
     """Read, write, and manage the cross-project knowledge wiki.
 
@@ -983,6 +984,8 @@ def wiki(
             sync_projects, file_bug, cosign_bug.
         old_text/new_text: For action="patch", exact text to replace server-side.
         expected_sha256: Optional full-page hash guard for action="patch".
+        changed_since: Optional ISO timestamp for action="read" ambient feed;
+            only pages updated after this timestamp are returned as feed items.
     """
     return _wiki_impl(
         action=action,
@@ -1015,6 +1018,7 @@ def wiki(
         force_new=force_new,
         bug_id=bug_id,
         reporter_context=reporter_context,
+        changed_since=changed_since,
     )
 
 

--- a/tests/test_api_wiki.py
+++ b/tests/test_api_wiki.py
@@ -226,6 +226,68 @@ def test_wiki_read_index_after_scaffold(wiki_env):
     assert "Wiki Index" in res["content"]
 
 
+def test_wiki_read_returns_source_proof_and_ambient_feed(wiki_env):
+    source = wiki_env / "pages" / "notes" / "live-brain.md"
+    source.write_text(
+        "---\n"
+        "title: Live Brain\n"
+        "type: note\n"
+        "updated: 2026-05-01\n"
+        "tags: ambient relevance\n"
+        "---\n\n"
+        "# Live Brain\n\n"
+        "Ambient relevance should move source-read proof across sessions.\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    related = wiki_env / "pages" / "notes" / "fresh-related.md"
+    related.write_text(
+        "---\n"
+        "title: Fresh Related\n"
+        "type: note\n"
+        "updated: 2026-05-06T12:00:00Z\n"
+        "tags: relevance feed\n"
+        "---\n\n"
+        "This note mentions ambient source-read proof for adjacent goals.\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    old = wiki_env / "pages" / "notes" / "old-related.md"
+    old.write_text(
+        "---\n"
+        "title: Old Related\n"
+        "type: note\n"
+        "updated: 2026-04-01\n"
+        "tags: ambient relevance\n"
+        "---\n\n"
+        "Old ambient relevance should be excluded by changed_since.\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    res = json.loads(
+        wiki(
+            action="read",
+            page="live-brain",
+            query="ambient relevance source proof",
+            changed_since="2026-05-02T00:00:00Z",
+            max_results=5,
+        )
+    )
+
+    assert res["source_read_proof"]["path"] == "pages/notes/live-brain.md"
+    assert res["source_read_proof"]["title"] == "Live Brain"
+    assert len(res["source_read_proof"]["sha256"]) == 64
+    feed = res["ambient_relevance_feed"]
+    assert feed["source_path"] == "pages/notes/live-brain.md"
+    paths = [item["path"] for item in feed["items"]]
+    assert "pages/notes/fresh-related.md" in paths
+    assert "pages/notes/old-related.md" not in paths
+    assert "pages/notes/live-brain.md" not in paths
+    fresh = next(item for item in feed["items"] if item["path"].endswith("fresh-related.md"))
+    assert "ambient" in fresh["matched_terms"]
+
+
 def test_wiki_write_requires_filename_and_content(wiki_env):
     res = json.loads(wiki(action="write", category="notes"))
     assert "error" in res

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -235,6 +235,122 @@ def _wiki_similarity_score(
     return jaccard * 0.4 + link_score * 0.3 + title_bonus
 
 
+def _parse_wiki_timestamp(value: str) -> datetime | None:
+    raw = value.strip()
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        try:
+            parsed = datetime.fromisoformat(f"{raw}T00:00:00+00:00")
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _page_updated_at(path: Path, meta: dict[str, str]) -> datetime:
+    parsed = _parse_wiki_timestamp(meta.get("updated", ""))
+    if parsed is not None:
+        return parsed
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+
+
+def _wiki_read_terms(
+    *,
+    page: str,
+    query: str,
+    meta: dict[str, str],
+    body: str,
+) -> set[str]:
+    text = query.strip()
+    if not text:
+        text = " ".join(
+            part for part in (
+                page,
+                meta.get("title", ""),
+                meta.get("tags", ""),
+                meta.get("type", ""),
+                body[:1200],
+            ) if part
+        )
+    return _extract_keywords(text)
+
+
+def _coerce_feed_limit(value: Any) -> int:
+    try:
+        raw = int(value or 0)
+    except (TypeError, ValueError):
+        raw = 10
+    return max(0, min(raw, 20))
+
+
+def _ambient_relevance_feed(
+    *,
+    source: Path,
+    page: str,
+    query: str,
+    changed_since: str,
+    max_results: int,
+    source_meta: dict[str, str],
+    source_body: str,
+) -> dict[str, Any]:
+    terms = _wiki_read_terms(
+        page=page,
+        query=query,
+        meta=source_meta,
+        body=source_body,
+    )
+    since = _parse_wiki_timestamp(changed_since)
+    limit = _coerce_feed_limit(max_results)
+    candidates: list[dict[str, Any]] = []
+    for candidate in (
+        _find_all_pages(_wiki_pages_dir()) + _find_all_pages(_wiki_drafts_dir())
+    ):
+        if candidate == source:
+            continue
+        raw = _read_text(candidate)
+        if not raw:
+            continue
+        meta, body = _parse_frontmatter(raw)
+        updated_at = _page_updated_at(candidate, meta)
+        if since is not None and updated_at <= since:
+            continue
+        haystack = " ".join(
+            part for part in (
+                meta.get("title", ""),
+                meta.get("tags", ""),
+                meta.get("type", ""),
+                body,
+            ) if part
+        ).lower()
+        matched_terms = sorted(term for term in terms if term in haystack)
+        if not matched_terms:
+            continue
+        title = meta.get("title") or candidate.stem
+        excerpt = body.replace("\n", " ").strip()[:220]
+        candidates.append({
+            "path": _page_rel_path(candidate),
+            "title": title,
+            "updated": updated_at.isoformat().replace("+00:00", "Z"),
+            "matched_terms": matched_terms[:8],
+            "score": len(matched_terms),
+            "excerpt": excerpt,
+        })
+
+    candidates.sort(key=lambda item: (-item["score"], item["path"]))
+    items = candidates[:limit]
+    return {
+        "source_path": _page_rel_path(source),
+        "query_terms": sorted(terms)[:20],
+        "changed_since": changed_since.strip(),
+        "items": items,
+        "truncated_count": max(0, len(candidates) - len(items)),
+    }
+
+
 def _add_to_index(category: str, slug: str, title: str) -> None:
     """Add an entry to the wiki index.md under the right section."""
     idx_path = _wiki_index_path()
@@ -339,7 +455,13 @@ def _resolve_bugs_canonical(parent: Path, slug: str) -> Path | None:
 # ---------------------------------------------------------------------------
 
 
-def _wiki_read(page: str = "", **_kwargs: Any) -> str:
+def _wiki_read(
+    page: str = "",
+    query: str = "",
+    changed_since: str = "",
+    max_results: int = 10,
+    **_kwargs: Any,
+) -> str:
     if not page:
         return json.dumps({"error": "page parameter is required."})
 
@@ -350,7 +472,25 @@ def _wiki_read(page: str = "", **_kwargs: Any) -> str:
     text = _read_text(resolved)
     is_draft = _wiki_drafts_dir() in resolved.parents
     rel = _page_rel_path(resolved)
+    meta, body = _parse_frontmatter(text)
+    updated_at = _page_updated_at(resolved, meta)
     content = _draft_read_content(text, is_draft=is_draft)
+    source_read_proof = {
+        "path": rel,
+        "title": meta.get("title") or resolved.stem,
+        "updated": updated_at.isoformat().replace("+00:00", "Z"),
+        "sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "is_draft": is_draft,
+    }
+    ambient_feed = _ambient_relevance_feed(
+        source=resolved,
+        page=page,
+        query=query,
+        changed_since=changed_since,
+        max_results=max_results,
+        source_meta=meta,
+        source_body=body,
+    )
 
     if len(text) > 15000:
         return json.dumps({
@@ -359,12 +499,16 @@ def _wiki_read(page: str = "", **_kwargs: Any) -> str:
             "content": content[:15000],
             "truncated": True,
             "total_chars": len(text),
+            "source_read_proof": source_read_proof,
+            "ambient_relevance_feed": ambient_feed,
         })
     return json.dumps({
         "path": rel,
         "is_draft": is_draft,
         "content": content,
         "truncated": False,
+        "source_read_proof": source_read_proof,
+        "ambient_relevance_feed": ambient_feed,
     })
 
 
@@ -1764,6 +1908,7 @@ def wiki(
     bug_id: str = "",
     reporter_context: str = "",
     verbose: bool = False,
+    changed_since: str = "",
 ) -> str:
     """Dispatch entry for the wiki MCP tool. See universe_server.py for the
     chatbot-facing docstring; this function is the implementation invoked by
@@ -1858,6 +2003,7 @@ def wiki(
         "bug_id": bug_id,
         "reporter_context": reporter_context,
         "verbose": verbose,
+        "changed_since": changed_since,
     }
 
     return handler(**kwargs)

--- a/workflow/directory_server.py
+++ b/workflow/directory_server.py
@@ -338,13 +338,27 @@ _mcp_search_workflow_wiki = _register_structured_tool(
     ),
 )
 
-def read_workflow_wiki_page(page: str) -> str:
+def read_workflow_wiki_page(
+    page: str,
+    query: str = "",
+    changed_since: str = "",
+    max_results: int = 10,
+) -> str:
     """Use this when the user wants to read one Workflow wiki page.
 
     Args:
         page: Wiki page slug or path.
+        query: Optional topic terms for the ambient relevance feed.
+        changed_since: Optional ISO timestamp for feed freshness filtering.
+        max_results: Maximum ambient feed items to return.
     """
-    return _wiki_impl(action="read", page=page)
+    return _wiki_impl(
+        action="read",
+        page=page,
+        query=query,
+        changed_since=changed_since,
+        max_results=max_results,
+    )
 
 
 _mcp_read_workflow_wiki_page = _register_structured_tool(

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -961,6 +961,7 @@ def wiki(
     force_new: bool = False,
     bug_id: str = "",
     reporter_context: str = "",
+    changed_since: str = "",
 ) -> str:
     """Read, write, and manage the cross-project knowledge wiki.
 
@@ -983,6 +984,8 @@ def wiki(
             sync_projects, file_bug, cosign_bug.
         old_text/new_text: For action="patch", exact text to replace server-side.
         expected_sha256: Optional full-page hash guard for action="patch".
+        changed_since: Optional ISO timestamp for action="read" ambient feed;
+            only pages updated after this timestamp are returned as feed items.
     """
     return _wiki_impl(
         action=action,
@@ -1015,6 +1018,7 @@ def wiki(
         force_new=force_new,
         bug_id=bug_id,
         reporter_context=reporter_context,
+        changed_since=changed_since,
     )
 
 


### PR DESCRIPTION
Fixes #542

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.