### PR TITLE
[auto-change] WIKI-PATCH: Patch-request dispatch must reconcile wiki page, GitHub issue, branch task, and PR artifacts so requests cannot disappear between surfaces

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -9,6 +9,12 @@ name: Auto-fix change
 #   -> an automated writer attempts a change, or the issue is marked
 #      `needs-human`.
 #
+# Lost-work guard:
+#   once an issue is labeled `auto-fix-attempted`, it must eventually gain a
+#   terminal receipt: PR artifact, `auto-fix-reviewed`, or `needs-human`.
+#   Attempted issues without a terminal receipt are treated as interrupted and
+#   retried instead of skipped.
+#
 # Why this has a backfill path:
 #   wiki-bug-sync intentionally uses GITHUB_TOKEN. GitHub suppresses most
 #   follow-on workflow runs caused by GITHUB_TOKEN events, so an issue label
@@ -139,6 +145,7 @@ jobs:
               const needsHuman = hasLabel(issue, 'needs-human');
               const attempted = hasLabel(issue, 'auto-fix-attempted');
               const reviewed = hasLabel(issue, 'auto-fix-reviewed');
+              const incompleteAttempt = attempted && !reviewed && !needsHuman;
               const retryPermissionBlocked = (
                 (
                   hasLabel(issue, 'auto-fix-branch-push-blocked') ||
@@ -148,11 +155,16 @@ jobs:
                 hasWorkflowPushToken &&
                 !autoFixDisabled
               );
-              const retryAttempted = options.retryAttempted || (
+              const retryAttempted = options.retryAttempted || incompleteAttempt || (
                 needsHuman && hasWriterAuth && !autoFixDisabled && !reviewed
               ) || retryPermissionBlocked;
               if (attempted && !retryAttempted) {
                 return;
+              }
+              if (incompleteAttempt) {
+                core.info(
+                  `Retrying issue #${issue.number} because auto-fix-attempted has no terminal receipt.`
+                );
               }
               if (attempted) {
                 core.info(`Retrying previously attempted issue #${issue.number}.`);
@@ -1133,6 +1145,27 @@ jobs:
                 'Do not accept this PR with a same-family checker.',
               ].join('\n'),
             });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: [
+                '**Auto-fix artifact receipt**',
+                '',
+                `- Wiki page: \`${wikiPath}\``,
+                `- GitHub issue: #${issueNumber}`,
+                `- Branch task: \`${expectedBranchTask}\``,
+                `- PR artifact: #${pr.number} (${pr.html_url})`,
+                `- Child invocation receipt: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                '- Terminal outcome: `pr-opened`',
+              ].join('\n'),
+            });
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['auto-fix-reviewed'],
+            });
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -1210,6 +1243,9 @@ jobs:
           steps.check-disabled.outputs.disabled == 'false' &&
           steps.auth.outputs.mode == 'claude_oauth'
         uses: actions/github-script@v7
+        env:
+          WIKI_PATH: ${{ steps.meta.outputs.wiki_path }}
+          EXPECTED_BRANCH_TASK: ${{ steps.meta.outputs.expected_branch_task }}
         with:
           script: |
             const issueNumber = Number('${{ matrix.issue.issue_number }}');
@@ -1329,6 +1365,29 @@ jobs:
                 'Do not accept this PR with a same-family checker.',
               ].join('\n'),
             });
+            const wikiPath = process.env.WIKI_PATH || 'not declared';
+            const expectedBranchTask = process.env.EXPECTED_BRANCH_TASK || `${branchPrefix}issue-${issueNumber}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: [
+                '**Auto-fix artifact receipt**',
+                '',
+                `- Wiki page: \`${wikiPath}\``,
+                `- GitHub issue: #${issueNumber}`,
+                `- Branch task: \`${expectedBranchTask}\``,
+                `- PR artifact: #${pr.number} (${pr.html_url})`,
+                `- Child invocation receipt: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                '- Terminal outcome: `pr-opened`',
+              ].join('\n'),
+            });
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['auto-fix-reviewed'],
+            });
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -1351,6 +1410,8 @@ jobs:
           CODEX_PR_BLOCK_REASON: ${{ steps.codex-pr-create.outputs.block_reason }}
           CODEX_PUSH_BLOCKED: ${{ steps.codex-subscription.outputs.push_blocked }}
           CODEX_PUSH_BLOCK_REASON: ${{ steps.codex-subscription.outputs.push_block_reason }}
+          WIKI_PATH: ${{ steps.meta.outputs.wiki_path }}
+          EXPECTED_BRANCH_TASK: ${{ steps.meta.outputs.expected_branch_task }}
           CLAUDE_OUTCOME: ${{ steps.claude-oauth.outcome }}
           CODEX_OUTCOME: ${{ steps.codex-subscription.outcome }}
         with:
@@ -1362,6 +1423,9 @@ jobs:
             const branch = mode === 'codex_subscription' && codexBranch
               ? codexBranch
               : `${branchPrefix}issue-${issueNumber}`;
+            const wikiPath = process.env.WIKI_PATH || 'not declared';
+            const expectedBranchTask = process.env.EXPECTED_BRANCH_TASK || `${branchPrefix}issue-${issueNumber}`;
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -1370,7 +1434,29 @@ jobs:
               per_page: 5,
             });
             if (prs.length) {
-              core.info(`Auto-fix PR exists: #${prs[0].number}`);
+              const pr = prs[0];
+              core.info(`Auto-fix PR exists: #${pr.number}`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: [
+                  '**Auto-fix artifact receipt**',
+                  '',
+                  `- Wiki page: \`${wikiPath}\``,
+                  `- GitHub issue: #${issueNumber}`,
+                  `- Branch task: \`${expectedBranchTask}\``,
+                  `- PR artifact: #${pr.number} (${pr.html_url})`,
+                  `- Child invocation receipt: ${runUrl}`,
+                  '- Terminal outcome: `pr-opened-existing`',
+                ].join('\n'),
+              });
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['auto-fix-reviewed'],
+              });
               return;
             }
 
