### PR TITLE
Fix community loop watch stale receipt false reds

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -36,6 +36,23 @@ Format for future entries:
 
 ---
 
+## 2026-05-07 19:50 - create loop-watch-skip-receipts
+
+- Provider: codex-gpt5-desktop
+- Branch: codex/loop-watch-skip-receipts
+- Lane state: Active lane
+- Worktree: C:\Users\Jonathan\Projects\wf-loop-watch-skip-receipts
+- STATUS/Issue/PR: STATUS row "Community loop watch false-red alignment"
+- PLAN refs: Forever Rule uptime; community loop health watch
+- Purpose: align community_loop_watch with writer skip semantics and direct schedule evidence lookup.
+- _PURPOSE.md: C:\Users\Jonathan\Projects\wf-loop-watch-skip-receipts\_PURPOSE.md
+- Memory refs: Cowork checker note for PR #594; PR #597 receipt-chain landing
+- Related implications: live watch run 25533591057, stale-gate issue flood at 2026-05-08T02:39Z
+- Idea feed refs: none
+- Ship/abandon: PR pending, abandon if a newer loop-health PR covers both mismatches
+
+---
+
 ## Initial Seed - 2026-05-02
 
 Generated from `git worktree list --porcelain` during the worktree discipline

--- a/STATUS.md
+++ b/STATUS.md
@@ -20,6 +20,7 @@ Run `python scripts/claim_check.py --provider <name>` before claiming. Claim by 
 
 | Task | Files | Depends | Status |
 |------|-------|---------|--------|
+| Community loop watch false-red alignment — live run 25533591057 still red after stale-gate batch because label floods hide schedule runs and `complete`/`await-primitive-layer` skip issues count stale. | `scripts/community_loop_watch.py`, `tests/test_community_loop_watch.py` | PR #594/#597 landed | claimed:codex-gpt5-desktop ACTIVE 2026-05-07 |
 | BUG-068 Phase A loop self-learning — blocked-patterns brain page + pre-claim read/evidence convention; opposite-family review needed. | `workflow/daemon_wiki.py`, `workflow/daemon_memory.py`, `tests/test_daemon_wiki.py`, docs/spec notes | BUG-049 for closed-loop trigger proof | dev-ready |
 | Scorched exact-original proof - mount guard green; needs rights-cleared Kickstart + input/sound/tank-hit acceptance. | WebSite/site/static/play/scorched-tanks/licensed/kickstart-a500-1.3.rom (deployment-only; do not commit ROM) | rights-cleared Kickstart | host-action |
 | OpenAI/Claude directory submission host actions - dashboard `/mcp-directory` green, domain verified, Claude UI read proof captured; ChatGPT DEV still `/mcp` as of 2026-05-02T15:37; needs directory-safe web/mobile proof after re-register, logo/publisher/legal/mature approvals, Claude form submit, final submit. | OpenAI Apps dashboard; ChatGPT dev/mobile app; Claude directory form | action-time approval for uploads/legal/final submit/custom MCP warning | host-action |

--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -17,6 +17,7 @@ import argparse
 import datetime as dt
 import json
 import os
+import re
 import subprocess
 import sys
 import urllib.error
@@ -53,6 +54,7 @@ AUTH_MISSING_LABEL = "auto-fix-auth-missing"
 CLAUDE_SUBSCRIPTION_MISSING_LABEL = "auto-fix-claude-subscription-missing"
 CODEX_SUBSCRIPTION_MISSING_LABEL = "auto-fix-codex-subscription-missing"
 PROVIDER_EXHAUSTED_LABEL = "auto-fix-provider-exhausted"
+READY_FOR_CHECKER_LABEL = "ready_for_checker"
 REVIEWED_LABEL = "auto-fix-reviewed"
 ALREADY_FIXED_LABEL = "auto-fix-already-fixed"
 BLOCKED_REVIEWED_LABEL = "auto-fix-blocked"
@@ -69,6 +71,10 @@ TERMINAL_REVIEW_LABELS = frozenset(
 )
 
 STATUS_RANK = {"green": 0, "yellow": 1, "red": 2}
+CLOSING_ISSUE_RE = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(?P<number>\d+)\b",
+    re.IGNORECASE,
+)
 
 
 class WatchError(Exception):
