### PR TITLE
[auto-change] BUG-048: tier=confidential silently accepted against universe with public-scope premise; no validation, no block

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -2549,6 +2549,7 @@ def _action_daemon_overview(
 _VALID_TIER_KEYS = frozenset({
     "external_requests", "goal_pool", "paid_bids", "opportunistic",
 })
+_TIER_CONFIG_ACTION = "set_tier_config"
 _TIER_KEY_TO_CONFIG_FIELD = {
     "external_requests": "accept_external_requests",
     "goal_pool": "accept_goal_pool",
@@ -2626,6 +2627,26 @@ def _action_set_tier_config(
         "tier": tier_name,
         "enabled": bool(enabled),
         "takes_effect": "next_dispatcher_cycle",
+    })
+
+
+def _reject_unsupported_tier_param(action: str, tier: str) -> str | None:
+    tier_name = (tier or "").strip().lower()
+    if not tier_name or action == _TIER_CONFIG_ACTION:
+        return None
+    return json.dumps({
+        "status": "rejected",
+        "error": "unsupported_tier_parameter",
+        "action": action,
+        "tier": tier_name,
+        "hint": (
+            "The universe tool's tier parameter only configures dispatcher "
+            "tiers through action='set_tier_config'. It is not a privacy or "
+            "confidentiality flag, and unsupported tier values are rejected "
+            "instead of being silently ignored."
+        ),
+        "available_tier_config_actions": [_TIER_CONFIG_ACTION],
+        "available_dispatcher_tiers": sorted(_VALID_TIER_KEYS),
     })
 
 
@@ -4312,6 +4333,9 @@ def _universe_impl(
             "error": f"Unknown action '{action}'.",
             "available_actions": sorted(dispatch.keys()),
         })
+    unsupported_tier = _reject_unsupported_tier_param(action, tier)
+    if unsupported_tier is not None:
+        return unsupported_tier
 
     # Build kwargs from all optional params
     kwargs: dict[str, Any] = {

--- a/tests/test_api_universe.py
+++ b/tests/test_api_universe.py
@@ -21,6 +21,7 @@ Surface guarded:
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -169,6 +170,36 @@ def test_scope_universe_response_prepends_universe_lead_in() -> None:
     raw = '{"text": "hello", "universe_id": "u_test"}'
     out = univ_mod._scope_universe_response(raw)
     assert "Universe:" in out
+
+
+def test_confidential_tier_rejected_when_action_does_not_support_tier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base = tmp_path / "output"
+    udir = base / "public-scope"
+    udir.mkdir(parents=True)
+    (udir / "PROGRAM.md").write_text(
+        "scope: public\n\nA public benchmark universe.",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(base))
+
+    out = json.loads(univ_mod._universe_impl(
+        action="set_premise",
+        universe_id="public-scope",
+        text="tier=confidential should not be ignored",
+        tier="confidential",
+    ))
+
+    assert out["status"] == "rejected"
+    assert out["error"] == "unsupported_tier_parameter"
+    assert out["action"] == "set_premise"
+    assert out["tier"] == "confidential"
+    assert "privacy or confidentiality flag" in out["hint"]
+    assert (udir / "PROGRAM.md").read_text(encoding="utf-8") == (
+        "scope: public\n\nA public benchmark universe."
+    )
 
 
 # ── Daemon telemetry helpers ─────────────────────────────────────────────────

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -2549,6 +2549,7 @@ def _action_daemon_overview(
 _VALID_TIER_KEYS = frozenset({
     "external_requests", "goal_pool", "paid_bids", "opportunistic",
 })
+_TIER_CONFIG_ACTION = "set_tier_config"
 _TIER_KEY_TO_CONFIG_FIELD = {
     "external_requests": "accept_external_requests",
     "goal_pool": "accept_goal_pool",
@@ -2626,6 +2627,26 @@ def _action_set_tier_config(
         "tier": tier_name,
         "enabled": bool(enabled),
         "takes_effect": "next_dispatcher_cycle",
+    })
+
+
+def _reject_unsupported_tier_param(action: str, tier: str) -> str | None:
+    tier_name = (tier or "").strip().lower()
+    if not tier_name or action == _TIER_CONFIG_ACTION:
+        return None
+    return json.dumps({
+        "status": "rejected",
+        "error": "unsupported_tier_parameter",
+        "action": action,
+        "tier": tier_name,
+        "hint": (
+            "The universe tool's tier parameter only configures dispatcher "
+            "tiers through action='set_tier_config'. It is not a privacy or "
+            "confidentiality flag, and unsupported tier values are rejected "
+            "instead of being silently ignored."
+        ),
+        "available_tier_config_actions": [_TIER_CONFIG_ACTION],
+        "available_dispatcher_tiers": sorted(_VALID_TIER_KEYS),
     })
 
 
@@ -4312,6 +4333,9 @@ def _universe_impl(
             "error": f"Unknown action '{action}'.",
             "available_actions": sorted(dispatch.keys()),
         })
+    unsupported_tier = _reject_unsupported_tier_param(action, tier)
+    if unsupported_tier is not None:
+        return unsupported_tier
 
     # Build kwargs from all optional params
     kwargs: dict[str, Any] = {


### PR DESCRIPTION
Fixes #187

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-048-tier-confidential-silently-accepted-against-universe-with-pu.md`
- GitHub issue: #187
- Branch task: `auto-change/issue-187`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.