### PR TITLE
[auto-change] BUG-052: Wiki bug list contains duplicate/stale bug pages that the loop should clean up autonomously

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -684,6 +684,97 @@ def _wiki_list(**_kwargs: Any) -> str:
     })
 
 
+def _bug_id_from_page(path: Path) -> str | None:
+    raw = _read_text(path)
+    meta, _ = _parse_frontmatter(raw)
+    candidate = meta.get("id") or meta.get("bug_id") or path.name
+    match = _BUG_ID_RE.search(candidate)
+    if match is None:
+        match = _BUG_ID_RE.search(path.name)
+    if match is None:
+        return None
+    return f"BUG-{int(match.group(1)):03d}"
+
+
+def _bug_page_cleanup_rank(path: Path) -> tuple[int, int, int, str]:
+    raw = _read_text(path)
+    meta, _ = _parse_frontmatter(raw)
+    status_text = " ".join((
+        meta.get("status", ""),
+        meta.get("resolution", ""),
+        meta.get("title", ""),
+        path.name,
+    )).lower()
+    stale_marked = int(any(
+        marker in status_text
+        for marker in ("duplicate", "stale", "superseded", "obsolete")
+    ))
+    uppercase_legacy_canonical = 0 if path.name.startswith("BUG-") else 1
+    richer_content = -len(raw)
+    return (stale_marked, uppercase_legacy_canonical, richer_content, path.name)
+
+
+def _wiki_cleanup_bug_pages(
+    dry_run: bool = True,
+    **_kwargs: Any,
+) -> str:
+    bugs_dir = _wiki_pages_dir() / _BUGS_CATEGORY
+    if not bugs_dir.is_dir():
+        return json.dumps({
+            "mode": "dry_run" if dry_run else "executed",
+            "duplicate_groups": [],
+            "removed": [],
+            "removed_count": 0,
+            "note": "No promoted bugs directory found.",
+        })
+
+    by_bug_id: dict[str, list[Path]] = {}
+    for path in sorted(bugs_dir.glob("*.md")):
+        bug_id = _bug_id_from_page(path)
+        if bug_id is None:
+            continue
+        by_bug_id.setdefault(bug_id, []).append(path)
+
+    duplicate_groups: list[dict[str, Any]] = []
+    removed: list[str] = []
+    for bug_id, paths in sorted(by_bug_id.items()):
+        if len(paths) < 2:
+            continue
+        ranked = sorted(paths, key=_bug_page_cleanup_rank)
+        keep = ranked[0]
+        duplicates = ranked[1:]
+        group: dict[str, Any] = {
+            "bug_id": bug_id,
+            "keep": _page_rel_path(keep),
+            "duplicates": [_page_rel_path(path) for path in duplicates],
+        }
+        duplicate_groups.append(group)
+        if dry_run:
+            continue
+        for duplicate in duplicates:
+            try:
+                duplicate.unlink()
+                removed.append(_page_rel_path(duplicate))
+            except OSError as exc:
+                group.setdefault("errors", []).append({
+                    "path": _page_rel_path(duplicate),
+                    "error": str(exc),
+                })
+
+    if removed:
+        _append_wiki_log(
+            "cleanup_bug_pages | removed duplicate promoted bug pages | "
+            + ", ".join(removed)
+        )
+
+    return json.dumps({
+        "mode": "dry_run" if dry_run else "executed",
+        "duplicate_groups": duplicate_groups,
+        "removed": removed,
+        "removed_count": len(removed),
+    })
+
+
 def _wiki_write(
     category: str = "",
     filename: str = "",
@@ -2043,6 +2134,7 @@ def wiki(
         "ingest": _wiki_ingest,
         "supersede": _wiki_supersede,
         "sync_projects": _wiki_sync_projects,
+        "cleanup_bug_pages": _wiki_cleanup_bug_pages,
         "file_bug": _wiki_file_bug,
         "cosign_bug": _wiki_cosign_bug,
     }

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -965,7 +965,7 @@ def wiki(
     Args:
         action: One of — reads: read, search, since, list, lint;
             writes: write, patch, consolidate, promote, ingest, supersede,
-            sync_projects, file_bug, cosign_bug.
+            sync_projects, cleanup_bug_pages, file_bug, cosign_bug.
             `search` is lexical best-effort, not a completeness proof; use
             `since` with `changed_since` to review pages updated after a known
             timestamp, then `read` the candidate pages.

--- a/scripts/wiki_bug_sync.py
+++ b/scripts/wiki_bug_sync.py
@@ -324,21 +324,73 @@ def _bug_number(path: str) -> int | None:
     return int(m.group(1)) if m else None
 
 
+def _bug_entry_rank(entry: dict[str, Any]) -> tuple[int, int, str]:
+    path = str(entry.get("path", ""))
+    name = Path(path).name
+    title = str(entry.get("title", "")).lower()
+    stale_marked = int(any(
+        marker in f"{title} {path.lower()}"
+        for marker in ("duplicate", "stale", "superseded", "obsolete")
+    ))
+    uppercase_legacy_canonical = 0 if name.startswith("BUG-") else 1
+    return (stale_marked, uppercase_legacy_canonical, path)
+
+
 def list_new_bugs(
     wiki_list: dict[str, Any],
     cursor: int,
 ) -> list[dict[str, Any]]:
-    """Return promoted bug entries with bug_number > cursor, sorted ascending."""
-    bugs = []
+    """Return promoted bug entries with bug_number > cursor, sorted ascending.
+
+    Wiki housekeeping can briefly leave duplicate promoted files for one
+    BUG-NNN. Process each bug number once so the sync loop never opens
+    duplicate GitHub issues while cleanup catches up.
+    """
+    bugs_by_number: dict[int, dict[str, Any]] = {}
     for entry in wiki_list.get("promoted", []):
         if entry.get("type") != "bug":
             continue
         num = _bug_number(entry.get("path", ""))
         if num is None or num <= cursor:
             continue
-        bugs.append({**entry, "bug_number": num})
+        candidate = {**entry, "bug_number": num}
+        current = bugs_by_number.get(num)
+        if current is None or _bug_entry_rank(candidate) < _bug_entry_rank(current):
+            bugs_by_number[num] = candidate
+    bugs = list(bugs_by_number.values())
     bugs.sort(key=lambda e: e["bug_number"])
     return bugs
+
+
+def cleanup_bug_pages(
+    url: str,
+    sid: str | None,
+    timeout: float,
+    *,
+    dry_run: bool = False,
+    post_fn=None,
+) -> dict[str, Any]:
+    """Ask the wiki server to prune duplicate promoted BUG-NNN pages.
+
+    Older servers may not expose this action yet. Treat that as unavailable so
+    local deduplication still protects issue creation on mixed deployments.
+    """
+    result = _mcp_call_tool(
+        url,
+        sid,
+        "wiki",
+        {"action": "cleanup_bug_pages", "dry_run": dry_run},
+        timeout,
+        post_fn,
+    )
+    text = _parse_text_result(result)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return {"status": "unavailable", "error": "cleanup returned non-JSON"}
+    if "error" in data and "Unknown action" in str(data.get("error")):
+        return {"status": "unavailable", "error": data["error"]}
+    return data
 
 
 def _change_kind(entry: dict[str, Any]) -> str | None:
@@ -711,6 +763,25 @@ def sync(
 
     try:
         sid = _mcp_initialize(url, timeout, post_fn)
+
+        if not dry_run:
+            try:
+                cleanup = cleanup_bug_pages(
+                    url, sid, timeout, dry_run=False, post_fn=post_fn
+                )
+                removed_count = int(cleanup.get("removed_count", 0) or 0)
+                duplicate_groups = cleanup.get("duplicate_groups", [])
+                if removed_count or duplicate_groups:
+                    print(
+                        "[wiki-bug-sync] bug-page cleanup "
+                        f"groups={len(duplicate_groups)} removed={removed_count}"
+                    )
+            except SyncError as exc:
+                print(
+                    "[wiki-bug-sync] bug-page cleanup skipped: "
+                    f"{exc.msg}",
+                    file=sys.stderr,
+                )
 
         # Fetch wiki list
         list_result = _mcp_call_tool(url, sid, "wiki", {"action": "list"}, timeout, post_fn)

--- a/tests/test_api_wiki.py
+++ b/tests/test_api_wiki.py
@@ -205,6 +205,39 @@ def test_wiki_list_returns_promoted_and_drafts_keys(wiki_env):
     assert "drafts_count" in res
 
 
+def test_wiki_cleanup_bug_pages_removes_duplicate_promoted_bug_ids(wiki_env):
+    bugs_dir = wiki_env / "pages" / "bugs"
+    canonical = bugs_dir / "bug-052-canonical.md"
+    duplicate = bugs_dir / "bug-052-stale-duplicate.md"
+    canonical.write_text(
+        "---\nid: BUG-052\ntitle: Canonical\nstatus: open\n---\n\ncanonical body\n",
+        encoding="utf-8",
+    )
+    duplicate.write_text(
+        "---\nid: BUG-052\ntitle: Stale duplicate\nstatus: duplicate\n---\n\nold\n",
+        encoding="utf-8",
+    )
+
+    dry = json.loads(wiki(action="cleanup_bug_pages", dry_run=True))
+
+    assert dry["mode"] == "dry_run"
+    assert dry["removed"] == []
+    assert dry["duplicate_groups"] == [{
+        "bug_id": "BUG-052",
+        "keep": "pages/bugs/bug-052-canonical.md",
+        "duplicates": ["pages/bugs/bug-052-stale-duplicate.md"],
+    }]
+    assert duplicate.exists()
+
+    cleaned = json.loads(wiki(action="cleanup_bug_pages", dry_run=False))
+
+    assert cleaned["mode"] == "executed"
+    assert cleaned["removed"] == ["pages/bugs/bug-052-stale-duplicate.md"]
+    assert cleaned["removed_count"] == 1
+    assert canonical.exists()
+    assert not duplicate.exists()
+
+
 def test_wiki_search_requires_query(wiki_env):
     res = json.loads(wiki(action="search", query=""))
     assert "error" in res

--- a/tests/test_mcp_dispatch_docstring_parity.py
+++ b/tests/test_mcp_dispatch_docstring_parity.py
@@ -130,8 +130,8 @@ def _wiki_dispatch_keys() -> set[str]:
     """Mirror of the local `dispatch = {...}` literal inside `wiki()`."""
     return {
         "read", "search", "list", "lint",
-        "write", "consolidate", "promote", "ingest", "supersede",
-        "sync_projects",
+        "write", "patch", "consolidate", "promote", "ingest", "supersede",
+        "sync_projects", "cleanup_bug_pages",
         "file_bug", "cosign_bug",
     }
 
@@ -273,7 +273,7 @@ def _docstring_actions_universe() -> set[str]:
     slab = _extract_slab(
         doc,
         r"action:\s*One of\s*[—\-]",
-        r"\n {4}\w+:\s",
+        r"\n {4}[\w/]+:\s",
     )
     return _flat_group_actions(slab)
 
@@ -283,7 +283,7 @@ def _docstring_actions_wiki() -> set[str]:
     slab = _extract_slab(
         doc,
         r"action:\s*One of\s*[—\-]",
-        r"\n {4}\w+:\s",
+        r"\n {4}[\w/]+:\s",
     )
     return _flat_group_actions(slab)
 

--- a/tests/test_wiki_bug_sync.py
+++ b/tests/test_wiki_bug_sync.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 from wiki_bug_sync import (  # noqa: E402
     SyncError,
     _bug_number,
+    cleanup_bug_pages,
     create_gh_change_issue,
     create_gh_issue,
     fetch_bug_detail,
@@ -155,6 +156,29 @@ def test_list_new_bugs_sorted_ascending():
     }
     result = list_new_bugs(wiki_list, cursor=2)
     assert [e["bug_number"] for e in result] == [3, 4, 5]
+
+
+def test_list_new_bugs_deduplicates_duplicate_promoted_bug_ids():
+    wiki_list = {
+        "promoted": [
+            {
+                "path": "pages/bugs/bug-052-stale-duplicate.md",
+                "type": "bug",
+                "title": "Stale duplicate",
+            },
+            {
+                "path": "pages/bugs/bug-052-canonical.md",
+                "type": "bug",
+                "title": "Canonical",
+            },
+            {"path": "pages/bugs/bug-053-next.md", "type": "bug"},
+        ]
+    }
+
+    result = list_new_bugs(wiki_list, cursor=51)
+
+    assert [entry["bug_number"] for entry in result] == [52, 53]
+    assert result[0]["path"] == "pages/bugs/bug-052-canonical.md"
 
 
 # ---------------------------------------------------------------------------
@@ -433,6 +457,43 @@ def test_fetch_bug_detail_reads_with_page_not_path():
     assert detail["title"] == "Bug"
 
 
+def test_cleanup_bug_pages_calls_wiki_housekeeping_action():
+    post = CapturingPost([
+        (
+            {
+                "jsonrpc": "2.0",
+                "id": 10,
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps({
+                                "mode": "executed",
+                                "duplicate_groups": [],
+                                "removed": [],
+                                "removed_count": 0,
+                            }),
+                        }
+                    ]
+                },
+            },
+            "sid1",
+        ),
+    ])
+
+    result = cleanup_bug_pages(
+        "http://fake/mcp",
+        "sid1",
+        5.0,
+        dry_run=False,
+        post_fn=post,
+    )
+
+    args = post.calls[0]["params"]["arguments"]
+    assert args == {"action": "cleanup_bug_pages", "dry_run": False}
+    assert result["removed_count"] == 0
+
+
 # ---------------------------------------------------------------------------
 # sync() — happy path: no new bugs
 # ---------------------------------------------------------------------------
