### PR TITLE
Add automatic independent checker dispatch

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -472,3 +472,14 @@ Notes:
   PRs with ineligible executor sessions route to an independent checker lane.
 - Ship condition: focused tests pass, PR opened for Cowork/Claude review, no
   merge/approval behavior added.
+
+## Checker Worker Dispatch - 2026-05-09
+
+- 2026-05-09 create `../wf-checker-worker-dispatch` on
+  `codex/checker-worker-dispatch` by codex-gpt5-desktop.
+- Source: host clarified #720 must be fixed by the loop doing checker work, not
+  by operators manually filling the checker role.
+- Purpose: add an automatic checker-worker dispatch/receipt slice above the
+  #728 independent-checker observability state.
+- Ship condition: focused tests pass, PR opened for Cowork/Claude review, #720
+  can route to a checker worker without manual session assignment.

--- a/.github/workflows/auto-check-pr.yml
+++ b/.github/workflows/auto-check-pr.yml
@@ -1,0 +1,351 @@
+name: Auto-check PR
+
+# Independent checker worker for ready_for_checker PRs.
+#
+# This workflow is intentionally a checker, not a writer or merge executor.
+# It never commits, pushes, approves through GitHub Review, or merges. It posts
+# a structured PR comment that merge-readiness can tie to the current head SHA.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to check.
+        required: true
+        type: string
+      checker_family:
+        description: Required checker family for this PR.
+        required: true
+        type: choice
+        options:
+          - codex
+          - claude
+      reason:
+        description: Routing reason from merge-readiness.
+        required: false
+        default: checker_queue
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: auto-check-pr-${{ inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  codex-check:
+    if: inputs.checker_family == 'codex'
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      GH_TOKEN: ${{ github.token }}
+      HAS_CODEX_AUTH: ${{ secrets.WORKFLOW_CODEX_AUTH_JSON_B64 != '' }}
+      PR_NUMBER: ${{ inputs.pr_number }}
+      CHECKER_FAMILY: ${{ inputs.checker_family }}
+      ROUTING_REASON: ${{ inputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Preflight PR
+        id: preflight
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          CHECKER_FAMILY: ${{ env.CHECKER_FAMILY }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const checkerFamily = process.env.CHECKER_FAMILY;
+            const marker = 'workflow-checker-verdict:v1';
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const labels = new Set((pr.labels || []).map((label) => label.name));
+            const head = pr.head?.sha || '';
+            const title = pr.title || '';
+            const url = pr.html_url || '';
+            let skipReason = '';
+            if (pr.state !== 'open') {
+              skipReason = `PR state is ${pr.state}`;
+            } else if (!labels.has('ready_for_checker')) {
+              skipReason = 'missing ready_for_checker label';
+            } else if (!labels.has(`checker:${checkerFamily}`)) {
+              skipReason = `missing checker:${checkerFamily} label`;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => {
+              const body = String(comment.body || '').toLowerCase();
+              return (
+                body.includes(marker) &&
+                body.includes(`family=${checkerFamily}`) &&
+                body.includes(`head=${head.toLowerCase()}`) &&
+                body.includes('verdict=approve')
+              );
+            });
+            if (existing) {
+              skipReason = `current head already has ${checkerFamily} checker verdict`;
+            }
+
+            core.setOutput('skip', skipReason ? 'true' : 'false');
+            core.setOutput('skip_reason', skipReason);
+            core.setOutput('head_sha', head);
+            core.setOutput('title', title);
+            core.setOutput('url', url);
+
+      - name: Skip summary
+        if: steps.preflight.outputs.skip == 'true'
+        run: |
+          {
+            echo "### Auto-check PR skipped"
+            echo ""
+            echo "- PR: #${PR_NUMBER}"
+            echo "- reason: ${{ steps.preflight.outputs.skip_reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Mark missing Codex auth
+        if: steps.preflight.outputs.skip == 'false' && env.HAS_CODEX_AUTH != 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                  color,
+                  description,
+                });
+              }
+            }
+            await ensureLabel(
+              'auto-checker-auth-missing',
+              'cfd3d7',
+              'Automatic checker worker auth was missing when the PR was last checked.',
+            );
+            await ensureLabel(
+              'auto-checker-failed',
+              'd93f0b',
+              'Automatic checker worker failed or requested send-back.',
+            );
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: ['auto-checker-auth-missing', 'auto-checker-failed'],
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: [
+                '**Auto-check skipped:** independent Codex checker auth is not configured.',
+                '',
+                'The checker worker could not run because `WORKFLOW_CODEX_AUTH_JSON_B64` is not visible to GitHub Actions.',
+              ].join('\n'),
+            });
+
+      - name: Run Codex checker
+        id: codex-review
+        if: steps.preflight.outputs.skip == 'false' && env.HAS_CODEX_AUTH == 'true'
+        continue-on-error: true
+        env:
+          WORKFLOW_CODEX_AUTH_JSON_B64: ${{ secrets.WORKFLOW_CODEX_AUTH_JSON_B64 }}
+          HEAD_SHA: ${{ steps.preflight.outputs.head_sha }}
+          PR_TITLE: ${{ steps.preflight.outputs.title }}
+          PR_URL: ${{ steps.preflight.outputs.url }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.codex"
+          printf '%s' "${WORKFLOW_CODEX_AUTH_JSON_B64}" | base64 -d > "$HOME/.codex/auth.json"
+          chmod 600 "$HOME/.codex/auth.json"
+          unset WORKFLOW_CODEX_AUTH_JSON_B64
+          unset OPENAI_API_KEY ANTHROPIC_API_KEY ANTHROPIC_BASE_URL GEMINI_API_KEY GROQ_API_KEY XAI_API_KEY
+
+          npm install -g @openai/codex
+          git fetch origin "pull/${PR_NUMBER}/head:pr-${PR_NUMBER}"
+          git checkout --detach "pr-${PR_NUMBER}"
+
+          codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --cd "$GITHUB_WORKSPACE" --output-last-message "$RUNNER_TEMP/checker.md" - <<'PROMPT'
+          You are an independent Codex checker for the Workflow community loop.
+
+          Review PR #${{ env.PR_NUMBER }}: ${{ env.PR_TITLE }}
+          URL: ${{ env.PR_URL }}
+          Head SHA: ${{ env.HEAD_SHA }}
+          Routing reason: ${{ env.ROUTING_REASON }}
+
+          You are checking, not writing. Do not commit, push, merge, approve via
+          GitHub Review, or intentionally edit files. Inspect the PR diff, tests,
+          workflow changes, and comments. Use local shell commands as needed.
+
+          Return your final answer with this exact first line:
+          VERDICT: approve
+          or:
+          VERDICT: send_back
+
+          Use approve only when the PR is safe to advance to the next gate for
+          the current head SHA. Use send_back for any blocking issue, missing
+          proof, wrong scope, stale/head mismatch, or unclear risk.
+          PROMPT
+
+          if [ -n "$(git status --porcelain)" ]; then
+            {
+              echo "VERDICT: send_back"
+              echo ""
+              echo "Checker worker left the checkout dirty, so the verdict is not accepted."
+              git status --short
+            } > "$RUNNER_TEMP/checker-dirty.md"
+            mv "$RUNNER_TEMP/checker-dirty.md" "$RUNNER_TEMP/checker.md"
+          fi
+
+          verdict="$(grep -Eim1 '^VERDICT:[[:space:]]*(approve|send_back)[[:space:]]*$' "$RUNNER_TEMP/checker.md" | sed -E 's/^VERDICT:[[:space:]]*//' | tr '[:upper:]' '[:lower:]' || true)"
+          if [ "$verdict" != "approve" ]; then
+            verdict="send_back"
+          fi
+
+          {
+            echo "verdict=${verdict}"
+            echo "summary_path=$RUNNER_TEMP/checker.md"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post Codex checker verdict
+        if: steps.preflight.outputs.skip == 'false' && env.HAS_CODEX_AUTH == 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          HEAD_SHA: ${{ steps.preflight.outputs.head_sha }}
+          VERDICT: ${{ steps.codex-review.outputs.verdict || 'send_back' }}
+          REVIEW_STEP_OUTCOME: ${{ steps.codex-review.outcome }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const prNumber = Number(process.env.PR_NUMBER);
+            const reviewSucceeded = process.env.REVIEW_STEP_OUTCOME === 'success';
+            const verdict = reviewSucceeded ? (process.env.VERDICT || 'send_back') : 'send_back';
+            const checkerPath = path.join(process.env.RUNNER_TEMP, 'checker.md');
+            const checkerBody = fs.existsSync(checkerPath)
+              ? fs.readFileSync(checkerPath, 'utf8').slice(0, 12000)
+              : 'VERDICT: send_back\n\nChecker worker did not leave a readable review summary.';
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                  color,
+                  description,
+                });
+              }
+            }
+            await ensureLabel(
+              'auto-checker-failed',
+              'd93f0b',
+              'Automatic checker worker failed or requested send-back.',
+            );
+            if (!reviewSucceeded) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: [
+                  '**Auto-check failed:** independent Codex checker worker did not complete cleanly.',
+                  '',
+                  checkerBody,
+                ].join('\n'),
+              });
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: ['auto-checker-failed'],
+              });
+              return;
+            }
+            const markerVerdict = verdict === 'approve' ? 'approve' : 'send_back';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: [
+                `<!-- workflow-checker-verdict:v1 family=codex verdict=${markerVerdict} head=${process.env.HEAD_SHA} run=${process.env.GITHUB_RUN_ID} -->`,
+                `**Automated independent Codex checker verdict:** ${markerVerdict === 'approve' ? 'approve' : 'send-back/amend'}`,
+                '',
+                checkerBody,
+              ].join('\n'),
+            });
+            if (markerVerdict === 'approve') {
+              for (const label of ['auto-checker-dispatched', 'auto-checker-failed', 'auto-checker-auth-missing']) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    name: label,
+                  });
+                } catch (error) {
+                  if (error.status !== 404) throw error;
+                }
+              }
+            } else {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: ['auto-checker-failed'],
+              });
+            }
+
+  unsupported-checker:
+    if: inputs.checker_family != 'codex'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Record unsupported checker worker family
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          CHECKER_FAMILY: ${{ inputs.checker_family }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: [
+                `**Auto-check skipped:** checker family \`${process.env.CHECKER_FAMILY}\` is not implemented in this workflow slice.`,
+                '',
+                'Route this PR to the matching external checker lane until the multi-family checker pool lands.',
+              ].join('\n'),
+            });

