### PR TITLE
[auto-change] WIKI-PATCH: Expose changed_since on all Workflow wiki MCP wrapper schemas for action=since

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
@@ -354,6 +354,8 @@ def read_page(
         query: Optional search text or ambient relevance terms.
         category: Optional wiki category filter for searches.
         changed_since: Optional ISO timestamp for feed freshness filtering.
+            With an empty page/query/category, returns pages changed after this
+            timestamp.
         max_results: Maximum result count.
     """
     if page:
@@ -361,6 +363,12 @@ def read_page(
             action="read",
             page=page,
             query=query,
+            changed_since=changed_since,
+            max_results=max_results,
+        )
+    if changed_since.strip() and not query.strip() and not category.strip():
+        return _wiki_impl(
+            action="since",
             changed_since=changed_since,
             max_results=max_results,
         )

--- a/tests/test_directory_server.py
+++ b/tests/test_directory_server.py
@@ -8,6 +8,7 @@ from workflow.directory_server import (
     _redact_directory_status,
     directory_mcp,
     read_graph,
+    read_page,
     write_graph,
     write_page,
 )
@@ -133,6 +134,18 @@ def test_directory_tool_inputs_avoid_sensitive_credentials() -> None:
         assert names.isdisjoint(sensitive_terms), (
             f"{tool.name} requests a sensitive credential-like field"
         )
+
+
+def test_directory_read_page_schema_advertises_changed_since() -> None:
+    """PR-088: directory wiki reads must expose the since-feed timestamp."""
+
+    tool = next(tool for tool in _list_tools() if tool.name == "read.page")
+    properties = tool.parameters["properties"]
+
+    assert properties["changed_since"]["type"] == "string"
+    assert properties["changed_since"]["default"] == ""
+    assert "changed after this" in properties["changed_since"]["description"]
+    assert "changed_since" not in tool.parameters.get("required", [])
 
 
 def test_directory_status_redacts_operator_diagnostics() -> None:
@@ -266,3 +279,30 @@ def test_directory_write_page_drafts_temp_wiki_page(monkeypatch, tmp_path) -> No
     assert (
         wiki_root / "drafts" / "notes" / "directory-page-smoke.md"
     ).read_text(encoding="utf-8") == "# Directory page smoke\n"
+
+
+def test_directory_read_page_changed_since_routes_to_since_feed(
+    monkeypatch, tmp_path,
+) -> None:
+    """Empty read.page + changed_since is the directory-safe since action."""
+    wiki_root = tmp_path / "wiki"
+    monkeypatch.setenv("WORKFLOW_WIKI_PATH", str(wiki_root))
+
+    from workflow.api.wiki import _ensure_wiki_scaffold
+
+    _ensure_wiki_scaffold(wiki_root)
+    fresh = wiki_root / "pages" / "notes" / "fresh-directory-feed.md"
+    fresh.write_text(
+        "---\ntitle: Fresh directory feed\ntype: note\n---\n# Fresh\n",
+        encoding="utf-8",
+    )
+
+    result = json.loads(
+        read_page(changed_since="2026-05-01T00:00:00Z", max_results=5)
+    )
+
+    assert result["changed_since"] == "2026-05-01T00:00:00Z"
+    assert any(
+        item["path"] == "pages/notes/fresh-directory-feed.md"
+        for item in result["results"]
+    )

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -753,3 +753,15 @@ class TestWikiMCPRegistration:
 
         assert properties["kind"] == {"default": "bug", "type": "string"}
         assert "kind" not in wiki_tool.parameters["required"]
+
+    def test_wiki_since_changed_since_field_is_in_mcp_schema(self):
+        """PR-088: action=since must advertise its timestamp parameter."""
+
+        tools = asyncio.run(mcp.list_tools(run_middleware=False))
+        wiki_tool = next(t for t in tools if t.name == "wiki")
+        properties = wiki_tool.parameters["properties"]
+
+        assert properties["changed_since"]["type"] == "string"
+        assert properties["changed_since"]["default"] == ""
+        assert "action=\"since\"" in properties["changed_since"]["description"]
+        assert "changed_since" not in wiki_tool.parameters["required"]

--- a/workflow/directory_server.py
+++ b/workflow/directory_server.py
@@ -354,6 +354,8 @@ def read_page(
         query: Optional search text or ambient relevance terms.
         category: Optional wiki category filter for searches.
         changed_since: Optional ISO timestamp for feed freshness filtering.
+            With an empty page/query/category, returns pages changed after this
+            timestamp.
         max_results: Maximum result count.
     """
     if page:
@@ -361,6 +363,12 @@ def read_page(
             action="read",
             page=page,
             query=query,
+            changed_since=changed_since,
+            max_results=max_results,
+        )
+    if changed_since.strip() and not query.strip() and not category.strip():
+        return _wiki_impl(
+            action="since",
             changed_since=changed_since,
             max_results=max_results,
         )


### PR DESCRIPTION
Fixes #726

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-088-expose-changed-since-on-all-workflow-wiki-mcp-wrapper-schema.md`
- GitHub issue: #726
- Branch task: `auto-change/issue-726`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.