### PR TITLE
[auto-change] WIKI-PATCH: Patch-loop should classify requests by access, meaning, and authority before implementation

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
@@ -74,6 +74,56 @@ PATCH_REQUEST_AUTHORITY_BOUNDARY: dict[str, bool] = {
     "affects_merge": False,
 }
 PATCH_REQUEST_PICKUP_SIGNAL_WEIGHT = 5.0
+_PATCH_REQUEST_MEANING_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("bug", ("bug", "broken", "crash", "error", "fail", "flake", "regression")),
+    ("project_design", ("architecture", "design note", "plan.md", "principle")),
+    ("docs_ops", ("docs", "documentation", "runbook", "ops", "deploy", "ci")),
+    ("feature", ("feature", "add support", "new capability")),
+    ("patch", ("patch", "fix", "update", "change", "cleanup")),
+)
+_REQUEST_TYPE_MEANING: dict[str, str] = {
+    "branch_proposal": "branch_refinement",
+    "canon_change": "patch",
+    "general": "patch",
+    "revision": "patch",
+    "scene_direction": "branch_refinement",
+}
+
+
+def classify_patch_request(
+    *,
+    text: str,
+    request_type: str,
+    requester_id: str,
+    host_id: str,
+    directed_daemon: bool = False,
+) -> dict[str, Any]:
+    """Classify patch-loop intake before daemon implementation work starts."""
+    lower_text = text.lower()
+    meaning = _REQUEST_TYPE_MEANING.get(request_type, "patch")
+    for candidate, keywords in _PATCH_REQUEST_MEANING_KEYWORDS:
+        if any(keyword in lower_text for keyword in keywords):
+            meaning = candidate
+            break
+
+    authority_scope = (
+        "host_priority_allowed" if requester_id == host_id else "requester_pickup_only"
+    )
+    if directed_daemon:
+        authority_scope = f"{authority_scope}+proposal_only_directed_daemon"
+
+    return {
+        "access": {
+            "claimable_by": ["free_daemon", "paid_daemon"],
+            "code_writer_gate": "claude_or_codex",
+            "checker_gate": "opposite_family_checker",
+        },
+        "meaning": meaning,
+        "authority": {
+            "scope": authority_scope,
+            "boundary": dict(PATCH_REQUEST_AUTHORITY_BOUNDARY),
+        },
+    }
 
 
 def normalize_patch_request_incentive(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -100,6 +100,7 @@ def _extract_submit_request(
             "branch_id": kwargs.get("branch_id", "") or None,
             "pickup_incentive": kwargs.get("pickup_incentive", "") or None,
             "directed_daemon_id": kwargs.get("directed_daemon_id", "") or None,
+            "request_classification": result.get("request_classification"),
         },
     )
 
@@ -1096,6 +1097,7 @@ def _action_submit_request(
 ) -> str:
     from workflow.api.market import (
         PATCH_REQUEST_AUTHORITY_BOUNDARY,
+        classify_patch_request,
         normalize_patch_request_incentive,
     )
     from workflow.branch_tasks import BranchTask, append_task, new_task_id
@@ -1167,6 +1169,13 @@ def _action_submit_request(
                 "error": "directed_daemon_not_authorized",
                 "requester_directed_daemon": requester_directed_daemon,
             })
