### PR TITLE
[auto-change] WIKI-PATCH: PR-054: auto-fix-bug.yml top-level concurrency group is over-broad — should be per-issue, not per-workflow

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -59,9 +59,10 @@ on:
     - cron: "7,22,37,52 * * * *"
 
 concurrency:
-  # Subscription-backed writer sessions are a shared daemon lane. Queue triggers
-  # instead of overlapping writers and burning through subscription rate limits.
-  group: auto-fix-subscription-writer
+  # Queue duplicate triggers for the same issue, but do not block unrelated
+  # issue-specific runs behind a single workflow-wide subscription lane. Backfill
+  # scans still share one lane because discovery intentionally claims one issue.
+  group: auto-fix-${{ github.event.issue.number || inputs.issue_number || 'backfill' }}
   cancel-in-progress: false
 
 permissions:

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -77,9 +77,12 @@ def test_has_pull_requests_write(wf):
 # ---------------------------------------------------------------------------
 
 
-def test_workflow_concurrency_serializes_subscription_writer_lane(wf):
+def test_workflow_concurrency_is_issue_scoped_with_backfill_lane(wf):
     conc = wf.get("concurrency", {})
-    assert conc.get("group") == "auto-fix-subscription-writer"
+    group = conc.get("group", "")
+    assert "github.event.issue.number" in group
+    assert "inputs.issue_number" in group
+    assert "'backfill'" in group
     assert conc.get("cancel-in-progress") is False
 
 


### PR DESCRIPTION
Fixes #525

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-060-pr-054-auto-fix-bug-yml-top-level-concurrency-group-is-over-.md`
- GitHub issue: #525
- Branch task: `auto-change/issue-525`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.