### PR TITLE
[auto-change] BUG-062: bug: Connector name "TinyAssets" implies asset generation/retrieval, but actual surfaces are wiki/canon/workflow — naming mismatch confuses first-time users

### DIFF
--- a/docs/ops/mcp-directory-submission-packet.md
+++ b/docs/ops/mcp-directory-submission-packet.md
@@ -190,6 +190,7 @@ Ready artifact:
 Submit:
 
 - Display name: Workflow
+- Connector display name: `Workflow`
 - Subtitle: Build durable workflows
 - Category: Productivity
 - MCP server URL: `https://tinyassets.io/mcp-directory`

--- a/docs/ops/openai-app-submission-final-review-2026-05-02.md
+++ b/docs/ops/openai-app-submission-final-review-2026-05-02.md
@@ -72,8 +72,10 @@ Post-rebase freshness check 2026-05-02T15:46-07:00:
 
 2026-05-02T15:35-07:00 in-app browser audit:
 
-- App Info populated: `Workflow`, `Build durable workflows`, `Productivity`,
-  developer `TinyAssets`, website/support/privacy/terms URLs.
+- App Info populated: connector display name `Workflow`, subtitle
+  `Build durable workflows`, `Productivity`, verified publisher/legal identity
+  `TinyAssets`, website/support/privacy/terms URLs.
+- Connector display name: `Workflow`
 - Logo upload control still visible; no logo uploaded.
 - MCP Server populated: `https://tinyassets.io/mcp-directory`, `No Auth`, 11
   tool rows, complete justifications, `Domain verified`.

--- a/docs/ops/openai-app-submission-final-submit-runbook-2026-05-02.md
+++ b/docs/ops/openai-app-submission-final-submit-runbook-2026-05-02.md
@@ -51,9 +51,11 @@ Submission implications:
 ## Dashboard Values
 
 - Display name: `Workflow`
+- Connector display name: `Workflow`
 - Subtitle: `Build durable workflows`
 - Category: `PRODUCTIVITY`
-- Developer/publisher: `TinyAssets` (host must confirm verified publisher)
+- Verified publisher/legal identity: `TinyAssets` (host must confirm verified
+  publisher; do not use this as the app or connector display name)
 - Website: `https://tinyassets.io`
 - Support: `https://tinyassets.io/legal#contact` or `ops@tinyassets.io`
 - Privacy policy: `https://tinyassets.io/legal#privacy`

--- a/docs/ops/openai-app-submission-prep-2026-05-02.md
+++ b/docs/ops/openai-app-submission-prep-2026-05-02.md
@@ -39,10 +39,12 @@ Historical ChatGPT Developer Mode proof is preserved in
 ## App Info
 
 - App name: `Workflow`
+- Connector display name: `Workflow`
 - Subtitle: `Build durable workflows` (23 chars; under OpenAI's 30-char
   guidance from the submission skill)
 - Category: `PRODUCTIVITY`
-- Developer/publisher: `TinyAssets`
+- Verified publisher/legal identity: `TinyAssets` (do not use this as the app
+  or connector display name)
 - Website URL: `https://tinyassets.io`
 - Support: `https://tinyassets.io/legal#contact` or `ops@tinyassets.io`
 - Privacy Policy URL: `https://tinyassets.io/legal#privacy`

--- a/docs/ops/openai-app-submission-readiness-2026-05-02.md
+++ b/docs/ops/openai-app-submission-readiness-2026-05-02.md
@@ -235,9 +235,11 @@ OpenAI dashboard audit 2026-05-02T15:05-07:00:
 
 OpenAI dashboard re-audit 2026-05-02T15:35-07:00:
 
-- App Info values are populated: `Workflow`, `Build durable workflows`,
-  `Productivity`, developer `TinyAssets`, website/support/privacy/terms URLs,
-  and no commerce/purchase checkbox selected.
+- App Info values are populated: connector display name `Workflow`, subtitle
+  `Build durable workflows`, `Productivity`, verified publisher/legal identity
+  `TinyAssets`, website/support/privacy/terms URLs, and no commerce/purchase
+  checkbox selected.
+- Connector display name: `Workflow`
 - Logo upload control is still visible; logo not uploaded.
 - MCP Server values are populated with `https://tinyassets.io/mcp-directory`,
   `No Auth`, 11 tool rows, complete justifications, and `Domain verified`.

--- a/tests/test_directory_server.py
+++ b/tests/test_directory_server.py
@@ -129,6 +129,37 @@ def test_chatgpt_submission_packet_matches_directory_surface() -> None:
         }
 
 
+def test_chatgpt_submission_uses_workflow_as_connector_display_name() -> None:
+    """BUG-062: TinyAssets is the publisher/legal identity, not the connector name."""
+    repo_root = Path(__file__).resolve().parents[1]
+    packet = json.loads(
+        (repo_root / "chatgpt-app-submission.json").read_text(encoding="utf-8")
+    )
+
+    app_info = packet["app_info"]
+    assert app_info["display_name"] == "Workflow"
+    assert app_info["subtitle"] == "Build durable workflows"
+    assert "TinyAssets" not in json.dumps(app_info)
+
+
+def test_openai_submission_docs_separate_display_name_from_publisher() -> None:
+    """Operator docs must not invite copying TinyAssets into app-name fields."""
+    repo_root = Path(__file__).resolve().parents[1]
+    docs = [
+        "docs/ops/mcp-directory-submission-packet.md",
+        "docs/ops/openai-app-submission-prep-2026-05-02.md",
+        "docs/ops/openai-app-submission-readiness-2026-05-02.md",
+        "docs/ops/openai-app-submission-final-review-2026-05-02.md",
+        "docs/ops/openai-app-submission-final-submit-runbook-2026-05-02.md",
+    ]
+
+    for rel_path in docs:
+        text = (repo_root / rel_path).read_text(encoding="utf-8")
+        assert "Developer/publisher: `TinyAssets`" not in text
+        assert "developer `TinyAssets`" not in text
+        assert "Connector display name: `Workflow`" in text
+
+
 def test_directory_tools_do_not_use_catch_all_action_inputs() -> None:
     for tool in _list_tools():
         properties = tool.parameters.get("properties", {})


### PR DESCRIPTION
Fixes #309

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-062-bug-connector-name-tinyassets-implies-asset-generation-retri.md`
- GitHub issue: #309
- Branch task: `auto-change/issue-309`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.