### PR TITLE
[auto-change] WIKI-PATCH: Per-node generic metadata primitive + describe_branch color-by-metadata overlay — supersedes PR-043's compliance-specific framing

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -738,7 +738,52 @@ def _mermaid_label(text: str) -> str:
     return text.replace('"', "'").replace("\n", " ")
 
 
-def _branch_mermaid(branch: Any) -> str:
+_METADATA_OVERLAY_COLORS = (
+    "#dbeafe", "#dcfce7", "#fef3c7", "#fee2e2",
+    "#ede9fe", "#ccfbf1", "#fce7f3", "#e5e7eb",
+)
+
+
+def _metadata_lookup(metadata: dict[str, Any], key_path: str) -> Any:
+    """Return a nested metadata value for ``key`` or ``a.b`` paths."""
+    current: Any = metadata
+    for part in key_path.split("."):
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def _metadata_color_legend(
+    branch: Any,
+    color_by_metadata: str,
+) -> tuple[dict[str, dict[str, str]], dict[str, str]]:
+    key_path = color_by_metadata.strip()
+    if not key_path:
+        return {}, {}
+
+    node_values: dict[str, str] = {}
+    ordered_values: list[str] = []
+    for node in branch.node_defs:
+        value = _metadata_lookup(getattr(node, "metadata", {}) or {}, key_path)
+        if value in (None, ""):
+            continue
+        value_text = str(value)
+        node_values[node.node_id] = value_text
+        if value_text not in ordered_values:
+            ordered_values.append(value_text)
+
+    legend: dict[str, dict[str, str]] = {}
+    for idx, value_text in enumerate(ordered_values):
+        class_name = f"metadata_{idx}"
+        legend[value_text] = {
+            "class": class_name,
+            "fill": _METADATA_OVERLAY_COLORS[idx % len(_METADATA_OVERLAY_COLORS)],
+        }
+    return legend, node_values
+
+
+def _branch_mermaid(branch: Any, *, color_by_metadata: str = "") -> str:
     """Render a BranchDefinition as a Mermaid ``flowchart LR`` block.
 
     Claude.ai and many markdown clients auto-render fenced ``mermaid``
@@ -775,6 +820,25 @@ def _branch_mermaid(branch: Any) -> str:
         for label, target in cedge.conditions.items():
             dst = _mermaid_node_id(target)
             lines.append(f"    {src} -.{_mermaid_label(label)}.-> {dst}")
+
+    if color_by_metadata:
+        legend, node_values = _metadata_color_legend(branch, color_by_metadata)
+        for value_text, item in legend.items():
+            fill = item["fill"]
+            class_name = item["class"]
+            lines.append(
+                f"    classDef {class_name} fill:{fill},stroke:#334155,stroke-width:2px"
+            )
+            lines.append(
+                f"    %% metadata {color_by_metadata}={_mermaid_label(value_text)}"
+            )
+        for node in branch.node_defs:
+            value_text = node_values.get(node.node_id)
+            if value_text is None:
+                continue
+            lines.append(
+                f"    class {_mermaid_node_id(node.node_id)} {legend[value_text]['class']}"
+            )
 
     if branch.entry_point:
         entry_id = _mermaid_node_id(branch.entry_point)
@@ -928,7 +992,16 @@ def _ext_branch_describe(kwargs: dict[str, Any]) -> str:
         else ["  (none — structure is valid)"]
     )
 
-    mermaid = _branch_mermaid(branch)
+    color_by_metadata = (
+        kwargs.get("color_by_metadata")
+        or kwargs.get("metadata_key")
+        or kwargs.get("color_by")
+        or ""
+    ).strip()
+    metadata_color_legend, metadata_node_values = _metadata_color_legend(
+        branch, color_by_metadata,
+    )
+    mermaid = _branch_mermaid(branch, color_by_metadata=color_by_metadata)
 
     summary_parts = [
         f"Branch: {branch.name or '(unnamed)'}  [{branch.branch_def_id}]",
@@ -994,6 +1067,9 @@ def _ext_branch_describe(kwargs: dict[str, Any]) -> str:
         "fork_descendants": fork_descendants,
         "related_wiki_pages": related["items"],
         "related_wiki_pages_truncated": related["truncated_count"],
+        "metadata_color_by": color_by_metadata,
+        "metadata_color_legend": metadata_color_legend,
+        "metadata_color_nodes": metadata_node_values,
     })
 
 
@@ -1173,6 +1249,7 @@ def _resolve_node_spec(
         for field_key in (
             "display_name", "description", "phase", "input_keys",
             "output_keys", "source_code", "prompt_template", "author",
+            "metadata",
         ):
             if field_key in raw and raw[field_key] not in (None, ""):
                 merged[field_key] = raw[field_key]
@@ -1236,6 +1313,7 @@ def _lookup_node_body(
             "output_keys": list(hit.get("output_keys") or []),
             "source_code": hit.get("source_code", ""),
             "prompt_template": hit.get("prompt_template", ""),
+            "metadata": dict(hit.get("metadata") or {}),
             "author": hit.get("author", ""),
             "approved": bool(hit.get("approved", False)),
         }, ""
@@ -1263,6 +1341,7 @@ def _lookup_node_body(
                 "output_keys": list(nd.get("output_keys") or []),
                 "source_code": nd.get("source_code", ""),
                 "prompt_template": nd.get("prompt_template", ""),
+                "metadata": dict(nd.get("metadata") or {}),
                 "author": nd.get("author", ""),
                 "approved": bool(nd.get("approved", False)),
             }, ""
@@ -1317,6 +1396,9 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
         invoke_branch_version if isinstance(invoke_branch_version, dict) else None
     )
     await_run_arg = await_run if isinstance(await_run, dict) else None
+    metadata = raw.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        return f"node '{nid}' metadata must be an object"
     try:
         node = NodeDefinition(
             node_id=nid,
@@ -1332,6 +1414,7 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
             invoke_branch_spec=invoke_branch_arg,
             invoke_branch_version_spec=invoke_branch_version_arg,
             await_run_spec=await_run_arg,
+            metadata=dict(metadata),
         )
     except ValueError as exc:
         return str(exc)
@@ -1689,6 +1772,11 @@ def _apply_patch_op(branch: Any, op: dict[str, Any]) -> str:
                     n.prompt_template = op["prompt_template"]
                 if "source_code" in op:
                     n.source_code = op["source_code"]
+                if "metadata" in op:
+                    metadata = op.get("metadata") or {}
+                    if not isinstance(metadata, dict):
+                        return "update_node metadata must be an object"
+                    n.metadata = dict(metadata)
                 if "input_keys" in op:
                     keys, err = _coerce_node_keys(
                         op["input_keys"], "input_keys",
@@ -1705,6 +1793,27 @@ def _apply_patch_op(branch: Any, op: dict[str, Any]) -> str:
                     n.output_keys = keys
                 return ""
         return f"update_node: node '{nid}' not found"
+    if name in {"set_node_metadata", "merge_node_metadata", "delete_node_metadata"}:
+        nid = (op.get("node_id") or "").strip()
+        if not nid:
+            return f"{name} requires node_id"
+        target = next((n for n in branch.node_defs if n.node_id == nid), None)
+        if target is None:
+            return f"{name}: node '{nid}' not found"
+        if name == "delete_node_metadata":
+            key = (op.get("key") or "").strip()
+            if not key:
+                return "delete_node_metadata requires key"
+            target.metadata.pop(key, None)
+            return ""
+        metadata = op.get("metadata") or {}
+        if not isinstance(metadata, dict):
+            return f"{name} requires metadata object"
+        if name == "set_node_metadata":
+            target.metadata = dict(metadata)
+        else:
+            target.metadata.update(metadata)
+        return ""
     if name == "add_skill":
         from workflow.branches import normalize_branch_skill_snapshot
 
@@ -2755,6 +2864,21 @@ extensions action=patch_branch branch_def_id=... changes_json='[
    "skill": {"name": "Review checklist",
              "body": "Check tests, code shape, and live proof."}}
 ]'
+```
+
+Per-node metadata is a generic annotation bag for domain facts, review
+state, ownership, risk, or later overlays. Keep keys domain-neutral when
+the value may be reused across branches:
+
+```
+extensions action=patch_branch branch_def_id=... changes_json='[
+  {"op": "set_node_metadata", "node_id": "novelty_check",
+   "metadata": {"risk": "high", "owner": "checker-daemon"}},
+  {"op": "merge_node_metadata", "node_id": "archive",
+   "metadata": {"stage": "publish"}},
+  {"op": "delete_node_metadata", "node_id": "archive", "key": "stage"}
+]'
+extensions action=describe_branch branch_def_id=... color_by_metadata="risk"
 ```
 
 ## Atomic actions (single-item surgery only)

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
@@ -347,6 +347,7 @@ def _extensions_impl(
     ship_class: str = "",
     changed_paths_json: str = "",
     stable_evidence_handle: str = "",
+    color_by_metadata: str = "",
 ) -> str:
     """Pattern A2 body — see ``workflow.universe_server.extensions`` for the
     chatbot-facing docstring. Behavior is identical; the decorator wrapper
