### PR TITLE
[auto-change] WIKI-PATCH: Auto-merge must require an explicit host-named merge key, not broad momentum language

### DIFF
--- a/auto_ship_ship_classes.yaml
+++ b/auto_ship_ship_classes.yaml
@@ -8,6 +8,8 @@ version: 1
 defaults:
   auto_merge: false
   keys_auto_open: false
+  auto_merge_required_keys:
+    - host_reviewer
   required_keys:
     - codex_reviewer
     - cowork_reviewer

--- a/docs/milestones/auto-ship-canary-v0.md
+++ b/docs/milestones/auto-ship-canary-v0.md
@@ -256,6 +256,8 @@ CI passed
 PR contains only allowlisted paths
 PR title includes [autoship-canary]
 shipper identity is expected bot/service identity
+required keys include explicit host_reviewer key
+all required keys are open in GitHub review state
 ```
 
 If any check fails:
@@ -448,6 +450,8 @@ changed_paths subset docs/autoship-canaries/**
 CI passed
 no human block label present
 release_gate_result == APPROVE_AUTO_SHIP
+required keys include explicit host_reviewer key
+all required keys are open in GitHub review state
 ```
 
 ### Phase 4 — observation gate

--- a/docs/specs/2026-05-04-loop-autonomy-roadmap.md
+++ b/docs/specs/2026-05-04-loop-autonomy-roadmap.md
@@ -91,6 +91,7 @@ Default for every new ship class:
 
 - `auto_merge=false`;
 - `keys_auto_open=false`;
+- auto-merge policy requires an explicit `host_reviewer` key;
 - required keys are `codex_reviewer` and `cowork_reviewer`;
 - approvals expire after the configured TTL;
 - missing approval is the safety state.
@@ -107,9 +108,10 @@ Auto-merge eligibility:
 3. Reviewers approve through normal GitHub PR review.
 4. Phase 3 polls every open auto-ship PR.
 5. The loop re-runs the safety envelope against the PR head and changed paths.
-6. Eligibility is true only when the envelope still passes and either:
-   `ship_class.auto_merge=true`, or all required keys are open in GitHub review
-   state.
+6. Eligibility is true only when the envelope still passes,
+   `ship_class.auto_merge=true`, all required keys are open in GitHub review
+   state, and the required keys include the explicit host-named merge key
+   `host_reviewer`.
 7. If eligible, the loop calls `gh pr merge` or the GitHub merge API itself.
 
 Humans authorize while required keys are manual. The loop executes. Later
@@ -140,8 +142,8 @@ GitHub remains the human approval substrate:
   `ship_class`.
 - Required review count and accepted reviewer classes match
   `auto_ship_ship_classes.yaml`.
-- Runtime/substrate classes, if proposed later, must add an explicit host key
-  and cannot inherit only the two default reviewer keys.
+- Every auto-merge class must add an explicit host key and cannot inherit only
+  the two default reviewer keys.
 - The loop must never merge around branch protection; it can only call GitHub's
   normal merge API and accept GitHub's refusal.
 

--- a/tests/test_auto_ship_ship_classes_config.py
+++ b/tests/test_auto_ship_ship_classes_config.py
@@ -25,3 +25,23 @@ def test_graduation_classes_start_disabled_until_policy_flip():
     assert ship_classes["tests_canary"]["enabled"] is False
     assert ship_classes["docs_canary"]["graduation"]["next_class"] == "docs_general"
     assert ship_classes["docs_general"]["graduation"]["next_class"] == "tests_canary"
+
+
+def test_auto_merge_requires_explicit_host_named_key():
+    config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+
+    defaults = config["defaults"]
+    auto_merge_required_keys = defaults["auto_merge_required_keys"]
+
+    assert auto_merge_required_keys == ["host_reviewer"]
+    assert "host_reviewer" in config["reviewer_roles"]
+    for name, policy in config["ship_classes"].items():
+        effective_auto_merge = policy.get("auto_merge", defaults["auto_merge"])
+        if not effective_auto_merge:
+            continue
+
+        effective_required_keys = policy.get("required_keys", defaults["required_keys"])
+        for required_key in auto_merge_required_keys:
+            assert required_key in effective_required_keys, (
+                f"{name} enables auto_merge without explicit {required_key}"
+            )


### PR DESCRIPTION
Fixes #558

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-068-auto-merge-must-require-an-explicit-host-named-merge-key-not.md`
- GitHub issue: #558
- Branch task: `auto-change/issue-558`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.