### PR TITLE
Fix community loop watch PR lookup in Actions

### DIFF
--- a/.github/workflows/community-loop-watch.yml
+++ b/.github/workflows/community-loop-watch.yml
@@ -24,6 +24,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: read
   actions: write
 
 concurrency:

--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -512,7 +512,7 @@ def list_open_prs_by_closing_issue(
     if not issue_numbers:
         return {}
     data = _gh_get_paginated(
-        f"/repos/{repo}/issues",
+        f"/repos/{repo}/pulls",
         api=api,
         token=token,
         timeout=timeout,
@@ -520,8 +520,6 @@ def list_open_prs_by_closing_issue(
     )
     result: dict[int, list[dict[str, Any]]] = {number: [] for number in issue_numbers}
     for item in data:
-        if not _is_pr(item):
-            continue
         for issue_number in _closing_issue_numbers(str(item.get("body") or "")):
             if issue_number in result:
                 result[issue_number].append(item)

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import subprocess
+from pathlib import Path
 
 from scripts import community_loop_watch as watch
 
@@ -65,21 +66,20 @@ def test_closing_issue_numbers_accepts_common_closing_keywords():
 
 def test_list_open_prs_by_closing_issue_maps_linked_prs(monkeypatch):
     def fake_gh_get(path, **kwargs):
-        assert path == "/repos/owner/repo/issues"
+        assert path == "/repos/owner/repo/pulls"
         assert kwargs["params"]["state"] == "open"
         return [
             {
                 "number": 598,
                 "body": "Fixes #568",
                 "html_url": "https://example.test/pull/598",
-                "pull_request": {},
                 "labels": [{"name": watch.READY_FOR_CHECKER_LABEL}],
             },
             {
-                "number": 568,
-                "body": "Bug body mentioning Fixes #999 should not count",
-                "html_url": "https://example.test/issues/568",
-                "labels": [{"name": "daemon-request"}],
+                "number": 599,
+                "body": "Mentions #999 without a closing keyword",
+                "html_url": "https://example.test/pull/599",
+                "labels": [],
             },
         ]
 
@@ -95,6 +95,14 @@ def test_list_open_prs_by_closing_issue_maps_linked_prs(monkeypatch):
 
     assert list(result) == [568]
     assert result[568][0]["number"] == 598
+
+
+def test_community_loop_watch_workflow_can_read_pull_requests():
+    workflow = Path(".github/workflows/community-loop-watch.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "pull-requests: read" in workflow
 
 
 def test_workflow_stage_ignores_neutral_skipped_runs(monkeypatch):


### PR DESCRIPTION
Follow-up to #677. After #677 merged, the local watcher exited 0/yellow, but the GitHub Actions Community loop watch still failed because the Actions run could not populate attempted_with_open_pr.\n\nThis patch makes the linked-open-PR lookup use the pulls API directly and grants the watch workflow pull-requests: read, so CI has the same PR metadata surface the operator run used.\n\nVerification:\n- python -m pytest tests/test_community_loop_watch.py — 27 passed\n- python -m py_compile scripts/community_loop_watch.py tests/test_community_loop_watch.py — passed\n- python -m ruff check scripts/community_loop_watch.py tests/test_community_loop_watch.py — passed\n- python scripts/community_loop_watch.py --json — exit 0 / overall yellow\n\nCodex-written operator PR. Needs Cowork/Claude checker key and explicit host key before merge.