### PR TITLE
[auto-change] WIKI-PATCH: Collapse user-facing MCP surface to 5 handles — read.graph / write.graph / run.graph / read.page / write.page (replace 50+ legacy action names; no aliases)

### DIFF
--- a/chatgpt-app-submission.json
+++ b/chatgpt-app-submission.json
@@ -4,140 +4,68 @@
   "app_info": {
     "display_name": "Workflow",
     "subtitle": "Build durable workflows",
-    "description": "Workflow connects ChatGPT to a durable open-source work graph. Users can check daemon status, browse shared goals and project wiki knowledge, and submit bounded requests that continue through the Workflow loop beyond a single chat.",
+    "description": "Workflow connects ChatGPT to a durable open-source work graph. Users can check daemon status, browse shared goals and project wiki knowledge, run graph branches, and submit bounded requests that continue through the Workflow loop beyond a single chat.",
     "category": "PRODUCTIVITY"
   },
   "tools": {
-    "get_workflow_status": {
+    "read.graph": {
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": false,
         "destructiveHint": false
       },
       "justifications": {
-        "read_only_justification": "Returns a directory-safe daemon status snapshot with raw logs, local paths, and host identifiers redacted, without changing Workflow state.",
+        "read_only_justification": "Reads directory-safe Workflow graph status, graph listings, goals, or run metadata without changing Workflow state.",
         "open_world_justification": "Does not publish content or modify public internet state.",
         "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
       }
     },
-    "list_workflow_universes": {
-      "annotations": {
-        "readOnlyHint": true,
-        "openWorldHint": false,
-        "destructiveHint": false
-      },
-      "justifications": {
-        "read_only_justification": "Lists available Workflow universes without creating or updating records.",
-        "open_world_justification": "Only reads Workflow-managed state and does not write to external systems.",
-        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
-      }
-    },
-    "inspect_workflow_universe": {
-      "annotations": {
-        "readOnlyHint": true,
-        "openWorldHint": false,
-        "destructiveHint": false
-      },
-      "justifications": {
-        "read_only_justification": "Inspects one Workflow universe and summarizes existing state without mutating it.",
-        "open_world_justification": "Does not publish content or affect third-party systems.",
-        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
-      }
-    },
-    "list_workflow_goals": {
-      "annotations": {
-        "readOnlyHint": true,
-        "openWorldHint": false,
-        "destructiveHint": false
-      },
-      "justifications": {
-        "read_only_justification": "Lists shared Workflow goals matching optional filters without changing them.",
-        "open_world_justification": "Only returns Workflow goal metadata and does not publish or modify external systems.",
-        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
-      }
-    },
-    "search_workflow_goals": {
-      "annotations": {
-        "readOnlyHint": true,
-        "openWorldHint": false,
-        "destructiveHint": false
-      },
-      "justifications": {
-        "read_only_justification": "Searches existing Workflow goal metadata without creating or updating records.",
-        "open_world_justification": "Does not write to public internet state or third-party systems.",
-        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
-      }
-    },
-    "get_workflow_goal": {
-      "annotations": {
-        "readOnlyHint": true,
-        "openWorldHint": false,
-        "destructiveHint": false
-      },
-      "justifications": {
-        "read_only_justification": "Returns one existing Workflow goal and its bound branches without changing state.",
-        "open_world_justification": "Does not publish content or affect third-party systems.",
-        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
-      }
-    },
-    "search_workflow_wiki": {
-      "annotations": {
-        "readOnlyHint": true,
-        "openWorldHint": false,
-        "destructiveHint": false
-      },
-      "justifications": {
-        "read_only_justification": "Searches existing Workflow wiki pages and returns matching snippets without modifying the wiki.",
-        "open_world_justification": "Does not publish content or write to external systems.",
-        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
-      }
-    },
-    "read_workflow_wiki_page": {
-      "annotations": {
-        "readOnlyHint": true,
-        "openWorldHint": false,
-        "destructiveHint": false
-      },
-      "justifications": {
-        "read_only_justification": "Reads one existing Workflow wiki page without changing it.",
-        "open_world_justification": "Does not publish content or affect third-party systems.",
-        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
-      }
-    },
-    "list_workflow_runs": {
-      "annotations": {
-        "readOnlyHint": true,
-        "openWorldHint": false,
-        "destructiveHint": false
-      },
-      "justifications": {
-        "read_only_justification": "Lists recent Workflow branch runs without starting, stopping, or editing runs.",
-        "open_world_justification": "Only reads Workflow run metadata and does not write to external systems.",
-        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
-      }
-    },
-    "propose_workflow_goal": {
+    "write.graph": {
       "annotations": {
         "readOnlyHint": false,
         "openWorldHint": true,
         "destructiveHint": false
       },
       "justifications": {
-        "read_only_justification": "Creates a shared Workflow goal proposal, so it changes Workflow state.",
-        "open_world_justification": "The created goal can be visible in shared Workflow goal discovery.",
-        "destructive_justification": "Creates a new proposal and does not delete, overwrite, revoke access, or perform irreversible actions."
+        "read_only_justification": "Creates shared Workflow goal proposals or queues bounded Workflow requests, so it changes Workflow state.",
+        "open_world_justification": "A created public goal can be visible in shared Workflow goal discovery.",
+        "destructive_justification": "Creates or queues new records and does not delete, overwrite, revoke access, or perform irreversible actions."
       }
     },
-    "submit_workflow_request": {
+    "run.graph": {
       "annotations": {
         "readOnlyHint": false,
         "openWorldHint": false,
         "destructiveHint": false
       },
       "justifications": {
-        "read_only_justification": "Queues a bounded request in Workflow, so it changes Workflow state.",
-        "open_world_justification": "Writes only to the Workflow request queue and does not publish content or modify third-party systems.",
-        "destructive_justification": "Queues a request and does not delete, overwrite, revoke access, or perform irreversible actions."
+        "read_only_justification": "Starts a Workflow graph branch run, so it changes Workflow state.",
+        "open_world_justification": "Runs Workflow-managed graph logic and does not publish content or modify third-party systems by itself.",
+        "destructive_justification": "Starts a run and does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "read.page": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Reads or searches existing Workflow wiki pages without modifying the wiki.",
+        "open_world_justification": "Does not publish content or write to external systems.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "write.page": {
+      "annotations": {
+        "readOnlyHint": false,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Writes, patches, or files Workflow wiki pages, so it changes Workflow state.",
+        "open_world_justification": "Filed public project pages can be visible through Workflow wiki discovery.",
+        "destructive_justification": "Writes or patches pages using bounded parameters and does not expose a destructive delete operation."
       }
     }
   },
@@ -146,7 +74,7 @@
       "description": "Check whether Workflow is connected and safe to use.",
       "user_prompt": "Use Workflow to check the current daemon status and tell me any caveats before I start.",
       "file_attachment_urls": null,
-      "tools_triggered": "get_workflow_status",
+      "tools_triggered": "read.graph",
       "expected_output": "Returns a factual daemon status summary with routing evidence and caveats.",
       "expected_output_url": null
     },
@@ -154,39 +82,23 @@
       "description": "Find existing durable goals for a user's work category.",
       "user_prompt": "Use Workflow to search for goals related to onboarding and show the best matches.",
       "file_attachment_urls": null,
-      "tools_triggered": "search_workflow_goals",
+      "tools_triggered": "read.graph",
       "expected_output": "Returns matching Workflow goals when present, or clearly reports that no goals matched and suggests a safe next step.",
       "expected_output_url": null
     },
     {
-      "description": "Find durable workflow goals from an outcome-oriented prompt.",
-      "user_prompt": "I'm planning onboarding for new MCP hosts. Search durable workflow goals about onboarding and summarize the best matches.",
+      "description": "Browse available graphs before choosing where to work.",
+      "user_prompt": "Use Workflow to list available graphs, then inspect the active one.",
       "file_attachment_urls": null,
-      "tools_triggered": "search_workflow_goals",
-      "expected_output": "Returns relevant shared Workflow goals when present, or clearly reports that no goals matched without creating new records.",
-      "expected_output_url": null
-    },
-    {
-      "description": "Browse shared goals and inspect one selected result.",
-      "user_prompt": "Use Workflow to list shared goals, then inspect the first relevant goal you find.",
-      "file_attachment_urls": null,
-      "tools_triggered": "list_workflow_goals, get_workflow_goal",
-      "expected_output": "Lists shared Workflow goals and, when a relevant goal exists, summarizes the selected goal and bound branches.",
-      "expected_output_url": null
-    },
-    {
-      "description": "Browse available universes before choosing where to work.",
-      "user_prompt": "Use Workflow to list available universes, then inspect the active one.",
-      "file_attachment_urls": null,
-      "tools_triggered": "list_workflow_universes, inspect_workflow_universe",
-      "expected_output": "Shows available universes and summarizes the selected universe's durable state.",
+      "tools_triggered": "read.graph",
+      "expected_output": "Shows available graphs and summarizes the selected graph's durable state.",
       "expected_output_url": null
     },
     {
       "description": "Read project knowledge from the Workflow wiki.",
       "user_prompt": "Use Workflow to search the wiki for current launch risks, then read the most relevant page.",
       "file_attachment_urls": null,
-      "tools_triggered": "search_workflow_wiki, read_workflow_wiki_page",
+      "tools_triggered": "read.page",
       "expected_output": "Returns relevant wiki search results and a grounded summary of the chosen page.",
       "expected_output_url": null
     },
@@ -194,7 +106,7 @@
       "description": "Review recent Workflow run history.",
       "user_prompt": "Use Workflow to list recent runs and tell me whether anything is currently active or blocked.",
       "file_attachment_urls": null,
-      "tools_triggered": "list_workflow_runs",
+      "tools_triggered": "read.graph",
       "expected_output": "Returns recent Workflow runs or a clear empty-state message without starting, stopping, or editing runs.",
       "expected_output_url": null
     },
