### PR TITLE
[auto-change] WIKI-FEATURE: feat: When wiki.promote fails lint, return an assisted-fix scaffold or required-frontmatter template

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -864,10 +864,17 @@ def _wiki_promote(
     if not skip_lint:
         issues = _promotion_lint_issues(meta, body, found_category)
         if issues:
+            scaffold = _promotion_lint_fix_scaffold(
+                slug=slug,
+                category=found_category,
+                meta=meta,
+                body=body,
+            )
             return json.dumps({
                 "error": "Promotion blocked.",
                 "issues": issues,
                 "hint": "Fix these issues or set skip_lint=true.",
+                **scaffold,
             })
 
     dest_path = _wiki_pages_dir() / found_category / (slug + ".md")
@@ -1013,6 +1020,77 @@ def _promotion_lint_issues(
             "for the first page in a fresh wiki"
         )
     return issues
+
+
+def _default_wiki_type_for_category(category: str) -> str:
+    category_types = {
+        "bugs": "bug",
+        "concepts": "concept",
+        "notes": "note",
+        "people": "person",
+        "plans": "plan",
+        "projects": "project",
+        "recipes": "recipe",
+        "references": "reference",
+        "research": "research",
+        "workflows": "workflow",
+    }
+    return category_types.get(category, category.removesuffix("s") or "note")
+
+
+def _format_frontmatter_field(name: str, value: str) -> list[str]:
+    if "\n" in value or value.lstrip().startswith("- "):
+        nested = [line for line in value.splitlines() if line.strip()]
+        return [f"{name}:"] + [f"  {line.strip()}" for line in nested]
+    return [f"{name}: {value}"]
+
+
+def _promotion_lint_fix_scaffold(
+    *,
+    slug: str,
+    category: str,
+    meta: dict[str, str],
+    body: str,
+) -> dict[str, Any]:
+    title = meta.get("title") or slug.replace("-", " ").title()
+    page_type = meta.get("type") or _default_wiki_type_for_category(category)
+    frontmatter_lines = [
+        "---",
+        *_format_frontmatter_field("title", title),
+        *_format_frontmatter_field("type", page_type),
+    ]
+    if meta.get("sources"):
+        frontmatter_lines.extend(_format_frontmatter_field("sources", meta["sources"]))
+    elif meta.get("path"):
+        frontmatter_lines.extend(_format_frontmatter_field("path", meta["path"]))
+    else:
+        frontmatter_lines.extend(_format_frontmatter_field("sources", "[]"))
+    frontmatter_lines.append("---")
+    frontmatter_template = "\n".join(frontmatter_lines)
+
+    scaffold_body = body.strip()
+    if len(scaffold_body) < 50:
+        scaffold_body = (
+            f"{scaffold_body}\n\n" if scaffold_body else ""
+        ) + (
+            "TODO: Expand this draft with enough durable context to explain "
+            "what the page records and why it belongs in the wiki."
+        )
+    if not re.search(r"\[\[.+?\]\]", scaffold_body) and category != "projects":
+        scaffold_body = (
+            f"{scaffold_body}\n\n"
+            "Related: [[index]]"
+        )
+
+    return {
+        "required_frontmatter_template": frontmatter_template,
+        "assisted_fix_scaffold": {
+            "action": "wiki.write",
+            "category": category,
+            "filename": slug,
+            "content": f"{frontmatter_template}\n\n{scaffold_body}\n",
+        },
+    }
 
 
 def _wiki_lint_single_page(page: str) -> str:

--- a/tests/test_api_wiki.py
+++ b/tests/test_api_wiki.py
@@ -426,6 +426,75 @@ def test_wiki_promote_lint_blocks_when_required_fields_missing(wiki_env):
     assert "error" in res
     assert res["error"] == "Promotion blocked."
     assert any("Body too short" in i for i in res["issues"])
+    assert res["required_frontmatter_template"] == (
+        "---\n"
+        "title: Skinny\n"
+        "type: note\n"
+        "sources: []\n"
+        "---"
+    )
+    assert res["assisted_fix_scaffold"]["action"] == "wiki.write"
+    assert res["assisted_fix_scaffold"]["category"] == "notes"
+    assert res["assisted_fix_scaffold"]["filename"] == "skinny"
+    assert "[[index]]" in res["assisted_fix_scaffold"]["content"]
+
+
+def test_wiki_promote_lint_scaffold_preserves_existing_type_and_sources(wiki_env):
+    body = (
+        "---\n"
+        "title: Local Source Draft\n"
+        "type: reference\n"
+        "sources:\n"
+        "  - file:///tmp/local-source.md\n"
+        "---\n"
+        "short\n"
+    )
+    json.loads(
+        wiki(
+            action="write",
+            category="references",
+            filename="local-source-draft",
+            content=body,
+        )
+    )
+
+    res = json.loads(wiki(action="promote", filename="local-source-draft"))
+
+    assert res["error"] == "Promotion blocked."
+    assert res["required_frontmatter_template"] == (
+        "---\n"
+        "title: Local Source Draft\n"
+        "type: reference\n"
+        "sources:\n"
+        "  - file:///tmp/local-source.md\n"
+        "---"
+    )
+    assert "file:///tmp/local-source.md" in res["assisted_fix_scaffold"]["content"]
+
+
+def test_wiki_promote_lint_scaffold_preserves_path_alternative(wiki_env):
+    body = (
+        "---\n"
+        "title: Project Draft\n"
+        "type: project\n"
+        "path: /tmp/project\n"
+        "---\n"
+        "short\n"
+    )
+    json.loads(
+        wiki(
+            action="write",
+            category="projects",
+            filename="project-draft",
+            content=body,
+        )
+    )
+
+    res = json.loads(wiki(action="promote", filename="project-draft"))
+
+    assert res["error"] == "Promotion blocked."
+    assert "path: /tmp/project" in res["required_frontmatter_template"]
+    assert "sources:" not in res["required_frontmatter_template"]
 
 
 def test_wiki_promote_lint_accepts_block_sources_with_non_http_uri(wiki_env):

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -864,10 +864,17 @@ def _wiki_promote(
     if not skip_lint:
         issues = _promotion_lint_issues(meta, body, found_category)
         if issues:
+            scaffold = _promotion_lint_fix_scaffold(
+                slug=slug,
+                category=found_category,
+                meta=meta,
+                body=body,
+            )
             return json.dumps({
                 "error": "Promotion blocked.",
                 "issues": issues,
                 "hint": "Fix these issues or set skip_lint=true.",
+                **scaffold,
             })
 
     dest_path = _wiki_pages_dir() / found_category / (slug + ".md")
@@ -1013,6 +1020,77 @@ def _promotion_lint_issues(
             "for the first page in a fresh wiki"
         )
     return issues
+
+
+def _default_wiki_type_for_category(category: str) -> str:
+    category_types = {
+        "bugs": "bug",
+        "concepts": "concept",
+        "notes": "note",
+        "people": "person",
+        "plans": "plan",
+        "projects": "project",
+        "recipes": "recipe",
+        "references": "reference",
+        "research": "research",
+        "workflows": "workflow",
+    }
+    return category_types.get(category, category.removesuffix("s") or "note")
+
+
+def _format_frontmatter_field(name: str, value: str) -> list[str]:
+    if "\n" in value or value.lstrip().startswith("- "):
+        nested = [line for line in value.splitlines() if line.strip()]
+        return [f"{name}:"] + [f"  {line.strip()}" for line in nested]
+    return [f"{name}: {value}"]
+
+
+def _promotion_lint_fix_scaffold(
+    *,
+    slug: str,
+    category: str,
+    meta: dict[str, str],
+    body: str,
+) -> dict[str, Any]:
+    title = meta.get("title") or slug.replace("-", " ").title()
+    page_type = meta.get("type") or _default_wiki_type_for_category(category)
+    frontmatter_lines = [
+        "---",
+        *_format_frontmatter_field("title", title),
+        *_format_frontmatter_field("type", page_type),
+    ]
+    if meta.get("sources"):
+        frontmatter_lines.extend(_format_frontmatter_field("sources", meta["sources"]))
+    elif meta.get("path"):
+        frontmatter_lines.extend(_format_frontmatter_field("path", meta["path"]))
+    else:
+        frontmatter_lines.extend(_format_frontmatter_field("sources", "[]"))
+    frontmatter_lines.append("---")
+    frontmatter_template = "\n".join(frontmatter_lines)
+
+    scaffold_body = body.strip()
+    if len(scaffold_body) < 50:
+        scaffold_body = (
+            f"{scaffold_body}\n\n" if scaffold_body else ""
+        ) + (
+            "TODO: Expand this draft with enough durable context to explain "
+            "what the page records and why it belongs in the wiki."
+        )
+    if not re.search(r"\[\[.+?\]\]", scaffold_body) and category != "projects":
+        scaffold_body = (
+            f"{scaffold_body}\n\n"
+            "Related: [[index]]"
+        )
+
+    return {
+        "required_frontmatter_template": frontmatter_template,
+        "assisted_fix_scaffold": {
+            "action": "wiki.write",
+            "category": category,
+            "filename": slug,
+            "content": f"{frontmatter_template}\n\n{scaffold_body}\n",
+        },
+    }
 
 
 def _wiki_lint_single_page(page: str) -> str:


### PR DESCRIPTION
Fixes #315

## Request artifact reconciliation

- Wiki page: `pages/feature-requests/feat-013-feat-when-wiki-promote-fails-lint-return-an-assisted-fix-sca.md`
- GitHub issue: #315
- Branch task: `auto-change/issue-315`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.