### PR TITLE
[auto-change] BUG-074: worktree_status.py crashes in default Windows PowerShell on non-CP1252 characters instead of emitting UTF-8 safely

### DIFF
--- a/scripts/worktree_status.py
+++ b/scripts/worktree_status.py
@@ -8,6 +8,7 @@ collisions; this script owns persistent local directories created by
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import shlex
 import subprocess
@@ -53,6 +54,36 @@ STATE_MAP_NOTE = (
     "READY_TO_REMOVE are action-required intermediates. "
     "Idea/reference-only lanes live in ideas/*.md or _PURPOSE.md idea refs."
 )
+
+
+def _force_utf8_stdio() -> None:
+    """Keep Windows console encodings from crashing on non-ASCII output."""
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name)
+        encoding = (getattr(stream, "encoding", None) or "").lower().replace("_", "-")
+        if encoding == "utf-8":
+            continue
+        if hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+                continue
+            except (AttributeError, ValueError, OSError):
+                pass
+        buffer = getattr(stream, "buffer", None)
+        if buffer is not None:
+            try:
+                setattr(
+                    sys,
+                    stream_name,
+                    io.TextIOWrapper(
+                        buffer,
+                        encoding="utf-8",
+                        errors="replace",
+                        line_buffering=True,
+                    ),
+                )
+            except (AttributeError, ValueError, OSError):
+                pass
 
 
 @dataclass
@@ -529,6 +560,7 @@ def _branch_can_be_deleted(branch: str) -> bool:
 
 
 def main(argv: list[str]) -> int:
+    _force_utf8_stdio()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="Emit JSON instead of a table.")
     parser.add_argument("--provider", help="Filter by provider/branch/slug substring.")

--- a/tests/test_worktree_status.py
+++ b/tests/test_worktree_status.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import subprocess
 import sys
 from pathlib import Path
@@ -268,6 +269,44 @@ def test_render_table_includes_state_branch_and_purpose() -> None:
     assert "Pickup through STATUS" in table
     assert "demo purpose" in table
     assert "state map" in table
+
+
+def test_force_utf8_stdio_reconfigures_narrow_windows_streams(monkeypatch) -> None:
+    class NarrowStream:
+        encoding = "cp1252"
+
+        def __init__(self) -> None:
+            self.reconfigured_to: str | None = None
+
+        def reconfigure(self, *, encoding: str) -> None:
+            self.reconfigured_to = encoding
+
+    stdout = NarrowStream()
+    stderr = NarrowStream()
+    monkeypatch.setattr(worktree_status.sys, "stdout", stdout)
+    monkeypatch.setattr(worktree_status.sys, "stderr", stderr)
+
+    worktree_status._force_utf8_stdio()
+
+    assert stdout.reconfigured_to == "utf-8"
+    assert stderr.reconfigured_to == "utf-8"
+
+
+def test_force_utf8_stdio_wraps_legacy_stream_buffer(monkeypatch) -> None:
+    class LegacyNarrowStream:
+        encoding = "cp1252"
+
+        def __init__(self) -> None:
+            self.buffer = io.BytesIO()
+
+    stdout = LegacyNarrowStream()
+    monkeypatch.setattr(worktree_status.sys, "stdout", stdout)
+
+    worktree_status._force_utf8_stdio()
+    worktree_status.sys.stdout.write("branch → ready\n")
+    worktree_status.sys.stdout.flush()
+
+    assert stdout.buffer.getvalue().decode("utf-8") == "branch → ready\n"
 
 
 def test_memory_refs_read_from_purpose_file(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #691

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-074-worktree-status-py-crashes-in-default-windows-powershell-on-.md`
- GitHub issue: #691
- Branch task: `auto-change/issue-691`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.