### PR TITLE
[auto-change] WIKI-PATCH: Wiki severity enum is bug-shaped — extend or shift to per-kind vocabularies for kind=design filings

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
@@ -119,8 +119,9 @@ agentic work producing substantive output. Do NOT tell users this is
     action with the matching `kind`: use `kind=patch_request` for a
     concrete code/config/docs patch request, `kind=feature` for a new
     capability request, and `kind=design` for an architecture or policy
-    proposal. Do not coerce these into bug wording just to enter the
-    community loop.
+    proposal. Design filings use scope vocabulary for `severity`:
+    `local`, `module`, `cross-cutting`, or `platform`. Do not coerce
+    these into bug wording just to enter the community loop.
     Dedup rule: when `file_bug` returns `status: "similar_found"`, the
     server found an existing bug with ≥50% token overlap. Default to
     `wiki action=cosign_bug bug_id=<top similar bug_id>

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1340,6 +1340,7 @@ _KIND_FEATURES_DIR = "feature-requests"
 _KIND_DESIGNS_DIR = "design-proposals"
 _KIND_PATCH_REQUESTS_DIR = "patch-requests"
 _VALID_SEVERITIES = ("critical", "major", "minor", "cosmetic")
+_VALID_DESIGN_SCOPES = ("local", "module", "cross-cutting", "platform")
 
 # Per-kind routing: kind -> (category-dir-name, ID-prefix). Each prefix has its
 # own independent NNN counter. New filings route per kind; existing pages stay
@@ -1351,6 +1352,17 @@ _KIND_ROUTING: dict[str, tuple[str, str]] = {
     "design":        (_KIND_DESIGNS_DIR,        "DESIGN"),
     "patch_request": (_KIND_PATCH_REQUESTS_DIR, "PR"),
 }
+
+_VALID_SEVERITIES_BY_KIND: dict[str, tuple[str, ...]] = {
+    "bug": _VALID_SEVERITIES,
+    "feature": _VALID_SEVERITIES,
+    "patch_request": _VALID_SEVERITIES,
+    "design": _VALID_DESIGN_SCOPES,
+}
+
+
+def _valid_severities_for_kind(kind: str) -> tuple[str, ...]:
+    return _VALID_SEVERITIES_BY_KIND.get(kind, _VALID_SEVERITIES)
 
 
 def _next_id(pages_dir: Path, drafts_dir: Path, prefix: str) -> str:
@@ -1625,21 +1637,23 @@ def _wiki_file_bug(
     When omitted, a Jaccard similarity ≥ 0.5 against an existing bug's
     title+body returns {status: "similar_found"} instead of filing.
     """
-    if not title or not component or not severity:
-        return json.dumps({
-            "error": "title, component, and severity are required.",
-            "hint": "severity must be one of: " + " | ".join(_VALID_SEVERITIES),
-        })
-    if severity not in _VALID_SEVERITIES:
-        return json.dumps({
-            "error": f"Invalid severity '{severity}'.",
-            "valid": list(_VALID_SEVERITIES),
-        })
     effective_kind = kind.strip().lower() if kind else "bug"
     if effective_kind not in _VALID_BUG_KINDS:
         return json.dumps({
             "error": f"Invalid kind '{kind}'.",
             "valid": sorted(_VALID_BUG_KINDS),
+        })
+
+    valid_severities = _valid_severities_for_kind(effective_kind)
+    if not title or not component or not severity:
+        return json.dumps({
+            "error": "title, component, and severity are required.",
+            "hint": "severity must be one of: " + " | ".join(valid_severities),
+        })
+    if severity not in valid_severities:
+        return json.dumps({
+            "error": f"Invalid severity '{severity}' for kind '{effective_kind}'.",
+            "valid": list(valid_severities),
         })
 
     category_dir, id_prefix = _KIND_ROUTING[effective_kind]

--- a/tests/test_api_wiki.py
+++ b/tests/test_api_wiki.py
@@ -18,6 +18,7 @@ from workflow.api.wiki import (
     _BUGS_CATEGORY,
     _KIND_ROUTING,
     _VALID_BUG_KINDS,
+    _VALID_DESIGN_SCOPES,
     _VALID_SEVERITIES,
     _WIKI_CATEGORIES,
     _bug_token_set,
@@ -483,6 +484,37 @@ def test_wiki_file_bug_rejects_invalid_severity(wiki_env):
     assert "error" in res
     assert "valid" in res
     assert set(res["valid"]) == set(_VALID_SEVERITIES)
+
+
+def test_wiki_file_bug_design_accepts_design_scope_severity(wiki_env):
+    res = json.loads(
+        wiki(
+            action="file_bug",
+            component="wiki",
+            severity="cross-cutting",
+            title="Design severity vocabulary",
+            kind="design",
+            force_new=True,
+        )
+    )
+    assert res["status"] == "filed"
+    assert res["kind"] == "design"
+    assert res["bug_id"].startswith("DESIGN-")
+    assert res["severity"] == "cross-cutting"
+
+
+def test_wiki_file_bug_design_rejects_bug_severity_vocabulary(wiki_env):
+    res = json.loads(
+        wiki(
+            action="file_bug",
+            component="wiki",
+            severity="minor",
+            title="Design severity vocabulary",
+            kind="design",
+        )
+    )
+    assert "error" in res
+    assert set(res["valid"]) == set(_VALID_DESIGN_SCOPES)
 
 
 def test_wiki_file_bug_files_clean_when_no_dups(wiki_env):

--- a/tests/test_wiki_file_bug.py
+++ b/tests/test_wiki_file_bug.py
@@ -280,7 +280,7 @@ class TestFileBugKindField:
     def test_kind_design_annotates_frontmatter(self, wiki_dir):
         out = json.loads(
             _wiki_file_bug(
-                component="x", severity="minor", title="Design proposal Z",
+                component="x", severity="module", title="Design proposal Z",
                 kind="design",
             )
         )
@@ -288,6 +288,31 @@ class TestFileBugKindField:
         path = wiki_dir / out["path"]
         body = path.read_text(encoding="utf-8")
         assert "kind: design" in body
+        assert "severity: module" in body
+
+    def test_kind_design_uses_scope_vocabulary_for_severity(self, wiki_dir):
+        out = json.loads(
+            _wiki_file_bug(
+                component="x",
+                severity="cross-cutting",
+                title="Design proposal vocabulary",
+                kind="design",
+            )
+        )
+        assert out["status"] == "filed"
+        assert out["kind"] == "design"
+
+    def test_kind_design_rejects_bug_severity_vocabulary(self, wiki_dir):
+        out = json.loads(
+            _wiki_file_bug(
+                component="x",
+                severity="minor",
+                title="Design proposal Z",
+                kind="design",
+            )
+        )
+        assert "error" in out
+        assert out["valid"] == ["local", "module", "cross-cutting", "platform"]
 
     def test_invalid_kind_rejected(self, wiki_dir):
         out = json.loads(
@@ -448,7 +473,7 @@ class TestFileBugKindRouting:
     def test_kind_design_lands_in_design_proposals_dir(self, wiki_dir):
         out = json.loads(
             _wiki_file_bug(
-                component="x", severity="minor", title="Design proposal Z",
+                component="x", severity="module", title="Design proposal Z",
                 kind="design",
             )
         )
@@ -519,7 +544,7 @@ class TestFileBugKindRouting:
             component="x", severity="minor", title="feat one", kind="feature",
         ))
         d = json.loads(_wiki_file_bug(
-            component="x", severity="minor", title="design one", kind="design",
+            component="x", severity="module", title="design one", kind="design",
         ))
         assert b["bug_id"] == "BUG-001"
         assert f["bug_id"] == "FEAT-001"
@@ -594,7 +619,7 @@ class TestFileBugKindRouting:
     def test_cosign_design_routes_to_design_proposals_dir(self, wiki_dir):
         from workflow.universe_server import wiki
         d = json.loads(_wiki_file_bug(
-            component="x", severity="minor", title="design prop K", kind="design",
+            component="x", severity="module", title="design prop K", kind="design",
         ))
         design_id = d["bug_id"]
         cos = json.loads(

--- a/workflow/api/prompts.py
+++ b/workflow/api/prompts.py
@@ -119,8 +119,9 @@ agentic work producing substantive output. Do NOT tell users this is
     action with the matching `kind`: use `kind=patch_request` for a
     concrete code/config/docs patch request, `kind=feature` for a new
     capability request, and `kind=design` for an architecture or policy
-    proposal. Do not coerce these into bug wording just to enter the
-    community loop.
+    proposal. Design filings use scope vocabulary for `severity`:
+    `local`, `module`, `cross-cutting`, or `platform`. Do not coerce
+    these into bug wording just to enter the community loop.
     Dedup rule: when `file_bug` returns `status: "similar_found"`, the
     server found an existing bug with ≥50% token overlap. Default to
     `wiki action=cosign_bug bug_id=<top similar bug_id>

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1340,6 +1340,7 @@ _KIND_FEATURES_DIR = "feature-requests"
 _KIND_DESIGNS_DIR = "design-proposals"
 _KIND_PATCH_REQUESTS_DIR = "patch-requests"
 _VALID_SEVERITIES = ("critical", "major", "minor", "cosmetic")