@@ -202,24 +114,32 @@
       "description": "Create a new shared goal proposal after user intent is clear.",
       "user_prompt": "Use Workflow to propose a public goal named 'Onboard new MCP hosts' with tags discovery,onboarding.",
       "file_attachment_urls": null,
-      "tools_triggered": "propose_workflow_goal",
+      "tools_triggered": "write.graph",
       "expected_output": "Confirms that a new Workflow goal proposal was created and reports its identifier or next step.",
       "expected_output_url": null
     },
     {
-      "description": "Create a shared durable goal from an outcome-oriented prompt.",
-      "user_prompt": "Create a shared durable workflow goal named 'Reduce MCP onboarding friction' with tags onboarding,hosts.",
+      "description": "Queue a bounded request into an existing Workflow graph.",
+      "user_prompt": "Use Workflow to submit a request asking the daemon to summarize today's discoverability blockers.",
       "file_attachment_urls": null,
-      "tools_triggered": "propose_workflow_goal",
-      "expected_output": "Shows write confirmation before creating the goal, then confirms the new Workflow goal proposal and reports its identifier or next step.",
+      "tools_triggered": "write.graph",
+      "expected_output": "Confirms the request was queued in Workflow and states what will happen next.",
       "expected_output_url": null
     },
     {
-      "description": "Queue a bounded request into an existing Workflow universe.",
-      "user_prompt": "Use Workflow to submit a request asking the daemon to summarize today's discoverability blockers.",
+      "description": "Run a graph branch after the user chooses a branch.",
+      "user_prompt": "Use Workflow to run branch br_demo with the saved default inputs.",
       "file_attachment_urls": null,
-      "tools_triggered": "submit_workflow_request",
-      "expected_output": "Confirms the request was queued in Workflow and states what will happen next.",
+      "tools_triggered": "run.graph",
+      "expected_output": "Starts the selected Workflow graph branch run and reports the run identifier or next step.",
+      "expected_output_url": null
+    },
+    {
+      "description": "File a project patch request into the Workflow wiki.",
+      "user_prompt": "Use Workflow to file a patch request about simplifying the public connector surface.",
+      "file_attachment_urls": null,
+      "tools_triggered": "write.page",
+      "expected_output": "Creates or reports a matching Workflow wiki filing with its identifier or page path.",
       "expected_output_url": null
     }
   ],
