### PR TITLE
[auto-change] BUG-073: Patch-request pages can reuse or contradict PR IDs, breaking exact-ID brain sweeps

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1357,9 +1357,11 @@ def _next_id(pages_dir: Path, drafts_dir: Path, prefix: str) -> str:
     """Allocate the next ``<PREFIX>-NNN`` id for a kind's directory pair.
 
     Scans both ``pages_dir`` and ``drafts_dir`` so concurrent writes don't
-    collide with an already-promoted entry. Returns ``<PREFIX>-001`` when
-    both dirs are empty or missing. Glob is case-insensitive via *.md plus a
-    prefix-anchored regex filter.
+    collide with an already-promoted entry. Both filename stems and
+    frontmatter ``id:`` fields reserve ordinals, so imported/manual pages with
+    mismatched names cannot make the allocator reuse an exact ID. Returns
+    ``<PREFIX>-001`` when both dirs are empty or missing. Glob is
+    case-insensitive via *.md plus a prefix-anchored regex filter.
     """
     pat = re.compile(rf"^{re.escape(prefix)}-(\d{{3,}})", re.IGNORECASE)
     seen: set[int] = set()
@@ -1368,6 +1370,18 @@ def _next_id(pages_dir: Path, drafts_dir: Path, prefix: str) -> str:
             continue
         for p in base.glob("*.md"):
             m = pat.match(p.stem)
+            if m:
+                try:
+                    seen.add(int(m.group(1)))
+                except ValueError:
+                    pass
+            try:
+                raw = p.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            meta, _ = _parse_frontmatter(raw)
+            frontmatter_id = meta.get("id", "").strip().strip("'\"")
+            m = pat.match(frontmatter_id)
             if m:
                 try:
                     seen.add(int(m.group(1)))

--- a/tests/test_api_wiki.py
+++ b/tests/test_api_wiki.py
@@ -163,6 +163,31 @@ def test_next_id_increments_past_existing(tmp_path):
     assert _next_id(pages, drafts, "BUG") == "BUG-008"
 
 
+def test_next_id_increments_past_frontmatter_id_mismatch(tmp_path):
+    pages = tmp_path / "pages"
+    drafts = tmp_path / "drafts"
+    pages.mkdir()
+    drafts.mkdir()
+    (pages / "pr-001-imported.md").write_text(
+        "---\n"
+        "id: PR-077\n"
+        "title: Imported patch request\n"
+        "---\n\n"
+        "# PR-077: Imported patch request\n",
+        encoding="utf-8",
+    )
+    (drafts / "pr-020-draft.md").write_text(
+        "---\n"
+        "id: PR-003\n"
+        "title: Draft patch request\n"
+        "---\n\n"
+        "# PR-003: Draft patch request\n",
+        encoding="utf-8",
+    )
+
+    assert _next_id(pages, drafts, "PR") == "PR-078"
+
+
 # ── scaffold ────────────────────────────────────────────────────────────────
 
 
@@ -499,6 +524,35 @@ def test_wiki_file_bug_files_clean_when_no_dups(wiki_env):
     )
     assert res["status"] == "filed"
     assert res["bug_id"].startswith("BUG-")
+
+
+def test_wiki_file_patch_request_avoids_frontmatter_id_collision(wiki_env):
+    patch_pages = wiki_env / "pages" / "patch-requests"
+    patch_pages.mkdir(parents=True, exist_ok=True)
+    (patch_pages / "pr-001-imported.md").write_text(
+        "---\n"
+        "id: PR-077\n"
+        "title: Imported patch request\n"
+        "type: patch_request\n"
+        "---\n\n"
+        "# PR-077: Imported patch request\n",
+        encoding="utf-8",
+    )
+
+    res = json.loads(
+        wiki(
+            action="file_bug",
+            kind="patch_request",
+            component="wiki-change-sync",
+            severity="major",
+            title="Exact id brain sweep regression",
+            force_new=True,
+        )
+    )
+
+    assert res["status"] == "filed"
+    assert res["bug_id"] == "PR-078"
+    assert res["path"].startswith("pages/patch-requests/pr-078-")
 
 
 def test_wiki_file_bug_queued_investigation_returns_branch_task_lease_shape(

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1357,9 +1357,11 @@ def _next_id(pages_dir: Path, drafts_dir: Path, prefix: str) -> str:
     """Allocate the next ``<PREFIX>-NNN`` id for a kind's directory pair.
 
     Scans both ``pages_dir`` and ``drafts_dir`` so concurrent writes don't
-    collide with an already-promoted entry. Returns ``<PREFIX>-001`` when
-    both dirs are empty or missing. Glob is case-insensitive via *.md plus a
-    prefix-anchored regex filter.
+    collide with an already-promoted entry. Both filename stems and
+    frontmatter ``id:`` fields reserve ordinals, so imported/manual pages with
+    mismatched names cannot make the allocator reuse an exact ID. Returns
+    ``<PREFIX>-001`` when both dirs are empty or missing. Glob is
+    case-insensitive via *.md plus a prefix-anchored regex filter.
     """
     pat = re.compile(rf"^{re.escape(prefix)}-(\d{{3,}})", re.IGNORECASE)
     seen: set[int] = set()
@@ -1368,6 +1370,18 @@ def _next_id(pages_dir: Path, drafts_dir: Path, prefix: str) -> str:
             continue
         for p in base.glob("*.md"):
             m = pat.match(p.stem)
+            if m:
+                try:
+                    seen.add(int(m.group(1)))
+                except ValueError:
+                    pass
+            try:
+                raw = p.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            meta, _ = _parse_frontmatter(raw)
+            frontmatter_id = meta.get("id", "").strip().strip("'\"")
+            m = pat.match(frontmatter_id)
             if m:
                 try:
                     seen.add(int(m.group(1)))


### PR DESCRIPTION
Fixes #581

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-073-patch-request-pages-can-reuse-or-contradict-pr-ids-breaking-.md`
- GitHub issue: #581
- Branch task: `auto-change/issue-581`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.