### PR TITLE
[auto-change] BUG-017: Daemon sandbox (bubblewrap) lacks user-namespace permissions; dev/checker cannot execute anything

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/base.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/base.py
@@ -166,7 +166,18 @@ def probe_sandbox_available() -> dict[str, object]:
             }
 
         launch_result = _subprocess.run(
-            [bwrap_path, "--ro-bind", "/", "/", "/bin/sh", "-c", "true"],
+            [
+                bwrap_path,
+                "--unshare-user",
+                "--uid",
+                "0",
+                "--gid",
+                "0",
+                "--ro-bind",
+                "/",
+                "/",
+                "/bin/true",
+            ],
             capture_output=True, text=True, check=False, timeout=5,
         )
         if launch_result.returncode == 0:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/sandbox/detect.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/sandbox/detect.py
@@ -121,7 +121,18 @@ def detect_bwrap() -> SandboxStatus:
 
     try:
         launch_result = subprocess.run(
-            [bwrap_path, "--ro-bind", "/", "/", "/bin/sh", "-c", "true"],
+            [
+                bwrap_path,
+                "--unshare-user",
+                "--uid",
+                "0",
+                "--gid",
+                "0",
+                "--ro-bind",
+                "/",
+                "/",
+                "/bin/true",
+            ],
             capture_output=True,
             text=True,
             timeout=5,

--- a/tests/test_sandbox_detect.py
+++ b/tests/test_sandbox_detect.py
@@ -140,6 +140,7 @@ class TestDetectBwrap:
         assert status.bwrap_path == "/usr/bin/bwrap"
         assert status.version == "bwrap 0.6.0"
         assert status.reason is None
+        assert "--unshare-user" in run_mock.call_args_list[1].args[0]
         assert run_mock.call_count == 2
 
     def test_bwrap_launch_failure_returns_unavailable(self, monkeypatch):

--- a/tests/test_sandbox_status.py
+++ b/tests/test_sandbox_status.py
@@ -99,6 +99,7 @@ class TestProbeSandboxAvailable:
         assert result["bwrap_available"] is True
         assert result.get("reason") is None
         assert run_mock.call_count == 2
+        assert "--unshare-user" in run_mock.call_args_list[1].args[0]
 
     def test_bwrap_launch_fails_returns_unavailable(self, monkeypatch):
         monkeypatch.setattr("sys.platform", "linux")

--- a/tests/test_sandbox_unavailable.py
+++ b/tests/test_sandbox_unavailable.py
@@ -156,6 +156,7 @@ class TestProbeSandboxAvailable:
         assert result["bwrap_available"] is True
         assert result["reason"] is None
         assert run_mock.call_count == 2
+        assert "--unshare-user" in run_mock.call_args_list[1].args[0]
 
     def test_returns_unavailable_when_bwrap_launch_nonzero(self):
         version_result = MagicMock()

--- a/workflow/providers/base.py
+++ b/workflow/providers/base.py
@@ -166,7 +166,18 @@ def probe_sandbox_available() -> dict[str, object]:
             }
 
         launch_result = _subprocess.run(
-            [bwrap_path, "--ro-bind", "/", "/", "/bin/sh", "-c", "true"],
+            [
+                bwrap_path,
+                "--unshare-user",
+                "--uid",
+                "0",
+                "--gid",
+                "0",
+                "--ro-bind",
+                "/",
+                "/",
+                "/bin/true",
+            ],
             capture_output=True, text=True, check=False, timeout=5,
         )
         if launch_result.returncode == 0:

--- a/workflow/sandbox/detect.py
+++ b/workflow/sandbox/detect.py
@@ -121,7 +121,18 @@ def detect_bwrap() -> SandboxStatus:
 
     try:
         launch_result = subprocess.run(
-            [bwrap_path, "--ro-bind", "/", "/", "/bin/sh", "-c", "true"],
+            [
+                bwrap_path,
+                "--unshare-user",
+                "--uid",
+                "0",
+                "--gid",
+                "0",
+                "--ro-bind",
+                "/",
+                "/",
+                "/bin/true",
+            ],
             capture_output=True,
             text=True,
             timeout=5,


### PR DESCRIPTION
Fixes #43

## Request artifact reconciliation

- Wiki page: `pages/bugs/BUG-017-daemon-sandbox-bubblewrap-lacks-user-namespace-permissions-d.md`
- GitHub issue: #43
- Branch task: `auto-change/issue-43`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.