### PR TITLE
[auto-change] WIKI-PATCH: Auto-merge must require an explicit host-named merge key, not broad momentum language

### DIFF
--- a/auto_ship_ship_classes.yaml
+++ b/auto_ship_ship_classes.yaml
@@ -1,7 +1,8 @@
 # Auto-ship ship-class policy.
 #
 # New ship classes inherit `defaults`, so the safe baseline is two manual
-# reviewer keys and no auto-merge/auto-open policy. Runtime code must treat
+# reviewer keys, one explicit host-named merge key, and no auto-merge/auto-open
+# policy. Runtime code must treat
 # missing or unknown classes as defaults plus a closed path allowlist.
 version: 1
 
@@ -11,6 +12,7 @@ defaults:
   required_keys:
     - codex_reviewer
     - cowork_reviewer
+    - host_merge_key
   approval_ttl_minutes: 30
   required_status_checks:
     - auto_ship_envelope
@@ -35,7 +37,7 @@ reviewer_roles:
   cowork_reviewer:
     provider_family: anthropic
     github_review_required: true
-  host_reviewer:
+  host_merge_key:
     provider_family: host
     github_review_required: true
 

--- a/docs/milestones/auto-ship-canary-v0.md
+++ b/docs/milestones/auto-ship-canary-v0.md
@@ -256,6 +256,7 @@ CI passed
 PR contains only allowlisted paths
 PR title includes [autoship-canary]
 shipper identity is expected bot/service identity
+explicit host-named merge key is open
 ```
 
 If any check fails:
@@ -448,6 +449,7 @@ changed_paths subset docs/autoship-canaries/**
 CI passed
 no human block label present
 release_gate_result == APPROVE_AUTO_SHIP
+host_merge_key explicitly open
 ```
 
 ### Phase 4 — observation gate

--- a/docs/specs/2026-05-03-dual-key-auto-ship-acceptance.md
+++ b/docs/specs/2026-05-03-dual-key-auto-ship-acceptance.md
@@ -1,4 +1,4 @@
-# Spec: Dual-Key Auto-Ship Acceptance
+# Spec: Required-Key Auto-Ship Acceptance
 
 Captured: 2026-05-03
 Status: proposal for Cowork/Codex agreement
