### PR TITLE
[auto-change] WIKI-PATCH: PR-070: auto-rebase-on-stale-base for already-dual-keyed PRs (sibling merge collision recovery)

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -1038,6 +1038,19 @@ jobs:
             const branchPrefix = '${{ steps.meta.outputs.branch_prefix }}';
             const wikiPath = process.env.WIKI_PATH || 'not declared';
             const expectedBranchTask = process.env.EXPECTED_BRANCH_TASK || `${branchPrefix}issue-${issueNumber}`;
+            async function shouldAutoUpdateDualKeyedPr(pr) {
+              const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+              const names = new Set(labels.map((label) => label.name));
+              return (
+                (names.has('writer:codex') && names.has('checker:claude')) ||
+                (names.has('writer:claude') && names.has('checker:codex'))
+              );
+            }
             async function selfReviewLoopPr(pr) {
               const failures = [];
               const headRef = pr.head?.ref || '';
@@ -1070,9 +1083,23 @@ jobs:
                   Number(compare.behind_by || 0) > 0 ||
                   !['ahead', 'identical'].includes(String(compare.status || ''))
                 ) {
-                  failures.push(
-                    `stale-base check failed: status=${compare.status || '(unknown)'} behind_by=${compare.behind_by || 0}`
-                  );
+                  if (await shouldAutoUpdateDualKeyedPr(pr)) {
+                    try {
+                      await github.rest.pulls.updateBranch({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: pr.number,
+                        expected_head_sha: pr.head?.sha,
+                      });
+                      core.info(`Requested branch update for stale already-dual-keyed PR #${pr.number}.`);
+                    } catch (error) {
+                      failures.push(`stale-base auto-update failed: ${error.message}`);
+                    }
+                  } else {
+                    failures.push(
+                      `stale-base check failed: status=${compare.status || '(unknown)'} behind_by=${compare.behind_by || 0}`
+                    );
+                  }
                 }
               } catch (error) {
                 failures.push(`stale-base check failed: ${error.message}`);
@@ -1357,6 +1384,19 @@ jobs:
             const branch = mode === 'codex_subscription'
               ? '${{ steps.codex-subscription.outputs.branch }}'
               : `${branchPrefix}issue-${issueNumber}`;
+            async function shouldAutoUpdateDualKeyedPr(pr) {
+              const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+              const names = new Set(labels.map((label) => label.name));
+              return (
+                (names.has('writer:codex') && names.has('checker:claude')) ||
+                (names.has('writer:claude') && names.has('checker:codex'))
+              );
+            }
             async function selfReviewLoopPr(pr) {
               const failures = [];
               const headRef = pr.head?.ref || '';
@@ -1389,9 +1429,23 @@ jobs:
                   Number(compare.behind_by || 0) > 0 ||
                   !['ahead', 'identical'].includes(String(compare.status || ''))
                 ) {
-                  failures.push(
-                    `stale-base check failed: status=${compare.status || '(unknown)'} behind_by=${compare.behind_by || 0}`
-                  );
+                  if (await shouldAutoUpdateDualKeyedPr(pr)) {
+                    try {
+                      await github.rest.pulls.updateBranch({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: pr.number,
+                        expected_head_sha: pr.head?.sha,
+                      });
+                      core.info(`Requested branch update for stale already-dual-keyed PR #${pr.number}.`);
+                    } catch (error) {
+                      failures.push(`stale-base auto-update failed: ${error.message}`);
+                    }
+                  } else {
+                    failures.push(
+                      `stale-base check failed: status=${compare.status || '(unknown)'} behind_by=${compare.behind_by || 0}`
+                    );
+                  }
                 }
               } catch (error) {
                 failures.push(`stale-base check failed: ${error.message}`);

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -519,6 +519,23 @@ def test_codex_ready_for_checker_requires_pre_checker_self_review(wf):
     )
 
 
+def test_codex_stale_dual_keyed_pr_requests_branch_update_before_blocking(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    codex_pr_step = next((s for s in steps if s.get("id") == "codex-pr-create"), None)
+    assert codex_pr_step is not None, "Must create a PR for Codex-authored changes"
+    script = str(codex_pr_step.get("with", {}).get("script", ""))
+    assert "async function shouldAutoUpdateDualKeyedPr" in script
+    assert "github.rest.issues.listLabelsOnIssue" in script
+    assert "writer:codex" in script
+    assert "checker:claude" in script
+    assert "github.rest.pulls.updateBranch" in script
+    assert "expected_head_sha: pr.head?.sha" in script
+    assert "stale-base auto-update failed" in script
+    assert script.index("github.rest.pulls.updateBranch") < script.index(
+        "`stale-base check failed: status=${compare.status || '(unknown)'}"
+    )
+
+
 def test_claude_ready_for_checker_requires_pre_checker_self_review(wf):
     steps = wf["jobs"]["fix"]["steps"]
     claude_pr_step = next((s for s in steps if s.get("id") == "claude-pr"), None)
@@ -539,6 +556,23 @@ def test_claude_ready_for_checker_requires_pre_checker_self_review(wf):
     )
     assert script.index("labels: ['writer:claude', 'checker:codex']") < (
         script.index("labels: ['ready_for_checker']")
+    )
+
+
+def test_claude_stale_dual_keyed_pr_requests_branch_update_before_blocking(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    claude_pr_step = next((s for s in steps if s.get("id") == "claude-pr"), None)
+    assert claude_pr_step is not None, "Must find and label Claude-created PRs"
+    script = str(claude_pr_step.get("with", {}).get("script", ""))
+    assert "async function shouldAutoUpdateDualKeyedPr" in script
+    assert "github.rest.issues.listLabelsOnIssue" in script
+    assert "writer:claude" in script
+    assert "checker:codex" in script
+    assert "github.rest.pulls.updateBranch" in script
+    assert "expected_head_sha: pr.head?.sha" in script
+    assert "stale-base auto-update failed" in script
+    assert script.index("github.rest.pulls.updateBranch") < script.index(
+        "`stale-base check failed: status=${compare.status || '(unknown)'}"
     )
 
 


### PR DESCRIPTION
Fixes #572

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-070-pr-070-auto-rebase-on-stale-base-for-already-dual-keyed-prs-.md`
- GitHub issue: #572
- Branch task: `auto-change/issue-572`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.