@@ -155,6 +161,34 @@ def _gh_get(
         raise WatchError(f"GitHub response was not JSON for {path}: {exc}") from exc
 
 
+def _gh_get_paginated(
+    path: str,
+    *,
+    api: str,
+    token: str | None,
+    timeout: float,
+    params: dict[str, str | int] | None = None,
+    max_pages: int = 10,
+) -> list[dict[str, Any]]:
+    base_params: dict[str, str | int] = dict(params or {})
+    per_page = int(base_params.get("per_page", 100))
+    items: list[dict[str, Any]] = []
+    for page in range(1, max_pages + 1):
+        data = _gh_get(
+            path,
+            api=api,
+            token=token,
+            timeout=timeout,
+            params={**base_params, "page": page},
+        )
+        if not isinstance(data, list):
+            raise WatchError(f"GitHub paginated response for {path} was not a list")
+        items.extend(data)
+        if len(data) < per_page:
+            break
+    return items
+
+
 def _labels(issue: dict[str, Any]) -> set[str]:
     result = set()
     for label in issue.get("labels", []):
@@ -167,6 +201,12 @@ def _labels(issue: dict[str, Any]) -> set[str]:
 
 def _is_pr(issue: dict[str, Any]) -> bool:
     return "pull_request" in issue
+
+
+def _closing_issue_numbers(text: str | None) -> set[int]:
+    if not text:
+        return set()
+    return {int(match.group("number")) for match in CLOSING_ISSUE_RE.finditer(text)}
 
 
 def _stage(
@@ -419,7 +459,7 @@ def list_open_issues_by_label(
     token: str | None,
     timeout: float,
 ) -> list[dict[str, Any]]:
-    data = _gh_get(
+    data = _gh_get_paginated(
         f"/repos/{repo}/issues",
         api=api,
         token=token,
@@ -429,6 +469,33 @@ def list_open_issues_by_label(
     if not isinstance(data, list):
         raise WatchError(f"GitHub issues response for {label!r} was not a list")
     return [issue for issue in data if not _is_pr(issue)]
+
+
+def list_open_prs_by_closing_issue(
+    repo: str,
+    issue_numbers: set[int],
+    *,
+    api: str,
+    token: str | None,
+    timeout: float,
+) -> dict[int, list[dict[str, Any]]]:
+    if not issue_numbers:
+        return {}
+    data = _gh_get_paginated(
+        f"/repos/{repo}/issues",
+        api=api,
+        token=token,
+        timeout=timeout,
+        params={"state": "open", "per_page": 100},
+    )
+    result: dict[int, list[dict[str, Any]]] = {number: [] for number in issue_numbers}
+    for item in data:
+        if not _is_pr(item):
+            continue
+        for issue_number in _closing_issue_numbers(str(item.get("body") or "")):
+            if issue_number in result:
+                result[issue_number].append(item)
+    return {number: prs for number, prs in result.items() if prs}
 
 
 def list_loop_issues(
@@ -459,6 +526,22 @@ def queue_stage(
     max_pending_age_min: int,
 ) -> dict[str, Any]:
     issues = list_loop_issues(repo, api=api, token=token, timeout=timeout)
+    attempted_issue_numbers = {
+        issue["number"]
+        for issue in issues
+        if isinstance(issue.get("number"), int)
+        and ATTEMPTED_LABEL in _labels(issue)
+        and COMPLETE_LABEL not in _labels(issue)
+        and _labels(issue).isdisjoint(TERMINAL_REVIEW_LABELS)
+        and AWAIT_PRIMITIVE_LAYER_LABEL not in _labels(issue)
+    }
+    linked_open_prs_by_issue = list_open_prs_by_closing_issue(
+        repo,
+        attempted_issue_numbers,
+        api=api,
+        token=token,
+        timeout=timeout,
+    )
     needs_human: list[dict[str, Any]] = []
     missing_subscription: list[dict[str, Any]] = []
     missing_codex_subscription: list[dict[str, Any]] = []
@@ -468,6 +551,7 @@ def queue_stage(
     branch_push_blocked: list[dict[str, Any]] = []
     reviewed_terminal: list[dict[str, Any]] = []
     stale_gate: list[dict[str, Any]] = []
+    attempted_with_open_pr: list[dict[str, Any]] = []
     attempted: list[dict[str, Any]] = []
     pending: list[dict[str, Any]] = []
     old_pending: list[dict[str, Any]] = []
@@ -505,6 +589,15 @@ def queue_stage(
             await_primitive_layer.append(issue)
         elif ATTEMPTED_LABEL in labels:
             attempted.append(issue)
+            linked_prs = linked_open_prs_by_issue.get(issue.get("number"), [])
+            if linked_prs:
+                attempted_with_open_pr.append(
+                    {
+                        "issue": issue,
+                        "prs": linked_prs,
+                    }
+                )
+                continue
             age = _age_min(issue.get("created_at"), now)
             if STALE_GATE_LABEL in labels or age is None or age > max_pending_age_min:
                 stale_gate.append(issue)
@@ -548,6 +641,18 @@ def queue_stage(
         "reviewed_terminal": [issue.get("number") for issue in reviewed_terminal],
         "stale_gate": [issue.get("number") for issue in stale_gate],
         "attempted": [issue.get("number") for issue in attempted],
+        "attempted_with_open_pr": [
+            {
+                "issue": item["issue"].get("number"),
+                "prs": [pr.get("number") for pr in item["prs"]],
+                "ready_for_checker": [
+                    pr.get("number")
+                    for pr in item["prs"]
+                    if READY_FOR_CHECKER_LABEL in _labels(pr)
+                ],
+            }
+            for item in attempted_with_open_pr
+        ],
         "request_labels": list(REQUEST_LABELS),
     }
 
@@ -623,6 +728,36 @@ def queue_stage(
                 f"(apply {STALE_GATE_LABEL} while triaging)"
             ),
             url=first.get("html_url"),
+            details=details,
+        )
+    if attempted_with_open_pr:
+        first = attempted_with_open_pr[0]
+        first_issue = first["issue"]
+        first_prs = first["prs"]
+        ready_prs = [
+            pr.get("number")
+            for item in attempted_with_open_pr
+            for pr in item["prs"]
+            if READY_FOR_CHECKER_LABEL in _labels(pr)
+        ]
+        ready_clause = (
+            f"; {len(ready_prs)} PR(s) are {READY_FOR_CHECKER_LABEL}"
+            if ready_prs
+            else ""
+        )
+        return _stage(
+            "Writer queue",
+            "yellow",
+            (
+                f"{len(attempted_with_open_pr)} attempted loop request(s) "
+                f"already have linked open PRs awaiting review/precheck"
+                f"{ready_clause}"
+            ),
+            evidence=(
+                f"issue #{first_issue.get('number')} is linked to open PR(s) "
+                f"{', '.join('#' + str(pr.get('number')) for pr in first_prs)}"
+            ),
+            url=first_prs[0].get("html_url") or first_issue.get("html_url"),
             details=details,
         )
     if legacy_priority_migrations:

--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -433,6 +433,35 @@ def workflow_stage(
             details=details,
         )
     if max_age_min is not None and (age is None or age > max_age_min):
+        fallback_run = next(iter(fallback_candidates), None)
+        fallback_age = _age_min(fallback_run.get("created_at"), now) if fallback_run else None
+        if (
+            fallback_run is not None
+            and fallback_age is not None
+            and fallback_age <= max_age_min
+        ):
+            fallback_event = fallback_run.get("event") or "unknown event"
+            return _stage(
+                label,
+                "yellow",
+                (
+                    f"{workflow_id} {required_success_event} success is stale, "
+                    f"but recent {fallback_event} success proves the workflow is productive"
+                ),
+                evidence=(
+                    f"required {required_success_event} success was {age_text}; "
+                    f"fallback {fallback_event} success was {fallback_age:.1f} min ago"
+                ),
+                url=fallback_run.get("html_url") or run.get("html_url"),
+                details={
+                    **details,
+                    "max_age_min": max_age_min,
+                    "fallback_run_id": fallback_run.get("id"),
+                    "fallback_event": fallback_event,
+                    "fallback_created_at": fallback_run.get("created_at"),
+                    "fallback_age_min": round(fallback_age, 1),
+                },
+            )
         return _stage(
             label,
             stale_status,

--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -46,6 +46,7 @@ BLOCKED_LABEL = "needs-human"
 AWAIT_PRIMITIVE_LAYER_LABEL = "await-primitive-layer"
 ATTEMPTED_LABEL = "auto-fix-attempted"
 STALE_GATE_LABEL = "auto-fix-stale-gate"
+COMPLETE_LABEL = "complete"
 P0_OUTAGE_LABEL = "p0-outage"
 TIER3_BROKEN_LABEL = "tier3-broken"
 AUTH_MISSING_LABEL = "auto-fix-auth-missing"
@@ -195,13 +196,17 @@ def _recent_workflow_runs(
     token: str | None,
     timeout: float,
     per_page: int = 20,
+    event: str | None = None,
 ) -> list[dict[str, Any]]:
+    params: dict[str, Any] = {"per_page": per_page}
+    if event is not None:
+        params["event"] = event
     data = _gh_get(
         f"/repos/{repo}/actions/workflows/{workflow_id}/runs",
         api=api,
         token=token,
         timeout=timeout,
-        params={"per_page": per_page},
+        params=params,
     )
     runs = data.get("workflow_runs", []) if isinstance(data, dict) else []
     return runs if isinstance(runs, list) else []
@@ -255,11 +260,28 @@ def workflow_stage(
     candidates = [candidate for candidate in runs if not _is_neutral_skipped_run(candidate)]
     fallback_candidates: list[dict[str, Any]] = []
     if required_success_event is not None:
+        event_runs = _recent_workflow_runs(
+            repo,
+            workflow_id,
+            api=api,
+            token=token,
+            timeout=timeout,
+            per_page=per_page,
+            event=required_success_event,
+        )
+        skipped_event_runs = [
+            candidate
+            for candidate in event_runs
+            if _is_neutral_skipped_run(candidate)
+            and candidate.get("event") == required_success_event
+        ]
         candidates = [
             candidate
-            for candidate in candidates
-            if candidate.get("event") == required_success_event
+            for candidate in event_runs
+            if not _is_neutral_skipped_run(candidate)
+            and candidate.get("event") == required_success_event
         ]
+        skipped_runs = skipped_event_runs
         fallback_candidates = [
             candidate
             for candidate in runs
@@ -282,6 +304,7 @@ def workflow_stage(
                 "latest_conclusion": latest.get("conclusion"),
                 "latest_created_at": latest.get("created_at"),
                 "checked_run_count": len(runs),
+                "checked_required_event_run_count": len(event_runs),
                 "ignored_skipped_run_ids": [
                     skipped.get("id") for skipped in skipped_runs
                 ],
@@ -476,15 +499,15 @@ def queue_stage(
                 branch_push_blocked.append(issue)
             if PROVIDER_EXHAUSTED_LABEL in labels:
                 provider_exhausted.append(issue)
-        elif not labels.isdisjoint(TERMINAL_REVIEW_LABELS):
+        elif COMPLETE_LABEL in labels or not labels.isdisjoint(TERMINAL_REVIEW_LABELS):
             reviewed_terminal.append(issue)
+        elif AWAIT_PRIMITIVE_LAYER_LABEL in labels:
+            await_primitive_layer.append(issue)
         elif ATTEMPTED_LABEL in labels:
             attempted.append(issue)
             age = _age_min(issue.get("created_at"), now)
             if STALE_GATE_LABEL in labels or age is None or age > max_pending_age_min:
                 stale_gate.append(issue)
-        elif AWAIT_PRIMITIVE_LAYER_LABEL in labels:
-            await_primitive_layer.append(issue)
         else:
             pending.append(issue)
             age = _age_min(issue.get("created_at"), now)

--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -33,6 +33,7 @@ WORKFLOWS = {
     "intake": "wiki-bug-sync.yml",
     "writer": "auto-fix-bug.yml",
     "observation": "uptime-canary.yml",
+    "tier3": "tier3-oss-clone-nightly.yml",
     "deploy_prod": "deploy-prod.yml",
     "deploy_site": "deploy-site.yml",
 }
@@ -885,6 +886,54 @@ def tier3_clone_smoke_stage(
     )
     if issues:
         issue = issues[0]
+        latest_run = _latest_workflow_run(
+            repo,
+            WORKFLOWS["tier3"],
+            api=api,
+            token=token,
+            timeout=timeout,
+        )
+        latest_run_time = _parse_time(latest_run.get("created_at")) if latest_run else None
+        issue_times = [
+            parsed
+            for parsed in (
+                _parse_time(item.get("created_at") or item.get("updated_at"))
+                for item in issues
+            )
+            if parsed is not None
+        ]
+        newest_issue_time = max(issue_times) if issue_times else None
+        if (
+            latest_run is not None
+            and latest_run.get("status") == "completed"
+            and latest_run.get("conclusion") == "success"
+            and latest_run_time is not None
+            and newest_issue_time is not None
+            and latest_run_time > newest_issue_time
+        ):
+            return _stage(
+                "Tier-3 clone smoke",
+                "yellow",
+                (
+                    f"latest {WORKFLOWS['tier3']} success is newer than "
+                    f"{len(issues)} open {TIER3_BROKEN_LABEL} issue(s)"
+                ),
+                evidence=(
+                    f"latest successful tier-3 run {latest_run.get('id')} at "
+                    f"{latest_run.get('created_at')}; newest open issue "
+                    f"#{issue.get('number')}: {issue.get('title')}"
+                ),
+                url=latest_run.get("html_url") or issue.get("html_url"),
+                details={
+                    "open_tier3_broken": [i.get("number") for i in issues],
+                    "latest_run_id": latest_run.get("id"),
+                    "latest_run_conclusion": latest_run.get("conclusion"),
+                    "latest_run_created_at": latest_run.get("created_at"),
+                    "newest_issue_at": newest_issue_time.isoformat().replace(
+                        "+00:00", "Z"
+                    ),
+                },
+            )
         return _stage(
             "Tier-3 clone smoke",
             "red",

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -55,6 +55,48 @@ def test_github_token_returns_none_when_gh_cli_unavailable(monkeypatch):
     assert watch._github_token(argparse.Namespace(token=None)) is None
 
 
+def test_closing_issue_numbers_accepts_common_closing_keywords():
+    assert watch._closing_issue_numbers("Fixes #568\nCloses #12; resolves #7") == {
+        568,
+        12,
+        7,
+    }
+
+
+def test_list_open_prs_by_closing_issue_maps_linked_prs(monkeypatch):
+    def fake_gh_get(path, **kwargs):
+        assert path == "/repos/owner/repo/issues"
+        assert kwargs["params"]["state"] == "open"
+        return [
+            {
+                "number": 598,
+                "body": "Fixes #568",
+                "html_url": "https://example.test/pull/598",
+                "pull_request": {},
+                "labels": [{"name": watch.READY_FOR_CHECKER_LABEL}],
+            },
+            {
+                "number": 568,
+                "body": "Bug body mentioning Fixes #999 should not count",
+                "html_url": "https://example.test/issues/568",
+                "labels": [{"name": "daemon-request"}],
+            },
+        ]
+
+    monkeypatch.setattr(watch, "_gh_get", fake_gh_get)
+
+    result = watch.list_open_prs_by_closing_issue(
+        "owner/repo",
+        {568, 999},
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+    )
+
+    assert list(result) == [568]
+    assert result[568][0]["number"] == 598
+
+
 def test_workflow_stage_ignores_neutral_skipped_runs(monkeypatch):
     now = dt.datetime(2026, 5, 1, 5, 10, tzinfo=dt.timezone.utc)
 
@@ -483,6 +525,7 @@ def test_queue_stage_treats_attempted_loop_smoke_as_not_waiting(monkeypatch):
         ]
 
     monkeypatch.setattr(watch, "list_loop_issues", fake_list_loop_issues)
+    monkeypatch.setattr(watch, "list_open_prs_by_closing_issue", lambda *_, **__: {})
 
     stage = watch.queue_stage(
         "owner/repo",
@@ -519,6 +562,7 @@ def test_queue_stage_marks_old_attempted_without_terminal_review_red(monkeypatch
         ]
 
     monkeypatch.setattr(watch, "list_loop_issues", fake_list_loop_issues)
+    monkeypatch.setattr(watch, "list_open_prs_by_closing_issue", lambda *_, **__: {})
 
     stage = watch.queue_stage(
         "owner/repo",
@@ -533,6 +577,58 @@ def test_queue_stage_marks_old_attempted_without_terminal_review_red(monkeypatch
     assert stage["details"]["attempted"] == [589]
     assert stage["details"]["stale_gate"] == [589]
     assert watch.STALE_GATE_LABEL in stage["evidence"]
+
+
+def test_queue_stage_treats_attempted_with_open_pr_as_review_waiting(monkeypatch):
+    now = dt.datetime(2026, 5, 8, 3, 30, tzinfo=dt.timezone.utc)
+
+    def fake_list_loop_issues(*_args, **_kwargs):
+        return [
+            {
+                "number": 568,
+                "title": "Attempted request with linked PR",
+                "created_at": "2026-05-07T23:00:00Z",
+                "html_url": "https://example.test/issues/568",
+                "labels": [
+                    {"name": "daemon-request"},
+                    {"name": "auto-change"},
+                    {"name": watch.ATTEMPTED_LABEL},
+                    {"name": watch.STALE_GATE_LABEL},
+                ],
+            }
+        ]
+
+    def fake_open_prs_by_issue(*_args, **_kwargs):
+        return {
+            568: [
+                {
+                    "number": 598,
+                    "html_url": "https://example.test/pull/598",
+                    "labels": [{"name": watch.READY_FOR_CHECKER_LABEL}],
+                }
+            ]
+        }
+
+    monkeypatch.setattr(watch, "list_loop_issues", fake_list_loop_issues)
+    monkeypatch.setattr(watch, "list_open_prs_by_closing_issue", fake_open_prs_by_issue)
+
+    stage = watch.queue_stage(
+        "owner/repo",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+        now=now,
+        max_pending_age_min=45,
+    )
+
+    assert stage["status"] == "yellow"
+    assert stage["details"]["attempted"] == [568]
+    assert stage["details"]["stale_gate"] == []
+    assert stage["details"]["attempted_with_open_pr"] == [
+        {"issue": 568, "prs": [598], "ready_for_checker": [598]}
+    ]
+    assert "linked open PRs" in stage["summary"]
+    assert stage["url"] == "https://example.test/pull/598"
 
 
 def test_queue_stage_treats_await_primitive_layer_as_deferred_not_stuck(

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -858,6 +858,7 @@ def test_tier3_broken_issue_marks_clone_smoke_stage_red(monkeypatch):
     monkeypatch.setattr(
         watch, "list_open_issues_by_label", fake_list_open_issues_by_label
     )
+    monkeypatch.setattr(watch, "_latest_workflow_run", lambda *_, **__: None)
 
     stage = watch.tier3_clone_smoke_stage(
         "owner/repo",
@@ -869,6 +870,46 @@ def test_tier3_broken_issue_marks_clone_smoke_stage_red(monkeypatch):
     assert stage["status"] == "red"
     assert stage["details"]["open_tier3_broken"] == [521]
     assert "Forever Rule" in stage["summary"]
+
+
+def test_tier3_broken_issues_are_yellow_when_newer_smoke_success_exists(
+    monkeypatch,
+):
+    def fake_list_open_issues_by_label(*_args, **_kwargs):
+        return [
+            {
+                "number": 506,
+                "title": "Tier-3 OSS clone smoke failed",
+                "created_at": "2026-05-06T09:37:32Z",
+                "html_url": "https://example.test/issues/506",
+            }
+        ]
+
+    def fake_latest_workflow_run(*_args, **_kwargs):
+        return {
+            "id": 25488453292,
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-05-07T09:46:45Z",
+            "html_url": "https://example.test/runs/25488453292",
+        }
+
+    monkeypatch.setattr(
+        watch, "list_open_issues_by_label", fake_list_open_issues_by_label
+    )
+    monkeypatch.setattr(watch, "_latest_workflow_run", fake_latest_workflow_run)
+
+    stage = watch.tier3_clone_smoke_stage(
+        "owner/repo",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+    )
+
+    assert stage["status"] == "yellow"
+    assert stage["details"]["open_tier3_broken"] == [506]
+    assert stage["details"]["latest_run_id"] == 25488453292
+    assert "newer than 1 open" in stage["summary"]
 
 
 def test_build_status_is_red_when_tier3_broken_issue_is_open(monkeypatch):

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -281,6 +281,66 @@ def test_writer_stage_uses_scheduled_success_when_other_runs_are_newer(monkeypat
     assert stage["details"]["required_success_event"] == "schedule"
 
 
+def test_writer_stage_fetches_required_event_when_general_runs_are_flooded(
+    monkeypatch,
+):
+    now = dt.datetime(2026, 5, 8, 2, 41, tzinfo=dt.timezone.utc)
+    calls = []
+
+    def fake_gh_get(*_args, **kwargs):
+        params = kwargs.get("params", {})
+        calls.append(params)
+        if params.get("event") == "schedule":
+            return {
+                "workflow_runs": [
+                    {
+                        "id": 90,
+                        "status": "completed",
+                        "conclusion": "success",
+                        "created_at": "2026-05-08T01:52:00Z",
+                        "updated_at": "2026-05-08T01:56:00Z",
+                        "event": "schedule",
+                        "html_url": "https://example.test/scheduled-success",
+                    }
+                ]
+            }
+        return {
+            "workflow_runs": [
+                {
+                    "id": issue_run_id,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "created_at": "2026-05-08T02:39:00Z",
+                    "updated_at": "2026-05-08T02:39:10Z",
+                    "event": "issues",
+                    "html_url": f"https://example.test/issues-run-{issue_run_id}",
+                }
+                for issue_run_id in range(100, 200)
+            ]
+        }
+
+    monkeypatch.setattr(watch, "_gh_get", fake_gh_get)
+
+    stage = watch.workflow_stage(
+        "Writer workflow",
+        "owner/repo",
+        "auto-fix-bug.yml",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+        now=now,
+        max_age_min=90,
+        required_success_event="schedule",
+        fallback_success_events=("workflow_dispatch", "issues"),
+        per_page=100,
+    )
+
+    assert stage["status"] == "green"
+    assert stage["details"]["run_id"] == 90
+    assert stage["details"]["required_success_event"] == "schedule"
+    assert any(call.get("event") == "schedule" for call in calls)
+
+
 def test_queue_stage_counts_push_blocked_issue_as_needs_human(monkeypatch):
     now = dt.datetime(2026, 5, 5, 4, 20, tzinfo=dt.timezone.utc)
 
@@ -512,6 +572,82 @@ def test_queue_stage_treats_await_primitive_layer_as_deferred_not_stuck(
     assert stage["details"]["old_pending"] == []
     assert stage["details"]["await_primitive_layer"] == [541]
     assert "intentionally waiting" in stage["summary"]
+
+
+def test_queue_stage_treats_attempted_await_primitive_layer_as_deferred(
+    monkeypatch,
+):
+    now = dt.datetime(2026, 5, 7, 3, 40, tzinfo=dt.timezone.utc)
+
+    def fake_list_loop_issues(*_args, **_kwargs):
+        return [
+            {
+                "number": 376,
+                "title": "Attempted request waits for primitive layer",
+                "created_at": "2026-05-06T23:46:00Z",
+                "html_url": "https://example.test/issues/376",
+                "labels": [
+                    {"name": "daemon-request"},
+                    {"name": "auto-change"},
+                    {"name": watch.ATTEMPTED_LABEL},
+                    {"name": watch.STALE_GATE_LABEL},
+                    {"name": watch.AWAIT_PRIMITIVE_LAYER_LABEL},
+                ],
+            }
+        ]
+
+    monkeypatch.setattr(watch, "list_loop_issues", fake_list_loop_issues)
+
+    stage = watch.queue_stage(
+        "owner/repo",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+        now=now,
+        max_pending_age_min=45,
+    )
+
+    assert stage["status"] == "yellow"
+    assert stage["details"]["attempted"] == []
+    assert stage["details"]["stale_gate"] == []
+    assert stage["details"]["await_primitive_layer"] == [376]
+
+
+def test_queue_stage_treats_complete_attempted_issue_as_terminal(monkeypatch):
+    now = dt.datetime(2026, 5, 8, 2, 41, tzinfo=dt.timezone.utc)
+
+    def fake_list_loop_issues(*_args, **_kwargs):
+        return [
+            {
+                "number": 300,
+                "title": "Completed request should not keep stale gate red",
+                "created_at": "2026-05-05T03:00:00Z",
+                "html_url": "https://example.test/issues/300",
+                "labels": [
+                    {"name": "daemon-request"},
+                    {"name": "auto-change"},
+                    {"name": watch.ATTEMPTED_LABEL},
+                    {"name": watch.STALE_GATE_LABEL},
+                    {"name": watch.COMPLETE_LABEL},
+                ],
+            }
+        ]
+
+    monkeypatch.setattr(watch, "list_loop_issues", fake_list_loop_issues)
+
+    stage = watch.queue_stage(
+        "owner/repo",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+        now=now,
+        max_pending_age_min=45,
+    )
+
+    assert stage["status"] == "green"
+    assert stage["details"]["attempted"] == []
+    assert stage["details"]["stale_gate"] == []
+    assert stage["details"]["reviewed_terminal"] == [300]
 
 
 def test_queue_stage_maps_legacy_priority_labels_before_pending_stuck(monkeypatch):

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -277,6 +277,62 @@ def test_writer_stage_downgrades_cancelled_schedule_when_dispatch_succeeds(
     assert stage["details"]["fallback_event"] == "workflow_dispatch"
 
 
+def test_writer_stage_downgrades_stale_schedule_when_issue_run_succeeds(
+    monkeypatch,
+):
+    now = dt.datetime(2026, 5, 8, 3, 30, tzinfo=dt.timezone.utc)
+
+    def fake_gh_get(*_args, **kwargs):
+        params = kwargs.get("params", {})
+        scheduled = {
+            "id": 44,
+            "status": "completed",
+            "conclusion": "success",
+            "created_at": "2026-05-08T00:10:00Z",
+            "updated_at": "2026-05-08T00:14:00Z",
+            "event": "schedule",
+            "html_url": "https://example.test/scheduled-success",
+        }
+        if params.get("event") == "schedule":
+            return {"workflow_runs": [scheduled]}
+        return {
+            "workflow_runs": [
+                {
+                    "id": 45,
+                    "status": "completed",
+                    "conclusion": "success",
+                    "created_at": "2026-05-08T02:39:00Z",
+                    "updated_at": "2026-05-08T02:40:00Z",
+                    "event": "issues",
+                    "html_url": "https://example.test/issues-success",
+                },
+                scheduled,
+            ]
+        }
+
+    monkeypatch.setattr(watch, "_gh_get", fake_gh_get)
+
+    stage = watch.workflow_stage(
+        "Writer workflow",
+        "owner/repo",
+        "auto-fix-bug.yml",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+        now=now,
+        max_age_min=90,
+        required_success_event="schedule",
+        fallback_success_events=("workflow_dispatch", "issues"),
+    )
+
+    assert stage["status"] == "yellow"
+    assert "success is stale" in stage["summary"]
+    assert "workflow is productive" in stage["summary"]
+    assert stage["details"]["run_id"] == 44
+    assert stage["details"]["fallback_run_id"] == 45
+    assert stage["details"]["fallback_event"] == "issues"
+
+
 def test_writer_stage_uses_scheduled_success_when_other_runs_are_newer(monkeypatch):
     now = dt.datetime(2026, 5, 5, 0, 0, tzinfo=dt.timezone.utc)
 


### PR DESCRIPTION
## Summary

- Make `community_loop_watch` fetch the required writer `schedule` event directly instead of relying only on the mixed recent-runs page, which can be flooded by issue-label events.
- Downgrade stale writer `schedule` freshness to yellow when a recent `workflow_dispatch`/`issues` success proves the writer workflow is still productive; stale scheduler freshness remains visible in details.
- Align queue classification with auto-fix discovery skip semantics: `complete` attempted issues are terminal, and `await-primitive-layer` attempted issues are deferred/yellow instead of stale-gate red.
- Classify attempted issues that already have linked open PRs as review/precheck waiting instead of writer-stuck red; keep attempted issues with no PR red.
- Downgrade stale `tier3-broken` alarm issues to yellow when the latest tier3 clone smoke run is a newer success than the open issues.
- Add regression tests for the live failure classes seen in community-loop watch runs `25533591057` and `2026-05-08T03:39Z` local live checks.

## Live evidence

Before this patch, the watch reported 42 stale attempted issues after the stale-gate label batch. The first patch reduced that false stale bucket to 18 by removing `complete` and `await-primitive-layer` skip/defer issues from the red stale class.

A second live check showed all remaining 18 stale-gate issues have linked open PRs (#598, #562, #565, #559, #552, #514, #513, #512, #511, #510, #509, #468, #561, #463, #448, #447, #560, #446). Running the patched watcher locally now reports the writer queue yellow: `18 attempted loop request(s) already have linked open PRs awaiting review/precheck; 1 PR(s) are ready_for_checker`.

A third live check showed `auto-fix-bug.yml` scheduled success is stale, but recent `issues` success run `25533549650` proves the writer workflow is productive. The patched watcher reports Writer workflow yellow instead of red, preserving scheduler freshness drift in `fallback_*` details.

A fourth live check showed tier3 clone smoke latest run `25488453292` succeeded on 2026-05-07, newer than the newest open `tier3-broken` issue (#506 from 2026-05-06). The patched watcher reports tier3 yellow stale-alarm cleanup, not red current clone breakage.

After manually dispatching stale `wiki-bug-sync.yml` and `uptime-canary.yml` workflows, `python scripts/community_loop_watch.py --json` reports overall yellow: intake green, observation green, production deploy green, website deploy green; writer workflow yellow, writer queue yellow, tier3 yellow.

## Verification

- `python -m pytest tests/test_community_loop_watch.py` — 26 passed
- `python -m py_compile scripts/community_loop_watch.py tests/test_community_loop_watch.py` — passed
- `python -m ruff check scripts/community_loop_watch.py tests/test_community_loop_watch.py` — passed
- `python scripts/community_loop_watch.py --json` — exit 0 / overall yellow with the live state above

## Gate note

Codex-written PR. Needs Claude/Cowork checker review and explicit host merge key before merge.