@@ -233,16 +153,16 @@
       "expected_output_url": null
     },
     {
-      "description": "Do not use Workflow to send messages through unrelated third-party systems.",
-      "user_prompt": "Use Workflow to send an email to my team about the launch.",
+      "description": "Do not use legacy implementation-shaped Workflow tool names.",
+      "user_prompt": "Use get_workflow_status, search_workflow_goals, and submit_workflow_request directly.",
       "file_attachment_urls": null,
       "tools_triggered": null,
-      "expected_output": "The app should not be invoked because Workflow does not send email.",
+      "expected_output": "The app should not advertise or call legacy implementation-shaped tool names; use the five public handles instead.",
       "expected_output_url": null
     },
     {
       "description": "Do not perform destructive admin operations.",
-      "user_prompt": "Use Workflow to delete every universe and wipe all stored data.",
+      "user_prompt": "Use Workflow to delete every graph and wipe all stored data.",
       "file_attachment_urls": null,
       "tools_triggered": null,
       "expected_output": "The app should not call any Workflow tool because the directory surface exposes no destructive delete operation.",

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
@@ -142,7 +142,15 @@ def _structured_return(raw):
     return {"result": raw}
 
 
-def _register_structured_tool(fn, *, server, title=None, tags=None, annotations=None):
+def _register_structured_tool(
+    fn,
+    *,
+    server,
+    name=None,
+    title=None,
+    tags=None,
+    annotations=None,
+):
     """Register an MCP adapter without changing the direct Python API."""
 
     @wraps(fn)
@@ -151,7 +159,7 @@ def _register_structured_tool(fn, *, server, title=None, tags=None, annotations=
 
     _tool.__name__ = f"_mcp_{fn.__name__}"
     _tool.__signature__ = signature(fn).replace(return_annotation=dict)
-    kwargs = {"name": fn.__name__, "output_schema": None}
+    kwargs = {"name": name or fn.__name__, "output_schema": None}
     if title is not None:
         kwargs["title"] = title
     if tags is not None:
@@ -161,213 +169,67 @@ def _register_structured_tool(fn, *, server, title=None, tags=None, annotations=
     return server.tool(**kwargs)(_tool)
 
 
-def get_workflow_status(universe_id: str = "") -> str:
-    """Use this when the user asks whether Workflow is reachable or safe to use.
-
-    Args:
-        universe_id: Optional universe scope. Empty uses the active universe.
-    """
-    return _directory_safe_status(universe_id=universe_id)
-
-
-_mcp_get_workflow_status = _register_structured_tool(
-    get_workflow_status,
-    server=directory_mcp,
-    title='Get Workflow Status',
-    tags={'status', 'workflow', 'diagnostics'},
-    annotations=ToolAnnotations(
-        title='Get Workflow Status',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
+def _unknown_target(handle: str, target: str, allowed: tuple[str, ...]) -> str:
+    return json.dumps({
+        "error": "unknown_target",
+        "handle": handle,
+        "target": target,
+        "allowed_targets": allowed,
+    })
 
 
-def list_workflow_universes(limit: int = 30) -> str:
-    """Use this when the user wants to browse available Workflow universes.
-
-    Args:
-        limit: Maximum number of universes to return.
-    """
-    return _universe_impl(action="list", limit=limit)
-
-
-_mcp_list_workflow_universes = _register_structured_tool(
-    list_workflow_universes,
-    server=directory_mcp,
-    title='List Workflow Universes',
-    tags={'universes', 'workflow', 'browse'},
-    annotations=ToolAnnotations(
-        title='List Workflow Universes',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
-
-
-def inspect_workflow_universe(universe_id: str = "") -> str:
-    """Use this when the user wants a summary of one Workflow universe.
-
-    Args:
-        universe_id: Optional universe scope. Empty uses the active universe.
-    """
-    return _universe_impl(action="inspect", universe_id=universe_id)
-
-
-_mcp_inspect_workflow_universe = _register_structured_tool(
-    inspect_workflow_universe,
-    server=directory_mcp,
-    title='Inspect Workflow Universe',
-    tags={'universes', 'workflow', 'inspect'},
-    annotations=ToolAnnotations(
-        title='Inspect Workflow Universe',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
-
-
-def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> str:
-    """Use this when the user wants to browse existing shared Workflow goals.
-
-    Args:
-        tags: Optional comma-separated tag filter.
-        author: Optional author filter.
-        limit: Maximum number of goals to return.
-    """
-    return _goals_impl(action="list", tags=tags, author=author, limit=limit)
-
-
-_mcp_list_workflow_goals = _register_structured_tool(
-    list_workflow_goals,
-    server=directory_mcp,
-    title='List Workflow Goals',
-    tags={'goals', 'workflow', 'browse'},
-    annotations=ToolAnnotations(
-        title='List Workflow Goals',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
-
-
-def search_workflow_goals(query: str, limit: int = 20) -> str:
-    """Use this when the user wants to find Workflow goals by text or tag.
-
-    Args:
-        query: Search text.
-        limit: Maximum number of goals to return.
-    """
-    return _goals_impl(action="search", query=query, limit=limit)
-
-
-_mcp_search_workflow_goals = _register_structured_tool(
-    search_workflow_goals,
-    server=directory_mcp,
-    title='Search Workflow Goals',
-    tags={'goals', 'workflow', 'search'},
-    annotations=ToolAnnotations(
-        title='Search Workflow Goals',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
-
-
-def get_workflow_goal(goal_id: str) -> str:
-    """Use this when the user wants details for a specific Workflow goal.
-
-    Args:
-        goal_id: Goal identifier to inspect.
-    """
-    return _goals_impl(action="get", goal_id=goal_id)
-
-
-_mcp_get_workflow_goal = _register_structured_tool(
-    get_workflow_goal,
-    server=directory_mcp,
-    title='Get Workflow Goal',
-    tags={'goals', 'workflow', 'inspect'},
-    annotations=ToolAnnotations(
-        title='Get Workflow Goal',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
-
-
-def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) -> str:
-    """Use this when the user wants to search Workflow project knowledge.
-
-    Args:
-        query: Search text.
-        category: Optional wiki category filter.
-        max_results: Maximum number of wiki hits to return.
-    """
-    return _wiki_impl(
-        action="search",
-        query=query,
-        category=category,
-        max_results=max_results,
-    )
-
-
-_mcp_search_workflow_wiki = _register_structured_tool(
-    search_workflow_wiki,
-    server=directory_mcp,
-    title='Search Workflow Wiki',
-    tags={'wiki', 'knowledge', 'workflow', 'search'},
-    annotations=ToolAnnotations(
-        title='Search Workflow Wiki',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
-
-def read_workflow_wiki_page(
-    page: str,
+def read_graph(
+    target: str = "status",
+    graph_id: str = "",
+    goal_id: str = "",
     query: str = "",
-    changed_since: str = "",
-    max_results: int = 10,
+    tags: str = "",
+    author: str = "",
+    run_status: str = "",
+    limit: int = 30,
 ) -> str:
-    """Use this when the user wants to read one Workflow wiki page.
+    """Read Workflow graph state without changing it.
 
     Args:
-        page: Wiki page slug or path.
-        query: Optional topic terms for the ambient relevance feed.
-        changed_since: Optional ISO timestamp for feed freshness filtering.
-        max_results: Maximum ambient feed items to return.
+        target: What to read: status, graphs, graph, goals, goal, or runs.
+        graph_id: Optional graph/universe identifier.
+        goal_id: Optional shared-goal identifier.
+        query: Optional search text.
+        tags: Optional comma-separated goal tag filter.
+        author: Optional goal author filter.
+        run_status: Optional run status filter.
+        limit: Maximum number of records to return.
     """
-    return _wiki_impl(
-        action="read",
-        page=page,
-        query=query,
-        changed_since=changed_since,
-        max_results=max_results,
+    normalized = (target or "status").strip().lower()
+    if normalized == "status":
+        return _directory_safe_status(universe_id=graph_id)
+    if normalized == "graphs":
+        return _universe_impl(action="list", limit=limit)
+    if normalized == "graph":
+        return _universe_impl(action="inspect", universe_id=graph_id)
+    if normalized == "goals":
+        if query:
+            return _goals_impl(action="search", query=query, limit=limit)
+        return _goals_impl(action="list", tags=tags, author=author, limit=limit)
+    if normalized == "goal":
+        return _goals_impl(action="get", goal_id=goal_id)
+    if normalized == "runs":
+        return _extensions_impl(action="list_runs", status=run_status, limit=limit)
+    return _unknown_target(
+        "read.graph",
+        target,
+        ("status", "graphs", "graph", "goals", "goal", "runs"),
     )
 
 
-_mcp_read_workflow_wiki_page = _register_structured_tool(
-    read_workflow_wiki_page,
+_mcp_read_graph = _register_structured_tool(
+    read_graph,
     server=directory_mcp,
-    title='Read Workflow Wiki Page',
-    tags={'wiki', 'knowledge', 'workflow', 'read'},
+    name="read.graph",
+    title="Read Graph",
+    tags={"graph", "workflow", "read"},
     annotations=ToolAnnotations(
-        title='Read Workflow Wiki Page',
+        title="Read Graph",
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
@@ -376,61 +238,58 @@ _mcp_read_workflow_wiki_page = _register_structured_tool(
 )
 
 
-def list_workflow_runs(status: str = "", limit: int = 20) -> str:
-    """Use this when the user wants recent Workflow run history.
-
-    Args:
-        status: Optional run status filter.
-        limit: Maximum number of runs to return.
-    """
-    return _extensions_impl(action="list_runs", status=status, limit=limit)
-
-
-_mcp_list_workflow_runs = _register_structured_tool(
-    list_workflow_runs,
-    server=directory_mcp,
-    title='List Workflow Runs',
-    tags={'runs', 'workflow', 'browse'},
-    annotations=ToolAnnotations(
-        title='List Workflow Runs',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
-
-
-def propose_workflow_goal(
-    name: str,
+def write_graph(
+    target: str,
+    name: str = "",
     description: str = "",
     tags: str = "",
     visibility: str = "public",
+    text: str = "",
+    graph_id: str = "",
+    request_type: str = "general",
+    branch_id: str = "",
 ) -> str:
-    """Use this when the user asks to create a shared Workflow goal proposal.
+    """Create or queue Workflow graph state.
 
     Args:
-        name: Human-readable goal name.
-        description: Optional goal description.
-        tags: Optional comma-separated tags.
-        visibility: Visibility value accepted by Workflow, usually public.
+        target: What to write: goal or request.
+        name: Human-readable shared-goal name.
+        description: Optional shared-goal description.
+        tags: Optional comma-separated shared-goal tags.
+        visibility: Shared-goal visibility, usually public.
+        text: Request text to queue.
+        graph_id: Optional target graph/universe identifier.
+        request_type: Workflow request type.
+        branch_id: Optional target branch identifier.
     """
-    return _goals_impl(
-        action="propose",
-        name=name,
-        description=description,
-        tags=tags,
-        visibility=visibility,
-    )
+    normalized = target.strip().lower()
+    if normalized == "goal":
+        return _goals_impl(
+            action="propose",
+            name=name,
+            description=description,
+            tags=tags,
+            visibility=visibility,
+        )
+    if normalized == "request":
+        return _universe_impl(
+            action="submit_request",
+            universe_id=graph_id,
+            text=text,
+            request_type=request_type,
+            branch_id=branch_id,
+        )
+    return _unknown_target("write.graph", target, ("goal", "request"))
 
 
-_mcp_propose_workflow_goal = _register_structured_tool(
-    propose_workflow_goal,
+_mcp_write_graph = _register_structured_tool(
+    write_graph,
     server=directory_mcp,
-    title='Propose Workflow Goal',
-    tags={'goals', 'workflow', 'create'},
+    name="write.graph",
+    title="Write Graph",
+    tags={"graph", "workflow", "write"},
     annotations=ToolAnnotations(
-        title='Propose Workflow Goal',
+        title="Write Graph",
         readOnlyHint=False,
         destructiveHint=False,
         idempotentHint=False,
@@ -439,39 +298,190 @@ _mcp_propose_workflow_goal = _register_structured_tool(
 )
 
 
-def submit_workflow_request(
-    text: str,
-    universe_id: str = "",
-    request_type: str = "scene_direction",
-    branch_id: str = "",
+def run_graph(
+    branch_def_id: str,
+    inputs_json: str = "",
+    run_name: str = "",
+    graph_id: str = "",
+    recursion_limit_override: int = 0,
 ) -> str:
-    """Use this when the user wants the Workflow daemon to handle a bounded request.
+    """Run a Workflow graph branch.
 
     Args:
-        text: Request text to queue.
-        universe_id: Optional target universe. Empty uses the active universe.
-        request_type: Workflow request type.
-        branch_id: Optional target branch identifier.
+        branch_def_id: Branch definition identifier to run.
+        inputs_json: Optional JSON object containing run inputs.
+        run_name: Optional display name for the run.
+        graph_id: Optional graph/universe identifier.
+        recursion_limit_override: Optional per-run recursion limit.
     """
-    return _universe_impl(
-        action="submit_request",
-        universe_id=universe_id,
-        text=text,
-        request_type=request_type,
-        branch_id=branch_id,
+    return _extensions_impl(
+        action="run_branch",
+        branch_def_id=branch_def_id,
+        inputs_json=inputs_json,
+        run_name=run_name,
+        universe_id=graph_id,
+        recursion_limit_override=recursion_limit_override,
     )
 
 
-_mcp_submit_workflow_request = _register_structured_tool(
-    submit_workflow_request,
+_mcp_run_graph = _register_structured_tool(
+    run_graph,
     server=directory_mcp,
-    title='Submit Workflow Request',
-    tags={'requests', 'workflow', 'queue'},
+    name="run.graph",
+    title="Run Graph",
+    tags={"graph", "workflow", "run"},
     annotations=ToolAnnotations(
-        title='Submit Workflow Request',
+        title="Run Graph",
         readOnlyHint=False,
         destructiveHint=False,
         idempotentHint=False,
         openWorldHint=False,
+    ),
+)
+
+
+def read_page(
+    page: str = "",
+    query: str = "",
+    category: str = "",
+    changed_since: str = "",
+    max_results: int = 10,
+) -> str:
+    """Read or search Workflow wiki pages.
+
+    Args:
+        page: Optional wiki page slug or path. Empty searches by query.
+        query: Optional search text or ambient relevance terms.
+        category: Optional wiki category filter for searches.
+        changed_since: Optional ISO timestamp for feed freshness filtering.
+        max_results: Maximum result count.
+    """
+    if page:
+        return _wiki_impl(
+            action="read",
+            page=page,
+            query=query,
+            changed_since=changed_since,
+            max_results=max_results,
+        )
+    return _wiki_impl(
+        action="search",
+        query=query,
+        category=category,
+        max_results=max_results,
+    )
+
+
+_mcp_read_page = _register_structured_tool(
+    read_page,
+    server=directory_mcp,
+    name="read.page",
+    title="Read Page",
+    tags={"page", "wiki", "workflow", "read"},
+    annotations=ToolAnnotations(
+        title="Read Page",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+
+
+def write_page(
+    page: str = "",
+    category: str = "",
+    filename: str = "",
+    content: str = "",
+    log_entry: str = "",
+    old_text: str = "",
+    new_text: str = "",
+    expected_sha256: str = "",
+    title: str = "",
+    kind: str = "",
+    component: str = "",
+    severity: str = "",
+    repro: str = "",
+    observed: str = "",
+    expected: str = "",
+    workaround: str = "",
+    tags: str = "",
+    force_new: bool = False,
+    reporter_context: str = "",
+    dry_run: bool = True,
+) -> str:
+    """Write, patch, or file a Workflow wiki page.
+
+    Args:
+        page: Wiki page slug or path for page writes.
+        category: Wiki category for full page writes.
+        filename: Wiki filename for full page writes.
+        content: Full page content for a page write.
+        log_entry: Optional wiki log entry for full writes or patches.
+        old_text: Existing text to replace for a targeted page patch.
+        new_text: Replacement text for a targeted page patch.
+        expected_sha256: Optional full-page hash guard for patches.
+        title: Filing title when creating a bug, patch, feature, or design page.
+        kind: Filing kind: bug, patch_request, feature, or design.
+        component: Optional affected component for filed issues.
+        severity: Optional severity for filed issues.
+        repro: Optional reproduction notes for filed issues.
+        observed: Optional observed behavior for filed issues.
+        expected: Optional expected behavior for filed issues.
+        workaround: Optional workaround for filed issues.
+        tags: Optional comma-separated tags.
+        force_new: Bypass duplicate detection for filed issues.
+        reporter_context: Optional reporter context for filed issues.
+        dry_run: Preview consolidation-style wiki writes when supported.
+    """
+    normalized_kind = kind.strip().lower()
+    if normalized_kind:
+        return _wiki_impl(
+            action="file_bug",
+            kind=normalized_kind,
+            title=title,
+            component=component,
+            severity=severity,
+            repro=repro,
+            observed=observed,
+            expected=expected,
+            workaround=workaround,
+            tags=tags,
+            force_new=force_new,
+            reporter_context=reporter_context,
+        )
+    if old_text or new_text:
+        return _wiki_impl(
+            action="patch",
+            page=page,
+            old_text=old_text,
+            new_text=new_text,
+            expected_sha256=expected_sha256,
+            log_entry=log_entry,
+            dry_run=dry_run,
+        )
+    write_filename = filename or page
+    return _wiki_impl(
+        action="write",
+        category=category,
+        filename=write_filename,
+        content=content,
+        log_entry=log_entry,
+        dry_run=dry_run,
+    )
+
+
+_mcp_write_page = _register_structured_tool(
+    write_page,
+    server=directory_mcp,
+    name="write.page",
+    title="Write Page",
+    tags={"page", "wiki", "workflow", "write"},
+    annotations=ToolAnnotations(
+        title="Write Page",
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
     ),
 )

--- a/scripts/mcp_tool_canary.py
+++ b/scripts/mcp_tool_canary.py
@@ -13,7 +13,7 @@ Canary flow
 3. POST ``tools/list`` → confirm the returned tools array is non-empty.
 4. POST ``tools/call`` for the strongest advertised read-only probe:
    ``universe`` with ``action=inspect`` on the legacy endpoint, or
-   ``get_workflow_status`` on the directory endpoint.
+   ``read.graph`` with ``target=status`` on the directory endpoint.
 
 Exit codes (task #6 spec)
 -------------------------
@@ -92,12 +92,12 @@ def _select_probe(tools: list[Any]) -> tuple[str, dict[str, Any], str]:
     names = _tool_names(tools)
     if "universe" in names:
         return "universe", {"action": "inspect"}, "universe inspect"
-    if "get_workflow_status" in names:
-        return "get_workflow_status", {}, "get_workflow_status"
+    if "read.graph" in names:
+        return "read.graph", {"target": "status"}, "read.graph status"
     raise ToolCanaryError(
         5,
         "tools/list did not advertise a supported read-only probe "
-        f"(wanted 'universe' or 'get_workflow_status'; saw {sorted(names)!r})",
+        f"(wanted 'universe' or 'read.graph'; saw {sorted(names)!r})",
     )
 
 
@@ -139,10 +139,10 @@ def _validate_probe_obj(obj: dict[str, Any], label: str) -> None:
             )
         return
 
-    if label == "get_workflow_status":
+    if label == "read.graph status":
         if "schema_version" not in obj:
             raise ToolCanaryError(
-                5, f"get_workflow_status missing schema_version: {obj!r}",
+                5, f"read.graph status missing schema_version: {obj!r}",
             )
         return
 

--- a/tests/test_directory_server.py
+++ b/tests/test_directory_server.py
@@ -7,78 +7,60 @@ from pathlib import Path
 from workflow.directory_server import (
     _redact_directory_status,
     directory_mcp,
-    propose_workflow_goal,
-    search_workflow_goals,
-    submit_workflow_request,
+    read_graph,
+    write_graph,
+    write_page,
 )
 
 EXPECTED_TOOLS = {
-    "get_workflow_status": {
+    "read.graph": {
         "readOnlyHint": True,
         "destructiveHint": False,
         "idempotentHint": True,
         "openWorldHint": False,
     },
-    "list_workflow_universes": {
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": False,
-    },
-    "inspect_workflow_universe": {
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": False,
-    },
-    "list_workflow_goals": {
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": False,
-    },
-    "search_workflow_goals": {
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": False,
-    },
-    "get_workflow_goal": {
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": False,
-    },
-    "search_workflow_wiki": {
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": False,
-    },
-    "read_workflow_wiki_page": {
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": False,
-    },
-    "list_workflow_runs": {
-        "readOnlyHint": True,
-        "destructiveHint": False,
-        "idempotentHint": True,
-        "openWorldHint": False,
-    },
-    "propose_workflow_goal": {
+    "write.graph": {
         "readOnlyHint": False,
         "destructiveHint": False,
         "idempotentHint": False,
         "openWorldHint": True,
     },
-    "submit_workflow_request": {
+    "run.graph": {
         "readOnlyHint": False,
         "destructiveHint": False,
         "idempotentHint": False,
         "openWorldHint": False,
     },
+    "read.page": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+    "write.page": {
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+}
+
+LEGACY_DIRECTORY_TOOL_NAMES = {
+    "get_workflow_status",
+    "list_workflow_universes",
+    "inspect_workflow_universe",
+    "list_workflow_goals",
+    "search_workflow_goals",
+    "get_workflow_goal",
+    "search_workflow_wiki",
+    "read_workflow_wiki_page",
+    "list_workflow_runs",
+    "propose_workflow_goal",
+    "submit_workflow_request",
+    "universe",
+    "extensions",
+    "goals",
+    "wiki",
 }
 
 
@@ -90,10 +72,7 @@ def test_directory_surface_exposes_review_scoped_tool_set() -> None:
     tools = {tool.name: tool for tool in _list_tools()}
 
     assert set(tools) == set(EXPECTED_TOOLS)
-    assert "universe" not in tools
-    assert "extensions" not in tools
-    assert "goals" not in tools
-    assert "wiki" not in tools
+    assert LEGACY_DIRECTORY_TOOL_NAMES.isdisjoint(tools)
 
 
 def test_directory_tools_have_explicit_submission_annotations() -> None:
@@ -213,7 +192,8 @@ def test_directory_goal_write_and_search_round_trip(monkeypatch, tmp_path) -> No
     invalidate_backend_cache()
     try:
         proposed = json.loads(
-            propose_workflow_goal(
+            write_graph(
+                target="goal",
                 name="Directory smoke goal",
                 tags="directory,smoke",
                 visibility="public",
@@ -221,7 +201,7 @@ def test_directory_goal_write_and_search_round_trip(monkeypatch, tmp_path) -> No
         )
         assert proposed["status"] == "proposed"
 
-        searched = json.loads(search_workflow_goals("Directory smoke"))
+        searched = json.loads(read_graph(target="goals", query="Directory smoke"))
         assert searched["count"] >= 1
         assert any(
             goal["goal_id"] == proposed["goal"]["goal_id"]
@@ -244,8 +224,9 @@ def test_directory_submit_request_queues_temp_universe_request(monkeypatch, tmp_
 
     try:
         result = json.loads(
-            submit_workflow_request(
-                universe_id="directory-universe",
+            write_graph(
+                target="request",
+                graph_id="directory-universe",
                 text="Summarize submission readiness blockers.",
                 request_type="general",
             )
@@ -264,3 +245,24 @@ def test_directory_submit_request_queues_temp_universe_request(monkeypatch, tmp_
         assert requests[0]["type"] == "general"
     finally:
         invalidate_backend_cache()
+
+
+def test_directory_write_page_drafts_temp_wiki_page(monkeypatch, tmp_path) -> None:
+    """Guard the five-handle page write adapter against parameter drift."""
+    wiki_root = tmp_path / "wiki"
+    monkeypatch.setenv("WORKFLOW_WIKI_PATH", str(wiki_root))
+
+    drafted = json.loads(
+        write_page(
+            category="notes",
+            filename="directory-page-smoke",
+            content="# Directory page smoke\n",
+            log_entry="directory page smoke",
+        )
+    )
+
+    assert drafted["status"] == "drafted"
+    assert drafted["path"] == "drafts/notes/directory-page-smoke.md"
+    assert (
+        wiki_root / "drafts" / "notes" / "directory-page-smoke.md"
+    ).read_text(encoding="utf-8") == "# Directory page smoke\n"

--- a/tests/test_mcp_tool_canary.py
+++ b/tests/test_mcp_tool_canary.py
@@ -143,8 +143,8 @@ def test_directory_tool_set_uses_workflow_status_probe():
         _init_resp(),
         _initialized_notif_resp(),
         _tools_list_resp(tools=[
-            {"name": "get_workflow_status", "description": "..."},
-            {"name": "search_workflow_goals", "description": "..."},
+            {"name": "read.graph", "description": "..."},
+            {"name": "read.page", "description": "..."},
         ]),
         _workflow_status_resp(schema_version=1),
     ])
@@ -152,8 +152,8 @@ def test_directory_tool_set_uses_workflow_status_probe():
     assert result["schema_version"] == 1
     assert result["universe_id"] == "demo-universe"
     assert scripted.calls[3]["payload"]["params"] == {
-        "name": "get_workflow_status",
-        "arguments": {},
+        "name": "read.graph",
+        "arguments": {"target": "status"},
     }
 
 
@@ -322,7 +322,7 @@ def test_exit_5_when_no_supported_probe_tool_advertised():
         _init_resp(),
         _initialized_notif_resp(),
         _tools_list_resp(tools=[
-            {"name": "search_workflow_goals", "description": "..."},
+            {"name": "read.page", "description": "..."},
         ]),
     ])
     with pytest.raises(tc.ToolCanaryError) as ei:
@@ -335,7 +335,7 @@ def test_exit_5_when_workflow_status_missing_schema_version():
     scripted = ScriptedPost([
         _init_resp(),
         _initialized_notif_resp(),
-        _tools_list_resp(tools=[{"name": "get_workflow_status"}]),
+        _tools_list_resp(tools=[{"name": "read.graph"}]),
         _workflow_status_resp(raw_text=json.dumps({"universe_id": "demo"})),
     ])
     with pytest.raises(tc.ToolCanaryError) as ei:

--- a/workflow/directory_server.py
+++ b/workflow/directory_server.py
@@ -142,7 +142,15 @@ def _structured_return(raw):
     return {"result": raw}
 
 
-def _register_structured_tool(fn, *, server, title=None, tags=None, annotations=None):
+def _register_structured_tool(
+    fn,
+    *,
+    server,
+    name=None,
+    title=None,
+    tags=None,
+    annotations=None,
+):
     """Register an MCP adapter without changing the direct Python API."""
 
     @wraps(fn)
@@ -151,7 +159,7 @@ def _register_structured_tool(fn, *, server, title=None, tags=None, annotations=
 
     _tool.__name__ = f"_mcp_{fn.__name__}"
     _tool.__signature__ = signature(fn).replace(return_annotation=dict)
-    kwargs = {"name": fn.__name__, "output_schema": None}
+    kwargs = {"name": name or fn.__name__, "output_schema": None}
     if title is not None:
         kwargs["title"] = title
     if tags is not None:
@@ -161,213 +169,67 @@ def _register_structured_tool(fn, *, server, title=None, tags=None, annotations=
     return server.tool(**kwargs)(_tool)
 
 
-def get_workflow_status(universe_id: str = "") -> str:
-    """Use this when the user asks whether Workflow is reachable or safe to use.
-
-    Args:
-        universe_id: Optional universe scope. Empty uses the active universe.
-    """
-    return _directory_safe_status(universe_id=universe_id)
-
-
-_mcp_get_workflow_status = _register_structured_tool(
-    get_workflow_status,
-    server=directory_mcp,
-    title='Get Workflow Status',
-    tags={'status', 'workflow', 'diagnostics'},
-    annotations=ToolAnnotations(
-        title='Get Workflow Status',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
+def _unknown_target(handle: str, target: str, allowed: tuple[str, ...]) -> str:
+    return json.dumps({
+        "error": "unknown_target",
+        "handle": handle,
+        "target": target,
+        "allowed_targets": allowed,
+    })
 
 
-def list_workflow_universes(limit: int = 30) -> str:
-    """Use this when the user wants to browse available Workflow universes.
-
-    Args:
-        limit: Maximum number of universes to return.
-    """
-    return _universe_impl(action="list", limit=limit)
-
-
-_mcp_list_workflow_universes = _register_structured_tool(
-    list_workflow_universes,
-    server=directory_mcp,
-    title='List Workflow Universes',
-    tags={'universes', 'workflow', 'browse'},
-    annotations=ToolAnnotations(
-        title='List Workflow Universes',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
-
-
-def inspect_workflow_universe(universe_id: str = "") -> str:
-    """Use this when the user wants a summary of one Workflow universe.
-
-    Args:
-        universe_id: Optional universe scope. Empty uses the active universe.
-    """
-    return _universe_impl(action="inspect", universe_id=universe_id)
-
-
-_mcp_inspect_workflow_universe = _register_structured_tool(
-    inspect_workflow_universe,
-    server=directory_mcp,
-    title='Inspect Workflow Universe',
-    tags={'universes', 'workflow', 'inspect'},
-    annotations=ToolAnnotations(
-        title='Inspect Workflow Universe',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
-
-
-def list_workflow_goals(tags: str = "", author: str = "", limit: int = 50) -> str:
-    """Use this when the user wants to browse existing shared Workflow goals.
-
-    Args:
-        tags: Optional comma-separated tag filter.
-        author: Optional author filter.
-        limit: Maximum number of goals to return.
-    """
-    return _goals_impl(action="list", tags=tags, author=author, limit=limit)
-
-
-_mcp_list_workflow_goals = _register_structured_tool(
-    list_workflow_goals,
-    server=directory_mcp,
-    title='List Workflow Goals',
-    tags={'goals', 'workflow', 'browse'},
-    annotations=ToolAnnotations(
-        title='List Workflow Goals',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
-
-
-def search_workflow_goals(query: str, limit: int = 20) -> str:
-    """Use this when the user wants to find Workflow goals by text or tag.
-
-    Args:
-        query: Search text.
-        limit: Maximum number of goals to return.
-    """
-    return _goals_impl(action="search", query=query, limit=limit)
-
-
-_mcp_search_workflow_goals = _register_structured_tool(
-    search_workflow_goals,
-    server=directory_mcp,
-    title='Search Workflow Goals',
-    tags={'goals', 'workflow', 'search'},
-    annotations=ToolAnnotations(
-        title='Search Workflow Goals',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
-
-
-def get_workflow_goal(goal_id: str) -> str:
-    """Use this when the user wants details for a specific Workflow goal.
-
-    Args:
-        goal_id: Goal identifier to inspect.
-    """
-    return _goals_impl(action="get", goal_id=goal_id)
-
-
-_mcp_get_workflow_goal = _register_structured_tool(
-    get_workflow_goal,
-    server=directory_mcp,
-    title='Get Workflow Goal',
-    tags={'goals', 'workflow', 'inspect'},
-    annotations=ToolAnnotations(
-        title='Get Workflow Goal',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
-
-
-def search_workflow_wiki(query: str, category: str = "", max_results: int = 10) -> str:
-    """Use this when the user wants to search Workflow project knowledge.
-
-    Args:
-        query: Search text.
-        category: Optional wiki category filter.
-        max_results: Maximum number of wiki hits to return.
-    """
-    return _wiki_impl(
-        action="search",
-        query=query,
-        category=category,
-        max_results=max_results,
-    )
-
-
-_mcp_search_workflow_wiki = _register_structured_tool(
-    search_workflow_wiki,
-    server=directory_mcp,
-    title='Search Workflow Wiki',
-    tags={'wiki', 'knowledge', 'workflow', 'search'},
-    annotations=ToolAnnotations(
-        title='Search Workflow Wiki',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
-
-def read_workflow_wiki_page(
-    page: str,
+def read_graph(
+    target: str = "status",
+    graph_id: str = "",
+    goal_id: str = "",
     query: str = "",
-    changed_since: str = "",
-    max_results: int = 10,
+    tags: str = "",
+    author: str = "",
+    run_status: str = "",
+    limit: int = 30,
 ) -> str:
-    """Use this when the user wants to read one Workflow wiki page.
+    """Read Workflow graph state without changing it.
 
     Args:
-        page: Wiki page slug or path.
-        query: Optional topic terms for the ambient relevance feed.
-        changed_since: Optional ISO timestamp for feed freshness filtering.
-        max_results: Maximum ambient feed items to return.
+        target: What to read: status, graphs, graph, goals, goal, or runs.
+        graph_id: Optional graph/universe identifier.
+        goal_id: Optional shared-goal identifier.
+        query: Optional search text.
+        tags: Optional comma-separated goal tag filter.
+        author: Optional goal author filter.
+        run_status: Optional run status filter.
+        limit: Maximum number of records to return.
     """
-    return _wiki_impl(
-        action="read",
-        page=page,
-        query=query,
-        changed_since=changed_since,
-        max_results=max_results,
+    normalized = (target or "status").strip().lower()
+    if normalized == "status":
+        return _directory_safe_status(universe_id=graph_id)
+    if normalized == "graphs":
+        return _universe_impl(action="list", limit=limit)
+    if normalized == "graph":
+        return _universe_impl(action="inspect", universe_id=graph_id)
+    if normalized == "goals":
+        if query:
+            return _goals_impl(action="search", query=query, limit=limit)
+        return _goals_impl(action="list", tags=tags, author=author, limit=limit)
+    if normalized == "goal":
+        return _goals_impl(action="get", goal_id=goal_id)
+    if normalized == "runs":
+        return _extensions_impl(action="list_runs", status=run_status, limit=limit)
+    return _unknown_target(
+        "read.graph",
+        target,
+        ("status", "graphs", "graph", "goals", "goal", "runs"),
     )
 
 
-_mcp_read_workflow_wiki_page = _register_structured_tool(
-    read_workflow_wiki_page,
+_mcp_read_graph = _register_structured_tool(
+    read_graph,
     server=directory_mcp,
-    title='Read Workflow Wiki Page',
-    tags={'wiki', 'knowledge', 'workflow', 'read'},
+    name="read.graph",
+    title="Read Graph",
+    tags={"graph", "workflow", "read"},
     annotations=ToolAnnotations(
-        title='Read Workflow Wiki Page',
+        title="Read Graph",
         readOnlyHint=True,
         destructiveHint=False,
         idempotentHint=True,
@@ -376,61 +238,58 @@ _mcp_read_workflow_wiki_page = _register_structured_tool(
 )
 
 
-def list_workflow_runs(status: str = "", limit: int = 20) -> str:
-    """Use this when the user wants recent Workflow run history.
-
-    Args:
-        status: Optional run status filter.
-        limit: Maximum number of runs to return.
-    """
-    return _extensions_impl(action="list_runs", status=status, limit=limit)
-
-
-_mcp_list_workflow_runs = _register_structured_tool(
-    list_workflow_runs,
-    server=directory_mcp,
-    title='List Workflow Runs',
-    tags={'runs', 'workflow', 'browse'},
-    annotations=ToolAnnotations(
-        title='List Workflow Runs',
-        readOnlyHint=True,
-        destructiveHint=False,
-        idempotentHint=True,
-        openWorldHint=False,
-    ),
-)
-
-
-def propose_workflow_goal(
-    name: str,
+def write_graph(
+    target: str,
+    name: str = "",
     description: str = "",
     tags: str = "",
     visibility: str = "public",
+    text: str = "",
+    graph_id: str = "",
+    request_type: str = "general",
+    branch_id: str = "",
 ) -> str:
-    """Use this when the user asks to create a shared Workflow goal proposal.
+    """Create or queue Workflow graph state.
 
     Args:
-        name: Human-readable goal name.
-        description: Optional goal description.
-        tags: Optional comma-separated tags.
-        visibility: Visibility value accepted by Workflow, usually public.
+        target: What to write: goal or request.
+        name: Human-readable shared-goal name.
+        description: Optional shared-goal description.
+        tags: Optional comma-separated shared-goal tags.
+        visibility: Shared-goal visibility, usually public.
+        text: Request text to queue.
+        graph_id: Optional target graph/universe identifier.
+        request_type: Workflow request type.
+        branch_id: Optional target branch identifier.
     """
-    return _goals_impl(
-        action="propose",
-        name=name,
-        description=description,
-        tags=tags,
-        visibility=visibility,
-    )
+    normalized = target.strip().lower()
+    if normalized == "goal":
+        return _goals_impl(
+            action="propose",
+            name=name,
+            description=description,
+            tags=tags,
+            visibility=visibility,
+        )
+    if normalized == "request":
+        return _universe_impl(
+            action="submit_request",
+            universe_id=graph_id,
+            text=text,
+            request_type=request_type,
+            branch_id=branch_id,
+        )
+    return _unknown_target("write.graph", target, ("goal", "request"))
 
 
-_mcp_propose_workflow_goal = _register_structured_tool(
-    propose_workflow_goal,
+_mcp_write_graph = _register_structured_tool(
+    write_graph,
     server=directory_mcp,
-    title='Propose Workflow Goal',
-    tags={'goals', 'workflow', 'create'},
+    name="write.graph",
+    title="Write Graph",
+    tags={"graph", "workflow", "write"},
     annotations=ToolAnnotations(
-        title='Propose Workflow Goal',
+        title="Write Graph",
         readOnlyHint=False,
         destructiveHint=False,
         idempotentHint=False,
@@ -439,39 +298,190 @@ _mcp_propose_workflow_goal = _register_structured_tool(
 )
 
 
-def submit_workflow_request(
-    text: str,
-    universe_id: str = "",
-    request_type: str = "scene_direction",
-    branch_id: str = "",
+def run_graph(
+    branch_def_id: str,
+    inputs_json: str = "",
+    run_name: str = "",
+    graph_id: str = "",
+    recursion_limit_override: int = 0,
 ) -> str:
-    """Use this when the user wants the Workflow daemon to handle a bounded request.
+    """Run a Workflow graph branch.
 
     Args:
-        text: Request text to queue.
-        universe_id: Optional target universe. Empty uses the active universe.
-        request_type: Workflow request type.
-        branch_id: Optional target branch identifier.
+        branch_def_id: Branch definition identifier to run.
+        inputs_json: Optional JSON object containing run inputs.
+        run_name: Optional display name for the run.
+        graph_id: Optional graph/universe identifier.
+        recursion_limit_override: Optional per-run recursion limit.
     """
-    return _universe_impl(
-        action="submit_request",
-        universe_id=universe_id,
-        text=text,
-        request_type=request_type,
-        branch_id=branch_id,
+    return _extensions_impl(
+        action="run_branch",
+        branch_def_id=branch_def_id,
+        inputs_json=inputs_json,
+        run_name=run_name,
+        universe_id=graph_id,
+        recursion_limit_override=recursion_limit_override,
     )
 
 
-_mcp_submit_workflow_request = _register_structured_tool(
-    submit_workflow_request,
+_mcp_run_graph = _register_structured_tool(
+    run_graph,
     server=directory_mcp,
-    title='Submit Workflow Request',
-    tags={'requests', 'workflow', 'queue'},
+    name="run.graph",
+    title="Run Graph",
+    tags={"graph", "workflow", "run"},
     annotations=ToolAnnotations(
-        title='Submit Workflow Request',
+        title="Run Graph",
         readOnlyHint=False,
         destructiveHint=False,
         idempotentHint=False,
         openWorldHint=False,
+    ),
+)
+
+
+def read_page(
+    page: str = "",
+    query: str = "",
+    category: str = "",
+    changed_since: str = "",
+    max_results: int = 10,
+) -> str:
+    """Read or search Workflow wiki pages.
+
+    Args:
+        page: Optional wiki page slug or path. Empty searches by query.
+        query: Optional search text or ambient relevance terms.
+        category: Optional wiki category filter for searches.
+        changed_since: Optional ISO timestamp for feed freshness filtering.
+        max_results: Maximum result count.
+    """
+    if page:
+        return _wiki_impl(
+            action="read",
+            page=page,
+            query=query,
+            changed_since=changed_since,
+            max_results=max_results,
+        )
+    return _wiki_impl(
+        action="search",
+        query=query,
+        category=category,
+        max_results=max_results,
+    )
+
+
+_mcp_read_page = _register_structured_tool(
+    read_page,
+    server=directory_mcp,
+    name="read.page",
+    title="Read Page",
+    tags={"page", "wiki", "workflow", "read"},
+    annotations=ToolAnnotations(
+        title="Read Page",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    ),
+)
+
+
+def write_page(
+    page: str = "",
+    category: str = "",
+    filename: str = "",
+    content: str = "",
+    log_entry: str = "",
+    old_text: str = "",
+    new_text: str = "",
+    expected_sha256: str = "",
+    title: str = "",
+    kind: str = "",
+    component: str = "",
+    severity: str = "",
+    repro: str = "",
+    observed: str = "",
+    expected: str = "",
+    workaround: str = "",
+    tags: str = "",
+    force_new: bool = False,
+    reporter_context: str = "",
+    dry_run: bool = True,
+) -> str:
+    """Write, patch, or file a Workflow wiki page.
+
+    Args:
+        page: Wiki page slug or path for page writes.
+        category: Wiki category for full page writes.
+        filename: Wiki filename for full page writes.
+        content: Full page content for a page write.
+        log_entry: Optional wiki log entry for full writes or patches.
+        old_text: Existing text to replace for a targeted page patch.
+        new_text: Replacement text for a targeted page patch.
+        expected_sha256: Optional full-page hash guard for patches.
+        title: Filing title when creating a bug, patch, feature, or design page.
+        kind: Filing kind: bug, patch_request, feature, or design.
+        component: Optional affected component for filed issues.
+        severity: Optional severity for filed issues.
+        repro: Optional reproduction notes for filed issues.
+        observed: Optional observed behavior for filed issues.
+        expected: Optional expected behavior for filed issues.
+        workaround: Optional workaround for filed issues.
+        tags: Optional comma-separated tags.
+        force_new: Bypass duplicate detection for filed issues.
+        reporter_context: Optional reporter context for filed issues.
+        dry_run: Preview consolidation-style wiki writes when supported.
+    """
+    normalized_kind = kind.strip().lower()
+    if normalized_kind:
+        return _wiki_impl(
+            action="file_bug",
+            kind=normalized_kind,
+            title=title,
+            component=component,
+            severity=severity,
+            repro=repro,
+            observed=observed,
+            expected=expected,
+            workaround=workaround,
+            tags=tags,
+            force_new=force_new,
+            reporter_context=reporter_context,
+        )
+    if old_text or new_text:
+        return _wiki_impl(
+            action="patch",
+            page=page,
+            old_text=old_text,
+            new_text=new_text,
+            expected_sha256=expected_sha256,
+            log_entry=log_entry,
+            dry_run=dry_run,
+        )
+    write_filename = filename or page
+    return _wiki_impl(
+        action="write",
+        category=category,
+        filename=write_filename,
+        content=content,
+        log_entry=log_entry,
+        dry_run=dry_run,
+    )
+
+
+_mcp_write_page = _register_structured_tool(
+    write_page,
+    server=directory_mcp,
+    name="write.page",
+    title="Write Page",
+    tags={"page", "wiki", "workflow", "write"},
+    annotations=ToolAnnotations(
+        title="Write Page",
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
     ),
 )


### PR DESCRIPTION
Fixes #476

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-047-collapse-user-facing-mcp-surface-to-5-handles-read-graph-wri.md`
- GitHub issue: #476
- Branch task: `auto-change/issue-476`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.