### PR TITLE
[auto-change] WIKI-PATCH: URGENT minimal slice — /mcp + /mcp-directory GET with Accept: text/html only returns discovery HTML; splits PR-083 to fit 480s child-run timeout

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -36,6 +36,9 @@ import uvicorn
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import HTMLResponse
 
 from workflow.api.branches import _branch_design_guide_prompt
 from workflow.api.engine_helpers import _warn_if_no_upload_whitelist
@@ -189,11 +192,31 @@ Workflow &middot; open collaborative design commons &middot; 2026
 """
 
 
+def _accepts_discovery_html(accept: str) -> bool:
+    """Return true for browser-style discovery requests, not MCP streams."""
+    media_ranges = {
+        part.split(";", 1)[0].strip().lower()
+        for part in accept.split(",")
+    }
+    return "text/html" in media_ranges and "text/event-stream" not in media_ranges
+
+
+class _McpDiscoveryHtmlMiddleware(BaseHTTPMiddleware):
+    """Serve static discovery HTML for browser GETs on MCP endpoint paths."""
+
+    async def dispatch(self, request, call_next):  # type: ignore[no-untyped-def]
+        if (
+            request.method == "GET"
+            and request.url.path in {"/mcp", "/mcp-directory"}
+            and _accepts_discovery_html(request.headers.get("accept", ""))
+        ):
+            return HTMLResponse(_LANDING_HTML)
+        return await call_next(request)
+
+
 @mcp.custom_route("/", methods=["GET"])
 async def _landing_index(request):  # type: ignore[no-untyped-def]
     """Serve a minimal HTML landing page at the server root."""
-    from starlette.responses import HTMLResponse
-
     return HTMLResponse(_LANDING_HTML)
 
 
@@ -1116,6 +1139,7 @@ def create_streamable_http_app() -> Starlette:
     app = Starlette(
         routes=[*legacy_app.routes, *directory_app.routes],
         lifespan=lifespan,
+        middleware=[Middleware(_McpDiscoveryHtmlMiddleware)],
     )
     app.state.path = "/mcp,/mcp-directory"
     app.state.transport_type = "streamable-http"

--- a/tests/test_universe_server_directory_app.py
+++ b/tests/test_universe_server_directory_app.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from starlette.testclient import TestClient
+
 from workflow.universe_server import create_streamable_http_app
 
 
@@ -11,3 +13,25 @@ def test_streamable_http_app_mounts_legacy_and_directory_surfaces() -> None:
     assert "/mcp-directory" in paths
     assert app.state.path == "/mcp,/mcp-directory"
     assert app.state.transport_type == "streamable-http"
+
+
+def test_mcp_get_with_html_accept_returns_discovery_html() -> None:
+    app = create_streamable_http_app()
+
+    with TestClient(app) as client:
+        response = client.get("/mcp", headers={"accept": "text/html"})
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "<title>Workflow Server</title>" in response.text
+
+
+def test_mcp_directory_get_with_html_accept_returns_discovery_html() -> None:
+    app = create_streamable_http_app()
+
+    with TestClient(app) as client:
+        response = client.get("/mcp-directory", headers={"accept": "text/html"})
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "<title>Workflow Server</title>" in response.text

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -36,6 +36,9 @@ import uvicorn
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import HTMLResponse
 
 from workflow.api.branches import _branch_design_guide_prompt
 from workflow.api.engine_helpers import _warn_if_no_upload_whitelist
@@ -189,11 +192,31 @@ Workflow &middot; open collaborative design commons &middot; 2026
 """
 
 
+def _accepts_discovery_html(accept: str) -> bool:
+    """Return true for browser-style discovery requests, not MCP streams."""
+    media_ranges = {
+        part.split(";", 1)[0].strip().lower()
+        for part in accept.split(",")
+    }
+    return "text/html" in media_ranges and "text/event-stream" not in media_ranges
+
+
+class _McpDiscoveryHtmlMiddleware(BaseHTTPMiddleware):
+    """Serve static discovery HTML for browser GETs on MCP endpoint paths."""
+
+    async def dispatch(self, request, call_next):  # type: ignore[no-untyped-def]
+        if (
+            request.method == "GET"
+            and request.url.path in {"/mcp", "/mcp-directory"}
+            and _accepts_discovery_html(request.headers.get("accept", ""))
+        ):
+            return HTMLResponse(_LANDING_HTML)
+        return await call_next(request)
+
+
 @mcp.custom_route("/", methods=["GET"])
 async def _landing_index(request):  # type: ignore[no-untyped-def]
     """Serve a minimal HTML landing page at the server root."""
-    from starlette.responses import HTMLResponse
-
     return HTMLResponse(_LANDING_HTML)
 
 
@@ -1116,6 +1139,7 @@ def create_streamable_http_app() -> Starlette:
     app = Starlette(
         routes=[*legacy_app.routes, *directory_app.routes],
         lifespan=lifespan,
+        middleware=[Middleware(_McpDiscoveryHtmlMiddleware)],
     )
     app.state.path = "/mcp,/mcp-directory"
     app.state.transport_type = "streamable-http"


### PR DESCRIPTION
Fixes #723

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-086-urgent-minimal-slice-mcp-mcp-directory-get-with-accept-text-.md`
- GitHub issue: #723
- Branch task: `auto-change/issue-723`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.