+    request_classification = classify_patch_request(
+        text=text,
+        request_type=request_type,
+        requester_id=source,
+        host_id=host_id,
+        directed_daemon=requester_directed_daemon is not None,
+    )
     request_obj = {
         "id": request_id,
         "type": request_type,
@@ -1177,6 +1186,7 @@ def _action_submit_request(
         "source": source,
         "pickup_incentive": incentive,
         "authority_boundary": authority_boundary,
+        "request_classification": request_classification,
     }
     if requester_directed_daemon is not None:
         request_obj["requester_directed_daemon"] = requester_directed_daemon
@@ -1214,6 +1224,7 @@ def _action_submit_request(
                 "branch_id": branch_id or "",
                 "pickup_incentive": incentive,
                 "authority_boundary": authority_boundary,
+                "request_classification": request_classification,
                 "requester_directed_daemon": requester_directed_daemon,
             },
             trigger_source=(
@@ -1253,6 +1264,7 @@ def _action_submit_request(
         "priority_weight": pw,
         "pickup_incentive": incentive,
         "authority_boundary": authority_boundary,
+        "request_classification": request_classification,
         "requester_directed_daemon": requester_directed_daemon,
         "queue_position": pending_count,
         "ahead_of_yours": ahead,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/work_targets.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/work_targets.py
@@ -460,10 +460,16 @@ def materialize_pending_requests(
         authority_boundary = req.get("authority_boundary")
         if isinstance(authority_boundary, dict):
             metadata["authority_boundary"] = dict(authority_boundary)
+        request_classification = req.get("request_classification")
+        if isinstance(request_classification, dict):
+            metadata["request_classification"] = dict(request_classification)
         directed_daemon = req.get("requester_directed_daemon")
         if isinstance(directed_daemon, dict):
             metadata["requester_directed_daemon"] = dict(directed_daemon)
         tags = ["user-request", req_type]
+        meaning = metadata.get("request_classification", {}).get("meaning")
+        if isinstance(meaning, str) and meaning:
+            tags.append(f"meaning:{meaning}")
         if _bounded_pickup_signal(metadata) > 0:
             if metadata.get("pickup_incentive"):
                 tags.append(PATCH_REQUEST_PICKUP_SIGNAL_TAG)

--- a/tests/test_patch_request_incentives.py
+++ b/tests/test_patch_request_incentives.py
@@ -59,9 +59,25 @@ def test_pickup_incentive_boosts_pickup_not_acceptance(
         "affects_release": False,
         "affects_merge": False,
     }
+    assert response["request_classification"] == {
+        "access": {
+            "claimable_by": ["free_daemon", "paid_daemon"],
+            "code_writer_gate": "claude_or_codex",
+            "checker_gate": "opposite_family_checker",
+        },
+        "meaning": "branch_refinement",
+        "authority": {
+            "scope": "requester_pickup_only",
+            "boundary": response["authority_boundary"],
+        },
+    }
     assert queue[0].priority_weight == 0.0
     assert 0.0 < queue[0].pickup_signal_weight <= 5.0
     assert queue[0].trigger_source == "user_request"
+    assert (
+        queue[0].inputs["request_classification"]
+        == response["request_classification"]
+    )
 
     plain = BranchTask(
         branch_task_id="plain",
@@ -116,6 +132,23 @@ def test_incentivized_request_materializes_ahead_with_metadata(server_base):
                     "affects_release": False,
                     "affects_merge": False,
                 },
+                "request_classification": {
+                    "access": {
+                        "claimable_by": ["free_daemon", "paid_daemon"],
+                        "code_writer_gate": "claude_or_codex",
+                        "checker_gate": "opposite_family_checker",
+                    },
+                    "meaning": "patch",
+                    "authority": {
+                        "scope": "requester_pickup_only",
+                        "boundary": {
+                            "affects_pickup_priority": True,
+                            "affects_acceptance": False,
+                            "affects_release": False,
+                            "affects_merge": False,
+                        },
+                    },
+                },
             },
         ]),
         encoding="utf-8",
@@ -126,9 +159,41 @@ def test_incentivized_request_materializes_ahead_with_metadata(server_base):
 
     assert ranked[0].metadata["request_id"] == "req_incentive"
     assert ranked[0].metadata["pickup_incentive"]["enabled"] is True
+    assert ranked[0].metadata["request_classification"]["meaning"] == "patch"
     assert "pickup-incentive" in ranked[0].tags
+    assert "meaning:patch" in ranked[0].tags
     stored = load_work_targets(udir)
     assert any(t.metadata.get("request_id") == "req_plain" for t in stored)
+
+
+def test_submit_request_classifies_access_meaning_and_authority(
+    server_base,
+    monkeypatch,
+):
+    base, uid = server_base
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "alice")
+
+    response = _submit(
+        universe_id=uid,
+        text="Patch-loop should classify requests before implementation.",
+        request_type="general",
+    )
+
+    assert response["request_classification"]["access"] == {
+        "claimable_by": ["free_daemon", "paid_daemon"],
+        "code_writer_gate": "claude_or_codex",
+        "checker_gate": "opposite_family_checker",
+    }
+    assert response["request_classification"]["meaning"] == "patch"
+    assert response["request_classification"]["authority"] == {
+        "scope": "requester_pickup_only",
+        "boundary": response["authority_boundary"],
+    }
+    queue = read_queue(base / uid)
+    assert (
+        queue[0].inputs["request_classification"]
+        == response["request_classification"]
+    )
 
 
 def test_requester_directed_daemon_requires_ownership(

--- a/workflow/api/market.py
+++ b/workflow/api/market.py
@@ -74,6 +74,56 @@ PATCH_REQUEST_AUTHORITY_BOUNDARY: dict[str, bool] = {
     "affects_merge": False,
 }
 PATCH_REQUEST_PICKUP_SIGNAL_WEIGHT = 5.0
+_PATCH_REQUEST_MEANING_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("bug", ("bug", "broken", "crash", "error", "fail", "flake", "regression")),
+    ("project_design", ("architecture", "design note", "plan.md", "principle")),
+    ("docs_ops", ("docs", "documentation", "runbook", "ops", "deploy", "ci")),
+    ("feature", ("feature", "add support", "new capability")),
+    ("patch", ("patch", "fix", "update", "change", "cleanup")),
+)
+_REQUEST_TYPE_MEANING: dict[str, str] = {
+    "branch_proposal": "branch_refinement",
+    "canon_change": "patch",
+    "general": "patch",
+    "revision": "patch",
+    "scene_direction": "branch_refinement",
+}
+
+
+def classify_patch_request(
+    *,
+    text: str,
+    request_type: str,
+    requester_id: str,
+    host_id: str,
+    directed_daemon: bool = False,
+) -> dict[str, Any]:
+    """Classify patch-loop intake before daemon implementation work starts."""
+    lower_text = text.lower()
+    meaning = _REQUEST_TYPE_MEANING.get(request_type, "patch")
+    for candidate, keywords in _PATCH_REQUEST_MEANING_KEYWORDS:
+        if any(keyword in lower_text for keyword in keywords):
+            meaning = candidate
+            break
+
+    authority_scope = (
+        "host_priority_allowed" if requester_id == host_id else "requester_pickup_only"
+    )
+    if directed_daemon:
+        authority_scope = f"{authority_scope}+proposal_only_directed_daemon"
+
+    return {
+        "access": {
+            "claimable_by": ["free_daemon", "paid_daemon"],
+            "code_writer_gate": "claude_or_codex",
+            "checker_gate": "opposite_family_checker",
+        },
+        "meaning": meaning,
+        "authority": {
+            "scope": authority_scope,
+            "boundary": dict(PATCH_REQUEST_AUTHORITY_BOUNDARY),
+        },
+    }
 
 
 def normalize_patch_request_incentive(

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -100,6 +100,7 @@ def _extract_submit_request(
             "branch_id": kwargs.get("branch_id", "") or None,
             "pickup_incentive": kwargs.get("pickup_incentive", "") or None,
             "directed_daemon_id": kwargs.get("directed_daemon_id", "") or None,
+            "request_classification": result.get("request_classification"),
         },
     )
 
