### PR TITLE
[auto-change] WIKI-PATCH: PR-077: writer-pool should detect multi-phase patch-requests and default to "Part of #N" instead of "Fixes #N" for non-final phases

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -650,6 +650,32 @@ jobs:
             const wikiPathMatch = body.match(/\*\*Wiki path:\*\*\s*`([^`]+)`/i);
             const wikiPath = wikiPathMatch ? wikiPathMatch[1] : '';
 
+            function issueLinkKeyword(requestKind, body) {
+              if (requestKind !== 'patch') {
+                return 'Fixes';
+              }
+              const text = String(body || '').toLowerCase();
+              const hasFinalMarker = [
+                /(^|\n)\s*(final|final_phase|is_final_phase)\s*:\s*true\b/,
+                /(^|\n)\s*phase\s*:\s*final\b/,
+                /(^|\n)\s*(?:the\s+)?final\s+phase\b/,
+                /\blast\s+phase\b/,
+              ].some((pattern) => pattern.test(text));
+              if (hasFinalMarker) {
+                return 'Fixes';
+              }
+              const hasNonFinalMarker = [
+                /(^|\n)\s*(final|final_phase|is_final_phase)\s*:\s*false\b/,
+                /\bnon[- ]final\b/,
+                /\bnot\s+(?:the\s+)?final\b/,
+                /\bintermediate\s+phase\b/,
+              ].some((pattern) => pattern.test(text));
+              const hasEarlierNumberedPhase = Array.from(
+                text.matchAll(/\bphase\s+(\d+)\s*(?:of|\/)\s*(\d+)\b/g)
+              ).some((match) => Number(match[1]) < Number(match[2]));
+              return hasNonFinalMarker || hasEarlierNumberedPhase ? 'Part of' : 'Fixes';
+            }
+
             // Pull request id from titles like "[BUG-003] ..." or "[WIKI-FEATURE] ...".
             const bugMatch = title.match(/\[?(BUG-\d+)\]?/i);
             const wikiMatch = title.match(/\[?(WIKI-[A-Z-]+)\]?/i);
@@ -672,6 +698,7 @@ jobs:
             core.setOutput('expected_branch_task', expectedBranchTask);
             core.setOutput('short_title', shortTitle);
             core.setOutput('pr_title', `${prTitlePrefix} ${requestId}: ${shortTitle}`);
+            core.setOutput('issue_link_line', `${issueLinkKeyword(requestKind, body)} #${issue.issue_number}`);
             core.setOutput('issue_body', body);
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -742,7 +769,7 @@ jobs:
             9. If you make changes, open a pull request titled:
                ${{ steps.meta.outputs.pr_title }}
             10. The PR body must start with:
-               Fixes #${{ steps.meta.outputs.issue_number }}
+               ${{ steps.meta.outputs.issue_link_line }}
             11. Include a `Request artifact reconciliation` section that lists:
                - Wiki page: `${{ steps.meta.outputs.wiki_path || 'not declared' }}`
                - GitHub issue: `#${{ steps.meta.outputs.issue_number }}`
@@ -766,6 +793,7 @@ jobs:
           WORKFLOW_PUSH_TOKEN: ${{ secrets.WORKFLOW_PUSH_TOKEN }}
           PR_TITLE: ${{ steps.meta.outputs.pr_title }}
           BRANCH_PREFIX: ${{ steps.meta.outputs.branch_prefix }}
+          ISSUE_LINK_LINE: ${{ steps.meta.outputs.issue_link_line }}
         run: |
           set -euo pipefail
           branch="${BRANCH_PREFIX}issue-${{ steps.meta.outputs.issue_number }}-codex-${GITHUB_RUN_ID}"
@@ -910,7 +938,7 @@ jobs:
           git config user.email "workflow-daemon[bot]@users.noreply.github.com"
           git add -A
           git commit -m "$PR_TITLE" \
-            -m "Fixes #${{ steps.meta.outputs.issue_number }}" \
+            -m "$ISSUE_LINK_LINE" \
             -m "Writer family: Codex" \
             -m "Required checker family: Claude"
           push_log="$RUNNER_TEMP/codex-git-push.log"
@@ -944,6 +972,7 @@ jobs:
           CODEX_BRANCH: ${{ steps.codex-subscription.outputs.branch }}
           PR_TITLE: ${{ steps.meta.outputs.pr_title }}
           ISSUE_NUMBER: ${{ steps.meta.outputs.issue_number }}
+          ISSUE_LINK_LINE: ${{ steps.meta.outputs.issue_link_line }}
           WIKI_PATH: ${{ steps.meta.outputs.wiki_path }}
           EXPECTED_BRANCH_TASK: ${{ steps.meta.outputs.expected_branch_task }}
         with:
