### PR TITLE
[auto-change] BUG-059: Loop-created PRs from stale auto-change branches show phantom deletions in diff; reviewer manually disambiguates real payload from stale-base noise

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -38,8 +38,8 @@ name: Auto-fix change
 # Variable-based toggle preserves the secrets; no data loss.
 #
 # Branch naming:
-#   mechanical filings:    auto-change/issue-<N>
-#   architectural filings: design-note-draft/issue-<N>
+#   mechanical filings:    auto-change/issue-<N>-<writer>-<run_id>
+#   architectural filings: design-note-draft/issue-<N>-<writer>-<run_id>
 # PR title/body are requested in the prompt because claude-code-action@v1 no
 # longer accepts the v0 `pr_title` / `pr_body` inputs.
 
@@ -793,7 +793,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           base_branch: main
           branch_prefix: ${{ steps.meta.outputs.branch_prefix }}
-          branch_name_template: issue-${{ steps.meta.outputs.issue_number }}
+          branch_name_template: issue-${{ steps.meta.outputs.issue_number }}-claude-${{ github.run_id }}
           prompt: |
             You are handling a community change request in the Workflow repository.
 
@@ -1356,7 +1356,7 @@ jobs:
             const filingShape = '${{ steps.meta.outputs.filing_shape }}';
             const branch = mode === 'codex_subscription'
               ? '${{ steps.codex-subscription.outputs.branch }}'
-              : `${branchPrefix}issue-${issueNumber}`;
+              : `${branchPrefix}issue-${issueNumber}-claude-${context.runId}`;
             async function selfReviewLoopPr(pr) {
               const failures = [];
               const headRef = pr.head?.ref || '';
@@ -1524,7 +1524,7 @@ jobs:
             const codexBranch = process.env.CODEX_BRANCH || '';
             const branch = mode === 'codex_subscription' && codexBranch
               ? codexBranch
-              : `${branchPrefix}issue-${issueNumber}`;
+              : `${branchPrefix}issue-${issueNumber}-claude-${context.runId}`;
             const wikiPath = process.env.WIKI_PATH || 'not declared';
             const expectedBranchTask = process.env.EXPECTED_BRANCH_TASK || `${branchPrefix}issue-${issueNumber}`;
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/docs/ops/auto-fix-runbook.md
+++ b/docs/ops/auto-fix-runbook.md
@@ -118,7 +118,7 @@ Variable-based toggle preserves secrets; no data loss from toggling.
 
 ## Branch and PR naming
 
-- Claude branch: `auto-change/issue-<N>` where N = GH issue number
+- Claude branch: `auto-change/issue-<N>-claude-<run_id>` to avoid stale branch reuse
 - Codex branch: `auto-change/issue-<N>-codex-<run_id>` to avoid collisions
 - PR title: `[auto-change] <request-id>: <short title>`
 - PR body: `Fixes #N` plus change summary, or `Part of #N` when the

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -542,6 +542,24 @@ def test_claude_ready_for_checker_requires_pre_checker_self_review(wf):
     )
 
 
+def test_claude_pr_lookup_uses_run_scoped_branch(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    claude_pr_step = next((s for s in steps if s.get("id") == "claude-pr"), None)
+    no_pr_step = next(
+        (s for s in steps if s.get("name") == "Mark needs-human if no PR opened"),
+        None,
+    )
+    assert claude_pr_step is not None, "Must find and label Claude-created PRs"
+    assert no_pr_step is not None, "Must detect existing Claude PRs before no-PR receipt"
+    claude_pr_script = str(claude_pr_step.get("with", {}).get("script", ""))
+    no_pr_script = str(no_pr_step.get("with", {}).get("script", ""))
+    branch_expression = "`${branchPrefix}issue-${issueNumber}-claude-${context.runId}`"
+    assert branch_expression in claude_pr_script
+    assert branch_expression in no_pr_script
+    assert "head: `${context.repo.owner}:${branch}`" in claude_pr_script
+    assert "head: `${context.repo.owner}:${branch}`" in no_pr_script
+
+
 def test_codex_pr_creation_uses_workflow_push_token_for_checks(wf):
     steps = wf["jobs"]["fix"]["steps"]
     codex_pr_step = next((s for s in steps if s.get("id") == "codex-pr-create"), None)
@@ -613,11 +631,10 @@ def test_branch_naming_convention(wf):
     assert "core.setOutput('branch_prefix', branchPrefix)" in meta_script
     with_block = oauth_step.get("with", {})
     assert with_block.get("branch_prefix") == "${{ steps.meta.outputs.branch_prefix }}"
-    assert "issue-${{ steps.meta.outputs.issue_number }}" == with_block.get(
-        "branch_name_template"
-    ), (
-        "Branch must follow the filing-shape branch prefix plus issue-<N>"
-    )
+    assert (
+        "issue-${{ steps.meta.outputs.issue_number }}-claude-${{ github.run_id }}"
+        == with_block.get("branch_name_template")
+    ), "Claude branches must be run-scoped so stale issue branches are not reused"
 
 
 def test_meta_step_extracts_reconciliation_artifacts(wf):


### PR DESCRIPTION
Fixes #258

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-059-loop-created-prs-from-stale-auto-change-branches-show-phanto.md`
- GitHub issue: #258
- Branch task: `auto-change/issue-258`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.