### PR TITLE
[auto-change] BUG-049: change_loop_v1 runs stall at invoke_autoresearch_lab boundary post-PR-191 (BUG-011 empirical evidence)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
@@ -1769,10 +1769,17 @@ def _build_await_branch_run_node(
                 raw_output = _json.loads(raw_output)
             except Exception:
                 raw_output = {}
+        status = str(record.get("status") or "")
+        updates, _failure = _dispatch_invoke_outcome(
+            child_status=status,
+            child_run_id=run_id,
+            child_output=raw_output,
+            output_mapping=output_mapping,
+            on_child_fail="propagate",
+            default_outputs=None,
+            node_id=node.node_id,
+        )
 
-        updates: dict[str, Any] = {}
-        for parent_key, child_key in output_mapping.items():
-            updates[parent_key] = raw_output.get(child_key)
         return updates
 
     return _node_fn

--- a/tests/test_sub_branch_invocation.py
+++ b/tests/test_sub_branch_invocation.py
@@ -301,6 +301,30 @@ class TestAwaitBranchRunNode:
             with pytest.raises(TimeoutError):
                 fn({"child_run_id": "some-run"})
 
+    def test_non_completed_child_propagates_failure(self, tmp_path):
+        from workflow.graph_compiler import ChildFailedError
+        from workflow.runs import RUN_STATUS_INTERRUPTED
+
+        nd = NodeDefinition(
+            node_id="await_autoresearch_lab",
+            display_name="Await autoresearch lab",
+            await_run_spec={
+                "run_id_field": "child_run_id",
+                "output_mapping": {"result": "answer"},
+                "timeout_seconds": 5.0,
+            },
+        )
+        child_record = {
+            "run_id": "child-interrupted",
+            "status": RUN_STATUS_INTERRUPTED,
+            "output": {"answer": "partial"},
+        }
+
+        with patch("workflow.runs.poll_child_run_status", return_value=child_record):
+            fn = _build_await_branch_run_node(nd, base_path=tmp_path, event_sink=None)
+            with pytest.raises(ChildFailedError, match="child_timeout"):
+                fn({"child_run_id": "child-interrupted"})
+
 
 # ─── recursion depth cap ──────────────────────────────────────────────────────
 

--- a/workflow/graph_compiler.py
+++ b/workflow/graph_compiler.py
@@ -1769,10 +1769,17 @@ def _build_await_branch_run_node(
                 raw_output = _json.loads(raw_output)
             except Exception:
                 raw_output = {}
+        status = str(record.get("status") or "")
+        updates, _failure = _dispatch_invoke_outcome(
+            child_status=status,
+            child_run_id=run_id,
+            child_output=raw_output,
+            output_mapping=output_mapping,
+            on_child_fail="propagate",
+            default_outputs=None,
+            node_id=node.node_id,
+        )
 
-        updates: dict[str, Any] = {}
-        for parent_key, child_key in output_mapping.items():
-            updates[parent_key] = raw_output.get(child_key)
         return updates
 
     return _node_fn


### PR DESCRIPTION
Fixes #195

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-049-change-loop-v1-runs-stall-at-invoke-autoresearch-lab-boundar.md`
- GitHub issue: #195
- Branch task: `auto-change/issue-195`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.