--- a/.github/workflows/community-loop-watch.yml
+++ b/.github/workflows/community-loop-watch.yml
@@ -17,13 +17,14 @@ on:
         required: false
         default: "false"
   workflow_run:
-    workflows: ["Wiki bug sync", "Auto-fix change", "Uptime canary", "tier3-oss-clone-nightly", "deploy-site", "Deploy prod"]
+    workflows: ["Wiki bug sync", "Auto-fix change", "Auto-check PR", "Uptime canary", "tier3-oss-clone-nightly", "deploy-site", "Deploy prod"]
     types: [completed]
   push:
     branches: [main]
     paths:
       - "scripts/community_loop_watch.py"
       - ".github/workflows/community-loop-watch.yml"
+      - ".github/workflows/auto-check-pr.yml"
       - "docs/exec-plans/active/2026-04-30-live-community-reiteration-loop.md"
 
 permissions:
@@ -253,8 +254,87 @@ jobs:
               return dispatched;
             }
 
+            async function ensureLabel(name, color, description) {
+              const existing = await githubCall(`lookup label ${name}`, () => github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name,
+              }));
+              if (existing) {
+                return true;
+              }
+              const created = await githubCall(`create label ${name}`, () => github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name,
+                color,
+                description,
+              }));
+              return Boolean(created);
+            }
+
+            async function dispatchCheckerWorkers() {
+              let status;
+              try {
+                status = JSON.parse(probeMsg);
+              } catch (error) {
+                core.warning(`Could not parse community loop status JSON for checker dispatch: ${error.message}`);
+                return false;
+              }
+
+              const stages = Array.isArray(status.stages) ? status.stages : [];
+              const checkerStage = stages.find((stage) => stage?.name === 'Checker queue');
+              const dispatches = Array.isArray(checkerStage?.details?.self_heal_dispatches)
+                ? checkerStage.details.self_heal_dispatches
+                : [];
+              if (!dispatches.length) {
+                return false;
+              }
+
+              await ensureLabel(
+                'auto-checker-dispatched',
+                '0052cc',
+                'An automatic independent checker worker has been dispatched for this PR.',
+              );
+
+              let dispatched = false;
+              for (const dispatch of dispatches) {
+                const workflowId = dispatch?.workflow_id || 'auto-check-pr.yml';
+                const inputs = dispatch?.inputs || {};
+                const prNumber = Number(dispatch?.pr_number || inputs.pr_number || 0);
+                if (!prNumber || !inputs.pr_number || !inputs.checker_family) {
+                  core.warning(`Skipping malformed checker dispatch: ${JSON.stringify(dispatch)}`);
+                  continue;
+                }
+
+                const result = await githubCall(`dispatch checker worker for PR #${prNumber}`, () => (
+                  github.rest.actions.createWorkflowDispatch({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: workflowId,
+                    ref: 'main',
+                    inputs,
+                  })
+                ));
+                if (!result) {
+                  continue;
+                }
+
+                await githubCall(`mark PR #${prNumber} checker-dispatched`, () => github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  labels: ['auto-checker-dispatched'],
+                }));
+                console.log(`dispatched ${workflowId} for PR #${prNumber}`);
+                dispatched = true;
+              }
+              return dispatched;
+            }
+
             const dispatchedSelfHeal = await dispatchStaleDependencies();
