### PR TITLE
[auto-change] WIKI-PATCH: URGENT: Add wiki action=since + completeness warnings to action=search + tool description guidance — hard structural fix for cross-AI-discovery-gap recurrence (now 7 instances)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -63,6 +63,13 @@ _STOP_WORDS = frozenset(
     "on of that this these those it its not no nor so very just also".split()
 )
 
+_WIKI_SEARCH_COMPLETENESS_WARNING = (
+    "wiki action=search is lexical best-effort, not a complete discovery or "
+    "change-feed proof. For recent changes use wiki action=since with "
+    "changed_since=<ISO timestamp>; for authoritative content read candidate "
+    "pages with action=read."
+)
+
 
 _logger_wiki = logging.getLogger("universe_server.wiki")
 
@@ -285,6 +292,14 @@ def _coerce_feed_limit(value: Any) -> int:
     except (TypeError, ValueError):
         raw = 10
     return max(0, min(raw, 20))
+
+
+def _coerce_result_limit(value: Any) -> int:
+    try:
+        raw = int(value or 0)
+    except (TypeError, ValueError):
+        raw = 10
+    return max(1, min(raw, 100))
 
 
 def _ambient_relevance_feed(
@@ -564,8 +579,74 @@ def _wiki_search(query: str = "", max_results: int = 10, **_kwargs: Any) -> str:
     top = scored[:max_results]
 
     if not top:
-        return json.dumps({"results": [], "note": f"No results for: {query}"})
-    return json.dumps({"query": query, "results": top, "count": len(top)})
+        return json.dumps({
+            "results": [],
+            "note": f"No results for: {query}",
+            "search_complete": False,
+            "completeness_warning": _WIKI_SEARCH_COMPLETENESS_WARNING,
+        })
+    return json.dumps({
+        "query": query,
+        "results": top,
+        "count": len(top),
+        "search_complete": False,
+        "completeness_warning": _WIKI_SEARCH_COMPLETENESS_WARNING,
+    })
+
+
+def _wiki_result_item(path: Path, *, is_draft: bool) -> dict[str, Any]:
+    raw = _read_text(path)
+    meta, body = _parse_frontmatter(raw)
+    updated_at = _page_updated_at(path, meta)
+    return {
+        "path": _page_rel_path(path),
+        "title": meta.get("title") or path.stem,
+        "type": meta.get("type", "unknown"),
+        "updated": updated_at.isoformat().replace("+00:00", "Z"),
+        "is_draft": is_draft,
+        "excerpt": body.replace("\n", " ").strip()[:220],
+    }
+
+
+def _wiki_since(
+    changed_since: str = "",
+    max_results: int = 10,
+    **_kwargs: Any,
+) -> str:
+    if not changed_since.strip():
+        return json.dumps({
+            "error": "changed_since parameter is required for action=since.",
+            "hint": "Pass an ISO timestamp, for example 2026-05-06T00:00:00Z.",
+        })
+    since = _parse_wiki_timestamp(changed_since)
+    if since is None:
+        return json.dumps({
+            "error": "changed_since must be a valid ISO timestamp.",
+            "changed_since": changed_since,
+        })
+
+    candidates: list[dict[str, Any]] = []
+    for path in _find_all_pages(_wiki_pages_dir()):
+        item = _wiki_result_item(path, is_draft=False)
+        updated_at = _parse_wiki_timestamp(item["updated"])
+        if updated_at is not None and updated_at > since:
+            candidates.append(item)
+    for path in _find_all_pages(_wiki_drafts_dir()):
+        item = _wiki_result_item(path, is_draft=True)
+        updated_at = _parse_wiki_timestamp(item["updated"])
+        if updated_at is not None and updated_at > since:
+            candidates.append(item)
+
+    candidates.sort(key=lambda item: (item["updated"], item["path"]), reverse=True)
+    limit = _coerce_result_limit(max_results)
+    results = candidates[:limit]
+    return json.dumps({
+        "changed_since": changed_since.strip(),
+        "results": results,
+        "count": len(results),
+        "total_matches": len(candidates),
+        "truncated_count": max(0, len(candidates) - len(results)),
+    })
 
 
 def _wiki_list(**_kwargs: Any) -> str:
@@ -1952,6 +2033,7 @@ def wiki(
     dispatch = {
         "read": _wiki_read,
         "search": _wiki_search,
+        "since": _wiki_since,
         "list": _wiki_list,
         "lint": _wiki_lint,
         "write": _wiki_write,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -979,13 +979,17 @@ def wiki(
     it returns status="similar_found" with the existing match.
 
     Args:
-        action: One of — reads: read, search, list, lint;
+        action: One of — reads: read, search, since, list, lint;
             writes: write, patch, consolidate, promote, ingest, supersede,
             sync_projects, file_bug, cosign_bug.
+            `search` is lexical best-effort, not a completeness proof; use
+            `since` with `changed_since` to review pages updated after a known
+            timestamp, then `read` the candidate pages.
         old_text/new_text: For action="patch", exact text to replace server-side.
         expected_sha256: Optional full-page hash guard for action="patch".
-        changed_since: Optional ISO timestamp for action="read" ambient feed;
-            only pages updated after this timestamp are returned as feed items.
+        changed_since: Optional ISO timestamp for action="read" ambient feed
+            and required ISO timestamp for action="since"; only pages updated
+            after this timestamp are returned.
     """
     return _wiki_impl(
         action=action,

--- a/tests/test_api_wiki.py
+++ b/tests/test_api_wiki.py
@@ -213,6 +213,74 @@ def test_wiki_search_requires_query(wiki_env):
 def test_wiki_search_no_results_returns_empty_list(wiki_env):
     res = json.loads(wiki(action="search", query="zzz_nothing_should_match"))
     assert res["results"] == []
+    assert res["search_complete"] is False
+    assert "action=since" in res["completeness_warning"]
+
+
+def test_wiki_search_returns_completeness_warning_with_matches(wiki_env):
+    page = wiki_env / "pages" / "notes" / "search-target.md"
+    page.write_text(
+        "---\n"
+        "title: Search Target\n"
+        "type: note\n"
+        "updated: 2026-05-06T12:00:00Z\n"
+        "---\n\n"
+        "This page mentions cross AI discovery gaps.\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    res = json.loads(wiki(action="search", query="discovery"))
+
+    assert res["count"] == 1
+    assert res["search_complete"] is False
+    assert "lexical" in res["completeness_warning"]
+    assert "action=since" in res["completeness_warning"]
+
+
+def test_wiki_since_returns_pages_updated_after_timestamp(wiki_env):
+    fresh_dir = wiki_env / "pages" / "patch-requests"
+    fresh_dir.mkdir(parents=True)
+    fresh = fresh_dir / "fresh-patch.md"
+    fresh.write_text(
+        "---\n"
+        "title: Fresh Patch\n"
+        "type: patch_request\n"
+        "updated: 2026-05-06T12:00:00Z\n"
+        "---\n\n"
+        "Fresh patch request content.\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    older = wiki_env / "pages" / "notes" / "older-note.md"
+    older.write_text(
+        "---\n"
+        "title: Older Note\n"
+        "type: note\n"
+        "updated: 2026-05-01T12:00:00Z\n"
+        "---\n\n"
+        "Older note content.\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    res = json.loads(
+        wiki(action="since", changed_since="2026-05-05T00:00:00Z")
+    )
+
+    assert res["changed_since"] == "2026-05-05T00:00:00Z"
+    assert res["count"] == 1
+    assert res["results"][0]["path"] == "pages/patch-requests/fresh-patch.md"
+    assert res["results"][0]["title"] == "Fresh Patch"
+    assert res["results"][0]["updated"] == "2026-05-06T12:00:00Z"
+
+
+def test_wiki_since_requires_valid_changed_since(wiki_env):
+    missing = json.loads(wiki(action="since"))
+    invalid = json.loads(wiki(action="since", changed_since="not-a-date"))
+
+    assert "changed_since parameter is required" in missing["error"]
+    assert "valid ISO" in invalid["error"]
 
 
 def test_wiki_read_requires_page(wiki_env):

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -63,6 +63,13 @@ _STOP_WORDS = frozenset(
     "on of that this these those it its not no nor so very just also".split()
 )
 
+_WIKI_SEARCH_COMPLETENESS_WARNING = (
+    "wiki action=search is lexical best-effort, not a complete discovery or "
+    "change-feed proof. For recent changes use wiki action=since with "
+    "changed_since=<ISO timestamp>; for authoritative content read candidate "
+    "pages with action=read."
+)
+
 
 _logger_wiki = logging.getLogger("universe_server.wiki")
 
@@ -285,6 +292,14 @@ def _coerce_feed_limit(value: Any) -> int:
     except (TypeError, ValueError):
         raw = 10
     return max(0, min(raw, 20))
+
+
+def _coerce_result_limit(value: Any) -> int:
+    try:
+        raw = int(value or 0)
+    except (TypeError, ValueError):
+        raw = 10
+    return max(1, min(raw, 100))
 
 
 def _ambient_relevance_feed(
@@ -564,8 +579,74 @@ def _wiki_search(query: str = "", max_results: int = 10, **_kwargs: Any) -> str:
     top = scored[:max_results]
 
     if not top:
-        return json.dumps({"results": [], "note": f"No results for: {query}"})
-    return json.dumps({"query": query, "results": top, "count": len(top)})
+        return json.dumps({
+            "results": [],
+            "note": f"No results for: {query}",
+            "search_complete": False,
+            "completeness_warning": _WIKI_SEARCH_COMPLETENESS_WARNING,
+        })
+    return json.dumps({
+        "query": query,
+        "results": top,
+        "count": len(top),
+        "search_complete": False,
+        "completeness_warning": _WIKI_SEARCH_COMPLETENESS_WARNING,
+    })
+
+
+def _wiki_result_item(path: Path, *, is_draft: bool) -> dict[str, Any]:
+    raw = _read_text(path)
+    meta, body = _parse_frontmatter(raw)
+    updated_at = _page_updated_at(path, meta)
+    return {
+        "path": _page_rel_path(path),
+        "title": meta.get("title") or path.stem,
+        "type": meta.get("type", "unknown"),
+        "updated": updated_at.isoformat().replace("+00:00", "Z"),
+        "is_draft": is_draft,
+        "excerpt": body.replace("\n", " ").strip()[:220],
+    }
+
+
+def _wiki_since(
+    changed_since: str = "",
+    max_results: int = 10,
+    **_kwargs: Any,
+) -> str:
+    if not changed_since.strip():
+        return json.dumps({
+            "error": "changed_since parameter is required for action=since.",
+            "hint": "Pass an ISO timestamp, for example 2026-05-06T00:00:00Z.",
+        })
+    since = _parse_wiki_timestamp(changed_since)
+    if since is None:
+        return json.dumps({
+            "error": "changed_since must be a valid ISO timestamp.",
+            "changed_since": changed_since,
+        })
+
+    candidates: list[dict[str, Any]] = []
+    for path in _find_all_pages(_wiki_pages_dir()):
+        item = _wiki_result_item(path, is_draft=False)
+        updated_at = _parse_wiki_timestamp(item["updated"])
+        if updated_at is not None and updated_at > since:
+            candidates.append(item)
+    for path in _find_all_pages(_wiki_drafts_dir()):
+        item = _wiki_result_item(path, is_draft=True)
+        updated_at = _parse_wiki_timestamp(item["updated"])
+        if updated_at is not None and updated_at > since:
+            candidates.append(item)
+
+    candidates.sort(key=lambda item: (item["updated"], item["path"]), reverse=True)
+    limit = _coerce_result_limit(max_results)
+    results = candidates[:limit]
+    return json.dumps({
+        "changed_since": changed_since.strip(),
+        "results": results,
+        "count": len(results),
+        "total_matches": len(candidates),
+        "truncated_count": max(0, len(candidates) - len(results)),
+    })
 
 
 def _wiki_list(**_kwargs: Any) -> str:
@@ -1952,6 +2033,7 @@ def wiki(
     dispatch = {
         "read": _wiki_read,
         "search": _wiki_search,
+        "since": _wiki_since,
         "list": _wiki_list,
         "lint": _wiki_lint,
         "write": _wiki_write,

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -979,13 +979,17 @@ def wiki(
     it returns status="similar_found" with the existing match.
 
     Args:
-        action: One of — reads: read, search, list, lint;
+        action: One of — reads: read, search, since, list, lint;
             writes: write, patch, consolidate, promote, ingest, supersede,
             sync_projects, file_bug, cosign_bug.
+            `search` is lexical best-effort, not a completeness proof; use
+            `since` with `changed_since` to review pages updated after a known
+            timestamp, then `read` the candidate pages.
         old_text/new_text: For action="patch", exact text to replace server-side.
         expected_sha256: Optional full-page hash guard for action="patch".
-        changed_since: Optional ISO timestamp for action="read" ambient feed;
-            only pages updated after this timestamp are returned as feed items.
+        changed_since: Optional ISO timestamp for action="read" ambient feed
+            and required ISO timestamp for action="since"; only pages updated
+            after this timestamp are returned.
     """
     return _wiki_impl(
         action=action,


### PR DESCRIPTION
Fixes #715

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-082-urgent-add-wiki-action-since-completeness-warnings-to-action.md`
- GitHub issue: #715
- Branch task: `auto-change/issue-715`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.