@@ -1384,6 +1470,15 @@ jobs:
             const claudeWriterFailed = mode === 'claude_oauth' && process.env.CLAUDE_OUTCOME === 'failure';
             const codexWriterFailed = mode === 'codex_subscription' && process.env.CODEX_OUTCOME === 'failure';
             const writerFailed = claudeWriterFailed || codexWriterFailed;
+            const terminalOutcome = writerFailed
+              ? 'writer-failed-before-pr'
+              : codexPushBlocked
+                ? 'branch-push-blocked'
+                : codexPrBlocked
+                  ? 'pr-creation-blocked'
+                  : codexNoChangeReason
+                    ? `no-change-${codexNoChangeReason}`
+                    : 'no-pr-artifact-created';
             const labels = ['needs-human'];
             if (codexNoChangeReason || codexPrBlocked || codexPushBlocked || writerFailed) {
               labels.push('auto-fix-reviewed');
@@ -1417,6 +1512,15 @@ jobs:
               issue_number: issueNumber,
               body: [
                 '**Auto-fix needs human review** - approved writer auth was present, but no automated PR was opened.',
+                '',
+                '## Request artifact reconciliation',
+                '',
+                `- Wiki page: \`${wikiPath}\``,
+                `- GitHub issue: #${issueNumber}`,
+                `- Branch task: \`${expectedBranchTask}\``,
+                '- PR artifact: `not created`',
+                `- Child invocation receipt: ${runUrl}`,
+                `- Terminal outcome: \`${terminalOutcome}\``,
                 '',
                 `Detected auth mode: \`${{ steps.auth.outputs.mode }}\``,
                 `Claude OAuth present: \`${{ steps.auth.outputs.has_claude_oauth }}\``,

--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -615,6 +615,8 @@ jobs:
             const filingShape = architecturalKinds.has(requestKind) ? 'architectural' : 'mechanical';
             const branchPrefix = filingShape === 'architectural' ? 'design-note-draft/' : 'auto-change/';
             const prTitlePrefix = filingShape === 'architectural' ? '[design-note]' : '[auto-change]';
+            const wikiPathMatch = body.match(/\*\*Wiki path:\*\*\s*`([^`]+)`/i);
+            const wikiPath = wikiPathMatch ? wikiPathMatch[1] : '';
 
             // Pull request id from titles like "[BUG-003] ..." or "[WIKI-FEATURE] ...".
             const bugMatch = title.match(/\[?(BUG-\d+)\]?/i);
@@ -624,6 +626,7 @@ jobs:
               : wikiMatch
                 ? wikiMatch[1].toUpperCase()
                 : `ISSUE-${String(issue.issue_number).padStart(3, '0')}`;
+            const expectedBranchTask = `${branchPrefix}issue-${issue.issue_number}`;
 
             // Short title = everything after the bracketed request prefix, trimmed.
             const shortTitle = title.replace(/^\[?(BUG-\d+|WIKI-[A-Z-]+)\]?\s*/i, '').trim() || title;
@@ -633,6 +636,8 @@ jobs:
             core.setOutput('request_kind', requestKind);
             core.setOutput('filing_shape', filingShape);
             core.setOutput('branch_prefix', branchPrefix);
+            core.setOutput('wiki_path', wikiPath);
+            core.setOutput('expected_branch_task', expectedBranchTask);
             core.setOutput('short_title', shortTitle);
             core.setOutput('pr_title', `${prTitlePrefix} ${requestId}: ${shortTitle}`);
             core.setOutput('issue_body', body);
@@ -706,9 +711,14 @@ jobs:
                ${{ steps.meta.outputs.pr_title }}
             10. The PR body must start with:
                Fixes #${{ steps.meta.outputs.issue_number }}
-            11. Include `Writer family: Claude` and `Required checker family: Codex`.
-            12. Include a short fix summary, tests run, and any remaining risks.
-            13. Do not redesign community-authored branches unless the issue explicitly asks for that.
+            11. Include a `Request artifact reconciliation` section that lists:
+               - Wiki page: `${{ steps.meta.outputs.wiki_path || 'not declared' }}`
+               - GitHub issue: `#${{ steps.meta.outputs.issue_number }}`
+               - Branch task: `${{ steps.meta.outputs.expected_branch_task }}`
+               - PR artifact: this PR
+            12. Include `Writer family: Claude` and `Required checker family: Codex`.
+            13. Include a short fix summary, tests run, and any remaining risks.
+            14. Do not redesign community-authored branches unless the issue explicitly asks for that.
 
             If you cannot find a safe targeted change or are not confident, leave a
             comment in the code and exit gracefully. Do not guess.
@@ -902,6 +912,8 @@ jobs:
           CODEX_BRANCH: ${{ steps.codex-subscription.outputs.branch }}
           PR_TITLE: ${{ steps.meta.outputs.pr_title }}
           ISSUE_NUMBER: ${{ steps.meta.outputs.issue_number }}
+          WIKI_PATH: ${{ steps.meta.outputs.wiki_path }}
+          EXPECTED_BRANCH_TASK: ${{ steps.meta.outputs.expected_branch_task }}
         with:
           # PAT-created PRs fire pull_request checks; GITHUB_TOKEN-created PRs do not.
           github-token: ${{ secrets.WORKFLOW_PUSH_TOKEN || github.token }}
@@ -910,6 +922,8 @@ jobs:
             const issueNumber = Number(process.env.ISSUE_NUMBER);
             const filingShape = '${{ steps.meta.outputs.filing_shape }}';
             const branchPrefix = '${{ steps.meta.outputs.branch_prefix }}';
+            const wikiPath = process.env.WIKI_PATH || 'not declared';
+            const expectedBranchTask = process.env.EXPECTED_BRANCH_TASK || `${branchPrefix}issue-${issueNumber}`;
             async function selfReviewLoopPr(pr) {
               const failures = [];
               const headRef = pr.head?.ref || '';
@@ -988,6 +1002,13 @@ jobs:
                   base: 'main',
                   body: [
                     `Fixes #${issueNumber}`,
+                    '',
+                    '## Request artifact reconciliation',
+                    '',
+                    `- Wiki page: \`${wikiPath}\``,
+                    `- GitHub issue: #${issueNumber}`,
+                    `- Branch task: \`${expectedBranchTask}\``,
+                    '- PR artifact: this PR',
                     '',
                     'Writer family: Codex',
                     'Required checker family: Claude',

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -584,6 +584,17 @@ def test_branch_naming_convention(wf):
     )
 
 
+def test_meta_step_extracts_reconciliation_artifacts(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    meta_step = next((s for s in steps if s.get("id") == "meta"), None)
+    assert meta_step is not None
+    script = str(meta_step.get("with", {}).get("script", ""))
+    assert r"body.match(/\*\*Wiki path:\*\*\s*`([^`]+)`/i)" in script
+    assert "core.setOutput('wiki_path', wikiPath)" in script
+    assert "const expectedBranchTask = `${branchPrefix}issue-${issue.issue_number}`" in script
+    assert "core.setOutput('expected_branch_task', expectedBranchTask)" in script
+
+
 def test_pr_title_prefix_uses_filing_shape(wf):
     steps = wf["jobs"]["fix"]["steps"]
     meta_step = next((s for s in steps if s.get("id") == "meta"), None)
@@ -629,6 +640,25 @@ def test_pr_body_references_fixes_keyword(wf):
     assert "Fixes #${{ steps.meta.outputs.issue_number }}" in prompt, (
         "Claude prompt must require PR body to reference the issue with Fixes #N"
     )
+
+
+def test_writer_pr_bodies_reconcile_request_surfaces(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    oauth_step = next((s for s in steps if s.get("id") == "claude-oauth"), None)
+    codex_pr_step = next((s for s in steps if s.get("id") == "codex-pr-create"), None)
+    assert oauth_step is not None, "Must have a Claude OAuth step"
+    assert codex_pr_step is not None, "Must create a PR for Codex-authored changes"
+    oauth_prompt = str(oauth_step.get("with", {}).get("prompt", ""))
+    codex_env = str(codex_pr_step.get("env", {}))
+    codex_script = str(codex_pr_step.get("with", {}).get("script", ""))
+    for text in (oauth_prompt, codex_script):
+        assert "Request artifact reconciliation" in text
+        assert "Wiki page" in text
+        assert "GitHub issue" in text
+        assert "Branch task" in text
+        assert "PR artifact" in text
+    assert "WIKI_PATH" in codex_env
+    assert "EXPECTED_BRANCH_TASK" in codex_env
 
 
 def test_writer_prompts_require_plugin_mirror_for_workflow_runtime_edits(wf):

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -595,6 +595,16 @@ def test_meta_step_extracts_reconciliation_artifacts(wf):
     assert "core.setOutput('expected_branch_task', expectedBranchTask)" in script
 
 
+def test_discovery_retries_attempted_without_terminal_receipt(wf):
+    steps = wf["jobs"]["discover"]["steps"]
+    discover_step = next((s for s in steps if s.get("id") == "discover"), None)
+    assert discover_step is not None
+    script = str(discover_step.get("with", {}).get("script", ""))
+    assert "const incompleteAttempt = attempted && !reviewed && !needsHuman" in script
+    assert "options.retryAttempted || incompleteAttempt" in script
+    assert "has no terminal receipt" in script
+
+
 def test_pr_title_prefix_uses_filing_shape(wf):
     steps = wf["jobs"]["fix"]["steps"]
     meta_step = next((s for s in steps if s.get("id") == "meta"), None)
@@ -659,6 +669,23 @@ def test_writer_pr_bodies_reconcile_request_surfaces(wf):
         assert "PR artifact" in text
     assert "WIKI_PATH" in codex_env
     assert "EXPECTED_BRANCH_TASK" in codex_env
+
+
+def test_writer_steps_record_issue_side_artifact_receipts(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    claude_pr_step = next((s for s in steps if s.get("id") == "claude-pr"), None)
+    codex_pr_step = next((s for s in steps if s.get("id") == "codex-pr-create"), None)
+    assert claude_pr_step is not None, "Must find and label Claude-authored PRs"
+    assert codex_pr_step is not None, "Must create Codex-authored PRs"
+    claude_script = str(claude_pr_step.get("with", {}).get("script", ""))
+    codex_script = str(codex_pr_step.get("with", {}).get("script", ""))
+    for script in (claude_script, codex_script):
+        assert "Auto-fix artifact receipt" in script
+        assert "issue_number: issueNumber" in script
+        assert "Child invocation receipt" in script
+        assert "Terminal outcome: `pr-opened`" in script
+        assert "pr.html_url" in script
+        assert "labels: ['auto-fix-reviewed']" in script
 
 
 def test_writer_prompts_require_plugin_mirror_for_workflow_runtime_edits(wf):
@@ -753,6 +780,8 @@ def test_no_pr_step_marks_review_without_failing_workflow(wf):
     assert "CODEX_BRANCH" in str(no_pr_step.get("env", {}))
     assert "CODEX_PR_BLOCKED" in str(no_pr_step.get("env", {}))
     assert "CODEX_PUSH_BLOCKED" in str(no_pr_step.get("env", {}))
+    assert "WIKI_PATH" in str(no_pr_step.get("env", {}))
+    assert "EXPECTED_BRANCH_TASK" in str(no_pr_step.get("env", {}))
     assert "CODEX_OUTCOME" in str(no_pr_step.get("env", {}))
     assert "CLAUDE_OUTCOME" in str(no_pr_step.get("env", {}))
     assert "mode === 'codex_subscription' && codexBranch" in script
@@ -760,6 +789,39 @@ def test_no_pr_step_marks_review_without_failing_workflow(wf):
     assert "WORKFLOW_PUSH_TOKEN" in script
     assert "Workflows write" in script
     assert "Pull requests write" in script
+
+
+def test_no_pr_comment_records_terminal_artifact_receipt(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    no_pr_step = next(
+        (s for s in steps if s.get("name") == "Mark needs-human if no PR opened"),
+        None,
+    )
+    assert no_pr_step is not None, "Must mark no-PR outcomes"
+    script = str(no_pr_step.get("with", {}).get("script", ""))
+    assert "Request artifact reconciliation" in script
+    assert "Wiki page" in script
+    assert "GitHub issue" in script
+    assert "Branch task" in script
+    assert "PR artifact: `not created`" in script
+    assert "Child invocation receipt" in script
+    assert "Terminal outcome" in script
+    assert "writer-failed-before-pr" in script
+    assert "context.runId" in script
+
+
+def test_no_pr_step_heals_existing_open_pr_receipt(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    no_pr_step = next(
+        (s for s in steps if s.get("name") == "Mark needs-human if no PR opened"),
+        None,
+    )
+    assert no_pr_step is not None, "Must mark no-PR outcomes"
+    script = str(no_pr_step.get("with", {}).get("script", ""))
+    assert "Auto-fix PR exists" in script
+    assert "pr-opened-existing" in script
+    assert "PR artifact: #${pr.number} (${pr.html_url})" in script
+    assert "labels: ['auto-fix-reviewed']" in script
 
 
 def test_no_pr_comment_distinguishes_successful_writer_from_pr_policy_block(wf):


### PR DESCRIPTION
Fixes #592

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.