@@ -395,6 +396,7 @@ def _extensions_impl(
         "query": node_query,
         "limit": limit,
         "force": force,
+        "color_by_metadata": color_by_metadata,
     }
     if node_ref_json:
         try:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branches.py
@@ -344,6 +344,10 @@ class NodeDefinition:
 
     # Quality
     evaluation_criteria: list[dict[str, str]] = field(default_factory=list)
+    # User/domain-authored per-node annotations. This is intentionally
+    # generic so overlays and later primitives can compose without baking
+    # one domain's vocabulary into NodeDefinition.
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     # Sub-branch invocation (invoke_branch node kind).
     # When set this node spawns a child branch run rather than executing an
@@ -422,6 +426,11 @@ class NodeDefinition:
                         f"[{idx}] must be a string, got "
                         f"{type(item).__name__}",
                     )
+        if not isinstance(self.metadata, dict):
+            raise NodeDefinitionValidationError(
+                "metadata",
+                f"must be a dict, got {type(self.metadata).__name__}",
+            )
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -448,6 +457,7 @@ class NodeDefinition:
             "output_keys": self.output_keys,
             "source_code": self.source_code,
             "dependencies": self.dependencies,
+            "metadata": self.metadata,
             "author": self.author,
             "registered_at": self.registered_at,
             "enabled": self.enabled,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -588,6 +588,7 @@ def extensions(
     ship_class: str = "",
     changed_paths_json: str = "",
     stable_evidence_handle: str = "",
+    color_by_metadata: str = "",
 ) -> str:
     """Workflow-builder surface: design, edit, run, judge custom AI graphs.
 
@@ -741,6 +742,7 @@ def extensions(
         ship_class=ship_class,
         changed_paths_json=changed_paths_json,
         stable_evidence_handle=stable_evidence_handle,
+        color_by_metadata=color_by_metadata,
     )
 
 

--- a/tests/test_describe_branch_approval.py
+++ b/tests/test_describe_branch_approval.py
@@ -20,6 +20,7 @@ def _make_node(node_id="n1", display_name="My Node", source_code="", approved=Fa
         "author": "anon",
         "registered_at": "",
         "enabled": True,
+        "metadata": {},
     }
 
 
@@ -55,7 +56,7 @@ def _call_validate_real(branch_dict):
     return json.loads(result)
 
 
-def _call_describe(branch_dict, validate_errors=None):
+def _call_describe(branch_dict, validate_errors=None, **kwargs):
     from workflow.api.branches import _ext_branch_describe
 
     if validate_errors is None:
@@ -72,7 +73,10 @@ def _call_describe(branch_dict, validate_errors=None):
         patch("workflow.daemon_server.list_branch_definitions", return_value=[]),
         patch("workflow.branches.BranchDefinition.validate", return_value=validate_errors),
     ):
-        result = _ext_branch_describe({"branch_def_id": branch_dict["branch_def_id"]})
+        result = _ext_branch_describe({
+            "branch_def_id": branch_dict["branch_def_id"],
+            **kwargs,
+        })
     return json.loads(result)
 
 
@@ -184,6 +188,36 @@ class TestDescribeBranchApproval:
         ids = {n["node_id"] for n in result["unapproved_source_code_nodes"]}
         assert ids == {"n1", "n3"}
         assert "n2" not in str(result["unapproved_source_code_nodes"])
+
+    def test_color_by_metadata_adds_mermaid_overlay(self):
+        nodes = [
+            {
+                **_make_node(node_id="n1", display_name="Intake"),
+                "metadata": {"risk": "high"},
+            },
+            {
+                **_make_node(node_id="n2", display_name="Review"),
+                "metadata": {"risk": "low"},
+            },
+        ]
+        branch = _make_branch_dict(node_defs=nodes)
+        result = _call_describe(branch, validate_errors=[])
+
+        assert "classDef metadata_" not in result["mermaid"]
+        assert result["metadata_color_by"] == ""
+        assert result["metadata_color_legend"] == {}
+
+        colored = _call_describe(
+            branch,
+            validate_errors=[],
+            color_by_metadata="risk",
+        )
+        assert colored["metadata_color_by"] == "risk"
+        assert set(colored["metadata_color_legend"]) == {"high", "low"}
+        assert colored["metadata_color_nodes"] == {"n1": "high", "n2": "low"}
+        assert "classDef metadata_0" in colored["mermaid"]
+        assert "class n1 metadata_0" in colored["mermaid"]
+        assert "class n2 metadata_1" in colored["mermaid"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_patch_branch_metadata.py
+++ b/tests/test_patch_branch_metadata.py
@@ -171,6 +171,92 @@ class TestPatchBranchMetadataOps:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# per-node generic metadata
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPatchBranchNodeMetadata:
+
+    def test_build_branch_persists_node_metadata(self, ext_env):
+        us, base = ext_env
+        spec = {
+            "name": "metadata-build",
+            "entry_point": "review",
+            "node_defs": [{
+                "node_id": "review",
+                "display_name": "Review",
+                "prompt_template": "review {x}",
+                "metadata": {"risk": "high", "owner": "checker"},
+            }],
+            "edges": [
+                {"from": "START", "to": "review"},
+                {"from": "review", "to": "END"},
+            ],
+            "state_schema": [{"name": "x", "type": "str"}],
+        }
+        res = _call(us, "extensions", "build_branch", spec_json=json.dumps(spec))
+        assert res["status"] == "built", res
+        loaded = _load(us, base, res["branch_def_id"])
+        assert loaded["node_defs"][0]["metadata"] == {
+            "risk": "high",
+            "owner": "checker",
+        }
+
+    def test_set_merge_delete_node_metadata_round_trips(self, ext_env):
+        us, base = ext_env
+        bid = _build(us)
+        res = _patch(us, bid, [
+            {
+                "op": "set_node_metadata",
+                "node_id": "capture",
+                "metadata": {"risk": "medium"},
+            },
+            {
+                "op": "merge_node_metadata",
+                "node_id": "capture",
+                "metadata": {"owner": "daemon-a"},
+            },
+            {
+                "op": "delete_node_metadata",
+                "node_id": "capture",
+                "key": "risk",
+            },
+        ])
+        assert res.get("status") == "patched", res
+        loaded = _load(us, base, bid)
+        assert loaded["node_defs"][0]["metadata"] == {"owner": "daemon-a"}
+
+    def test_node_metadata_patch_is_transactional(self, ext_env):
+        us, base = ext_env
+        bid = _build(us)
+        res = _patch(us, bid, [
+            {
+                "op": "set_node_metadata",
+                "node_id": "capture",
+                "metadata": {"risk": "high"},
+            },
+            {
+                "op": "merge_node_metadata",
+                "node_id": "missing",
+                "metadata": {"owner": "daemon-a"},
+            },
+        ])
+        assert res.get("status") == "rejected"
+        loaded = _load(us, base, bid)
+        assert loaded["node_defs"][0].get("metadata", {}) == {}
+
+    def test_node_metadata_rejects_non_object(self, ext_env):
+        us, _ = ext_env
+        bid = _build(us)
+        res = _patch(us, bid, [{
+            "op": "set_node_metadata",
+            "node_id": "capture",
+            "metadata": "risk=high",
+        }])
+        assert res.get("status") == "rejected"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Identity preservation + combined batches
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -738,7 +738,52 @@ def _mermaid_label(text: str) -> str:
     return text.replace('"', "'").replace("\n", " ")
 
 
-def _branch_mermaid(branch: Any) -> str:
+_METADATA_OVERLAY_COLORS = (
+    "#dbeafe", "#dcfce7", "#fef3c7", "#fee2e2",
+    "#ede9fe", "#ccfbf1", "#fce7f3", "#e5e7eb",
+)
+
+
+def _metadata_lookup(metadata: dict[str, Any], key_path: str) -> Any:
+    """Return a nested metadata value for ``key`` or ``a.b`` paths."""
+    current: Any = metadata
+    for part in key_path.split("."):
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def _metadata_color_legend(
+    branch: Any,
+    color_by_metadata: str,
+) -> tuple[dict[str, dict[str, str]], dict[str, str]]:
+    key_path = color_by_metadata.strip()
+    if not key_path:
+        return {}, {}
+
+    node_values: dict[str, str] = {}
+    ordered_values: list[str] = []
+    for node in branch.node_defs:
+        value = _metadata_lookup(getattr(node, "metadata", {}) or {}, key_path)
+        if value in (None, ""):
+            continue
+        value_text = str(value)
+        node_values[node.node_id] = value_text
+        if value_text not in ordered_values:
+            ordered_values.append(value_text)
+
+    legend: dict[str, dict[str, str]] = {}
+    for idx, value_text in enumerate(ordered_values):
+        class_name = f"metadata_{idx}"
+        legend[value_text] = {
+            "class": class_name,
+            "fill": _METADATA_OVERLAY_COLORS[idx % len(_METADATA_OVERLAY_COLORS)],
+        }
+    return legend, node_values
+
+
+def _branch_mermaid(branch: Any, *, color_by_metadata: str = "") -> str:
     """Render a BranchDefinition as a Mermaid ``flowchart LR`` block.
 
     Claude.ai and many markdown clients auto-render fenced ``mermaid``