@@ -7,15 +7,14 @@ Builds on: `docs/milestones/auto-ship-canary-v0.md`, `workflow.auto_ship.validat
 
 ## Objective
 
-Let the patch loop experience the full autonomous ship path while Codex and
-Cowork retain a reversible safety gate.
+Let the patch loop experience the full autonomous ship path while Codex,
+Cowork, and an explicit host-named merge key retain a reversible safety gate.
 
 The host's model is correct: close the full steps 1-8 loop, but put a
-double-key acceptance gate at step 4. Codex and Cowork should already be
-watching before the gate opens, so by the time step 4 asks for acceptance,
-both reviewers have followed the packet through the preceding stages and can
-turn their keys quickly. If either key is not turned, the loop parks at the
-acceptance gate instead of silently shipping or losing state.
+required-key acceptance gate at step 4. Codex and Cowork should already be
+watching before the gate opens, and the host merge key must be explicit rather
+than inferred from momentum. If any required key is not turned, the loop parks
+at the acceptance gate instead of silently shipping or losing state.
 
 Success means a docs-canary ship can proceed through the same machinery that
 will eventually be fully autonomous: the loop opens a PR, the acceptance gate
@@ -29,10 +28,10 @@ different code path.
   and before the shipper merges or deploys anything.
 - Existing auto-ship validation remains the final structural envelope for path
   allowlists, diff limits, secret checks, rollback handle requirements, and CI.
-- The dual keys are policy gates, not replacement review systems. They do not
+- Required keys are policy gates, not replacement review systems. They do not
   bypass tests, CI, rollback requirements, or ship-class restrictions.
-- Reviewers are provider-family independent at first: one OpenAI-family key and
-  one Anthropic-family key.
+- Reviewers are provider-family independent at first: one OpenAI-family key,
+  one Anthropic-family key, and one explicit host-named merge key.
 - The initial implementation should be feature-flagged and observable before
   it is allowed to merge anything.
 - For PR-backed ships, GitHub PR approval state is the canonical key surface.
@@ -45,7 +44,7 @@ Use this eight-stage map unless Cowork has a sharper naming scheme:
 1. User intake through chatbot/wiki.
 2. Dedup, classification, and dispatcher queueing.
 3. Loop investigation, coding packet, and release safety analysis.
-4. Dual-key acceptance/auto-merge gate.
+4. Required-key acceptance/auto-merge gate.
 5. Shipper action: merge or park according to ship class.
 6. CI, deploy, canary, and live observation.
 7. Rollback, revert PR, or parked remediation if observation turns red.
@@ -64,8 +63,9 @@ There are two key surfaces:
    auto-ship attempt ledger.
 
 For PR-backed ships, GitHub is authoritative. A Codex approval review opens
-the Codex key. A Cowork approval review opens the Cowork key. Missing approval
-is the default safety state: the PR waits.
+the Codex key. A Cowork approval review opens the Cowork key. A host approval
+review opens `host_merge_key`. Missing approval is the default safety state:
+the PR waits.
 
 The mirror ledger exists so `get_status`, wiki Investigation write-back, and
 dry-run/non-PR attempts can explain what is waiting without forcing chatbots to
@@ -196,10 +196,11 @@ Add read-only summaries after PR-open and mirror-key recording exist:
         "request_id": "BUG-055",
         "pr_url": "https://github.com/Jonnyton/Workflow/pull/243",
         "ship_class": "docs_canary",
-        "required_keys": ["codex", "cowork"],
+        "required_keys": ["codex_reviewer", "cowork_reviewer", "host_merge_key"],
         "key_state": {
-          "codex": "open",
-          "cowork": "pending"
+          "codex_reviewer": "open",
+          "cowork_reviewer": "pending",
+          "host_merge_key": "pending"
         },
         "expires_at": "2026-05-03T23:00:00Z"
       }

--- a/docs/specs/2026-05-04-loop-autonomy-roadmap.md
+++ b/docs/specs/2026-05-04-loop-autonomy-roadmap.md
@@ -13,8 +13,9 @@ roll back regressions, and seek new work when the queue is empty.
 This stays one roadmap entry for now because the parts are coupled. PR
 creation, keyed auto-merge, ship-class graduation, branch protection,
 observation, rollback, and self-seeking define one control loop. Splitting
-them too early would hide the central constraint: assisted, double-keyed, and
-eventually keyless ship classes must use the same loop code path.
+them too early would hide the central constraint: assisted, required-keyed,
+and eventually auto-opened non-host-key ship classes must use the same loop
+code path.
 
 ## Current State
 
@@ -91,7 +92,8 @@ Default for every new ship class:
 
 - `auto_merge=false`;
 - `keys_auto_open=false`;
-- required keys are `codex_reviewer` and `cowork_reviewer`;
+- required keys are `codex_reviewer`, `cowork_reviewer`, and the explicit
+  host-named `host_merge_key`;
 - approvals expire after the configured TTL;
 - missing approval is the safety state.
 
@@ -107,14 +109,15 @@ Auto-merge eligibility:
 3. Reviewers approve through normal GitHub PR review.
 4. Phase 3 polls every open auto-ship PR.
 5. The loop re-runs the safety envelope against the PR head and changed paths.
-6. Eligibility is true only when the envelope still passes and either:
-   `ship_class.auto_merge=true`, or all required keys are open in GitHub review
-   state.
+6. Eligibility is true only when the envelope still passes, `host_merge_key` is
+   explicitly open in GitHub review state, and either `ship_class.auto_merge=true`
+   or all non-host required keys are open in GitHub review state.
 7. If eligible, the loop calls `gh pr merge` or the GitHub merge API itself.
 
 Humans authorize while required keys are manual. The loop executes. Later
-graduation flips policy so a class can auto-open keys, still through the same
-poll-and-merge path.
+graduation may auto-open non-host keys for a class, but it must not replace or
+infer `host_merge_key` from broad momentum, successful history, or class
+graduation.
 
 ## Failure Semantics
 

--- a/tests/test_auto_ship_ship_classes_config.py
+++ b/tests/test_auto_ship_ship_classes_config.py
@@ -5,14 +5,19 @@ import yaml
 CONFIG_PATH = Path(__file__).resolve().parents[1] / "auto_ship_ship_classes.yaml"
 
 
-def test_ship_class_defaults_require_two_manual_keys():
+def test_ship_class_defaults_require_manual_review_and_host_merge_key():
     config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
 
     defaults = config["defaults"]
 
     assert defaults["auto_merge"] is False
     assert defaults["keys_auto_open"] is False
-    assert defaults["required_keys"] == ["codex_reviewer", "cowork_reviewer"]
+    assert defaults["required_keys"] == [
+        "codex_reviewer",
+        "cowork_reviewer",
+        "host_merge_key",
+    ]
+    assert config["reviewer_roles"]["host_merge_key"]["provider_family"] == "host"
 
 
 def test_graduation_classes_start_disabled_until_policy_flip():


### PR DESCRIPTION
Fixes #558

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.