### PR TITLE
[auto-change] WIKI-PATCH: gates tool rejects action=list with "Unknown action 'list'" while every other Workflow MCP tool accepts action=list — chatbots' natural discovery probe hits a dead end

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
@@ -2339,7 +2339,17 @@ _GATE_EVENT_ACTIONS: dict[str, Any] = {
 }
 
 
+def _action_gates_list(_kwargs: dict[str, Any]) -> str:
+    return json.dumps({
+        "status": "ok",
+        "tool": "gates",
+        "available_actions": sorted(_GATES_ACTIONS.keys()),
+        "gate_event_actions": sorted(_GATE_EVENT_ACTIONS.keys()),
+    })
+
+
 _GATES_ACTIONS: dict[str, Any] = {
+    "list": _action_gates_list,
     "define_ladder": _action_gates_define_ladder,
     "get_ladder": _action_gates_get_ladder,
     "claim": _action_gates_claim,
@@ -2382,6 +2392,7 @@ def gates(
     additionally require WORKFLOW_PAID_MARKET=on.
 
     Actions (all live when GATES_ENABLED=1):
+      list          Discover supported gates actions.
       define_ladder Owner sets the rung list on a Goal. Needs goal_id
                     and `ladder` (JSON list of {rung_key, name,
                     description}).

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -870,6 +870,7 @@ def gates(
     additionally require WORKFLOW_PAID_MARKET=on.
 
     Actions (all live when GATES_ENABLED=1):
+      list          Discover supported gates actions.
       define_ladder Owner sets the rung list on a Goal. Needs goal_id
                     and `ladder` (JSON list of {rung_key, name,
                     description}).

--- a/tests/test_api_market.py
+++ b/tests/test_api_market.py
@@ -180,13 +180,13 @@ def test_goals_unknown_action_lists_directory_aliases():
 # ── _GATES_ACTIONS dispatch table ───────────────────────────────────────────
 
 
-def test_gates_actions_table_has_9_handlers():
-    assert len(_GATES_ACTIONS) == 9
+def test_gates_actions_table_has_10_handlers():
+    assert len(_GATES_ACTIONS) == 10
 
 
 def test_gates_actions_keys():
     expected = {
-        "define_ladder", "get_ladder", "claim", "retract",
+        "define_ladder", "get_ladder", "claim", "retract", "list",
         "list_claims", "leaderboard",
         "stake_bonus", "unstake_bonus", "release_bonus",
     }
@@ -266,6 +266,17 @@ def test_gates_when_flag_off_returns_not_available(monkeypatch):
     monkeypatch.delenv("GATES_ENABLED", raising=False)
     out = json.loads(gates(action="claim"))
     assert out["status"] == "not_available"
+
+
+def test_gates_list_returns_discovery_payload(monkeypatch):
+    monkeypatch.setenv("GATES_ENABLED", "1")
+
+    out = json.loads(gates(action="list"))
+
+    assert out["status"] == "ok"
+    assert out["tool"] == "gates"
+    assert "list" in out["available_actions"]
+    assert "list_claims" in out["available_actions"]
 
 
 def test_gates_enabled_default_off(monkeypatch):

--- a/tests/test_outcome_gates.py
+++ b/tests/test_outcome_gates.py
@@ -77,6 +77,17 @@ def test_gates_tool_gated_by_flag(tmp_path, monkeypatch):
         importlib.reload(us)
 
 
+def test_gates_list_discovers_actions(gates_env):
+    us, _ = gates_env
+
+    result = _call(us, "gates", "list")
+
+    assert result["status"] == "ok"
+    assert result["tool"] == "gates"
+    assert "list" in result["available_actions"]
+    assert "list_claims" in result["available_actions"]
+
+
 # ─── define_ladder ─────────────────────────────────────────────────────
 
 

--- a/workflow/api/market.py
+++ b/workflow/api/market.py
@@ -2339,7 +2339,17 @@ _GATE_EVENT_ACTIONS: dict[str, Any] = {
 }
 
 
+def _action_gates_list(_kwargs: dict[str, Any]) -> str:
+    return json.dumps({
+        "status": "ok",
+        "tool": "gates",
+        "available_actions": sorted(_GATES_ACTIONS.keys()),
+        "gate_event_actions": sorted(_GATE_EVENT_ACTIONS.keys()),
+    })
+
+
 _GATES_ACTIONS: dict[str, Any] = {
+    "list": _action_gates_list,
     "define_ladder": _action_gates_define_ladder,
     "get_ladder": _action_gates_get_ladder,
     "claim": _action_gates_claim,
@@ -2382,6 +2392,7 @@ def gates(
     additionally require WORKFLOW_PAID_MARKET=on.
 
     Actions (all live when GATES_ENABLED=1):
+      list          Discover supported gates actions.
       define_ladder Owner sets the rung list on a Goal. Needs goal_id
                     and `ladder` (JSON list of {rung_key, name,
                     description}).

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -870,6 +870,7 @@ def gates(
     additionally require WORKFLOW_PAID_MARKET=on.
 
     Actions (all live when GATES_ENABLED=1):
+      list          Discover supported gates actions.
       define_ladder Owner sets the rung list on a Goal. Needs goal_id
                     and `ladder` (JSON list of {rung_key, name,
                     description}).


### PR DESCRIPTION
Fixes #735

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-090-gates-tool-rejects-action-list-with-unknown-action-list-whil.md`
- GitHub issue: #735
- Branch task: `auto-change/issue-735`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.