### PR TITLE
[auto-change] BUG-013: No file_feature_request wiki verb parallel to file_bug

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -11,6 +11,7 @@ Public surface (test imports):
     _ensure_wiki_scaffold(root)  → None: idempotent dir + anchor scaffold
     _WIKI_CATEGORIES             → tuple: canonical category enum
     _wiki_file_bug(...)          → str: bug-filing handler (referenced by docs)
+    _wiki_file_feature_request(...) → str: feature-request filing alias
     _wiki_cosign_bug(...)        → str: cosign handler
 
 Other helpers and action handlers are module-private (single-leading-underscore)
@@ -1951,6 +1952,12 @@ def _wiki_file_bug(
     return json.dumps(response_body)
 
 
+def _wiki_file_feature_request(**kwargs: Any) -> str:
+    """File a feature request via the same vetted request pipeline as file_bug."""
+    kwargs["kind"] = "feature"
+    return _wiki_file_bug(**kwargs)
+
+
 # ---------------------------------------------------------------------------
 # Dispatch entry — plain function. The MCP tool wrapper lives in
 # workflow/universe_server.py and delegates here (Pattern A2).
@@ -2044,6 +2051,7 @@ def wiki(
         "supersede": _wiki_supersede,
         "sync_projects": _wiki_sync_projects,
         "file_bug": _wiki_file_bug,
+        "file_feature_request": _wiki_file_feature_request,
         "cosign_bug": _wiki_cosign_bug,
     }
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -948,17 +948,18 @@ def wiki(
     for "save this how-to / ref / note", "what is X", or filing user
     bugs, patch requests, feature requests, and design proposals.
 
-    When the user asks to file a bug, patch request, feature request, or
-    design proposal, call `file_bug` directly with the matching `kind`
-    (`bug`, `patch_request`, `feature`, or `design`). `file_bug` already
-    does Jaccard duplicate detection server-side; you do NOT need to search/list/read
-    the wiki before filing. If a similar filing exists,
-    it returns status="similar_found" with the existing match.
+    When the user asks to file a feature request, call
+    `file_feature_request` directly. When the user asks to file a bug,
+    patch request, or design proposal, call `file_bug` directly with the
+    matching `kind` (`bug`, `patch_request`, or `design`). These filing
+    actions already do Jaccard duplicate detection server-side; you do NOT
+    need to search/list/read the wiki before filing. If a similar filing
+    exists, they return status="similar_found" with the existing match.
 
     Args:
         action: One of — reads: read, search, since, list, lint;
             writes: write, patch, consolidate, promote, ingest, supersede,
-            sync_projects, file_bug, cosign_bug.
+            sync_projects, file_bug, file_feature_request, cosign_bug.
             `search` is lexical best-effort, not a completeness proof; use
             `since` with `changed_since` to review pages updated after a known
             timestamp, then `read` the candidate pages.

--- a/tests/test_mcp_dispatch_docstring_parity.py
+++ b/tests/test_mcp_dispatch_docstring_parity.py
@@ -130,9 +130,9 @@ def _wiki_dispatch_keys() -> set[str]:
     """Mirror of the local `dispatch = {...}` literal inside `wiki()`."""
     return {
         "read", "search", "list", "lint",
-        "write", "consolidate", "promote", "ingest", "supersede",
+        "write", "patch", "consolidate", "promote", "ingest", "supersede",
         "sync_projects",
-        "file_bug", "cosign_bug",
+        "file_bug", "file_feature_request", "cosign_bug",
     }
 
 
@@ -386,8 +386,9 @@ def test_wiki_docstring_tells_clients_to_file_bug_directly() -> None:
     doc = _tool_doc(us.wiki)
 
     assert "call `file_bug` directly" in doc
+    assert "`file_feature_request` directly" in doc
     assert "duplicate detection server-side" in doc
-    assert "do NOT need to search/list/read" in doc
+    assert re.search(r"do NOT\s+need to search/list/read", doc)
     assert "status=\"similar_found\"" in doc
     assert "Start with `action=\"list\"`" not in doc
     assert "Start with `action=\"read\"`" not in doc

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -666,6 +666,26 @@ class TestWikiFileBugDispatch:
         assert out["bug_id"].startswith("BUG-")
         assert "path" in out
 
+    def test_file_feature_request_alias_returns_feat_id_and_path(self, wiki_dir):
+        (wiki_dir / "pages" / "feature-requests").mkdir(parents=True, exist_ok=True)
+        (wiki_dir / "drafts" / "feature-requests").mkdir(parents=True, exist_ok=True)
+
+        out = json.loads(
+            wiki(
+                "file_feature_request",
+                component="wiki-mcp",
+                severity="minor",
+                title="Let clients file feature requests directly",
+                observed="No action alias exists",
+                expected="Action alias routes to feature request filing",
+            )
+        )
+
+        assert out["status"] == "filed"
+        assert out["kind"] == "feature"
+        assert out["bug_id"].startswith("FEAT-")
+        assert out["path"].startswith("pages/feature-requests/")
+
     def test_file_bug_accepts_tags_via_public_wrapper(self, wiki_dir):
         """BUG-040: public wiki wrapper must pass tags through to file_bug."""
         (wiki_dir / "pages" / "bugs").mkdir(parents=True, exist_ok=True)

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -11,6 +11,7 @@ Public surface (test imports):
     _ensure_wiki_scaffold(root)  → None: idempotent dir + anchor scaffold
     _WIKI_CATEGORIES             → tuple: canonical category enum
     _wiki_file_bug(...)          → str: bug-filing handler (referenced by docs)
+    _wiki_file_feature_request(...) → str: feature-request filing alias
     _wiki_cosign_bug(...)        → str: cosign handler
 
 Other helpers and action handlers are module-private (single-leading-underscore)
@@ -1951,6 +1952,12 @@ def _wiki_file_bug(
     return json.dumps(response_body)
 
 
+def _wiki_file_feature_request(**kwargs: Any) -> str:
+    """File a feature request via the same vetted request pipeline as file_bug."""
+    kwargs["kind"] = "feature"
+    return _wiki_file_bug(**kwargs)
+
+
 # ---------------------------------------------------------------------------
 # Dispatch entry — plain function. The MCP tool wrapper lives in
 # workflow/universe_server.py and delegates here (Pattern A2).
@@ -2044,6 +2051,7 @@ def wiki(
         "supersede": _wiki_supersede,
         "sync_projects": _wiki_sync_projects,
         "file_bug": _wiki_file_bug,
+        "file_feature_request": _wiki_file_feature_request,
         "cosign_bug": _wiki_cosign_bug,
     }
 

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -948,17 +948,18 @@ def wiki(
     for "save this how-to / ref / note", "what is X", or filing user
     bugs, patch requests, feature requests, and design proposals.
 
-    When the user asks to file a bug, patch request, feature request, or
-    design proposal, call `file_bug` directly with the matching `kind`
-    (`bug`, `patch_request`, `feature`, or `design`). `file_bug` already
-    does Jaccard duplicate detection server-side; you do NOT need to search/list/read
-    the wiki before filing. If a similar filing exists,
-    it returns status="similar_found" with the existing match.
+    When the user asks to file a feature request, call
+    `file_feature_request` directly. When the user asks to file a bug,
+    patch request, or design proposal, call `file_bug` directly with the
+    matching `kind` (`bug`, `patch_request`, or `design`). These filing
+    actions already do Jaccard duplicate detection server-side; you do NOT
+    need to search/list/read the wiki before filing. If a similar filing
+    exists, they return status="similar_found" with the existing match.
 
     Args:
         action: One of — reads: read, search, since, list, lint;
             writes: write, patch, consolidate, promote, ingest, supersede,
-            sync_projects, file_bug, cosign_bug.
+            sync_projects, file_bug, file_feature_request, cosign_bug.
             `search` is lexical best-effort, not a completeness proof; use
             `since` with `changed_since` to review pages updated after a known
             timestamp, then `read` the candidate pages.


### PR DESCRIPTION
Fixes #39

## Request artifact reconciliation

- Wiki page: `pages/bugs/BUG-013-no-file-feature-request-wiki-verb-parallel-to-file-bug.md`
- GitHub issue: #39
- Branch task: `auto-change/issue-39`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.