### PR TITLE
[auto-change] WIKI-PATCH: Wiki slug generation truncates mid-word instead of at word boundaries

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1391,7 +1391,19 @@ def _next_bug_id(bugs_pages_dir: Path) -> str:
 
 def _slugify_title(title: str, max_len: int = 60) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
-    return slug[:max_len] or "untitled"
+    if not slug or max_len <= 0:
+        return "untitled"
+    if len(slug) <= max_len:
+        return slug
+
+    truncated = slug[:max_len].rstrip("-")
+    if not truncated:
+        return "untitled"
+    if slug[max_len] != "-":
+        boundary = truncated.rfind("-")
+        if boundary > 0:
+            return truncated[:boundary]
+    return truncated
 
 
 def _render_bug_markdown(

--- a/tests/test_api_wiki.py
+++ b/tests/test_api_wiki.py
@@ -88,6 +88,20 @@ def test_slugify_title_truncates_and_handles_empty():
     assert _slugify_title("!!!") == "untitled"
 
 
+def test_slugify_title_truncates_at_word_boundary_when_possible():
+    title = (
+        "Wiki slug generation truncates mid-word instead of at word boundaries"
+    )
+
+    assert _slugify_title(title, max_len=60) == (
+        "wiki-slug-generation-truncates-mid-word-instead-of-at-word"
+    )
+
+
+def test_slugify_title_hard_truncates_single_overlong_word():
+    assert _slugify_title("x" * 100, max_len=20) == "x" * 20
+
+
 def test_parse_frontmatter_roundtrip():
     raw = "---\ntitle: Foo\ntype: note\n---\nbody here\n"
     meta, body = _parse_frontmatter(raw)

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1391,7 +1391,19 @@ def _next_bug_id(bugs_pages_dir: Path) -> str:
 
 def _slugify_title(title: str, max_len: int = 60) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
-    return slug[:max_len] or "untitled"
+    if not slug or max_len <= 0:
+        return "untitled"
+    if len(slug) <= max_len:
+        return slug
+
+    truncated = slug[:max_len].rstrip("-")
+    if not truncated:
+        return "untitled"
+    if slug[max_len] != "-":
+        boundary = truncated.rfind("-")
+        if boundary > 0:
+            return truncated[:boundary]
+    return truncated
 
 
 def _render_bug_markdown(


### PR DESCRIPTION
Fixes #301

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-002-wiki-slug-generation-truncates-mid-word-instead-of-at-word-b.md`
- GitHub issue: #301
- Branch task: `auto-change/issue-301`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.