@@ -775,6 +820,25 @@ def _branch_mermaid(branch: Any) -> str:
         for label, target in cedge.conditions.items():
             dst = _mermaid_node_id(target)
             lines.append(f"    {src} -.{_mermaid_label(label)}.-> {dst}")
+
+    if color_by_metadata:
+        legend, node_values = _metadata_color_legend(branch, color_by_metadata)
+        for value_text, item in legend.items():
+            fill = item["fill"]
+            class_name = item["class"]
+            lines.append(
+                f"    classDef {class_name} fill:{fill},stroke:#334155,stroke-width:2px"
+            )
+            lines.append(
+                f"    %% metadata {color_by_metadata}={_mermaid_label(value_text)}"
+            )
+        for node in branch.node_defs:
+            value_text = node_values.get(node.node_id)
+            if value_text is None:
+                continue
+            lines.append(
+                f"    class {_mermaid_node_id(node.node_id)} {legend[value_text]['class']}"
+            )
 
     if branch.entry_point:
         entry_id = _mermaid_node_id(branch.entry_point)
@@ -928,7 +992,16 @@ def _ext_branch_describe(kwargs: dict[str, Any]) -> str:
         else ["  (none — structure is valid)"]
     )
 
-    mermaid = _branch_mermaid(branch)
+    color_by_metadata = (
+        kwargs.get("color_by_metadata")
+        or kwargs.get("metadata_key")
+        or kwargs.get("color_by")
+        or ""
+    ).strip()
+    metadata_color_legend, metadata_node_values = _metadata_color_legend(
+        branch, color_by_metadata,
+    )
+    mermaid = _branch_mermaid(branch, color_by_metadata=color_by_metadata)
 
     summary_parts = [
         f"Branch: {branch.name or '(unnamed)'}  [{branch.branch_def_id}]",
@@ -994,6 +1067,9 @@ def _ext_branch_describe(kwargs: dict[str, Any]) -> str:
         "fork_descendants": fork_descendants,
         "related_wiki_pages": related["items"],
         "related_wiki_pages_truncated": related["truncated_count"],
+        "metadata_color_by": color_by_metadata,
+        "metadata_color_legend": metadata_color_legend,
+        "metadata_color_nodes": metadata_node_values,
     })
 
 