@@ -454,6 +515,61 @@ def test_sync_no_new_bugs(tmp_path):
     rc = sync("http://fake/mcp", 5.0, dry_run=True, cursor_path=cursor_path, post_fn=post_fn)
     assert rc == 0
     assert read_cursor(cursor_path) == 5  # unchanged
+
+
+def test_sync_runs_bug_page_cleanup_before_live_list(tmp_path):
+    cursor_path = tmp_path / "cursor"
+    write_cursor(5, cursor_path)
+    post = CapturingPost([
+        (_INIT_OK, "sid1"),
+        (_NOTIF_NONE, "sid1"),
+        (
+            {
+                "jsonrpc": "2.0",
+                "id": 10,
+                "result": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps({
+                                "mode": "executed",
+                                "duplicate_groups": [{
+                                    "bug_id": "BUG-052",
+                                    "keep": "pages/bugs/bug-052-canonical.md",
+                                    "duplicates": [
+                                        "pages/bugs/bug-052-stale-duplicate.md"
+                                    ],
+                                }],
+                                "removed": [
+                                    "pages/bugs/bug-052-stale-duplicate.md"
+                                ],
+                                "removed_count": 1,
+                            }),
+                        }
+                    ]
+                },
+            },
+            "sid1",
+        ),
+        (_wiki_list_resp([]), "sid1"),
+    ])
+
+    rc = sync(
+        "http://fake/mcp",
+        5.0,
+        dry_run=False,
+        token="fake-token",
+        cursor_path=cursor_path,
+        post_fn=post,
+    )
+
+    assert rc == 0
+    tool_actions = [
+        call["params"]["arguments"]["action"]
+        for call in post.calls
+        if call.get("method") == "tools/call"
+    ]
+    assert tool_actions == ["cleanup_bug_pages", "list"]
 
 
 # ---------------------------------------------------------------------------
