### PR TITLE
Improve community loop health classification

### DIFF
--- a/.agents/skills/using-agent-skills/SKILL.md
+++ b/.agents/skills/using-agent-skills/SKILL.md
@@ -32,6 +32,7 @@ Task arrives
     |-- Have a spec, need tasks? --------------------> planning-and-task-breakdown
     |-- Implementing code? --------------------------> incremental-implementation
     |   |-- Website edit / preview loop? -----------> website-editing
+    |   |-- Game or interactive prototype? ---------> game-prototyping
     |   |-- UI work? --------------------------------> frontend-ui-engineering
     |   |-- API / interface work? -------------------> api-and-interface-design
     |   |-- Mostly simplification / clarity? --------> code-simplification
@@ -52,6 +53,7 @@ Task arrives
     |-- GoDaddy domain / DNS / site ops? ------------> godaddy-ops
     |-- Writing docs or rationale? ------------------> documentation-and-adrs
     |-- Deploying or launching? ---------------------> shipping-and-launch
+    |-- Recurring agent behavior failed again? ------> auto-iterate
     `-- Agent-team behavior needs tuning? -----------> team-iterate
 ```
 
@@ -148,6 +150,7 @@ Not every task needs every step. Bug triage might be:
 | Plan | planning-and-task-breakdown | Decompose work into small verifiable tasks |
 | Build | incremental-implementation | Ship thin vertical slices |
 | Build | website-editing | Edit the Workflow website with its preview and ship loop |
+| Build | game-prototyping | Build playable browser games and game-like interactive prototypes |
 | Build | context-engineering | Load the right context at the right time |
 | Build | frontend-ui-engineering | Build production-quality user interfaces |
 | Build | api-and-interface-design | Design stable interfaces and contracts |
@@ -170,4 +173,5 @@ Not every task needs every step. Bug triage might be:
 | Ops | cloudflare-ops | Operate Cloudflare DNS, routes, and website surfaces |
 | Ops | godaddy-ops | Operate GoDaddy domain and site surfaces |
 | Meta | skill-authoring | Create or update project-local skills correctly |
+| Meta | auto-iterate | Ratchet prevention after repeated agent behavioral failures |
 | Meta | team-iterate | Improve agent-team definitions and launch prompts |

--- a/.claude/skills/using-agent-skills/SKILL.md
+++ b/.claude/skills/using-agent-skills/SKILL.md
@@ -32,6 +32,7 @@ Task arrives
     |-- Have a spec, need tasks? --------------------> planning-and-task-breakdown
     |-- Implementing code? --------------------------> incremental-implementation
     |   |-- Website edit / preview loop? -----------> website-editing
+    |   |-- Game or interactive prototype? ---------> game-prototyping
     |   |-- UI work? --------------------------------> frontend-ui-engineering
     |   |-- API / interface work? -------------------> api-and-interface-design
     |   |-- Mostly simplification / clarity? --------> code-simplification
@@ -52,6 +53,7 @@ Task arrives
     |-- GoDaddy domain / DNS / site ops? ------------> godaddy-ops
     |-- Writing docs or rationale? ------------------> documentation-and-adrs
     |-- Deploying or launching? ---------------------> shipping-and-launch
+    |-- Recurring agent behavior failed again? ------> auto-iterate
     `-- Agent-team behavior needs tuning? -----------> team-iterate
 ```
 
@@ -148,6 +150,7 @@ Not every task needs every step. Bug triage might be:
 | Plan | planning-and-task-breakdown | Decompose work into small verifiable tasks |
 | Build | incremental-implementation | Ship thin vertical slices |
 | Build | website-editing | Edit the Workflow website with its preview and ship loop |
+| Build | game-prototyping | Build playable browser games and game-like interactive prototypes |
 | Build | context-engineering | Load the right context at the right time |
 | Build | frontend-ui-engineering | Build production-quality user interfaces |
 | Build | api-and-interface-design | Design stable interfaces and contracts |
@@ -170,4 +173,5 @@ Not every task needs every step. Bug triage might be:
 | Ops | cloudflare-ops | Operate Cloudflare DNS, routes, and website surfaces |
 | Ops | godaddy-ops | Operate GoDaddy domain and site surfaces |
 | Meta | skill-authoring | Create or update project-local skills correctly |
+| Meta | auto-iterate | Ratchet prevention after repeated agent behavioral failures |
 | Meta | team-iterate | Improve agent-team definitions and launch prompts |

--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -93,6 +93,11 @@ jobs:
             const hasWriterAuth = process.env.HAS_WRITER_AUTH === 'true';
             const hasWorkflowPushToken = process.env.HAS_WORKFLOW_PUSH_TOKEN === 'true';
             const autoFixDisabled = process.env.AUTO_FIX_DISABLED === 'true';