@@ -1173,6 +1249,7 @@ def _resolve_node_spec(
         for field_key in (
             "display_name", "description", "phase", "input_keys",
             "output_keys", "source_code", "prompt_template", "author",
+            "metadata",
         ):
             if field_key in raw and raw[field_key] not in (None, ""):
                 merged[field_key] = raw[field_key]
@@ -1236,6 +1313,7 @@ def _lookup_node_body(
             "output_keys": list(hit.get("output_keys") or []),
             "source_code": hit.get("source_code", ""),
             "prompt_template": hit.get("prompt_template", ""),
+            "metadata": dict(hit.get("metadata") or {}),
             "author": hit.get("author", ""),
             "approved": bool(hit.get("approved", False)),
         }, ""
@@ -1263,6 +1341,7 @@ def _lookup_node_body(
                 "output_keys": list(nd.get("output_keys") or []),
                 "source_code": nd.get("source_code", ""),
                 "prompt_template": nd.get("prompt_template", ""),
+                "metadata": dict(nd.get("metadata") or {}),
                 "author": nd.get("author", ""),
                 "approved": bool(nd.get("approved", False)),
             }, ""
@@ -1317,6 +1396,9 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
         invoke_branch_version if isinstance(invoke_branch_version, dict) else None
     )
     await_run_arg = await_run if isinstance(await_run, dict) else None
