### PR TITLE
[auto-change] WIKI-PATCH: Runtime impl: queue-aware writer recency — when writer schedule stale BUT queue has no writer-eligible work (only await-primitive-layer deferrals), downgrade red→yellow with evidence "no writer-eligible queue"; post-PR682 loop-health follow-up per Codex finding

### DIFF
--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -76,6 +76,13 @@ CLOSING_ISSUE_RE = re.compile(
     r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(?P<number>\d+)\b",
     re.IGNORECASE,
 )
+WRITER_ELIGIBLE_QUEUE_DETAIL_KEYS = (
+    "needs_human",
+    "old_pending",
+    "stale_gate",
+    "attempted_with_open_pr",
+    "pending",
+)
 
 
 class WatchError(Exception):
@@ -884,6 +891,28 @@ def queue_stage(
     )
 
 
+def _has_no_writer_eligible_queue(stage: dict[str, Any]) -> bool:
+    if stage.get("name") != "Writer queue":
+        return False
+    details = stage.get("details")
+    if not isinstance(details, dict):
+        return False
+    return all(not details.get(key) for key in WRITER_ELIGIBLE_QUEUE_DETAIL_KEYS)
+
+
+def _is_stale_writer_schedule_stage(stage: dict[str, Any]) -> bool:
+    if stage.get("name") != "Writer workflow":
+        return False
+    details = stage.get("details")
+    if not isinstance(details, dict):
+        return False
+    return (
+        stage.get("status") == "red"
+        and details.get("required_success_event") == "schedule"
+        and "max_age_min" in details
+    )
+
+
 def incident_stage(
     repo: str,
     *,
@@ -1067,6 +1096,33 @@ def build_status(args: argparse.Namespace, now: dt.datetime | None = None) -> di
             max_age_min=None,
         ),
     ]
+    writer_workflow = next(
+        (stage for stage in stages if stage.get("name") == "Writer workflow"),
+        None,
+    )
+    writer_queue = next(
+        (stage for stage in stages if stage.get("name") == "Writer queue"),
+        None,
+    )
+    if (
+        writer_workflow is not None
+        and writer_queue is not None
+        and _is_stale_writer_schedule_stage(writer_workflow)
+        and _has_no_writer_eligible_queue(writer_queue)
+    ):
+        writer_workflow["status"] = "yellow"
+        writer_workflow["summary"] = (
+            f"{writer_workflow.get('summary')}; no writer-eligible queue"
+        )
+        existing_evidence = writer_workflow.get("evidence")
+        writer_workflow["evidence"] = (
+            f"{existing_evidence}; no writer-eligible queue"
+            if existing_evidence
+            else "no writer-eligible queue"
+        )
+        details = writer_workflow.get("details")
+        if isinstance(details, dict):
+            details["queue_downgrade"] = "no writer-eligible queue"
     overall = classify(stages)
     return {
         "version": 1,

--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -900,6 +900,19 @@ def _has_no_writer_eligible_queue(stage: dict[str, Any]) -> bool:
     return all(not details.get(key) for key in WRITER_ELIGIBLE_QUEUE_DETAIL_KEYS)
 
 
+def _writer_queue_downgrade_reason(stage: dict[str, Any]) -> str:
+    details = stage.get("details")
+    if not isinstance(details, dict):
+        return "no writer-eligible queue"
+    deferred = details.get("await_primitive_layer")
+    if isinstance(deferred, list) and deferred:
+        return (
+            f"no writer-eligible queue ({len(deferred)} "
+            "await-primitive-layer deferrals)"
+        )
+    return "no writer-eligible queue"
+
+
 def _is_stale_writer_schedule_stage(stage: dict[str, Any]) -> bool:
     if stage.get("name") != "Writer workflow":
         return False
@@ -1110,19 +1123,20 @@ def build_status(args: argparse.Namespace, now: dt.datetime | None = None) -> di
         and _is_stale_writer_schedule_stage(writer_workflow)
         and _has_no_writer_eligible_queue(writer_queue)
     ):
+        downgrade_reason = _writer_queue_downgrade_reason(writer_queue)
         writer_workflow["status"] = "yellow"
         writer_workflow["summary"] = (
-            f"{writer_workflow.get('summary')}; no writer-eligible queue"
+            f"{writer_workflow.get('summary')}; {downgrade_reason}"
         )
         existing_evidence = writer_workflow.get("evidence")
         writer_workflow["evidence"] = (
-            f"{existing_evidence}; no writer-eligible queue"
+            f"{existing_evidence}; {downgrade_reason}"
             if existing_evidence
-            else "no writer-eligible queue"
+            else downgrade_reason
         )
         details = writer_workflow.get("details")
         if isinstance(details, dict):
