### PR TITLE
[auto-change] WIKI-PATCH: Dispatcher should prioritize claimable priority:loop-discipline requests before lower-priority work

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -298,7 +298,11 @@ jobs:
               async function scanAutoLabels(options = {}) {
                 const onlyPermissionBlocked = options.onlyPermissionBlocked || false;
                 const onlyStaleGate = options.onlyStaleGate || false;
+                const onlyPriorityLabel = options.onlyPriorityLabel || '';
                 async function scanLabelQuery(labelNames) {
+                  if (onlyPriorityLabel && !labelNames.includes(onlyPriorityLabel)) {
+                    return false;
+                  }
                   const issues = await github.paginate(github.rest.issues.listForRepo, {
                     owner,
                     repo,
@@ -342,7 +346,13 @@ jobs:
                 }
               }
 
-              await scanAutoLabels({ onlyStaleGate: true });
+              await scanAutoLabels({ onlyPriorityLabel: 'priority:loop-discipline' });
+              if (rows.length >= maxIssues) {
+                core.info('Prioritized claimable priority:loop-discipline issue before retry queues.');
+              }
+              if (rows.length < maxIssues) {
+                await scanAutoLabels({ onlyStaleGate: true });
+              }
               if (rows.length >= maxIssues) {
                 core.info('Prioritized stale-gate issue before normal queue discovery.');
               }

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -138,6 +138,9 @@ def test_discover_prioritizes_permission_blocked_before_normal_queue(wf):
 def test_discover_prioritizes_stale_gate_before_normal_queue(wf):
     discover_step = wf["jobs"]["discover"]["steps"][0]
     script = str(discover_step.get("with", {}).get("script", ""))
+    priority_loop_pass = (
+        "await scanAutoLabels({ onlyPriorityLabel: 'priority:loop-discipline' });"
+    )
     stale_gate_pass = "await scanAutoLabels({ onlyStaleGate: true });"
     normal_pass = "await scanAutoLabels();"
     assert "const staleGateLabel = 'auto-fix-stale-gate'" in script
@@ -145,6 +148,7 @@ def test_discover_prioritizes_stale_gate_before_normal_queue(wf):
     assert "retryPermissionBlocked || staleGate" in script
     assert "onlyStaleGate" in script
     assert "Prioritized stale-gate issue before normal queue discovery" in script
+    assert script.index(priority_loop_pass) < script.index(stale_gate_pass)
     assert script.index(stale_gate_pass) < script.index(normal_pass)
 
 
@@ -160,6 +164,24 @@ def test_discover_skips_issues_that_already_have_linked_open_prs(wf):
     assert script.index("const linkedPrNumbers = await linkedOpenPrNumbers(issue);") < (
         script.index("const needsHuman = hasLabel(issue, 'needs-human');")
     )
+
+
+def test_discover_prioritizes_claimable_loop_discipline_before_lower_priority_retries(wf):
+    discover_step = wf["jobs"]["discover"]["steps"][0]
+    script = str(discover_step.get("with", {}).get("script", ""))
+    priority_loop_pass = (
+        "await scanAutoLabels({ onlyPriorityLabel: 'priority:loop-discipline' });"
+    )
+    stale_gate_pass = "await scanAutoLabels({ onlyStaleGate: true });"
+    permission_blocked_pass = "await scanAutoLabels({ onlyPermissionBlocked: true });"
+    assert "onlyPriorityLabel" in script
+    assert "labelNames.includes(onlyPriorityLabel)" in script
+    assert (
+        "Prioritized claimable priority:loop-discipline issue before retry queues."
+        in script
+    )
+    assert script.index(priority_loop_pass) < script.index(stale_gate_pass)
+    assert script.index(priority_loop_pass) < script.index(permission_blocked_pass)
 
 
 def test_discover_respects_priority_and_skip_labels(wf):


### PR DESCRIPTION
Fixes #453

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-042-dispatcher-should-prioritize-claimable-priority-loop-discipl.md`
- GitHub issue: #453
- Branch task: `auto-change/issue-453`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.