+    metadata = raw.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        return f"node '{nid}' metadata must be an object"
     try:
         node = NodeDefinition(
             node_id=nid,
@@ -1332,6 +1414,7 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
             invoke_branch_spec=invoke_branch_arg,
             invoke_branch_version_spec=invoke_branch_version_arg,
             await_run_spec=await_run_arg,
+            metadata=dict(metadata),
         )
     except ValueError as exc:
         return str(exc)
@@ -1689,6 +1772,11 @@ def _apply_patch_op(branch: Any, op: dict[str, Any]) -> str:
                     n.prompt_template = op["prompt_template"]
                 if "source_code" in op:
                     n.source_code = op["source_code"]
+                if "metadata" in op:
+                    metadata = op.get("metadata") or {}
+                    if not isinstance(metadata, dict):
+                        return "update_node metadata must be an object"
+                    n.metadata = dict(metadata)
                 if "input_keys" in op:
                     keys, err = _coerce_node_keys(
                         op["input_keys"], "input_keys",
@@ -1705,6 +1793,27 @@ def _apply_patch_op(branch: Any, op: dict[str, Any]) -> str:
                     n.output_keys = keys
                 return ""
         return f"update_node: node '{nid}' not found"
+    if name in {"set_node_metadata", "merge_node_metadata", "delete_node_metadata"}:
+        nid = (op.get("node_id") or "").strip()
+        if not nid:
+            return f"{name} requires node_id"
+        target = next((n for n in branch.node_defs if n.node_id == nid), None)
+        if target is None:
+            return f"{name}: node '{nid}' not found"
+        if name == "delete_node_metadata":
+            key = (op.get("key") or "").strip()
+            if not key:
+                return "delete_node_metadata requires key"
+            target.metadata.pop(key, None)
+            return ""
+        metadata = op.get("metadata") or {}
+        if not isinstance(metadata, dict):
+            return f"{name} requires metadata object"
+        if name == "set_node_metadata":
+            target.metadata = dict(metadata)
+        else:
+            target.metadata.update(metadata)
+        return ""
     if name == "add_skill":
         from workflow.branches import normalize_branch_skill_snapshot
 
@@ -2755,6 +2864,21 @@ extensions action=patch_branch branch_def_id=... changes_json='[
    "skill": {"name": "Review checklist",
              "body": "Check tests, code shape, and live proof."}}
 ]'