-            details["queue_downgrade"] = "no writer-eligible queue"
+            details["queue_downgrade"] = downgrade_reason
     overall = classify(stages)
     return {
         "version": 1,

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -541,8 +541,12 @@ def test_build_status_downgrades_stale_writer_schedule_when_queue_has_only_defer
     ][0]
     assert status["overall"] == "yellow"
     assert writer_stage["status"] == "yellow"
-    assert "no writer-eligible queue" in writer_stage["evidence"]
-    assert writer_stage["details"]["queue_downgrade"] == "no writer-eligible queue"
+    expected_reason = "no writer-eligible queue (1 await-primitive-layer deferrals)"
+    assert expected_reason in writer_stage["evidence"]
+    assert (
+        writer_stage["details"]["queue_downgrade"]
+        == expected_reason
+    )
     assert queue_stage["details"]["await_primitive_layer"] == [541]
 
 

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -467,6 +467,85 @@ def test_build_status_downgrades_stale_writer_schedule_when_workflow_run_succeed
     assert writer_stage["details"]["fallback_event"] == "workflow_run"
 
 
+def test_build_status_downgrades_stale_writer_schedule_when_queue_has_only_deferrals(
+    monkeypatch,
+):
+    now = dt.datetime(2026, 5, 8, 5, 47, tzinfo=dt.timezone.utc)
+    stale_writer_schedule = {
+        "id": 44,
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-05-08T03:55:48Z",
+        "updated_at": "2026-05-08T03:59:15Z",
+        "event": "schedule",
+        "html_url": "https://example.test/auto-fix-schedule",
+    }
+    fresh_schedule = {
+        "id": 46,
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-05-08T04:45:00Z",
+        "updated_at": "2026-05-08T04:46:00Z",
+        "event": "schedule",
+        "html_url": "https://example.test/other-schedule",
+    }
+
+    def fake_recent_workflow_runs(_repo, workflow_id, **kwargs):
+        if workflow_id == watch.WORKFLOWS["writer"]:
+            return [stale_writer_schedule]
+        if kwargs.get("event") == "schedule":
+            return [fresh_schedule]
+        return [fresh_schedule]
+
+    def fake_list_loop_issues(*_args, **_kwargs):
+        return [
+            {
+                "number": 541,
+                "title": "Single-server architecture waits for primitive layer",
+                "created_at": "2026-05-06T23:46:00Z",
+                "html_url": "https://example.test/issues/541",
+                "labels": [
+                    {"name": "daemon-request"},
+                    {"name": "auto-change"},
+                    {"name": watch.AWAIT_PRIMITIVE_LAYER_LABEL},
+                ],
+            }
+        ]
+
+    monkeypatch.setattr(watch, "_recent_workflow_runs", fake_recent_workflow_runs)
+    monkeypatch.setattr(watch, "list_loop_issues", fake_list_loop_issues)
+    monkeypatch.setattr(
+        watch, "list_open_issues_by_label", lambda *_args, **_kwargs: []
+    )
+    monkeypatch.setattr(watch, "_github_token", lambda _args: None)
+
+    status = watch.build_status(
+        argparse.Namespace(
+            repo="owner/repo",
+            api="https://api.github.test",
+            token=None,
+            timeout=1,
+            max_sync_age_min=90,
+            max_writer_age_min=90,
+            max_observation_age_min=90,
+            max_pending_age_min=45,
+        ),
+        now=now,
+    )
+
+    writer_stage = [
+        stage for stage in status["stages"] if stage["name"] == "Writer workflow"
+    ][0]
+    queue_stage = [
+        stage for stage in status["stages"] if stage["name"] == "Writer queue"
+    ][0]
+    assert status["overall"] == "yellow"
+    assert writer_stage["status"] == "yellow"
+    assert "no writer-eligible queue" in writer_stage["evidence"]
+    assert writer_stage["details"]["queue_downgrade"] == "no writer-eligible queue"
+    assert queue_stage["details"]["await_primitive_layer"] == [541]
+
+
 def test_writer_stage_uses_scheduled_success_when_other_runs_are_newer(monkeypatch):
     now = dt.datetime(2026, 5, 5, 0, 0, tzinfo=dt.timezone.utc)
 


### PR DESCRIPTION
Fixes #718

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-085-runtime-impl-queue-aware-writer-recency-when-writer-schedule.md`
- GitHub issue: #718
- Branch task: `auto-change/issue-718`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.