@@ -952,6 +981,7 @@ jobs:
           script: |
             const branch = process.env.CODEX_BRANCH;
             const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const issueLinkLine = process.env.ISSUE_LINK_LINE || `Fixes #${issueNumber}`;
             const filingShape = '${{ steps.meta.outputs.filing_shape }}';
             const branchPrefix = '${{ steps.meta.outputs.branch_prefix }}';
             const wikiPath = process.env.WIKI_PATH || 'not declared';
@@ -1033,7 +1063,7 @@ jobs:
                   head: branch,
                   base: 'main',
                   body: [
-                    `Fixes #${issueNumber}`,
+                    issueLinkLine,
                     '',
                     '## Request artifact reconciliation',
                     '',

--- a/docs/ops/auto-fix-runbook.md
+++ b/docs/ops/auto-fix-runbook.md
@@ -121,7 +121,8 @@ Variable-based toggle preserves secrets; no data loss from toggling.
 - Claude branch: `auto-change/issue-<N>` where N = GH issue number
 - Codex branch: `auto-change/issue-<N>-codex-<run_id>` to avoid collisions
 - PR title: `[auto-change] <request-id>: <short title>`
-- PR body: `Fixes #N` plus change summary
+- PR body: `Fixes #N` plus change summary, or `Part of #N` when the
+  request metadata marks a patch request as a non-final multi-phase change.
 - PR labels: `writer:claude` requires `checker:codex`; `writer:codex`
   requires `checker:claude`. The `Daemon request policy` PR check enforces
   that same-family machine review is not accepted.

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -664,13 +664,52 @@ def test_meta_step_fetches_recent_issue_comments_for_feedback(wf):
     assert "slice(-5)" in script
 
 
-def test_pr_body_references_fixes_keyword(wf):
+def test_meta_step_defaults_non_final_patch_phases_to_part_of(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    meta_step = next((s for s in steps if s.get("id") == "meta"), None)
+    oauth_step = next((s for s in steps if s.get("id") == "claude-oauth"), None)
+    codex_step = next((s for s in steps if s.get("id") == "codex-subscription"), None)
+    codex_pr_step = next((s for s in steps if s.get("id") == "codex-pr-create"), None)
+    assert meta_step is not None, "Must have request metadata step"
+    assert oauth_step is not None, "Must have a Claude OAuth step"
+    assert codex_step is not None, "Must have a Codex subscription writer step"
+    assert codex_pr_step is not None, "Must create a PR for Codex-authored changes"
+
+    meta_script = str(meta_step.get("with", {}).get("script", ""))
+    assert "function issueLinkKeyword" in meta_script
+    assert "requestKind !== 'patch'" in meta_script
+    assert "final_phase" in meta_script
+    assert "matchAll" in meta_script
+    assert "Number(match[1]) < Number(match[2])" in meta_script
+    assert "'Part of'" in meta_script
+    assert "core.setOutput('issue_link_line'" in meta_script
+
+    prompt = str(oauth_step.get("with", {}).get("prompt", ""))
+    assert "${{ steps.meta.outputs.issue_link_line }}" in prompt
+
+    codex_run = str(codex_step.get("run", ""))
+    assert codex_step.get("env", {}).get("ISSUE_LINK_LINE") == (
+        "${{ steps.meta.outputs.issue_link_line }}"
+    )
+    assert '-m "$ISSUE_LINK_LINE"' in codex_run
+    assert '"Fixes #${{ steps.meta.outputs.issue_number }}"' not in codex_run
+
+    codex_pr_script = str(codex_pr_step.get("with", {}).get("script", ""))
+    assert codex_pr_step.get("env", {}).get("ISSUE_LINK_LINE") == (
+        "${{ steps.meta.outputs.issue_link_line }}"
+    )
+    assert "process.env.ISSUE_LINK_LINE" in codex_pr_script
+    assert "body: [" in codex_pr_script
+    assert "issueLinkLine," in codex_pr_script
+
+
+def test_pr_body_references_issue_link_output(wf):
     steps = wf["jobs"]["fix"]["steps"]
     oauth_step = next((s for s in steps if s.get("id") == "claude-oauth"), None)
     assert oauth_step is not None, "Must have a Claude OAuth step"
     prompt = str(oauth_step.get("with", {}).get("prompt", ""))
-    assert "Fixes #${{ steps.meta.outputs.issue_number }}" in prompt, (
-        "Claude prompt must require PR body to reference the issue with Fixes #N"
+    assert "${{ steps.meta.outputs.issue_link_line }}" in prompt, (
+        "Claude prompt must use the computed issue link line"
     )
 
 


### PR DESCRIPTION
Fixes #591

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.