### PR TITLE
[auto-change] WIKI-PATCH: Wiki slug generation truncates mid-word instead of at word boundaries

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1391,7 +1391,13 @@ def _next_bug_id(bugs_pages_dir: Path) -> str:
 
 def _slugify_title(title: str, max_len: int = 60) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
-    return slug[:max_len] or "untitled"
+    if len(slug) <= max_len:
+        return slug or "untitled"
+    truncated = slug[:max_len]
+    boundary = truncated.rfind("-")
+    if boundary > 0:
+        truncated = truncated[:boundary]
+    return truncated or "untitled"
 
 
 def _render_bug_markdown(

--- a/tests/test_api_wiki.py
+++ b/tests/test_api_wiki.py
@@ -88,6 +88,14 @@ def test_slugify_title_truncates_and_handles_empty():
     assert _slugify_title("!!!") == "untitled"
 
 
+def test_slugify_title_truncates_at_word_boundary():
+    title = "Wiki slug generation truncates mid-word instead of at word boundaries"
+    assert (
+        _slugify_title(title)
+        == "wiki-slug-generation-truncates-mid-word-instead-of-at-word"
+    )
+
+
 def test_parse_frontmatter_roundtrip():
     raw = "---\ntitle: Foo\ntype: note\n---\nbody here\n"
     meta, body = _parse_frontmatter(raw)

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1391,7 +1391,13 @@ def _next_bug_id(bugs_pages_dir: Path) -> str:
 
 def _slugify_title(title: str, max_len: int = 60) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
-    return slug[:max_len] or "untitled"
+    if len(slug) <= max_len:
+        return slug or "untitled"
+    truncated = slug[:max_len]
+    boundary = truncated.rfind("-")
+    if boundary > 0:
+        truncated = truncated[:boundary]
+    return truncated or "untitled"
 
 
 def _render_bug_markdown(


### PR DESCRIPTION
Fixes #293

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-002-wiki-slug-generation-truncates-mid-word-instead-of-at-word-b.md`
- GitHub issue: #293
- Branch task: `auto-change/issue-293`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.