+_VALID_DESIGN_SCOPES = ("local", "module", "cross-cutting", "platform")
 
 # Per-kind routing: kind -> (category-dir-name, ID-prefix). Each prefix has its
 # own independent NNN counter. New filings route per kind; existing pages stay
@@ -1351,6 +1352,17 @@ _KIND_ROUTING: dict[str, tuple[str, str]] = {
     "design":        (_KIND_DESIGNS_DIR,        "DESIGN"),
     "patch_request": (_KIND_PATCH_REQUESTS_DIR, "PR"),
 }
+
+_VALID_SEVERITIES_BY_KIND: dict[str, tuple[str, ...]] = {
+    "bug": _VALID_SEVERITIES,
+    "feature": _VALID_SEVERITIES,
+    "patch_request": _VALID_SEVERITIES,
+    "design": _VALID_DESIGN_SCOPES,
+}
+
+
+def _valid_severities_for_kind(kind: str) -> tuple[str, ...]:
+    return _VALID_SEVERITIES_BY_KIND.get(kind, _VALID_SEVERITIES)
 
 
 def _next_id(pages_dir: Path, drafts_dir: Path, prefix: str) -> str:
@@ -1625,21 +1637,23 @@ def _wiki_file_bug(
     When omitted, a Jaccard similarity ≥ 0.5 against an existing bug's
     title+body returns {status: "similar_found"} instead of filing.
     """
-    if not title or not component or not severity:
-        return json.dumps({
-            "error": "title, component, and severity are required.",
-            "hint": "severity must be one of: " + " | ".join(_VALID_SEVERITIES),
-        })
-    if severity not in _VALID_SEVERITIES:
-        return json.dumps({
-            "error": f"Invalid severity '{severity}'.",
-            "valid": list(_VALID_SEVERITIES),
-        })
     effective_kind = kind.strip().lower() if kind else "bug"
     if effective_kind not in _VALID_BUG_KINDS:
         return json.dumps({
             "error": f"Invalid kind '{kind}'.",
             "valid": sorted(_VALID_BUG_KINDS),
+        })
+
+    valid_severities = _valid_severities_for_kind(effective_kind)
+    if not title or not component or not severity:
+        return json.dumps({
+            "error": "title, component, and severity are required.",
+            "hint": "severity must be one of: " + " | ".join(valid_severities),
+        })
+    if severity not in valid_severities:
+        return json.dumps({
+            "error": f"Invalid severity '{severity}' for kind '{effective_kind}'.",
+            "valid": list(valid_severities),
         })
 
     category_dir, id_prefix = _KIND_ROUTING[effective_kind]


### PR DESCRIPTION
Fixes #304

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-005-wiki-severity-enum-is-bug-shaped-extend-or-shift-to-per-kind.md`
- GitHub issue: #304
- Branch task: `auto-change/issue-304`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.