### PR TITLE
[auto-change] BUG-073: Patch-request pages can reuse or contradict PR IDs, breaking exact-ID brain sweeps

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1358,10 +1358,17 @@ def _next_id(pages_dir: Path, drafts_dir: Path, prefix: str) -> str:
 
     Scans both ``pages_dir`` and ``drafts_dir`` so concurrent writes don't
     collide with an already-promoted entry. Returns ``<PREFIX>-001`` when
-    both dirs are empty or missing. Glob is case-insensitive via *.md plus a
-    prefix-anchored regex filter.
+    both dirs are empty or missing. Glob is case-insensitive via *.md plus
+    prefix-anchored regex filters against both the filename stem and the
+    frontmatter ``id`` field. The frontmatter scan prevents imported or
+    manually edited wiki pages from silently reusing an existing request ID
+    when their filename and canonical ID disagree.
     """
     pat = re.compile(rf"^{re.escape(prefix)}-(\d{{3,}})", re.IGNORECASE)
+    fm_id_pat = re.compile(
+        rf"^id:\s*['\"]?{re.escape(prefix)}-(\d{{3,}})['\"]?\s*$",
+        re.IGNORECASE,
+    )
     seen: set[int] = set()
     for base in (pages_dir, drafts_dir):
         if not base.is_dir():
@@ -1373,6 +1380,24 @@ def _next_id(pages_dir: Path, drafts_dir: Path, prefix: str) -> str:
                     seen.add(int(m.group(1)))
                 except ValueError:
                     continue
+            try:
+                lines = p.read_text(
+                    encoding="utf-8",
+                    errors="replace",
+                ).splitlines()
+                in_frontmatter = bool(lines and lines[0].strip() == "---")
+                for i, line in enumerate(lines[:80]):
+                    stripped = line.strip()
+                    if i > 0 and in_frontmatter and stripped == "---":
+                        break
+                    fm_match = fm_id_pat.match(stripped)
+                    if fm_match:
+                        seen.add(int(fm_match.group(1)))
+                        break
+                    if not in_frontmatter and stripped:
+                        break
+            except (OSError, ValueError):
+                continue
     next_n = (max(seen) + 1) if seen else 1
     return f"{prefix}-{next_n:03d}"
 
@@ -1392,6 +1417,26 @@ def _next_bug_id(bugs_pages_dir: Path) -> str:
 def _slugify_title(title: str, max_len: int = 60) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
     return slug[:max_len] or "untitled"
+
+
+def _slugify_request_title(title: str, prefix: str, max_len: int = 60) -> str:
+    """Slugify a request title without embedding same-prefix request IDs."""
+    parts = _slugify_title(title, max_len=max_len).split("-")
+    prefix_part = prefix.lower()
+    filtered: list[str] = []
+    i = 0
+    while i < len(parts):
+        if (
+            parts[i] == prefix_part
+            and i + 1 < len(parts)
+            and len(parts[i + 1]) >= 3
+            and parts[i + 1].isdigit()
+        ):
+            i += 2
+            continue
+        filtered.append(parts[i])
+        i += 1
+    return "-".join(filtered).strip("-") or "untitled"
 
 
 def _render_bug_markdown(
@@ -1651,7 +1696,7 @@ def _wiki_file_bug(
         return json.dumps({"error": f"Cannot create {category_dir} dir: {exc}"})
 
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    slug = _slugify_title(title)
+    slug = _slugify_request_title(title, id_prefix)
 
     # Dedup check: scan existing filings of THIS kind for Jaccard similarity
     # ≥ threshold. Per-kind only — a feature-request shouldn't dedup against

--- a/tests/test_api_wiki.py
+++ b/tests/test_api_wiki.py
@@ -550,6 +550,73 @@ def test_wiki_file_bug_dedup_returns_similar_found(wiki_env):
     assert len(dup["similar"]) >= 1
 
 
+def test_patch_request_counter_scans_frontmatter_ids(wiki_env):
+    patch_dir = wiki_env / "pages" / "patch-requests"
+    patch_dir.mkdir(parents=True)
+    (patch_dir / "pr-001-contradictory-page.md").write_text(
+        "---\nid: PR-010\ntitle: old imported patch request\n---\n",
+        encoding="utf-8",
+    )
+
+    res = json.loads(
+        wiki(
+            action="file_bug",
+            component="wiki.file_bug",
+            severity="minor",
+            title="Fresh patch request after imported wiki page",
+            kind="patch_request",
+            force_new=True,
+        )
+    )
+
+    assert res["status"] == "filed"
+    assert res["bug_id"] == "PR-011"
+
+
+def test_patch_request_slug_does_not_repeat_assigned_pr_id(wiki_env):
+    patch_dir = wiki_env / "pages" / "patch-requests"
+    patch_dir.mkdir(parents=True)
+    (patch_dir / "pr-052-existing.md").write_text("x", encoding="utf-8")
+
+    res = json.loads(
+        wiki(
+            action="file_bug",
+            component="wiki.file_bug",
+            severity="minor",
+            title="PR-053 Escalation replay on substrate fix",
+            kind="patch_request",
+            force_new=True,
+        )
+    )
+
+    assert res["status"] == "filed"
+    assert res["bug_id"] == "PR-053"
+    assert res["path"].startswith("pages/patch-requests/pr-053-")
+    assert "pr-053-pr-053" not in res["path"]
+
+
+def test_patch_request_slug_does_not_embed_contradictory_pr_id(wiki_env):
+    patch_dir = wiki_env / "pages" / "patch-requests"
+    patch_dir.mkdir(parents=True)
+    (patch_dir / "pr-052-existing.md").write_text("x", encoding="utf-8")
+
+    res = json.loads(
+        wiki(
+            action="file_bug",
+            component="wiki.file_bug",
+            severity="minor",
+            title="PR-999 Escalation replay on substrate fix",
+            kind="patch_request",
+            force_new=True,
+        )
+    )
+
+    assert res["status"] == "filed"
+    assert res["bug_id"] == "PR-053"
+    assert res["path"].startswith("pages/patch-requests/pr-053-")
+    assert "pr-999" not in res["path"]
+
+
 def test_wiki_cosign_bug_requires_args(wiki_env):
     res = json.loads(wiki(action="cosign_bug"))
     assert "error" in res

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1358,10 +1358,17 @@ def _next_id(pages_dir: Path, drafts_dir: Path, prefix: str) -> str:
 
     Scans both ``pages_dir`` and ``drafts_dir`` so concurrent writes don't
     collide with an already-promoted entry. Returns ``<PREFIX>-001`` when
-    both dirs are empty or missing. Glob is case-insensitive via *.md plus a
-    prefix-anchored regex filter.
+    both dirs are empty or missing. Glob is case-insensitive via *.md plus
+    prefix-anchored regex filters against both the filename stem and the
+    frontmatter ``id`` field. The frontmatter scan prevents imported or
+    manually edited wiki pages from silently reusing an existing request ID
+    when their filename and canonical ID disagree.
     """
     pat = re.compile(rf"^{re.escape(prefix)}-(\d{{3,}})", re.IGNORECASE)