@@ -1096,6 +1097,7 @@ def _action_submit_request(
 ) -> str:
     from workflow.api.market import (
         PATCH_REQUEST_AUTHORITY_BOUNDARY,
+        classify_patch_request,
         normalize_patch_request_incentive,
     )
     from workflow.branch_tasks import BranchTask, append_task, new_task_id
@@ -1167,6 +1169,13 @@ def _action_submit_request(
                 "error": "directed_daemon_not_authorized",
                 "requester_directed_daemon": requester_directed_daemon,
             })
+    request_classification = classify_patch_request(
+        text=text,
+        request_type=request_type,
+        requester_id=source,
+        host_id=host_id,
+        directed_daemon=requester_directed_daemon is not None,
+    )
     request_obj = {
         "id": request_id,
         "type": request_type,
@@ -1177,6 +1186,7 @@ def _action_submit_request(
         "source": source,
         "pickup_incentive": incentive,
         "authority_boundary": authority_boundary,
+        "request_classification": request_classification,
     }
     if requester_directed_daemon is not None:
         request_obj["requester_directed_daemon"] = requester_directed_daemon
@@ -1214,6 +1224,7 @@ def _action_submit_request(
                 "branch_id": branch_id or "",
                 "pickup_incentive": incentive,
                 "authority_boundary": authority_boundary,
+                "request_classification": request_classification,
                 "requester_directed_daemon": requester_directed_daemon,
             },
             trigger_source=(
@@ -1253,6 +1264,7 @@ def _action_submit_request(
         "priority_weight": pw,
         "pickup_incentive": incentive,
         "authority_boundary": authority_boundary,
+        "request_classification": request_classification,
         "requester_directed_daemon": requester_directed_daemon,
         "queue_position": pending_count,
         "ahead_of_yours": ahead,

--- a/workflow/work_targets.py
+++ b/workflow/work_targets.py
@@ -460,10 +460,16 @@ def materialize_pending_requests(
         authority_boundary = req.get("authority_boundary")
         if isinstance(authority_boundary, dict):
             metadata["authority_boundary"] = dict(authority_boundary)
+        request_classification = req.get("request_classification")
+        if isinstance(request_classification, dict):
+            metadata["request_classification"] = dict(request_classification)
         directed_daemon = req.get("requester_directed_daemon")
         if isinstance(directed_daemon, dict):
             metadata["requester_directed_daemon"] = dict(directed_daemon)
         tags = ["user-request", req_type]
+        meaning = metadata.get("request_classification", {}).get("meaning")
+        if isinstance(meaning, str) and meaning:
+            tags.append(f"meaning:{meaning}")
         if _bounded_pickup_signal(metadata) > 0:
             if metadata.get("pickup_incentive"):
                 tags.append(PATCH_REQUEST_PICKUP_SIGNAL_TAG)


### PR DESCRIPTION
Fixes #569

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.