### PR TITLE
[auto-change] BUG-069: BUG-067 variant — chatbot wedges at access-granted-then-Thinking after substrate-changing tool call (5+ reproductions tonight; canonical session captured)

### DIFF
--- a/tests/test_universe_server_mcp_structured_results.py
+++ b/tests/test_universe_server_mcp_structured_results.py
@@ -33,3 +33,40 @@ def test_mcp_tool_result_has_structured_content_and_text_content() -> None:
     assert result.content
     assert result.content[0].type == "text"
     assert json.loads(result.content[0].text)["schema_version"] == 1
+
+
+def test_mcp_substrate_changing_tool_result_has_structured_and_text_content(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """BUG-069: substrate-changing calls must finalize on ChatGPT's strict surface."""
+    from workflow import universe_server as us
+
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("WORKFLOW_WIKI_PATH", str(tmp_path / "wiki"))
+
+    async def _call_file_bug():
+        return await us.mcp.call_tool(
+            "wiki",
+            {
+                "action": "file_bug",
+                "component": "chatgpt.workflow_connector",
+                "severity": "major",
+                "title": "BUG-069 regression probe unique substrate write",
+                "observed": (
+                    "ChatGPT showed access granted, then Thinking forever "
+                    "after a substrate-changing call."
+                ),
+                "expected": "The chatbot renders a visible final response.",
+                "force_new": True,
+            },
+        )
+
+    result = asyncio.run(_call_file_bug())
+
+    assert isinstance(result.structured_content, dict)
+    assert result.structured_content["status"] == "filed"
+    assert result.structured_content["bug_id"].startswith("BUG-")
+    assert result.content
+    assert result.content[0].type == "text"
+    assert json.loads(result.content[0].text)["status"] == "filed"


### PR DESCRIPTION
Fixes #481

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-069-bug-067-variant-chatbot-wedges-at-access-granted-then-thinki.md`
- GitHub issue: #481
- Branch task: `auto-change/issue-481`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.