### PR TITLE
[auto-change] WIKI-PATCH: Loop PR readiness should require cross-family maturation before checker-key escalation

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -348,7 +348,7 @@ jobs:
               {
                 name: 'ready_for_checker',
                 color: '0e8a16',
-                description: 'Loop PR passed source, duplicate, stale-base, and scope-split pre-checks.',
+                description: 'Loop PR matured through source, duplicate, stale-base, and scope-split pre-checks before checker escalation.',
               },
               {
                 name: 'writer:claude',
@@ -1004,26 +1004,6 @@ jobs:
             core.setOutput('blocked', 'false');
             core.setOutput('block_reason', '');
             core.setOutput('number', String(pr.number));
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              labels: ['writer:codex', 'checker:claude'],
-            });
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              body: [
-                '**Loop review policy**',
-                '',
-                '- Writer family: Codex',
-                '- Required checker family: Claude',
-                '',
-                'Do not accept this PR with a same-family checker.',
-              ].join('\n'),
-            });
-
             const issueBranchRoot = `${branchPrefix}issue-${issueNumber}`;
             const issueBranchPrefix = `${issueBranchRoot}-`;
             const { data: issuePrs } = await github.rest.pulls.list({
@@ -1103,6 +1083,25 @@ jobs:
               });
               return;
             }
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: ['writer:codex', 'checker:claude'],
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: [
+                '**Loop review policy**',
+                '',
+                '- Writer family: Codex',
+                '- Required checker family: Claude',
+                '',
+                'Do not accept this PR with a same-family checker.',
+              ].join('\n'),
+            });
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -1263,6 +1262,23 @@ jobs:
               core.info(`No Claude-created PR found for ${branch}.`);
               return;
             }
+            const selfReviewFailures = await selfReviewLoopPr(pr);
+            if (selfReviewFailures.length) {
+              core.warning(`Loop PR #${pr.number} is not ready_for_checker: ${selfReviewFailures.join('; ')}`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: [
+                  '**Pre-checker self-review blocked `ready_for_checker`**',
+                  '',
+                  ...selfReviewFailures.map((failure) => `- ${failure}`),
+                  '',
+                  'Fix the pre-check failure before routing this loop PR to a checker.',
+                ].join('\n'),
+              });
+              return;
+            }
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -1282,23 +1298,6 @@ jobs:
                 'Do not accept this PR with a same-family checker.',
               ].join('\n'),
             });
-            const selfReviewFailures = await selfReviewLoopPr(pr);
-            if (selfReviewFailures.length) {
-              core.warning(`Loop PR #${pr.number} is not ready_for_checker: ${selfReviewFailures.join('; ')}`);
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: [
-                  '**Pre-checker self-review blocked `ready_for_checker`**',
-                  '',
-                  ...selfReviewFailures.map((failure) => `- ${failure}`),
-                  '',
-                  'Fix the pre-check failure before routing this loop PR to a checker.',
-                ].join('\n'),
-              });
-              return;
-            }
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -446,7 +446,10 @@ def test_ready_for_checker_label_is_defined(wf):
     assert labels_step is not None, "Must define automation labels"
     script = str(labels_step.get("with", {}).get("script", ""))
     assert "ready_for_checker" in script
-    assert "source, duplicate, stale-base, and scope-split pre-checks" in script
+    assert (
+        "matured through source, duplicate, stale-base, and scope-split "
+        "pre-checks before checker escalation"
+    ) in script
 
 
 def test_codex_ready_for_checker_requires_pre_checker_self_review(wf):
@@ -464,6 +467,12 @@ def test_codex_ready_for_checker_requires_pre_checker_self_review(wf):
     assert script.index("const selfReviewFailures = await selfReviewLoopPr(pr)") < (
         script.index("labels: ['ready_for_checker']")
     )
+    assert script.index("const selfReviewFailures = await selfReviewLoopPr(pr)") < (
+        script.index("labels: ['writer:codex', 'checker:claude']")
+    )
+    assert script.index("labels: ['writer:codex', 'checker:claude']") < (
+        script.index("labels: ['ready_for_checker']")
+    )
 
 
 def test_claude_ready_for_checker_requires_pre_checker_self_review(wf):
@@ -479,6 +488,12 @@ def test_claude_ready_for_checker_requires_pre_checker_self_review(wf):
     assert "Pre-checker self-review blocked `ready_for_checker`" in script
     assert "labels: ['ready_for_checker']" in script
     assert script.index("const selfReviewFailures = await selfReviewLoopPr(pr)") < (
+        script.index("labels: ['ready_for_checker']")
+    )
+    assert script.index("const selfReviewFailures = await selfReviewLoopPr(pr)") < (
+        script.index("labels: ['writer:claude', 'checker:codex']")
+    )
+    assert script.index("labels: ['writer:claude', 'checker:codex']") < (
         script.index("labels: ['ready_for_checker']")
     )
 


### PR DESCRIPTION
Fixes #557

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.