### PR TITLE
[auto-change] WIKI-PATCH: PR-055: Render-to-shareable-artifact via read.page format= parameter (refile of #470 shape under 5-handle surface)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -475,10 +475,18 @@ def _wiki_read(
     query: str = "",
     changed_since: str = "",
     max_results: int = 10,
+    format: str = "",
     **_kwargs: Any,
 ) -> str:
     if not page:
         return json.dumps({"error": "page parameter is required."})
+
+    read_format = (format or "json").strip().lower()
+    if read_format not in {"json", "artifact"}:
+        return json.dumps({
+            "error": f"Unsupported read format: {read_format}",
+            "available_formats": ["artifact", "json"],
+        })
 
     resolved = _resolve_page(page)
     if resolved is None:
@@ -506,9 +514,10 @@ def _wiki_read(
         source_meta=meta,
         source_body=body,
     )
+    result: dict[str, Any]
 
     if len(text) > 15000:
-        return json.dumps({
+        result = {
             "path": rel,
             "is_draft": is_draft,
             "content": content[:15000],
@@ -516,15 +525,57 @@ def _wiki_read(
             "total_chars": len(text),
             "source_read_proof": source_read_proof,
             "ambient_relevance_feed": ambient_feed,
-        })
-    return json.dumps({
-        "path": rel,
-        "is_draft": is_draft,
+        }
+    else:
+        result = {
+            "path": rel,
+            "is_draft": is_draft,
+            "content": content,
+            "truncated": False,
+            "source_read_proof": source_read_proof,
+            "ambient_relevance_feed": ambient_feed,
+        }
+
+    if read_format == "artifact":
+        title = meta.get("title") or resolved.stem
+        artifact = _wiki_page_artifact(
+            title=title,
+            body=body,
+            rel_path=rel,
+            filename=resolved.name,
+            is_draft=is_draft,
+        )
+        result["format"] = "artifact"
+        result["artifact"] = artifact
+        result["text"] = (
+            f"**{title}** is ready as a shareable Markdown artifact.\n\n"
+            f"Source: `{rel}`"
+        )
+
+    return json.dumps(result)
+
+
+def _wiki_page_artifact(
+    *,
+    title: str,
+    body: str,
+    rel_path: str,
+    filename: str,
+    is_draft: bool,
+) -> dict[str, str]:
+    content = body.strip()
+    if content and not content.startswith("#"):
+        content = f"# {title}\n\n{content}"
+    if is_draft and not content.startswith("[DRAFT]"):
+        content = "[DRAFT] " + content
+    return {
+        "kind": "markdown",
+        "title": title,
+        "filename": filename,
+        "mime_type": "text/markdown",
         "content": content,
-        "truncated": False,
-        "source_read_proof": source_read_proof,
-        "ambient_relevance_feed": ambient_feed,
-    })
+        "source_path": rel_path,
+    }
 
 
 def _draft_read_content(text: str, *, is_draft: bool) -> str:
@@ -1961,6 +2012,7 @@ def wiki(
     action: str,
     page: str = "",
     query: str = "",
+    format: str = "",
     category: str = "",
     filename: str = "",
     content: str = "",
@@ -2057,6 +2109,7 @@ def wiki(
     kwargs: dict[str, Any] = {
         "page": page,
         "query": query,
+        "format": format,
         "category": category,
         "filename": filename,
         "content": content,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -911,6 +911,7 @@ def wiki(
     action: str,
     page: str = "",
     query: str = "",
+    format: str = "",
     category: str = "",
     filename: str = "",
     content: str = "",
@@ -962,6 +963,9 @@ def wiki(
             `search` is lexical best-effort, not a completeness proof; use
             `since` with `changed_since` to review pages updated after a known
             timestamp, then `read` the candidate pages.
+        format: Optional read output format. For action="read", use
+            format="artifact" to include a shareable Markdown artifact
+            envelope alongside the normal read payload.
         old_text/new_text: For action="patch", exact text to replace server-side.
         expected_sha256: Optional full-page hash guard for action="patch".
         changed_since: Optional ISO timestamp for action="read" ambient feed
@@ -972,6 +976,7 @@ def wiki(
         action=action,
         page=page,
         query=query,
+        format=format,
         category=category,
         filename=filename,
         content=content,

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -182,6 +182,28 @@ class TestWikiRead:
         assert result["content"].startswith("[DRAFT] # Pending Concept")
         assert not result["content"].startswith("[DRAFT] [DRAFT]")
 
+    def test_read_page_as_shareable_artifact(self, wiki_dir):
+        result = json.loads(wiki("read", page="test-project", format="artifact"))
+
+        assert result["format"] == "artifact"
+        assert result["content"].startswith("---\ntitle: Test Project")
+        assert result["artifact"] == {
+            "kind": "markdown",
+            "title": "Test Project",
+            "filename": "test-project.md",
+            "mime_type": "text/markdown",
+            "content": "# Test Project\n\nA test project for unit tests.\n\n"
+            "## See Also\n\n- [[workflow-engine]]",
+            "source_path": "pages/projects/test-project.md",
+        }
+        assert result["text"].startswith("**Test Project**")
+
+    def test_read_page_rejects_unknown_format(self, wiki_dir):
+        result = json.loads(wiki("read", page="test-project", format="pdf"))
+
+        assert result["error"] == "Unsupported read format: pdf"
+        assert result["available_formats"] == ["artifact", "json"]
+
 
 class TestWikiList:
     def test_list_pages(self, wiki_dir):

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -475,10 +475,18 @@ def _wiki_read(
     query: str = "",
     changed_since: str = "",
     max_results: int = 10,
+    format: str = "",
     **_kwargs: Any,
 ) -> str:
     if not page:
         return json.dumps({"error": "page parameter is required."})
+
+    read_format = (format or "json").strip().lower()
+    if read_format not in {"json", "artifact"}:
+        return json.dumps({
+            "error": f"Unsupported read format: {read_format}",
+            "available_formats": ["artifact", "json"],
+        })
 
     resolved = _resolve_page(page)
     if resolved is None:
@@ -506,9 +514,10 @@ def _wiki_read(
         source_meta=meta,
         source_body=body,
     )
+    result: dict[str, Any]
 
     if len(text) > 15000:
-        return json.dumps({
+        result = {
             "path": rel,
             "is_draft": is_draft,
             "content": content[:15000],
@@ -516,15 +525,57 @@ def _wiki_read(
             "total_chars": len(text),
             "source_read_proof": source_read_proof,
             "ambient_relevance_feed": ambient_feed,
-        })
-    return json.dumps({
-        "path": rel,
-        "is_draft": is_draft,
+        }
+    else:
+        result = {
+            "path": rel,
+            "is_draft": is_draft,
+            "content": content,
+            "truncated": False,
+            "source_read_proof": source_read_proof,
+            "ambient_relevance_feed": ambient_feed,
+        }
+
+    if read_format == "artifact":
+        title = meta.get("title") or resolved.stem
+        artifact = _wiki_page_artifact(
+            title=title,
+            body=body,
+            rel_path=rel,
+            filename=resolved.name,
+            is_draft=is_draft,
+        )
+        result["format"] = "artifact"
+        result["artifact"] = artifact
+        result["text"] = (
+            f"**{title}** is ready as a shareable Markdown artifact.\n\n"
+            f"Source: `{rel}`"
+        )
+
+    return json.dumps(result)
+
+
+def _wiki_page_artifact(
+    *,
+    title: str,
+    body: str,
+    rel_path: str,
+    filename: str,
+    is_draft: bool,
+) -> dict[str, str]:
+    content = body.strip()
+    if content and not content.startswith("#"):
+        content = f"# {title}\n\n{content}"
+    if is_draft and not content.startswith("[DRAFT]"):
+        content = "[DRAFT] " + content
+    return {
+        "kind": "markdown",
+        "title": title,
+        "filename": filename,
+        "mime_type": "text/markdown",
         "content": content,
-        "truncated": False,
-        "source_read_proof": source_read_proof,
-        "ambient_relevance_feed": ambient_feed,
-    })
+        "source_path": rel_path,
+    }
 
 
 def _draft_read_content(text: str, *, is_draft: bool) -> str:
@@ -1961,6 +2012,7 @@ def wiki(
     action: str,
     page: str = "",
     query: str = "",
+    format: str = "",
     category: str = "",
     filename: str = "",
     content: str = "",
@@ -2057,6 +2109,7 @@ def wiki(
     kwargs: dict[str, Any] = {
         "page": page,
         "query": query,
+        "format": format,
         "category": category,
         "filename": filename,
         "content": content,

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -911,6 +911,7 @@ def wiki(
     action: str,
     page: str = "",
     query: str = "",
+    format: str = "",
     category: str = "",
     filename: str = "",
     content: str = "",
@@ -962,6 +963,9 @@ def wiki(
             `search` is lexical best-effort, not a completeness proof; use
             `since` with `changed_since` to review pages updated after a known
             timestamp, then `read` the candidate pages.
+        format: Optional read output format. For action="read", use
+            format="artifact" to include a shareable Markdown artifact
+            envelope alongside the normal read payload.
         old_text/new_text: For action="patch", exact text to replace server-side.
         expected_sha256: Optional full-page hash guard for action="patch".
         changed_since: Optional ISO timestamp for action="read" ambient feed
@@ -972,6 +976,7 @@ def wiki(
         action=action,
         page=page,
         query=query,
+        format=format,
         category=category,
         filename=filename,
         content=content,


### PR DESCRIPTION
Fixes #526

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-061-pr-055-render-to-shareable-artifact-via-read-page-format-par.md`
- GitHub issue: #526
- Branch task: `auto-change/issue-526`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.