-            if (dispatchedSelfHeal && !isSelfHealFollowup) {
+            const dispatchedChecker = await dispatchCheckerWorkers();
+            if ((dispatchedSelfHeal || dispatchedChecker) && !isSelfHealFollowup) {
               try {
                 await github.rest.actions.createWorkflowDispatch({
                   owner: context.repo.owner,

--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -62,6 +62,10 @@ CODEX_SUBSCRIPTION_MISSING_LABEL = "auto-fix-codex-subscription-missing"
 PROVIDER_EXHAUSTED_LABEL = "auto-fix-provider-exhausted"
 READY_FOR_CHECKER_LABEL = "ready_for_checker"
 CHECKER_CODEX_LABEL = "checker:codex"
+CHECKER_CLAUDE_LABEL = "checker:claude"
+AUTO_CHECKER_DISPATCHED_LABEL = "auto-checker-dispatched"
+AUTO_CHECKER_FAILED_LABEL = "auto-checker-failed"
+AUTO_CHECK_PR_WORKFLOW = "auto-check-pr.yml"
 REVIEWED_LABEL = "auto-fix-reviewed"
 ALREADY_FIXED_LABEL = "auto-fix-already-fixed"
 BLOCKED_REVIEWED_LABEL = "auto-fix-blocked"
@@ -621,6 +625,36 @@ def checker_queue_stage(
     independent_blockers = [
         result for result in results if result.state.startswith("needs_independent_")
     ]
+    prs_by_number = {int(pr["number"]): pr for pr in prs if isinstance(pr.get("number"), int)}
+    self_heal_dispatches: list[dict[str, Any]] = []
+    already_dispatched: list[int] = []
+    failed_dispatches: list[int] = []
+    for blocker in independent_blockers:
+        pr = prs_by_number.get(blocker.number, {})
+        labels = _labels(pr)
+        if AUTO_CHECKER_FAILED_LABEL in labels:
+            failed_dispatches.append(blocker.number)
+            continue
+        if AUTO_CHECKER_DISPATCHED_LABEL in labels:
+            already_dispatched.append(blocker.number)
+            continue
+        checker_family = _checker_family_from_state(blocker.state)
+        if not checker_family:
+            continue
+        reason = blocker.merge_executor_state
+        self_heal_dispatches.append(
+            {
+                "workflow_id": AUTO_CHECK_PR_WORKFLOW,
+                "pr_number": blocker.number,
+                "checker_family": checker_family,
+                "reason": reason,
+                "inputs": {
+                    "pr_number": str(blocker.number),
+                    "checker_family": checker_family,
+                    "reason": reason,
+                },
+            }
+        )
     checker_waiting = [
         result
         for result in results
@@ -630,8 +664,11 @@ def checker_queue_stage(
         "ready_for_checker_prs": [pr.get("number") for pr in prs],
         "by_state": by_state,
         "items": [result.as_dict() for result in results],
+        "self_heal_dispatches": self_heal_dispatches,
+        "already_dispatched_independent_checkers": already_dispatched,
+        "failed_independent_checker_dispatches": failed_dispatches,
     }
-    if independent_blockers:
+    if self_heal_dispatches:
         first = independent_blockers[0]
         first_pr = next((pr for pr in prs if pr.get("number") == first.number), {})
         return _stage(
@@ -642,6 +679,31 @@ def checker_queue_stage(
                 "checker because the current executor is ineligible"
             ),
             evidence=f"PR #{first.number}: {first.next_action}",
+            url=first_pr.get("html_url"),
+            details=details,
+        )
+    if failed_dispatches:
+        first = independent_blockers[0]
+        first_pr = next((pr for pr in prs if pr.get("number") == first.number), {})
+        return _stage(
+            "Checker queue",
+            "yellow",
+            f"{len(failed_dispatches)} ready PR(s) have failed independent checker dispatch",
+            evidence=f"PR #{failed_dispatches[0]}: repair checker worker/auth and redispatch",
+            url=first_pr.get("html_url"),
+            details=details,
+        )
+    if independent_blockers:
+        first = independent_blockers[0]
+        first_pr = next((pr for pr in prs if pr.get("number") == first.number), {})
+        return _stage(
+            "Checker queue",
+            "yellow",
+            (
+                f"{len(independent_blockers)} ready PR(s) already dispatched "
+                "to independent checker workers"
+            ),
+            evidence=f"PR #{first.number}: waiting on dispatched independent checker",
             url=first_pr.get("html_url"),
             details=details,
         )
@@ -662,6 +724,14 @@ def checker_queue_stage(
         "no ready_for_checker PRs are waiting on independent checker routing",
         details=details,
     )
+
+
+def _checker_family_from_state(state: str) -> str | None:
+    prefix = "needs_independent_"
+    suffix = "_checker"
+    if not state.startswith(prefix) or not state.endswith(suffix):
+        return None
+    return state[len(prefix) : -len(suffix)]
 
 
 def list_open_prs_by_closing_issue(

--- a/scripts/merge_readiness.py
+++ b/scripts/merge_readiness.py
@@ -43,6 +43,9 @@ HOST_KEY_PATTERNS = (
     "host explicitly turned keys",
 )
 
+CHECKER_VERDICT_MARKER = "workflow-checker-verdict:v1"
+CHECKER_VERDICT_ATTR_RE = re.compile(r"([a-z_]+)=([^\s>]+)")
+
 INDEPENDENT_CHECKER_BLOCKER_TERMS = (
     "independent checker",
     "independent codex checker",
@@ -116,6 +119,7 @@ class PullRequestFacts:
     number: int
     title: str
     state: str = "OPEN"
+    head_oid: str = ""
     merge_state_status: str = "UNKNOWN"
     labels: frozenset[str] = frozenset()
     opposite_family_checker_approved: bool = False
@@ -132,10 +136,12 @@ class PullRequestFacts:
         comments = pr.get("comments", [])
         reviews = pr.get("reviews", [])
         checker_family = _checker_family(labels)
+        head_oid = str(pr.get("headRefOid") or pr.get("head_oid") or pr.get("head_sha") or "")
         return cls(
             number=int(pr["number"]),
             title=str(pr.get("title") or ""),
             state=str(pr.get("state") or "OPEN"),
+            head_oid=head_oid,
             merge_state_status=str(
                 pr.get("merge_state_status")
                 or pr.get("mergeStateStatus")
@@ -144,12 +150,16 @@ class PullRequestFacts:
             ),
             labels=labels,
             opposite_family_checker_approved=bool(
-                pr.get("opposite_family_checker_approved") or _has_required_family_approval(reviews)
+                pr.get("opposite_family_checker_approved")
+                or _has_required_family_approval(reviews)
+                or _has_required_checker_verdict(comments, checker_family, head_oid)
             ),
             host_keyed=bool(pr.get("host_keyed") or _has_host_key_comment(comments)),
             checks_green=pr.get("checks_green"),
             send_back_advisory=bool(
-                pr.get("send_back_advisory") or _has_send_back_advisory(comments)
+                pr.get("send_back_advisory")
+                or _has_send_back_advisory(comments)
+                or _has_checker_send_back_verdict(comments, checker_family, head_oid)
             ),
             precheck_blocked=bool(pr.get("precheck_blocked") or _has_precheck_blocker(comments)),
             checker_executor_ineligible=bool(
@@ -387,6 +397,61 @@ def _has_host_key_comment(comments: Any) -> bool:
     return False
 
 
+def _checker_verdicts(comments: Any) -> list[dict[str, str]]:
+    verdicts: list[dict[str, str]] = []
+    for comment in comments or []:
+        body = comment.get("body") if isinstance(comment, dict) else str(comment)
+        lowered = str(body or "").lower()
+        marker_index = lowered.find(CHECKER_VERDICT_MARKER)
+        if marker_index < 0:
+            continue
+        marker_tail = lowered[marker_index + len(CHECKER_VERDICT_MARKER) :]
+        marker_tail = marker_tail.split("-->", 1)[0]
+        verdicts.append(dict(CHECKER_VERDICT_ATTR_RE.findall(marker_tail)))
+    return verdicts
+
+
+def _head_matches(verdict: dict[str, str], head_oid: Any) -> bool:
+    head = str(head_oid or "").lower()
+    verdict_head = str(verdict.get("head") or "").lower()
+    if not head:
+        return True
+    return bool(verdict_head) and verdict_head == head
+
+
+def _has_required_checker_verdict(
+    comments: Any,
+    checker_family: str | None,
+    head_oid: Any,
+) -> bool:
+    if not checker_family:
+        return False
+    for verdict in _checker_verdicts(comments):
+        if (
+            verdict.get("family") == checker_family
+            and verdict.get("verdict") == "approve"
+            and _head_matches(verdict, head_oid)
+        ):
+            return True
+    return False
+
+
+def _has_checker_send_back_verdict(
+    comments: Any,
+    checker_family: str | None,
+    head_oid: Any,
+) -> bool:
+    for verdict in _checker_verdicts(comments):
+        family_matches = not checker_family or verdict.get("family") == checker_family
+        if (
+            family_matches
+            and verdict.get("verdict") in {"send_back", "reject", "changes_requested"}
+            and _head_matches(verdict, head_oid)
+        ):
+            return True
+    return False
+
+
 def _has_checker_executor_ineligibility(comments: Any, checker_family: str | None) -> bool:
     if not checker_family:
         return False
@@ -499,7 +564,7 @@ def _read_input(path: str | None) -> list[dict[str, Any]]:
 
 
 def _fetch_gh_prs(repo: str, limit: int, hydrate_comments: bool = False) -> list[dict[str, Any]]:
-    fields = "number,state,mergeStateStatus,title,labels"
+    fields = "number,state,mergeStateStatus,title,headRefOid,labels"
     raw = subprocess.check_output(
         ["gh", "pr", "list", "--repo", repo, "--limit", str(limit), "--json", fields],
         text=True,

--- a/tests/test_auto_check_workflow.py
+++ b/tests/test_auto_check_workflow.py
@@ -1,0 +1,60 @@
+"""Static tests for .github/workflows/auto-check-pr.yml."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "auto-check-pr.yml"
+COMMUNITY_WATCH = REPO_ROOT / ".github" / "workflows" / "community-loop-watch.yml"
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_auto_check_is_dispatch_only():
+    wf = _workflow()
+    triggers = wf.get(True, wf.get("on", {}))
+
+    assert "workflow_dispatch" in triggers
+    assert "schedule" not in triggers
+    assert "push" not in triggers
+
+
+def test_auto_check_uses_pr_scoped_concurrency():
+    wf = _workflow()
+    concurrency = wf.get("concurrency", {})
+
+    assert "inputs.pr_number" in concurrency.get("group", "")
+    assert concurrency.get("cancel-in-progress") is False
+
+
+def test_auto_check_has_checker_permissions_not_writer_permissions():
+    wf = _workflow()
+    permissions = wf.get("permissions", {})
+
+    assert permissions.get("contents") == "read"
+    assert permissions.get("issues") == "write"
+    assert permissions.get("pull-requests") == "read"
+
+
+def test_auto_check_codex_lane_posts_structured_verdict_marker():
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "WORKFLOW_CODEX_AUTH_JSON_B64" in text
+    assert "workflow-checker-verdict:v1 family=codex" in text
+    assert "verdict=${markerVerdict}" in text
+    assert "head=${process.env.HEAD_SHA}" in text
+    assert "Do not commit, push, merge" in text
+
+
+def test_community_watch_dispatches_auto_check_workflow():
+    text = COMMUNITY_WATCH.read_text(encoding="utf-8")
+
+    assert '"Auto-check PR"' in text
+    assert "self_heal_dispatches" in text
+    assert "auto-check-pr.yml" in text
+    assert "auto-checker-dispatched" in text

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -941,6 +941,112 @@ def test_checker_queue_surfaces_independent_checker_blocker(monkeypatch):
     assert "independent checker" in stage["summary"]
     assert stage["details"]["by_state"] == {"needs_independent_codex_checker": [720]}
     assert "current executor is ineligible" in stage["evidence"]
+    assert stage["details"]["self_heal_dispatches"] == [
+        {
+            "workflow_id": "auto-check-pr.yml",
+            "pr_number": 720,
+            "checker_family": "codex",
+            "reason": "blocked_ineligible_checker",
+            "inputs": {
+                "pr_number": "720",
+                "checker_family": "codex",
+                "reason": "blocked_ineligible_checker",
+            },
+        }
+    ]
+
+
+def test_checker_queue_does_not_redispatch_labeled_checker_pr(monkeypatch):
+    def fake_list_open_issues_by_label(*_args, **_kwargs):
+        return [
+            {
+                "number": 720,
+                "title": "Recruiter-readiness bundle",
+                "state": "open",
+                "html_url": "https://example.test/pull/720",
+                "pull_request": {},
+                "labels": [
+                    {"name": "writer:claude"},
+                    {"name": "checker:codex"},
+                    {"name": watch.READY_FOR_CHECKER_LABEL},
+                    {"name": watch.AUTO_CHECKER_DISPATCHED_LABEL},
+                ],
+            }
+        ]
+
+    def fake_gh_get_paginated(path, **_kwargs):
+        if path == "/repos/owner/repo/issues/720/comments":
+            return [
+                {
+                    "body": (
+                        "Host key recorded: user explicitly said `720 approved`.\n\n"
+                        "This same Codex executor session mechanically opened the "
+                        "PR, so it is not an independent Codex checker path."
+                    )
+                }
+            ]
+        raise AssertionError(path)
+
+    monkeypatch.setattr(watch, "list_open_issues_by_label", fake_list_open_issues_by_label)
+    monkeypatch.setattr(watch, "_gh_get_paginated", fake_gh_get_paginated)
+
+    stage = watch.checker_queue_stage(
+        "owner/repo",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+    )
+
+    assert stage["status"] == "yellow"
+    assert "already dispatched" in stage["summary"]
+    assert stage["details"]["self_heal_dispatches"] == []
+
+
+def test_checker_queue_surfaces_failed_checker_dispatch(monkeypatch):
+    def fake_list_open_issues_by_label(*_args, **_kwargs):
+        return [
+            {
+                "number": 720,
+                "title": "Recruiter-readiness bundle",
+                "state": "open",
+                "html_url": "https://example.test/pull/720",
+                "pull_request": {},
+                "labels": [
+                    {"name": "writer:claude"},
+                    {"name": "checker:codex"},
+                    {"name": watch.READY_FOR_CHECKER_LABEL},
+                    {"name": watch.AUTO_CHECKER_FAILED_LABEL},
+                ],
+            }
+        ]
+
+    def fake_gh_get_paginated(path, **_kwargs):
+        if path == "/repos/owner/repo/issues/720/comments":
+            return [
+                {
+                    "body": (
+                        "Host key recorded: user explicitly said `720 approved`.\n\n"
+                        "This same Codex executor session mechanically opened the "
+                        "PR, so it is not an independent Codex checker path."
+                    )
+                }
+            ]
+        raise AssertionError(path)
+
+    monkeypatch.setattr(watch, "list_open_issues_by_label", fake_list_open_issues_by_label)
+    monkeypatch.setattr(watch, "_gh_get_paginated", fake_gh_get_paginated)
+
+    stage = watch.checker_queue_stage(
+        "owner/repo",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+    )
+
+    assert stage["status"] == "yellow"
+    assert "failed independent checker dispatch" in stage["summary"]
+    assert stage["details"]["failed_independent_checker_dispatches"] == [720]
+    assert stage["details"]["self_heal_dispatches"] == []
 
 
 def test_checker_queue_green_when_no_ready_prs(monkeypatch):

--- a/tests/test_merge_readiness.py
+++ b/tests/test_merge_readiness.py
@@ -76,6 +76,86 @@ def test_mixed_provenance_pr_routes_to_independent_checker_when_executor_ineligi
     assert "current executor/session cannot provide checker key" in result.reasons
 
 
+def test_independent_checker_verdict_for_current_head_clears_ineligible_executor_block():
+    result = classify_pr(
+        PullRequestFacts.from_mapping(
+            _claude_pr(
+                headRefOid="abc123",
+                checks_green=True,
+                comments=[
+                    {
+                        "body": (
+                            "Host key recorded: user explicitly said `720 approved`.\n\n"
+                            "This same Codex executor session mechanically opened the PR, "
+                            "so it is not an independent Codex checker path."
+                        )
+                    },
+                    {
+                        "body": (
+                            "<!-- workflow-checker-verdict:v1 "
+                            "family=codex verdict=approve head=abc123 run=42 -->\n"
+                            "**Automated independent Codex checker verdict:** approve"
+                        )
+                    },
+                ],
+            )
+        )
+    )
+
+    assert result.state == "merge_executor_ready"
+    assert result.merge_executor_state == "ready"
+
+
+def test_independent_checker_verdict_for_stale_head_is_ignored():
+    result = classify_pr(
+        PullRequestFacts.from_mapping(
+            _claude_pr(
+                headRefOid="new-head",
+                comments=[
+                    {
+                        "body": (
+                            "Host key recorded: user explicitly said `720 approved`.\n\n"
+                            "This same Codex executor session mechanically opened the PR, "
+                            "so it is not an independent Codex checker path."
+                        )
+                    },
+                    {
+                        "body": (
+                            "<!-- workflow-checker-verdict:v1 "
+                            "family=codex verdict=approve head=old-head run=42 -->\n"
+                            "**Automated independent Codex checker verdict:** approve"
+                        )
+                    },
+                ],
+            )
+        )
+    )
+
+    assert result.state == "needs_independent_codex_checker"
+
+
+def test_structured_checker_send_back_blocks_routing():
+    result = classify_pr(
+        PullRequestFacts.from_mapping(
+            _claude_pr(
+                headRefOid="abc123",
+                comments=[
+                    {
+                        "body": (
+                            "<!-- workflow-checker-verdict:v1 "
+                            "family=codex verdict=send_back head=abc123 run=42 -->\n"
+                            "**Automated independent Codex checker verdict:** send-back/amend"
+                        )
+                    }
+                ],
+            )
+        )
+    )
+
+    assert result.state == "send_back_amend"
+    assert result.next_action == "amend or regenerate before checker review"
+
+
 def test_consensus_send_back_advisory_blocks_checker_routing():
     result = classify_pr(
         PullRequestFacts.from_mapping(


### PR DESCRIPTION
## Summary

This is the narrow loop-health fix for the #720 jam after PR #728 made the blocker visible but did not give the loop a worker to resolve it.

- add dispatch output from `community_loop_watch.py` for `needs_independent_*_checker` PRs that are not already dispatched or failed
- add `auto-check-pr.yml`, a dispatch-only independent checker workflow that can run a Codex checker, post a structured `workflow-checker-verdict:v1` comment tied to the current head SHA, and never commit/push/approve/merge
- teach `merge_readiness.py` to accept only current-head structured checker verdicts, and to route structured send-back verdicts to amend
- wire `community-loop-watch.yml` to dispatch the checker worker and mark PRs with `auto-checker-dispatched`

## Why

For #720 specifically: no, it will not clear on its own with current `main`. It needs this loop capability (or equivalent) to land. Once this lands, the next community loop watch pass can dispatch the independent Codex checker worker for #720. If the worker returns `approve` for the current head, merge readiness can advance #720 without this executor session manually doing checker work.

## Scope notes

This slice implements the Codex checker-worker lane needed for #720. It intentionally does not solve the broader `checker:claude` backlog yet; unsupported families get an explicit skip note until the multi-family checker pool lands.

## Verification

- `python -m pytest tests/test_merge_readiness.py tests/test_community_loop_watch.py tests/test_auto_check_workflow.py -q` => 53 passed, 8 warnings
- `python -m ruff check scripts/merge_readiness.py scripts/community_loop_watch.py tests/test_merge_readiness.py tests/test_community_loop_watch.py tests/test_auto_check_workflow.py` => all checks passed
- `python -m ruff format --check scripts/merge_readiness.py scripts/community_loop_watch.py tests/test_merge_readiness.py tests/test_community_loop_watch.py tests/test_auto_check_workflow.py` => 5 files already formatted
- `python scripts/community_loop_watch.py --json` => yellow with `self_heal_dispatches` for PR #720 to `auto-check-pr.yml`
- YAML parse smoke for `.github/workflows/auto-check-pr.yml` and `.github/workflows/community-loop-watch.yml` passed

Local `actionlint` is not installed; pre-commit skipped that fast-feedback hook. CI should run the repository workflow lint.