+            const dispatchIssueNumber = (
+              core.getInput('issue_number') ||
+              context.payload.inputs?.issue_number ||
+              ''
+            ).trim();
 
             function hasLabel(issue, name) {
               return (issue.labels || []).some((label) => label.name === name);
@@ -174,16 +179,20 @@ jobs:
               ) {
                 pushIfPending(issue, { retryAttempted: true });
               }
-            } else if (context.eventName === 'workflow_dispatch' && core.getInput('issue_number')) {
-              const issue = await issueFromNumber(core.getInput('issue_number'));
+            } else if (context.eventName === 'workflow_dispatch' && dispatchIssueNumber) {
+              core.info(`Workflow dispatch requested issue #${dispatchIssueNumber}.`);
+              const issue = await issueFromNumber(dispatchIssueNumber);
               if (issue) {
                 pushIfPending(issue, { retryAttempted: true });
               }
             } else {
+              if (context.eventName === 'workflow_dispatch') {
+                core.info('Workflow dispatch did not include issue_number; scanning pending daemon requests.');
+              }
               async function scanAutoLabels(options = {}) {
                 const onlyPermissionBlocked = options.onlyPermissionBlocked || false;
                 async function scanLabelQuery(labelNames) {
-                  const { data: issues } = await github.rest.issues.listForRepo({
+                  const issues = await github.paginate(github.rest.issues.listForRepo, {
                     owner,
                     repo,
                     state: 'open',
@@ -192,6 +201,7 @@ jobs:
                     direction: 'asc',
                     per_page: 100,
                   });
+                  core.info(`Scanning ${issues.length} open issue(s) for labels ${labelNames.join(',')}.`);
                   for (const issue of issues) {
                     if (
                       onlyPermissionBlocked &&

--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -43,6 +43,7 @@ LEGACY_PRIORITY_LABEL_MAP = {
     "primitive-surface": "priority:primitive-surface",
 }
 BLOCKED_LABEL = "needs-human"
+AWAIT_PRIMITIVE_LAYER_LABEL = "await-primitive-layer"
 ATTEMPTED_LABEL = "auto-fix-attempted"
 P0_OUTAGE_LABEL = "p0-outage"
 AUTH_MISSING_LABEL = "auto-fix-auth-missing"
@@ -237,6 +238,7 @@ def workflow_stage(
     max_age_min: int | None,
     stale_status: str = "red",
     required_success_event: str | None = None,
+    fallback_success_events: tuple[str, ...] = (),
     per_page: int = 20,
 ) -> dict[str, Any]:
     runs = _recent_workflow_runs(
@@ -249,11 +251,20 @@ def workflow_stage(
     )
     skipped_runs = [candidate for candidate in runs if _is_neutral_skipped_run(candidate)]
     candidates = [candidate for candidate in runs if not _is_neutral_skipped_run(candidate)]
+    fallback_candidates: list[dict[str, Any]] = []
     if required_success_event is not None:
         candidates = [
             candidate
             for candidate in candidates
             if candidate.get("event") == required_success_event
+        ]
+        fallback_candidates = [
+            candidate
+            for candidate in runs
+            if not _is_neutral_skipped_run(candidate)
+            and candidate.get("event") in fallback_success_events
+            and candidate.get("status") == "completed"
+            and candidate.get("conclusion") == "success"
         ]
     run = next(iter(candidates), None)
     if run is None and runs:
@@ -319,6 +330,35 @@ def workflow_stage(
             details=details,
         )
     if conclusion != "success":
+        fallback_run = next(iter(fallback_candidates), None)
+        fallback_age = _age_min(fallback_run.get("created_at"), now) if fallback_run else None
+        if (
+            fallback_run is not None
+            and max_age_min is not None
+            and fallback_age is not None
+            and fallback_age <= max_age_min
+        ):
+            fallback_event = fallback_run.get("event") or "unknown event"
+            return _stage(
+                label,
+                "yellow",
+                (
+                    f"{workflow_id} {required_success_event} run concluded {conclusion}, "
+                    f"but recent {fallback_event} success proves the workflow is dispatchable"
+                ),
+                evidence=(
+                    f"required {required_success_event} run was {status}/{conclusion}; "
+                    f"fallback {fallback_event} success was {fallback_age:.1f} min ago"
+                ),
+                url=fallback_run.get("html_url") or run.get("html_url"),
+                details={
+                    **details,
+                    "fallback_run_id": fallback_run.get("id"),
+                    "fallback_event": fallback_event,
+                    "fallback_created_at": fallback_run.get("created_at"),
+                    "fallback_age_min": round(fallback_age, 1),
+                },
+            )
         return _stage(
             label,
             "red",
@@ -405,6 +445,7 @@ def queue_stage(
     attempted: list[dict[str, Any]] = []
     pending: list[dict[str, Any]] = []
     old_pending: list[dict[str, Any]] = []
+    await_primitive_layer: list[dict[str, Any]] = []
     legacy_priority_migrations: list[dict[str, Any]] = []
 
     for issue in issues:
@@ -436,6 +477,8 @@ def queue_stage(
             reviewed_terminal.append(issue)
         elif ATTEMPTED_LABEL in labels:
             attempted.append(issue)
+        elif AWAIT_PRIMITIVE_LAYER_LABEL in labels:
+            await_primitive_layer.append(issue)
         else:
             pending.append(issue)
             age = _age_min(issue.get("created_at"), now)
@@ -469,6 +512,9 @@ def queue_stage(
         "provider_exhausted": [issue.get("number") for issue in provider_exhausted],
         "pending": [issue.get("number") for issue in pending],
         "old_pending": [issue.get("number") for issue in old_pending],
+        "await_primitive_layer": [
+            issue.get("number") for issue in await_primitive_layer
+        ],
         "legacy_priority_migrations": legacy_priority_migrations,
         "reviewed_terminal": [issue.get("number") for issue in reviewed_terminal],
         "attempted": [issue.get("number") for issue in attempted],
@@ -565,6 +611,22 @@ def queue_stage(
             url=first.get("html_url"),
             details=details,
         )
+    if await_primitive_layer:
+        first = await_primitive_layer[0]
+        return _stage(
+            "Writer queue",
+            "yellow",
+            (
+                f"{len(await_primitive_layer)} loop request(s) are intentionally "
+                f"waiting on {AWAIT_PRIMITIVE_LAYER_LABEL}"
+            ),
+            evidence=(
+                f"first deferred issue #{first.get('number')}: "
+                f"{first.get('title')}"
+            ),
+            url=first.get("html_url"),
+            details=details,
+        )
     return _stage(
         "Writer queue",
         "green",
@@ -633,6 +695,7 @@ def build_status(args: argparse.Namespace, now: dt.datetime | None = None) -> di
             now=current_now,
             max_age_min=args.max_writer_age_min,
             required_success_event="schedule",
+            fallback_success_events=("workflow_dispatch", "issues"),
             per_page=100,
         ),
         queue_stage(

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -177,6 +177,23 @@ def test_discover_scheduled_backfill_reads_oldest_pending_first(wf):
     assert "direction: 'asc'" in script
 
 
+def test_discover_paginates_past_deferred_oldest_issues(wf):
+    discover_step = wf["jobs"]["discover"]["steps"][0]
+    script = str(discover_step.get("with", {}).get("script", ""))
+    assert "github.paginate(github.rest.issues.listForRepo" in script
+    assert "Scanning ${issues.length} open issue(s)" in script
+
+
+def test_workflow_dispatch_logs_and_uses_target_issue_input(wf):
+    discover_step = wf["jobs"]["discover"]["steps"][0]
+    script = str(discover_step.get("with", {}).get("script", ""))
+    assert "const dispatchIssueNumber" in script
+    assert "context.payload.inputs?.issue_number" in script
+    assert "Workflow dispatch requested issue #" in script
+    assert "issueFromNumber(dispatchIssueNumber)" in script
+    assert "Workflow dispatch did not include issue_number" in script
+
+
 # ---------------------------------------------------------------------------
 # Disable toggle
 # ---------------------------------------------------------------------------

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -144,7 +144,9 @@ def test_workflow_stage_keeps_in_progress_meaningful_run(monkeypatch):
     assert stage["details"]["run_id"] == 3
 
 
-def test_writer_stage_requires_recent_schedule_backfill_run(monkeypatch):
+def test_writer_stage_requires_recent_schedule_backfill_run_without_fallback(
+    monkeypatch,
+):
     now = dt.datetime(2026, 5, 5, 0, 0, tzinfo=dt.timezone.utc)
 
     def fake_gh_get(*_args, **_kwargs):
@@ -180,6 +182,57 @@ def test_writer_stage_requires_recent_schedule_backfill_run(monkeypatch):
     assert "schedule backfill" in stage["summary"]
     assert stage["details"]["required_success_event"] == "schedule"
     assert stage["details"]["latest_event"] == "workflow_dispatch"
+
+
+def test_writer_stage_downgrades_cancelled_schedule_when_dispatch_succeeds(
+    monkeypatch,
+):
+    now = dt.datetime(2026, 5, 5, 0, 0, tzinfo=dt.timezone.utc)
+
+    def fake_gh_get(*_args, **_kwargs):
+        return {
+            "workflow_runs": [
+                {
+                    "id": 43,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "created_at": "2026-05-04T23:58:00Z",
+                    "updated_at": "2026-05-04T23:59:00Z",
+                    "event": "workflow_dispatch",
+                    "html_url": "https://example.test/manual-success",
+                },
+                {
+                    "id": 44,
+                    "status": "completed",
+                    "conclusion": "cancelled",
+                    "created_at": "2026-05-04T23:37:00Z",
+                    "updated_at": "2026-05-04T23:38:00Z",
+                    "event": "schedule",
+                    "html_url": "https://example.test/scheduled-cancelled",
+                },
+            ]
+        }
+
+    monkeypatch.setattr(watch, "_gh_get", fake_gh_get)
+
+    stage = watch.workflow_stage(
+        "Writer workflow",
+        "owner/repo",
+        "auto-fix-bug.yml",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+        now=now,
+        max_age_min=90,
+        required_success_event="schedule",
+        fallback_success_events=("workflow_dispatch", "issues"),
+    )
+
+    assert stage["status"] == "yellow"
+    assert "workflow is dispatchable" in stage["summary"]
+    assert stage["details"]["run_id"] == 44
+    assert stage["details"]["fallback_run_id"] == 43
+    assert stage["details"]["fallback_event"] == "workflow_dispatch"
 
 
 def test_writer_stage_uses_scheduled_success_when_other_runs_are_newer(monkeypatch):
@@ -384,6 +437,45 @@ def test_queue_stage_treats_attempted_loop_smoke_as_not_waiting(monkeypatch):
     assert stage["details"]["attempted"] == [178]
     assert stage["details"]["pending"] == []
     assert stage["details"]["old_pending"] == []
+
+
+def test_queue_stage_treats_await_primitive_layer_as_deferred_not_stuck(
+    monkeypatch,
+):
+    now = dt.datetime(2026, 5, 7, 3, 40, tzinfo=dt.timezone.utc)
+
+    def fake_list_loop_issues(*_args, **_kwargs):
+        return [
+            {
+                "number": 541,
+                "title": "Single-server architecture waits for primitive layer",
+                "created_at": "2026-05-06T23:46:00Z",
+                "html_url": "https://example.test/issues/541",
+                "labels": [
+                    {"name": "daemon-request"},
+                    {"name": "auto-change"},
+                    {"name": "request:project-design"},
+                    {"name": watch.AWAIT_PRIMITIVE_LAYER_LABEL},
+                ],
+            }
+        ]
+
+    monkeypatch.setattr(watch, "list_loop_issues", fake_list_loop_issues)
+
+    stage = watch.queue_stage(
+        "owner/repo",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+        now=now,
+        max_pending_age_min=45,
+    )
+
+    assert stage["status"] == "yellow"
+    assert stage["details"]["pending"] == []
+    assert stage["details"]["old_pending"] == []
+    assert stage["details"]["await_primitive_layer"] == [541]
+    assert "intentionally waiting" in stage["summary"]
 
 
 def test_queue_stage_maps_legacy_priority_labels_before_pending_stuck(monkeypatch):


### PR DESCRIPTION
## Summary
- Paginate auto-fix queue discovery so older deferred/terminal issues cannot hide newer actionable daemon requests.
- Treat await-primitive-layer requests as intentionally deferred in community_loop_watch instead of stuck pending work.
- Downgrade writer-workflow schedule failures to yellow when a recent manual/issue-triggered success proves the writer workflow is dispatchable.
- Log targeted workflow_dispatch issue inputs and fall back to payload inputs for better manual-run diagnosis.
- Repair using-agent-skills router entries for auto-iterate and game-prototyping so the commit hooks pass.

## Verification
- python -m pytest tests/test_community_loop_watch.py tests/test_community_loop_watch_workflow.py tests/test_auto_fix_workflow.py
- python -m py_compile scripts/community_loop_watch.py tests/test_community_loop_watch.py tests/test_auto_fix_workflow.py
- python -m ruff check scripts/community_loop_watch.py tests/test_community_loop_watch.py tests/test_auto_fix_workflow.py
- python scripts/validate_skills.py
- git diff --check
- Local actionlint unavailable; hook skipped with actionlint not on PATH. CI still owns workflow lint on PR.

## Live evidence before landing
- wiki-bug-sync.yml dispatch run 25474680975 succeeded.
- uptime-canary.yml dispatch run 25474680969 succeeded.
- auto-fix-bug.yml workflow_dispatch run 25474762586 succeeded but discovered 0 because current main scans only the first page of oldest skipped issues.
- Patched community_loop_watch reports writer workflow yellow via recent workflow_dispatch success, while writer queue remains red on live main pending #583/#582/#568 until this patch lands.

## Gates
Writer family: Codex. Requires Claude/Cowork checker review and explicit host approval before merge.