### PR TITLE
[auto-change] WIKI-PATCH: Dispatcher should detect filing-shape (mechanical vs architectural) and route architectural filings to design-note drafts instead of auto-change branches

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -696,11 +696,43 @@ jobs:
             const requestKindLabel = labels.find((name) => name?.startsWith('request:'));
             const requestKind = requestKindLabel ? requestKindLabel.replace('request:', '') : 'change';
             const architecturalKinds = new Set(['project-design']);
-            const filingShape = architecturalKinds.has(requestKind) ? 'architectural' : 'mechanical';
-            const branchPrefix = filingShape === 'architectural' ? 'design-note-draft/' : 'auto-change/';
-            const prTitlePrefix = filingShape === 'architectural' ? '[design-note]' : '[auto-change]';
             const wikiPathMatch = body.match(/\*\*Wiki path:\*\*\s*`([^`]+)`/i);
             const wikiPath = wikiPathMatch ? wikiPathMatch[1] : '';
+            const architecturalFilingMarkers = [
+              'architecture',
+              'architectural',
+              'design-note',
+              'design note',
+              'project design',
+              'operating-model',
+              'operating model',
+              'roadmap',
+              'strategic',
+              'substrate',
+            ];
+
+            function declaredFilingShape(body) {
+              const match = String(body || '').match(/\*\*Filing shape:\*\*\s*`?([A-Za-z-]+)`?/i);
+              if (!match) {
+                return '';
+              }
+              const value = match[1].toLowerCase();
+              return ['architectural', 'mechanical'].includes(value) ? value : '';
+            }
+
+            function hasArchitecturalFilingShape(...parts) {
+              const corpus = parts.join(' ').toLowerCase();
+              return architecturalFilingMarkers.some((marker) => corpus.includes(marker));
+            }
+
+            const declaredShape = declaredFilingShape(body);
+            const markerShape = hasArchitecturalFilingShape(requestKind, title, wikiPath, body) ? 'architectural' : '';
+            const labelShape = architecturalKinds.has(requestKind) ? 'architectural' : 'mechanical';
+            const filingShape = [declaredShape, markerShape, labelShape].includes('architectural')
+              ? 'architectural'
+              : (declaredShape || labelShape);
+            const branchPrefix = filingShape === 'architectural' ? 'design-note-draft/' : 'auto-change/';
+            const prTitlePrefix = filingShape === 'architectural' ? '[design-note]' : '[auto-change]';
 
             function issueLinkKeyword(requestKind, body) {
               if (requestKind !== 'patch') {

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -653,6 +653,32 @@ def test_pr_title_prefix_uses_filing_shape(wf):
     assert "prTitlePrefix" in script
 
 
+def test_meta_step_detects_architectural_filing_shape_from_issue_text(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    meta_step = next((s for s in steps if s.get("id") == "meta"), None)
+    assert meta_step is not None
+    script = str(meta_step.get("with", {}).get("script", ""))
+    assert "const architecturalFilingMarkers = [" in script
+    assert "'architectural'" in script
+    assert "'design-note'" in script
+    assert "'substrate'" in script
+    assert "function hasArchitecturalFilingShape" in script
+    assert "hasArchitecturalFilingShape(requestKind, title, wikiPath, body)" in script
+    assert "design-note-draft/" in script
+
+
+def test_meta_step_allows_explicit_filing_shape_override(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    meta_step = next((s for s in steps if s.get("id") == "meta"), None)
+    assert meta_step is not None
+    script = str(meta_step.get("with", {}).get("script", ""))
+    assert "function declaredFilingShape" in script
+    assert r"body || '').match(/\*\*Filing shape:\*\*" in script
+    assert "const declaredShape = declaredFilingShape(body)" in script
+    assert "const markerShape = hasArchitecturalFilingShape" in script
+    assert "[declaredShape, markerShape, labelShape].includes('architectural')" in script
+
+
 def test_architectural_prompt_routes_to_design_note_draft(wf):
     steps = wf["jobs"]["fix"]["steps"]
     oauth_step = next((s for s in steps if s.get("id") == "claude-oauth"), None)


### PR DESCRIPTION
Fixes #303

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-004-dispatcher-should-detect-filing-shape-mechanical-vs-architec.md`
- GitHub issue: #303
- Branch task: `auto-change/issue-303`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.