### PR TITLE
[auto-change] WIKI-FEATURE: Feature request: invalidate chatbot connector tool catalog after substrate schema updates

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/connector_catalog.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/connector_catalog.py
@@ -1,0 +1,17 @@
+"""Connector catalog versioning for chatbot-host cache invalidation."""
+
+from __future__ import annotations
+
+# Bump when the chatbot-visible MCP tool catalog changes: tool names,
+# parameters, annotations, descriptions, or structured output contracts.
+DIRECTORY_TOOL_CATALOG_VERSION = "2026-05-07-issue-269"
+
+DIRECTORY_MCP_PATH = "/mcp-directory"
+VERSIONED_DIRECTORY_MCP_PATH = (
+    f"{DIRECTORY_MCP_PATH}/catalog/{DIRECTORY_TOOL_CATALOG_VERSION}"
+)
+
+
+def directory_mcp_remote_url(base_url: str = "https://tinyassets.io") -> str:
+    """Return the versioned directory MCP URL advertised to chatbot hosts."""
+    return f"{base_url.rstrip('/')}{VERSIONED_DIRECTORY_MCP_PATH}"

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -46,6 +46,7 @@ from workflow.api.prompts import _CONTROL_STATION_PROMPT
 from workflow.api.status import get_status as _get_status_impl
 from workflow.api.universe import _universe_impl
 from workflow.api.wiki import wiki as _wiki_impl
+from workflow.connector_catalog import DIRECTORY_MCP_PATH, VERSIONED_DIRECTORY_MCP_PATH
 from workflow.directory_server import directory_mcp
 
 logger = logging.getLogger("universe_server")
@@ -1089,12 +1090,18 @@ def create_streamable_http_app() -> Starlette:
     """Create the production HTTP app with both MCP surfaces.
 
     `/mcp` preserves the legacy custom-connector surface. `/mcp-directory`
-    exposes the narrow directory-review surface used for app-store style host
-    submissions. Both route to the same backend state.
+    remains as the stable directory surface. The versioned directory path is
+    the advertised chatbot-host URL; changing it invalidates host-side cached
+    tool catalogs after substrate schema updates. Both route to the same
+    backend state.
     """
     legacy_app = mcp.http_app(path="/mcp", transport="streamable-http")
     directory_app = directory_mcp.http_app(
-        path="/mcp-directory",
+        path=DIRECTORY_MCP_PATH,
+        transport="streamable-http",
+    )
+    versioned_directory_app = directory_mcp.http_app(
+        path=VERSIONED_DIRECTORY_MCP_PATH,
         transport="streamable-http",
     )
 
@@ -1107,13 +1114,20 @@ def create_streamable_http_app() -> Starlette:
             await stack.enter_async_context(
                 directory_app.router.lifespan_context(directory_app),
             )
+            await stack.enter_async_context(
+                versioned_directory_app.router.lifespan_context(versioned_directory_app),
+            )
             yield
 
     app = Starlette(
-        routes=[*legacy_app.routes, *directory_app.routes],
+        routes=[
+            *legacy_app.routes,
+            *directory_app.routes,
+            *versioned_directory_app.routes,
+        ],
         lifespan=lifespan,
     )
-    app.state.path = "/mcp,/mcp-directory"
+    app.state.path = f"/mcp,{DIRECTORY_MCP_PATH},{VERSIONED_DIRECTORY_MCP_PATH}"
     app.state.transport_type = "streamable-http"
     return app
 

--- a/packaging/registry/generate_server_json.py
+++ b/packaging/registry/generate_server_json.py
@@ -6,6 +6,8 @@ import json
 import urllib.request
 from pathlib import Path
 
+from workflow.connector_catalog import directory_mcp_remote_url
+
 SCHEMA_URL = (
     "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
 )
@@ -16,7 +18,7 @@ DESCRIPTION = (
 )
 REPOSITORY_URL = "https://github.com/Jonnyton/Workflow"
 WEBSITE_URL = "https://tinyassets.io/connect"
-REMOTE_URL = "https://tinyassets.io/mcp-directory"
+REMOTE_URL = directory_mcp_remote_url()
 ICON_URL = "https://raw.githubusercontent.com/Jonnyton/Workflow/main/assets/icon.png"
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/packaging/registry/server.json
+++ b/packaging/registry/server.json
@@ -21,7 +21,7 @@
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://tinyassets.io/mcp-directory"
+      "url": "https://tinyassets.io/mcp-directory/catalog/2026-05-07-issue-269"
     }
   ]
 }

