### PR TITLE
Surface independent checker blockers in loop watch

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -461,3 +461,14 @@ Notes:
   observable before any merge automation.
 - Ship condition: focused tests, no PR mutation behavior, draft PR opened for
   Claude/Cowork review.
+
+## Independent Checker Routing - 2026-05-09
+
+- 2026-05-09 create `../wf-independent-checker-routing` on
+  `codex/independent-checker-routing` by codex-gpt5-desktop.
+- Source: live #720 recruiter-readiness stall; host asked to make the
+  independent-checker self-heal gap real instead of a session workaround.
+- Purpose: extend merge-readiness / loop-watch observability so mixed-provenance
+  PRs with ineligible executor sessions route to an independent checker lane.
+- Ship condition: focused tests pass, PR opened for Cowork/Claude review, no
+  merge/approval behavior added.

--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -23,7 +23,12 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
 from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 DEFAULT_REPO = "Jonnyton/Workflow"
 DEFAULT_API = "https://api.github.com"
@@ -56,6 +61,7 @@ CLAUDE_SUBSCRIPTION_MISSING_LABEL = "auto-fix-claude-subscription-missing"
 CODEX_SUBSCRIPTION_MISSING_LABEL = "auto-fix-codex-subscription-missing"
 PROVIDER_EXHAUSTED_LABEL = "auto-fix-provider-exhausted"
 READY_FOR_CHECKER_LABEL = "ready_for_checker"
+CHECKER_CODEX_LABEL = "checker:codex"
 REVIEWED_LABEL = "auto-fix-reviewed"
 ALREADY_FIXED_LABEL = "auto-fix-already-fixed"
 BLOCKED_REVIEWED_LABEL = "auto-fix-blocked"
@@ -272,9 +278,7 @@ def _latest_workflow_run(
     token: str | None,
     timeout: float,
 ) -> dict[str, Any] | None:
-    runs = _recent_workflow_runs(
-        repo, workflow_id, api=api, token=token, timeout=timeout
-    )
+    runs = _recent_workflow_runs(repo, workflow_id, api=api, token=token, timeout=timeout)
     for run in runs:
         if not _is_neutral_skipped_run(run):
             return run