+    fm_id_pat = re.compile(
+        rf"^id:\s*['\"]?{re.escape(prefix)}-(\d{{3,}})['\"]?\s*$",
+        re.IGNORECASE,
+    )
     seen: set[int] = set()
     for base in (pages_dir, drafts_dir):
         if not base.is_dir():
@@ -1373,6 +1380,24 @@ def _next_id(pages_dir: Path, drafts_dir: Path, prefix: str) -> str:
                     seen.add(int(m.group(1)))
                 except ValueError:
                     continue
+            try:
+                lines = p.read_text(
+                    encoding="utf-8",
+                    errors="replace",
+                ).splitlines()
+                in_frontmatter = bool(lines and lines[0].strip() == "---")
+                for i, line in enumerate(lines[:80]):
+                    stripped = line.strip()
+                    if i > 0 and in_frontmatter and stripped == "---":
+                        break
+                    fm_match = fm_id_pat.match(stripped)
+                    if fm_match:
+                        seen.add(int(fm_match.group(1)))
+                        break
+                    if not in_frontmatter and stripped:
+                        break
+            except (OSError, ValueError):
+                continue
     next_n = (max(seen) + 1) if seen else 1
     return f"{prefix}-{next_n:03d}"
 
@@ -1392,6 +1417,26 @@ def _next_bug_id(bugs_pages_dir: Path) -> str:
 def _slugify_title(title: str, max_len: int = 60) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
     return slug[:max_len] or "untitled"
+
+
+def _slugify_request_title(title: str, prefix: str, max_len: int = 60) -> str:
+    """Slugify a request title without embedding same-prefix request IDs."""
+    parts = _slugify_title(title, max_len=max_len).split("-")
+    prefix_part = prefix.lower()
+    filtered: list[str] = []
+    i = 0
+    while i < len(parts):
+        if (
+            parts[i] == prefix_part
+            and i + 1 < len(parts)
+            and len(parts[i + 1]) >= 3
+            and parts[i + 1].isdigit()
+        ):
+            i += 2
+            continue
+        filtered.append(parts[i])
+        i += 1
+    return "-".join(filtered).strip("-") or "untitled"
 
 
 def _render_bug_markdown(
@@ -1651,7 +1696,7 @@ def _wiki_file_bug(
         return json.dumps({"error": f"Cannot create {category_dir} dir: {exc}"})
 
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    slug = _slugify_title(title)
+    slug = _slugify_request_title(title, id_prefix)
 
     # Dedup check: scan existing filings of THIS kind for Jaccard similarity
     # ≥ threshold. Per-kind only — a feature-request shouldn't dedup against


### PR DESCRIPTION
Fixes #581

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.