+```
+
+Per-node metadata is a generic annotation bag for domain facts, review
+state, ownership, risk, or later overlays. Keep keys domain-neutral when
+the value may be reused across branches:
+
+```
+extensions action=patch_branch branch_def_id=... changes_json='[
+  {"op": "set_node_metadata", "node_id": "novelty_check",
+   "metadata": {"risk": "high", "owner": "checker-daemon"}},
+  {"op": "merge_node_metadata", "node_id": "archive",
+   "metadata": {"stage": "publish"}},
+  {"op": "delete_node_metadata", "node_id": "archive", "key": "stage"}
+]'
+extensions action=describe_branch branch_def_id=... color_by_metadata="risk"
 ```
 
 ## Atomic actions (single-item surgery only)

--- a/workflow/api/extensions.py
+++ b/workflow/api/extensions.py
@@ -347,6 +347,7 @@ def _extensions_impl(
     ship_class: str = "",
     changed_paths_json: str = "",
     stable_evidence_handle: str = "",
+    color_by_metadata: str = "",
 ) -> str:
     """Pattern A2 body — see ``workflow.universe_server.extensions`` for the
     chatbot-facing docstring. Behavior is identical; the decorator wrapper
@@ -395,6 +396,7 @@ def _extensions_impl(
         "query": node_query,
         "limit": limit,
         "force": force,
+        "color_by_metadata": color_by_metadata,
     }
     if node_ref_json:
         try:

--- a/workflow/branches.py
+++ b/workflow/branches.py
@@ -344,6 +344,10 @@ class NodeDefinition:
 
     # Quality
     evaluation_criteria: list[dict[str, str]] = field(default_factory=list)
+    # User/domain-authored per-node annotations. This is intentionally
+    # generic so overlays and later primitives can compose without baking
+    # one domain's vocabulary into NodeDefinition.
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     # Sub-branch invocation (invoke_branch node kind).
     # When set this node spawns a child branch run rather than executing an
@@ -422,6 +426,11 @@ class NodeDefinition:
                         f"[{idx}] must be a string, got "
                         f"{type(item).__name__}",
                     )
+        if not isinstance(self.metadata, dict):
+            raise NodeDefinitionValidationError(
+                "metadata",
+                f"must be a dict, got {type(self.metadata).__name__}",
+            )
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -448,6 +457,7 @@ class NodeDefinition:
             "output_keys": self.output_keys,
             "source_code": self.source_code,
             "dependencies": self.dependencies,
+            "metadata": self.metadata,
             "author": self.author,
             "registered_at": self.registered_at,
             "enabled": self.enabled,

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -588,6 +588,7 @@ def extensions(
     ship_class: str = "",
     changed_paths_json: str = "",
     stable_evidence_handle: str = "",
+    color_by_metadata: str = "",
 ) -> str:
     """Workflow-builder surface: design, edit, run, judge custom AI graphs.
 
@@ -741,6 +742,7 @@ def extensions(
         ship_class=ship_class,
         changed_paths_json=changed_paths_json,
         stable_evidence_handle=stable_evidence_handle,
+        color_by_metadata=color_by_metadata,
     )
 
 


### PR DESCRIPTION
Fixes #455

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-044-per-node-generic-metadata-primitive-describe-branch-color-by.md`
- GitHub issue: #455
- Branch task: `auto-change/issue-455`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.