@@ -362,9 +366,7 @@ def workflow_stage(
                 "latest_created_at": latest.get("created_at"),
                 "checked_run_count": len(runs),
                 "checked_required_event_run_count": len(event_runs),
-                "ignored_skipped_run_ids": [
-                    skipped.get("id") for skipped in skipped_runs
-                ],
+                "ignored_skipped_run_ids": [skipped.get("id") for skipped in skipped_runs],
             }
             return _stage(
                 label,
@@ -452,11 +454,7 @@ def workflow_stage(
     if max_age_min is not None and (age is None or age > max_age_min):
         fallback_run = next(iter(fallback_candidates), None)
         fallback_age = _age_min(fallback_run.get("created_at"), now) if fallback_run else None
-        if (
-            fallback_run is not None
-            and fallback_age is not None
-            and fallback_age <= max_age_min
-        ):
+        if fallback_run is not None and fallback_age is not None and fallback_age <= max_age_min:
             fallback_event = fallback_run.get("event") or "unknown event"
             return _stage(
                 label,
@@ -481,11 +479,7 @@ def workflow_stage(
             )
         fallback_run = next(iter(fallback_in_progress_candidates), None)
         fallback_age = _age_min(fallback_run.get("created_at"), now) if fallback_run else None
-        if (
-            fallback_run is not None
-            and fallback_age is not None
-            and fallback_age <= max_age_min
-        ):
+        if fallback_run is not None and fallback_age is not None and fallback_age <= max_age_min:
             fallback_event = fallback_run.get("event") or "unknown event"
             fallback_status = fallback_run.get("status") or "unknown"
             return _stage(
@@ -535,6 +529,7 @@ def list_open_issues_by_label(
     api: str,
     token: str | None,
     timeout: float,
+    include_prs: bool = False,
 ) -> list[dict[str, Any]]:
     data = _gh_get_paginated(
         f"/repos/{repo}/issues",
@@ -545,7 +540,128 @@ def list_open_issues_by_label(
     )
     if not isinstance(data, list):
         raise WatchError(f"GitHub issues response for {label!r} was not a list")
-    return [issue for issue in data if not _is_pr(issue)]
+    return [issue for issue in data if include_prs or not _is_pr(issue)]
+
+
+def _pull_comments(
+    repo: str,
+    number: int,
+    *,
+    api: str,
+    token: str | None,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    return _gh_get_paginated(
+        f"/repos/{repo}/issues/{number}/comments",
+        api=api,
+        token=token,
+        timeout=timeout,
+        params={"per_page": 100},
+    )
+
+
+def list_ready_for_checker_prs(
+    repo: str,
+    *,
+    api: str,
+    token: str | None,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    issues = list_open_issues_by_label(
+        repo,
+        READY_FOR_CHECKER_LABEL,
+        api=api,
+        token=token,
+        timeout=timeout,
+        include_prs=True,
+    )
+    prs: list[dict[str, Any]] = []
+    for issue in issues:
+        if not _is_pr(issue) or not isinstance(issue.get("number"), int):
+            continue
+        number = int(issue["number"])
+        labels = _labels(issue)
+        should_hydrate_comments = CHECKER_CODEX_LABEL in labels or "priority:urgent" in labels
+        prs.append(
+            {
+                "number": number,
+                "title": issue.get("title") or "",
+                "state": str(issue.get("state") or "open").upper(),
+                # ready_for_checker is added only after stale-base pre-checks.
+                # Keep this watch stage cheap and checker-focused; hydrated
+                # merge-state proof remains in scripts/merge_readiness.py.
+                "mergeStateStatus": "CLEAN",
+                "labels": issue.get("labels", []),
+                "comments": (
+                    _pull_comments(repo, number, api=api, token=token, timeout=timeout)
+                    if should_hydrate_comments
+                    else []
+                ),
+                "reviews": [],
+                "html_url": issue.get("html_url"),
+            }
+        )
+    return prs
+
+
+def checker_queue_stage(
+    repo: str,
+    *,
+    api: str,
+    token: str | None,
+    timeout: float,
+) -> dict[str, Any]:
+    from scripts.merge_readiness import PullRequestFacts, classify_pr
+
+    prs = list_ready_for_checker_prs(repo, api=api, token=token, timeout=timeout)
+    results = [classify_pr(PullRequestFacts.from_mapping(pr)) for pr in prs]
+    by_state: dict[str, list[int]] = {}
+    for result in results:
+        by_state.setdefault(result.state, []).append(result.number)
+    independent_blockers = [
+        result for result in results if result.state.startswith("needs_independent_")
+    ]
+    checker_waiting = [
+        result
+        for result in results
+        if result.state in {"needs_codex_checker", "needs_claude_checker"}
+    ]
+    details = {
+        "ready_for_checker_prs": [pr.get("number") for pr in prs],
+        "by_state": by_state,
+        "items": [result.as_dict() for result in results],
+    }
+    if independent_blockers:
+        first = independent_blockers[0]
+        first_pr = next((pr for pr in prs if pr.get("number") == first.number), {})
+        return _stage(
+            "Checker queue",
+            "yellow",
+            (
+                f"{len(independent_blockers)} ready PR(s) need an independent "
+                "checker because the current executor is ineligible"
+            ),
+            evidence=f"PR #{first.number}: {first.next_action}",
+            url=first_pr.get("html_url"),
+            details=details,
+        )
+    if checker_waiting:
+        first = checker_waiting[0]
+        first_pr = next((pr for pr in prs if pr.get("number") == first.number), {})
+        return _stage(
+            "Checker queue",
+            "yellow",
+            f"{len(checker_waiting)} ready PR(s) are waiting on checker keys",
+            evidence=f"PR #{first.number}: {first.next_action}",
+            url=first_pr.get("html_url"),
+            details=details,
+        )
+    return _stage(
+        "Checker queue",
+        "green",
+        "no ready_for_checker PRs are waiting on independent checker routing",
+        details=details,
+    )
 
 
 def list_open_prs_by_closing_issue(
@@ -582,9 +698,7 @@ def list_loop_issues(
 ) -> list[dict[str, Any]]:
     by_number: dict[int, dict[str, Any]] = {}
     for label in REQUEST_LABELS:
-        for issue in list_open_issues_by_label(
-            repo, label, api=api, token=token, timeout=timeout
-        ):
+        for issue in list_open_issues_by_label(repo, label, api=api, token=token, timeout=timeout):
             number = issue.get("number")
             if isinstance(number, int):
                 by_number[number] = issue
@@ -695,23 +809,15 @@ def queue_stage(
     details = {
         "open_loop_issues": len(issues),
         "needs_human": [issue.get("number") for issue in needs_human],
-        "missing_claude_subscription": [
-            issue.get("number") for issue in missing_subscription
-        ],
-        "missing_codex_subscription": [
-            issue.get("number") for issue in missing_codex_subscription
-        ],
+        "missing_claude_subscription": [issue.get("number") for issue in missing_subscription],
+        "missing_codex_subscription": [issue.get("number") for issue in missing_codex_subscription],
         "auth_missing": [issue.get("number") for issue in auth_missing],
-        "branch_push_blocked": [
-            issue.get("number") for issue in branch_push_blocked
-        ],
+        "branch_push_blocked": [issue.get("number") for issue in branch_push_blocked],
         "pr_blocked": [issue.get("number") for issue in pr_blocked],
         "provider_exhausted": [issue.get("number") for issue in provider_exhausted],
         "pending": [issue.get("number") for issue in pending],
         "old_pending": [issue.get("number") for issue in old_pending],
-        "await_primitive_layer": [
-            issue.get("number") for issue in await_primitive_layer
-        ],
+        "await_primitive_layer": [issue.get("number") for issue in await_primitive_layer],
         "legacy_priority_migrations": legacy_priority_migrations,
         "reviewed_terminal": [issue.get("number") for issue in reviewed_terminal],
         "stale_gate": [issue.get("number") for issue in stale_gate],
@@ -721,9 +827,7 @@ def queue_stage(
                 "issue": item["issue"].get("number"),
                 "prs": [pr.get("number") for pr in item["prs"]],
                 "ready_for_checker": [
-                    pr.get("number")
-                    for pr in item["prs"]
-                    if READY_FOR_CHECKER_LABEL in _labels(pr)
+                    pr.get("number") for pr in item["prs"] if READY_FOR_CHECKER_LABEL in _labels(pr)
                 ],
             }
             for item in attempted_with_open_pr
@@ -735,9 +839,7 @@ def queue_stage(
         first = needs_human[0]
         root_cause = "automated writer is blocked"
         if branch_push_blocked and pr_blocked:
-            root_cause = (
-                "automated writer hit branch-push and PR-creation permission blocks"
-            )
+            root_cause = "automated writer hit branch-push and PR-creation permission blocks"
         elif branch_push_blocked:
             root_cause = "automated writer produced a patch but branch push was blocked"
         elif pr_blocked:
@@ -748,20 +850,15 @@ def queue_stage(
                 "are not visible to GitHub Actions"
             )
         elif missing_subscription:
-            root_cause = (
-                "Claude subscription OAuth is not visible to GitHub Actions"
-            )
+            root_cause = "Claude subscription OAuth is not visible to GitHub Actions"
         elif missing_codex_subscription:
-            root_cause = (
-                "Codex subscription auth bundle is not visible to GitHub Actions"
-            )
+            root_cause = "Codex subscription auth bundle is not visible to GitHub Actions"
         elif auth_missing:
             root_cause = "approved subscription-backed writer auth is missing"
         elif provider_exhausted:
             root_cause = "approved writer provider returned quota/capacity exhaustion"
         pending_clause = (
-            f" and {len(old_pending)} pending request(s) are older than "
-            f"{max_pending_age_min} min"
+            f" and {len(old_pending)} pending request(s) are older than {max_pending_age_min} min"
             if old_pending
             else ""
         )
@@ -816,9 +913,7 @@ def queue_stage(
             if READY_FOR_CHECKER_LABEL in _labels(pr)
         ]
         ready_clause = (
-            f"; {len(ready_prs)} PR(s) are {READY_FOR_CHECKER_LABEL}"
-            if ready_prs
-            else ""
+            f"; {len(ready_prs)} PR(s) are {READY_FOR_CHECKER_LABEL}" if ready_prs else ""
         )
         return _stage(
             "Writer queue",
@@ -848,11 +943,7 @@ def queue_stage(
             ),
             evidence=f"issue #{issue_number} should use {mapped_label}",
             url=next(
-                (
-                    issue.get("html_url")
-                    for issue in pending
-                    if issue.get("number") == issue_number
-                ),
+                (issue.get("html_url") for issue in pending if issue.get("number") == issue_number),
                 None,
             ),
             details=details,
@@ -876,10 +967,7 @@ def queue_stage(
                 f"{len(await_primitive_layer)} loop request(s) are intentionally "
                 f"waiting on {AWAIT_PRIMITIVE_LAYER_LABEL}"
             ),
-            evidence=(
-                f"first deferred issue #{first.get('number')}: "
-                f"{first.get('title')}"
-            ),
+            evidence=(f"first deferred issue #{first.get('number')}: {first.get('title')}"),
             url=first.get("html_url"),
             details=details,
         )
@@ -906,10 +994,7 @@ def _writer_queue_downgrade_reason(stage: dict[str, Any]) -> str:
         return "no writer-eligible queue"
     deferred = details.get("await_primitive_layer")
     if isinstance(deferred, list) and deferred:
-        return (
-            f"no writer-eligible queue ({len(deferred)} "
-            "await-primitive-layer deferrals)"
-        )
+        return f"no writer-eligible queue ({len(deferred)} await-primitive-layer deferrals)"
     return "no writer-eligible queue"
 
 
@@ -933,9 +1018,7 @@ def incident_stage(
     token: str | None,
     timeout: float,
 ) -> dict[str, Any]:
-    issues = list_open_issues_by_label(
-        repo, P0_OUTAGE_LABEL, api=api, token=token, timeout=timeout
-    )
+    issues = list_open_issues_by_label(repo, P0_OUTAGE_LABEL, api=api, token=token, timeout=timeout)
     if issues:
         issue = issues[0]
         return _stage(
@@ -977,8 +1060,7 @@ def tier3_clone_smoke_stage(
         issue_times = [
             parsed
             for parsed in (
-                _parse_time(item.get("created_at") or item.get("updated_at"))
-                for item in issues
+                _parse_time(item.get("created_at") or item.get("updated_at")) for item in issues
             )
             if parsed is not None
         ]
@@ -1009,9 +1091,7 @@ def tier3_clone_smoke_stage(
                     "latest_run_id": latest_run.get("id"),
                     "latest_run_conclusion": latest_run.get("conclusion"),
                     "latest_run_created_at": latest_run.get("created_at"),
-                    "newest_issue_at": newest_issue_time.isoformat().replace(
-                        "+00:00", "Z"
-                    ),
+                    "newest_issue_at": newest_issue_time.isoformat().replace("+00:00", "Z"),
                 },
             )
         return _stage(
@@ -1076,6 +1156,7 @@ def build_status(args: argparse.Namespace, now: dt.datetime | None = None) -> di
             now=current_now,
             max_pending_age_min=args.max_pending_age_min,
         ),
+        checker_queue_stage(repo, api=api, token=token, timeout=timeout),
         workflow_stage(
             "Observation canary",
             repo,
@@ -1125,14 +1206,10 @@ def build_status(args: argparse.Namespace, now: dt.datetime | None = None) -> di
     ):
         downgrade_reason = _writer_queue_downgrade_reason(writer_queue)
         writer_workflow["status"] = "yellow"
-        writer_workflow["summary"] = (
-            f"{writer_workflow.get('summary')}; {downgrade_reason}"
-        )
+        writer_workflow["summary"] = f"{writer_workflow.get('summary')}; {downgrade_reason}"
         existing_evidence = writer_workflow.get("evidence")
         writer_workflow["evidence"] = (
-            f"{existing_evidence}; {downgrade_reason}"
-            if existing_evidence
-            else downgrade_reason
+            f"{existing_evidence}; {downgrade_reason}" if existing_evidence else downgrade_reason
         )
         details = writer_workflow.get("details")
         if isinstance(details, dict):

--- a/scripts/merge_readiness.py
+++ b/scripts/merge_readiness.py
@@ -37,6 +37,31 @@ PRECHECK_BLOCKED_PATTERNS = (
     "stale-base check failed",
 )
 
+HOST_KEY_PATTERNS = (
+    "host key recorded",
+    "host third-key explicit",
+    "host explicitly turned keys",
+)
+
+INDEPENDENT_CHECKER_BLOCKER_TERMS = (
+    "independent checker",
+    "independent codex checker",
+    "independent claude checker",
+    "not an independent",
+)
+
+EXECUTOR_INELIGIBILITY_TERMS = (
+    "current executor",
+    "executor session",
+    "same session",
+    "mechanically applied",
+    "mechanically executed",
+    "mechanically opened",
+    "support commit",
+    "support commits",
+    "ineligible",
+)
+
 
 @dataclass(frozen=True)
 class ConsensusMirrorFacts:
@@ -98,6 +123,7 @@ class PullRequestFacts:
     checks_green: bool | None = None
     send_back_advisory: bool = False
     precheck_blocked: bool = False
+    checker_executor_ineligible: bool = False
     consensus_mirror: ConsensusMirrorFacts = ConsensusMirrorFacts()
 
     @classmethod
@@ -105,6 +131,7 @@ class PullRequestFacts:
         labels = frozenset(_label_names(pr.get("labels", [])))
         comments = pr.get("comments", [])
         reviews = pr.get("reviews", [])
+        checker_family = _checker_family(labels)
         return cls(
             number=int(pr["number"]),
             title=str(pr.get("title") or ""),
@@ -119,12 +146,16 @@ class PullRequestFacts:
             opposite_family_checker_approved=bool(
                 pr.get("opposite_family_checker_approved") or _has_required_family_approval(reviews)
             ),
-            host_keyed=bool(pr.get("host_keyed")),
+            host_keyed=bool(pr.get("host_keyed") or _has_host_key_comment(comments)),
             checks_green=pr.get("checks_green"),
             send_back_advisory=bool(
                 pr.get("send_back_advisory") or _has_send_back_advisory(comments)
             ),
             precheck_blocked=bool(pr.get("precheck_blocked") or _has_precheck_blocker(comments)),
+            checker_executor_ineligible=bool(
+                pr.get("checker_executor_ineligible")
+                or _has_checker_executor_ineligibility(comments, checker_family)
+            ),
             consensus_mirror=ConsensusMirrorFacts.from_mapping(pr.get("consensus_mirror")),
         )
 
@@ -245,6 +276,19 @@ def classify_pr(facts: PullRequestFacts) -> ReadinessResult:
 
     if checker_family and not facts.opposite_family_checker_approved:
         checker_name = "Cowork/Claude" if checker_family == "claude" else "Codex"
+        if facts.checker_executor_ineligible:
+            return _result(
+                facts,
+                f"needs_independent_{checker_family}_checker",
+                f"route to independent {checker_name} checker; current executor is ineligible",
+                risk_class,
+                "blocked_ineligible_checker",
+                reasons
+                + [
+                    f"required_checker_family={checker_family}",
+                    "current executor/session cannot provide checker key",
+                ],
+            )
         return _result(
             facts,
             f"needs_{checker_family}_checker",
@@ -330,6 +374,31 @@ def _has_precheck_blocker(comments: Any) -> bool:
         body = comment.get("body") if isinstance(comment, dict) else str(comment)
         lowered = str(body or "").lower()
         if any(pattern in lowered for pattern in PRECHECK_BLOCKED_PATTERNS):
+            return True
+    return False
+
+
+def _has_host_key_comment(comments: Any) -> bool:
+    for comment in comments or []:
+        body = comment.get("body") if isinstance(comment, dict) else str(comment)
+        lowered = str(body or "").lower()
+        if any(pattern in lowered for pattern in HOST_KEY_PATTERNS):
+            return True
+    return False
+
+
+def _has_checker_executor_ineligibility(comments: Any, checker_family: str | None) -> bool:
+    if not checker_family:
+        return False
+    family_term = f"independent {checker_family} checker"
+    for comment in comments or []:
+        body = comment.get("body") if isinstance(comment, dict) else str(comment)
+        lowered = str(body or "").lower()
+        has_independent_checker_reference = family_term in lowered or any(
+            term in lowered for term in INDEPENDENT_CHECKER_BLOCKER_TERMS
+        )
+        has_executor_ineligibility = any(term in lowered for term in EXECUTOR_INELIGIBILITY_TERMS)
+        if has_independent_checker_reference and has_executor_ineligibility:
             return True
     return False
 

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -98,9 +98,7 @@ def test_list_open_prs_by_closing_issue_maps_linked_prs(monkeypatch):
 
 
 def test_community_loop_watch_workflow_can_read_pull_requests():
-    workflow = Path(".github/workflows/community-loop-watch.yml").read_text(
-        encoding="utf-8"
-    )
+    workflow = Path(".github/workflows/community-loop-watch.yml").read_text(encoding="utf-8")
 
     assert "pull-requests: read" in workflow
 
@@ -438,9 +436,7 @@ def test_build_status_downgrades_stale_writer_schedule_when_workflow_run_succeed
 
     monkeypatch.setattr(watch, "_recent_workflow_runs", fake_recent_workflow_runs)
     monkeypatch.setattr(watch, "list_loop_issues", lambda *_args, **_kwargs: [])
-    monkeypatch.setattr(
-        watch, "list_open_issues_by_label", lambda *_args, **_kwargs: []
-    )
+    monkeypatch.setattr(watch, "list_open_issues_by_label", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(watch, "_github_token", lambda _args: None)
 
     status = watch.build_status(
@@ -457,9 +453,7 @@ def test_build_status_downgrades_stale_writer_schedule_when_workflow_run_succeed
         now=now,
     )
 
-    writer_stage = [
-        stage for stage in status["stages"] if stage["name"] == "Writer workflow"
-    ][0]
+    writer_stage = [stage for stage in status["stages"] if stage["name"] == "Writer workflow"][0]
     assert status["overall"] == "yellow"
     assert writer_stage["status"] == "yellow"
     assert writer_stage["details"]["run_id"] == 44
@@ -514,9 +508,7 @@ def test_build_status_downgrades_stale_writer_schedule_when_queue_has_only_defer
 
     monkeypatch.setattr(watch, "_recent_workflow_runs", fake_recent_workflow_runs)
     monkeypatch.setattr(watch, "list_loop_issues", fake_list_loop_issues)
-    monkeypatch.setattr(
-        watch, "list_open_issues_by_label", lambda *_args, **_kwargs: []
-    )
+    monkeypatch.setattr(watch, "list_open_issues_by_label", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(watch, "_github_token", lambda _args: None)
 
     status = watch.build_status(
@@ -533,20 +525,13 @@ def test_build_status_downgrades_stale_writer_schedule_when_queue_has_only_defer
         now=now,
     )
 
-    writer_stage = [
-        stage for stage in status["stages"] if stage["name"] == "Writer workflow"
-    ][0]
-    queue_stage = [
-        stage for stage in status["stages"] if stage["name"] == "Writer queue"
-    ][0]
+    writer_stage = [stage for stage in status["stages"] if stage["name"] == "Writer workflow"][0]
+    queue_stage = [stage for stage in status["stages"] if stage["name"] == "Writer queue"][0]
     assert status["overall"] == "yellow"
     assert writer_stage["status"] == "yellow"
     expected_reason = "no writer-eligible queue (1 await-primitive-layer deferrals)"
     assert expected_reason in writer_stage["evidence"]
-    assert (
-        writer_stage["details"]["queue_downgrade"]
-        == expected_reason
-    )
+    assert writer_stage["details"]["queue_downgrade"] == expected_reason
     assert queue_stage["details"]["await_primitive_layer"] == [541]
 
 
@@ -904,6 +889,74 @@ def test_queue_stage_treats_attempted_with_open_pr_as_review_waiting(monkeypatch
     assert stage["url"] == "https://example.test/pull/598"
 
 
+def test_checker_queue_surfaces_independent_checker_blocker(monkeypatch):
+    def fake_list_open_issues_by_label(*_args, **_kwargs):
+        return [
+            {
+                "number": 720,
+                "title": "Recruiter-readiness bundle",
+                "state": "open",
+                "html_url": "https://example.test/pull/720",
+                "pull_request": {},
+                "labels": [
+                    {"name": "writer:claude"},
+                    {"name": "checker:codex"},
+                    {"name": watch.READY_FOR_CHECKER_LABEL},
+                    {"name": "priority:urgent"},
+                ],
+            }
+        ]
+
+    def fake_gh_get(path, **_kwargs):
+        assert path == "/repos/owner/repo/pulls/720"
+        return {"mergeable_state": "clean", "html_url": "https://example.test/pull/720"}
+
+    def fake_gh_get_paginated(path, **_kwargs):
+        if path == "/repos/owner/repo/issues/720/comments":
+            return [
+                {
+                    "body": (
+                        "Host key recorded: user explicitly said `720 approved`.\n\n"
+                        "This same Codex executor session mechanically opened the "
+                        "PR, so it is not an independent Codex checker path."
+                    )
+                }
+            ]
+        if path == "/repos/owner/repo/pulls/720/reviews":
+            return []
+        raise AssertionError(path)
+
+    monkeypatch.setattr(watch, "list_open_issues_by_label", fake_list_open_issues_by_label)
+    monkeypatch.setattr(watch, "_gh_get", fake_gh_get)
+    monkeypatch.setattr(watch, "_gh_get_paginated", fake_gh_get_paginated)
+
+    stage = watch.checker_queue_stage(
+        "owner/repo",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+    )
+
+    assert stage["status"] == "yellow"
+    assert "independent checker" in stage["summary"]
+    assert stage["details"]["by_state"] == {"needs_independent_codex_checker": [720]}
+    assert "current executor is ineligible" in stage["evidence"]
+
+
+def test_checker_queue_green_when_no_ready_prs(monkeypatch):
+    monkeypatch.setattr(watch, "list_open_issues_by_label", lambda *_args, **_kwargs: [])
+
+    stage = watch.checker_queue_stage(
+        "owner/repo",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+    )
+
+    assert stage["status"] == "green"
+    assert stage["details"]["ready_for_checker_prs"] == []
+
+
 def test_queue_stage_treats_await_primitive_layer_as_deferred_not_stuck(
     monkeypatch,
 ):
@@ -1072,9 +1125,7 @@ def test_tier3_broken_issue_marks_clone_smoke_stage_red(monkeypatch):
             }
         ]
 
-    monkeypatch.setattr(
-        watch, "list_open_issues_by_label", fake_list_open_issues_by_label
-    )
+    monkeypatch.setattr(watch, "list_open_issues_by_label", fake_list_open_issues_by_label)
     monkeypatch.setattr(watch, "_latest_workflow_run", lambda *_, **__: None)
 
     stage = watch.tier3_clone_smoke_stage(
@@ -1111,9 +1162,7 @@ def test_tier3_broken_issues_are_yellow_when_newer_smoke_success_exists(
             "html_url": "https://example.test/runs/25488453292",
         }
 
-    monkeypatch.setattr(
-        watch, "list_open_issues_by_label", fake_list_open_issues_by_label
-    )
+    monkeypatch.setattr(watch, "list_open_issues_by_label", fake_list_open_issues_by_label)
     monkeypatch.setattr(watch, "_latest_workflow_run", fake_latest_workflow_run)
 
     stage = watch.tier3_clone_smoke_stage(
@@ -1161,9 +1210,7 @@ def test_build_status_is_red_when_tier3_broken_issue_is_open(monkeypatch):
 
     monkeypatch.setattr(watch, "_recent_workflow_runs", fake_recent_workflow_runs)
     monkeypatch.setattr(watch, "list_loop_issues", fake_list_loop_issues)
-    monkeypatch.setattr(
-        watch, "list_open_issues_by_label", fake_list_open_issues_by_label
-    )
+    monkeypatch.setattr(watch, "list_open_issues_by_label", fake_list_open_issues_by_label)
     monkeypatch.setattr(watch, "_github_token", lambda _args: None)
 
     status = watch.build_status(
@@ -1182,6 +1229,6 @@ def test_build_status_is_red_when_tier3_broken_issue_is_open(monkeypatch):
 
     assert status["overall"] == "red"
     assert status["exit_code"] == 2
-    assert [
-        stage for stage in status["stages"] if stage["name"] == "Tier-3 clone smoke"
-    ][0]["status"] == "red"
+    assert [stage for stage in status["stages"] if stage["name"] == "Tier-3 clone smoke"][0][
+        "status"
+    ] == "red"

--- a/tests/test_merge_readiness.py
+++ b/tests/test_merge_readiness.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from scripts.merge_readiness import (
     CHECKER_CLAUDE_LABEL,
+    CHECKER_CODEX_LABEL,
     READY_FOR_CHECKER_LABEL,
+    WRITER_CLAUDE_LABEL,
     WRITER_CODEX_LABEL,
     PullRequestFacts,
     classify_many,
@@ -25,12 +27,53 @@ def _codex_pr(**overrides):
     return data
 
 
+def _claude_pr(**overrides):
+    data = {
+        "number": 720,
+        "title": "Recruiter-readiness bundle: public framing",
+        "mergeStateStatus": "CLEAN",
+        "labels": [
+            {"name": WRITER_CLAUDE_LABEL},
+            {"name": CHECKER_CODEX_LABEL},
+            {"name": READY_FOR_CHECKER_LABEL},
+        ],
+    }
+    data.update(overrides)
+    return data
+
+
 def test_codex_written_ready_pr_needs_claude_checker_first():
     result = classify_pr(PullRequestFacts.from_mapping(_codex_pr()))
 
     assert result.state == "needs_claude_checker"
     assert result.merge_executor_state == "blocked"
     assert result.next_action == "route to Cowork/Claude checker"
+
+
+def test_mixed_provenance_pr_routes_to_independent_checker_when_executor_ineligible():
+    result = classify_pr(
+        PullRequestFacts.from_mapping(
+            _claude_pr(
+                comments=[
+                    {
+                        "body": (
+                            "Host key recorded: user explicitly said `720 approved`.\n\n"
+                            "I am not merging from this Codex session because this same "
+                            "session mechanically applied the Cowork bundle and added "
+                            "support commits, so it is not an independent Codex checker path."
+                        )
+                    }
+                ],
+            )
+        )
+    )
+
+    assert result.state == "needs_independent_codex_checker"
+    assert result.merge_executor_state == "blocked_ineligible_checker"
+    assert result.next_action == (
+        "route to independent Codex checker; current executor is ineligible"
+    )
+    assert "current executor/session cannot provide checker key" in result.reasons
 
 
 def test_consensus_send_back_advisory_blocks_checker_routing():


### PR DESCRIPTION
## Summary

Adds a read-only checker-queue observability slice for the #720 stall pattern.

- `scripts/merge_readiness.py` now distinguishes ordinary `needs_codex_checker` / `needs_claude_checker` from `needs_independent_<family>_checker` when PR comments show the current executor session is not eligible to supply the required checker key.
- `scripts/community_loop_watch.py` now adds a `Checker queue` stage that scans `ready_for_checker` PRs and surfaces independent-checker blockers as yellow loop-health evidence.
- The live watcher currently reports PR #720 as `needs_independent_codex_checker` with `merge_executor_state=blocked_ineligible_checker`, which turns the manual #720 stall question into an observable queue state.

## Provenance / gate note

Writer: Codex/OpenAI family.
Required checker: Claude/Cowork family.

This does not merge or approve #720. It only teaches the loop to see and route the blocker that #720 exposed.

## Verification

- `python scripts/community_loop_watch.py --json` => yellow `Checker queue`, evidence `PR #720: route to independent Codex checker; current executor is ineligible`
- `python scripts/merge_readiness.py --repo Jonnyton/Workflow --limit 30 --hydrate-comments --pretty` => `needs_independent_codex_checker: [720]`
- `python -m pytest tests/test_merge_readiness.py tests/test_community_loop_watch.py -q` => 43 passed, 8 warnings
- `python -m ruff check scripts/merge_readiness.py scripts/community_loop_watch.py tests/test_merge_readiness.py tests/test_community_loop_watch.py` => all checks passed
- `python -m ruff format --check scripts/merge_readiness.py scripts/community_loop_watch.py tests/test_merge_readiness.py tests/test_community_loop_watch.py` => 4 files already formatted

Refs #720.