@@ -501,6 +617,24 @@ def test_sync_one_new_bug_updates_cursor(tmp_path):
         tool = payload.get("params", {}).get("name")
         if tool == "wiki":
             args = payload.get("params", {}).get("arguments", {})
+            if args.get("action") == "cleanup_bug_pages":
+                return {
+                    "jsonrpc": "2.0",
+                    "id": 10,
+                    "result": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": json.dumps({
+                                    "mode": "executed",
+                                    "duplicate_groups": [],
+                                    "removed": [],
+                                    "removed_count": 0,
+                                }),
+                            }
+                        ]
+                    },
+                }, "sid1"
             if args.get("action") == "list":
                 return _wiki_list_resp([{"path": "bugs/BUG-003-new", "title": "New Bug"}]), "sid1"
             if args.get("action") == "read":

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -684,6 +684,97 @@ def _wiki_list(**_kwargs: Any) -> str:
     })
 
 
+def _bug_id_from_page(path: Path) -> str | None:
+    raw = _read_text(path)
+    meta, _ = _parse_frontmatter(raw)
+    candidate = meta.get("id") or meta.get("bug_id") or path.name
+    match = _BUG_ID_RE.search(candidate)
+    if match is None:
+        match = _BUG_ID_RE.search(path.name)
+    if match is None:
+        return None
+    return f"BUG-{int(match.group(1)):03d}"
+
+
+def _bug_page_cleanup_rank(path: Path) -> tuple[int, int, int, str]:
+    raw = _read_text(path)
+    meta, _ = _parse_frontmatter(raw)
+    status_text = " ".join((
+        meta.get("status", ""),
+        meta.get("resolution", ""),
+        meta.get("title", ""),
+        path.name,
+    )).lower()
+    stale_marked = int(any(
+        marker in status_text
+        for marker in ("duplicate", "stale", "superseded", "obsolete")
+    ))
+    uppercase_legacy_canonical = 0 if path.name.startswith("BUG-") else 1
+    richer_content = -len(raw)
+    return (stale_marked, uppercase_legacy_canonical, richer_content, path.name)
+
+
+def _wiki_cleanup_bug_pages(
+    dry_run: bool = True,
+    **_kwargs: Any,
+) -> str:
+    bugs_dir = _wiki_pages_dir() / _BUGS_CATEGORY
+    if not bugs_dir.is_dir():
+        return json.dumps({
+            "mode": "dry_run" if dry_run else "executed",
+            "duplicate_groups": [],
+            "removed": [],
+            "removed_count": 0,
+            "note": "No promoted bugs directory found.",
+        })
+
+    by_bug_id: dict[str, list[Path]] = {}
+    for path in sorted(bugs_dir.glob("*.md")):
+        bug_id = _bug_id_from_page(path)
+        if bug_id is None:
+            continue
+        by_bug_id.setdefault(bug_id, []).append(path)
+
+    duplicate_groups: list[dict[str, Any]] = []
+    removed: list[str] = []
+    for bug_id, paths in sorted(by_bug_id.items()):
+        if len(paths) < 2:
+            continue
+        ranked = sorted(paths, key=_bug_page_cleanup_rank)
+        keep = ranked[0]
+        duplicates = ranked[1:]
+        group: dict[str, Any] = {
+            "bug_id": bug_id,
+            "keep": _page_rel_path(keep),
+            "duplicates": [_page_rel_path(path) for path in duplicates],
+        }
+        duplicate_groups.append(group)
+        if dry_run:
+            continue
+        for duplicate in duplicates:
+            try:
+                duplicate.unlink()
+                removed.append(_page_rel_path(duplicate))
+            except OSError as exc:
+                group.setdefault("errors", []).append({
+                    "path": _page_rel_path(duplicate),
+                    "error": str(exc),
+                })
+
+    if removed:
+        _append_wiki_log(
+            "cleanup_bug_pages | removed duplicate promoted bug pages | "
+            + ", ".join(removed)
+        )
+
+    return json.dumps({
+        "mode": "dry_run" if dry_run else "executed",
+        "duplicate_groups": duplicate_groups,
+        "removed": removed,
+        "removed_count": len(removed),
+    })
+
+
 def _wiki_write(
     category: str = "",
     filename: str = "",
@@ -2043,6 +2134,7 @@ def wiki(
         "ingest": _wiki_ingest,
         "supersede": _wiki_supersede,
         "sync_projects": _wiki_sync_projects,
+        "cleanup_bug_pages": _wiki_cleanup_bug_pages,
         "file_bug": _wiki_file_bug,
         "cosign_bug": _wiki_cosign_bug,
     }

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -965,7 +965,7 @@ def wiki(
     Args:
         action: One of — reads: read, search, since, list, lint;
             writes: write, patch, consolidate, promote, ingest, supersede,
-            sync_projects, file_bug, cosign_bug.
+            sync_projects, cleanup_bug_pages, file_bug, cosign_bug.
             `search` is lexical best-effort, not a completeness proof; use
             `since` with `changed_since` to review pages updated after a known
             timestamp, then `read` the candidate pages.


### PR DESCRIPTION
Fixes #221

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-052-wiki-bug-list-contains-duplicate-stale-bug-pages-that-the-lo.md`
- GitHub issue: #221
- Branch task: `auto-change/issue-221`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.