### PR TITLE
[auto-change] BUG-060: Loop investigations start with empty coding workspace instead of repo source/tests

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/claude_provider.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/claude_provider.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import shlex
 import shutil
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 from workflow.exceptions import (
     ProviderError,
@@ -48,6 +50,14 @@ def _resolve_claude_cmd() -> tuple[list[str], bool]:
     return ["claude"], False
 
 
+def _claude_workdir() -> str:
+    """Return the source workspace Claude should inspect for coding tasks."""
+    configured = os.environ.get("WORKFLOW_CLAUDE_WORKDIR", "").strip()
+    if configured:
+        return configured
+    return str(Path(__file__).resolve().parents[2])
+
+
 class ClaudeProvider(BaseProvider):
     """Calls Claude via the ``claude -p`` CLI binary."""
 
@@ -71,6 +81,7 @@ class ClaudeProvider(BaseProvider):
         proc_env = subprocess_env_without_api_keys()
 
         win_kw = _no_window_kwargs()
+        workdir = _claude_workdir()
         if use_shell:
             proc = await asyncio.create_subprocess_shell(
                 shlex.join(cmd),
@@ -78,6 +89,7 @@ class ClaudeProvider(BaseProvider):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=proc_env,
+                cwd=workdir,
                 **win_kw,
             )
         else:
@@ -87,6 +99,7 @@ class ClaudeProvider(BaseProvider):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=proc_env,
+                cwd=workdir,
                 **win_kw,
             )
 
@@ -156,6 +169,7 @@ class ClaudeProvider(BaseProvider):
         proc_env = subprocess_env_without_api_keys()
 
         win_kw = _no_window_kwargs()
+        workdir = _claude_workdir()
         if use_shell:
             proc = await asyncio.create_subprocess_shell(
                 shlex.join(cmd),
@@ -163,6 +177,7 @@ class ClaudeProvider(BaseProvider):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=proc_env,
+                cwd=workdir,
                 **win_kw,
             )
         else:
@@ -172,6 +187,7 @@ class ClaudeProvider(BaseProvider):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=proc_env,
+                cwd=workdir,
                 **win_kw,
             )
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -569,6 +569,34 @@ class TestClaudeProvider:
             with pytest.raises(ProviderTimeoutError):
                 await provider.complete("prompt", "system", ModelConfig(timeout=1))
 
+    @pytest.mark.asyncio
+    async def test_runs_from_repo_root_so_coding_tasks_can_read_source(self):
+        """BUG-060: Claude loop investigations need repo source/tests."""
+        import workflow.providers.claude_provider as claude_provider
+        from workflow.providers.claude_provider import ClaudeProvider
+
+        captured_kwargs = {}
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"Hello world", b""))
+        mock_proc.returncode = 0
+        mock_proc.kill = AsyncMock()
+        mock_proc.wait = AsyncMock()
+
+        async def _fake_exec(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return mock_proc
+
+        with (
+            patch("workflow.providers.claude_provider._resolve_claude_cmd",
+                  return_value=(["claude"], False)),
+            patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+        ):
+            provider = ClaudeProvider()
+            await provider.complete("prompt", "system", ModelConfig())
+
+        repo_root = Path(claude_provider.__file__).resolve().parents[2]
+        assert captured_kwargs["cwd"] == str(repo_root)
+
 
 # =====================================================================
 # CodexProvider (subprocess mock)

--- a/workflow/providers/claude_provider.py
+++ b/workflow/providers/claude_provider.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import shlex
 import shutil
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 from workflow.exceptions import (
     ProviderError,
@@ -48,6 +50,14 @@ def _resolve_claude_cmd() -> tuple[list[str], bool]:
     return ["claude"], False
 
 
+def _claude_workdir() -> str:
+    """Return the source workspace Claude should inspect for coding tasks."""
+    configured = os.environ.get("WORKFLOW_CLAUDE_WORKDIR", "").strip()
+    if configured:
+        return configured
+    return str(Path(__file__).resolve().parents[2])
+
+
 class ClaudeProvider(BaseProvider):
     """Calls Claude via the ``claude -p`` CLI binary."""
 
@@ -71,6 +81,7 @@ class ClaudeProvider(BaseProvider):
         proc_env = subprocess_env_without_api_keys()
 
         win_kw = _no_window_kwargs()
+        workdir = _claude_workdir()
         if use_shell:
             proc = await asyncio.create_subprocess_shell(
                 shlex.join(cmd),
@@ -78,6 +89,7 @@ class ClaudeProvider(BaseProvider):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=proc_env,
+                cwd=workdir,
                 **win_kw,
             )
         else:
@@ -87,6 +99,7 @@ class ClaudeProvider(BaseProvider):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=proc_env,
+                cwd=workdir,
                 **win_kw,
             )
 
@@ -156,6 +169,7 @@ class ClaudeProvider(BaseProvider):
         proc_env = subprocess_env_without_api_keys()
 
         win_kw = _no_window_kwargs()
+        workdir = _claude_workdir()
         if use_shell:
             proc = await asyncio.create_subprocess_shell(
                 shlex.join(cmd),
@@ -163,6 +177,7 @@ class ClaudeProvider(BaseProvider):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=proc_env,
+                cwd=workdir,
                 **win_kw,
             )
         else:
@@ -172,6 +187,7 @@ class ClaudeProvider(BaseProvider):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=proc_env,
+                cwd=workdir,
                 **win_kw,
             )
 


### PR DESCRIPTION
Fixes #259

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-060-loop-investigations-start-with-empty-coding-workspace-instea.md`
- GitHub issue: #259
- Branch task: `auto-change/issue-259`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.