--- a/tests/test_connector_catalog.py
+++ b/tests/test_connector_catalog.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+from workflow.connector_catalog import (
+    DIRECTORY_MCP_PATH,
+    DIRECTORY_TOOL_CATALOG_VERSION,
+    VERSIONED_DIRECTORY_MCP_PATH,
+    directory_mcp_remote_url,
+)
+
+
+def _load_generate_server_json() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "packaging"
+        / "registry"
+        / "generate_server_json.py"
+    )
+    spec = importlib.util.spec_from_file_location("generate_server_json", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_directory_catalog_path_is_versioned_for_host_cache_invalidation() -> None:
+    assert DIRECTORY_MCP_PATH == "/mcp-directory"
+    assert DIRECTORY_TOOL_CATALOG_VERSION in VERSIONED_DIRECTORY_MCP_PATH
+    assert VERSIONED_DIRECTORY_MCP_PATH.startswith("/mcp-directory/catalog/")
+
+
+def test_registry_advertises_versioned_directory_catalog_url() -> None:
+    document = _load_generate_server_json()._build_document()
+
+    assert document["remotes"] == [
+        {
+            "type": "streamable-http",
+            "url": directory_mcp_remote_url(),
+        }
+    ]

--- a/tests/test_universe_server_directory_app.py
+++ b/tests/test_universe_server_directory_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from workflow.connector_catalog import DIRECTORY_MCP_PATH, VERSIONED_DIRECTORY_MCP_PATH
 from workflow.universe_server import create_streamable_http_app
 
 
@@ -8,6 +9,7 @@ def test_streamable_http_app_mounts_legacy_and_directory_surfaces() -> None:
     paths = {getattr(route, "path", None) for route in app.routes}
 
     assert "/mcp" in paths
-    assert "/mcp-directory" in paths
-    assert app.state.path == "/mcp,/mcp-directory"
+    assert DIRECTORY_MCP_PATH in paths
+    assert VERSIONED_DIRECTORY_MCP_PATH in paths
+    assert app.state.path == f"/mcp,{DIRECTORY_MCP_PATH},{VERSIONED_DIRECTORY_MCP_PATH}"
     assert app.state.transport_type == "streamable-http"

--- a/workflow/connector_catalog.py
+++ b/workflow/connector_catalog.py
@@ -1,0 +1,17 @@
+"""Connector catalog versioning for chatbot-host cache invalidation."""
+
+from __future__ import annotations
+
+# Bump when the chatbot-visible MCP tool catalog changes: tool names,
+# parameters, annotations, descriptions, or structured output contracts.
+DIRECTORY_TOOL_CATALOG_VERSION = "2026-05-07-issue-269"
+
+DIRECTORY_MCP_PATH = "/mcp-directory"
+VERSIONED_DIRECTORY_MCP_PATH = (
+    f"{DIRECTORY_MCP_PATH}/catalog/{DIRECTORY_TOOL_CATALOG_VERSION}"
+)
+
+
+def directory_mcp_remote_url(base_url: str = "https://tinyassets.io") -> str:
+    """Return the versioned directory MCP URL advertised to chatbot hosts."""
+    return f"{base_url.rstrip('/')}{VERSIONED_DIRECTORY_MCP_PATH}"

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -46,6 +46,7 @@ from workflow.api.prompts import _CONTROL_STATION_PROMPT
 from workflow.api.status import get_status as _get_status_impl
 from workflow.api.universe import _universe_impl
 from workflow.api.wiki import wiki as _wiki_impl
+from workflow.connector_catalog import DIRECTORY_MCP_PATH, VERSIONED_DIRECTORY_MCP_PATH
 from workflow.directory_server import directory_mcp
 
 logger = logging.getLogger("universe_server")
@@ -1089,12 +1090,18 @@ def create_streamable_http_app() -> Starlette:
     """Create the production HTTP app with both MCP surfaces.
 
     `/mcp` preserves the legacy custom-connector surface. `/mcp-directory`
-    exposes the narrow directory-review surface used for app-store style host
-    submissions. Both route to the same backend state.
+    remains as the stable directory surface. The versioned directory path is
+    the advertised chatbot-host URL; changing it invalidates host-side cached
+    tool catalogs after substrate schema updates. Both route to the same
+    backend state.
     """
     legacy_app = mcp.http_app(path="/mcp", transport="streamable-http")
     directory_app = directory_mcp.http_app(
-        path="/mcp-directory",
+        path=DIRECTORY_MCP_PATH,
+        transport="streamable-http",
+    )
+    versioned_directory_app = directory_mcp.http_app(
+        path=VERSIONED_DIRECTORY_MCP_PATH,
         transport="streamable-http",
     )
 
@@ -1107,13 +1114,20 @@ def create_streamable_http_app() -> Starlette:
             await stack.enter_async_context(
                 directory_app.router.lifespan_context(directory_app),
             )
+            await stack.enter_async_context(
+                versioned_directory_app.router.lifespan_context(versioned_directory_app),
+            )
             yield
 
     app = Starlette(
-        routes=[*legacy_app.routes, *directory_app.routes],
+        routes=[
+            *legacy_app.routes,
+            *directory_app.routes,
+            *versioned_directory_app.routes,
+        ],
         lifespan=lifespan,
     )
-    app.state.path = "/mcp,/mcp-directory"
+    app.state.path = f"/mcp,{DIRECTORY_MCP_PATH},{VERSIONED_DIRECTORY_MCP_PATH}"
     app.state.transport_type = "streamable-http"
     return app
 


### PR DESCRIPTION
Fixes #269

## Request artifact reconciliation

- Wiki page: `pages/feature-requests/feat-005-feature-request-invalidate-chatbot-connector-tool-catalog-af.md`
- GitHub issue: #269
- Branch task: `auto-change/issue-269`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.