### PR TITLE
[auto-change] WIKI-PATCH: Universe cycle wrapper polls every ~22 seconds when no active work — should back off (cadence concern separate from PR #720's reason_code rename)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker.py
@@ -294,6 +294,7 @@ class SupervisorState:
 
     def __init__(self) -> None:
         self.crash_count = 0
+        self.clean_exit_count = 0
         self.total_spawns = 0
         self.total_clean_exits = 0
         self.total_crashes = 0
@@ -302,9 +303,11 @@ class SupervisorState:
         self.total_spawns += 1
         if returncode == 0:
             self.crash_count = 0
+            self.clean_exit_count += 1
             self.total_clean_exits += 1
         else:
             self.crash_count += 1
+            self.clean_exit_count = 0
             self.total_crashes += 1
 
     def summary(self) -> str:
@@ -335,7 +338,9 @@ def run_supervisor(
       1. Spawn fantasy_daemon against the universe.
       2. Wait for it to exit.
       3. Record exit as clean or crash.
-      4. Sleep idle_backoff (clean) or crash_backoff*mult^(crashes-1) (crash).
+      4. Sleep with exponential backoff after consecutive clean exits or
+         crashes. Clean exits usually mean no active work; backing them off
+         prevents the universe-cycle wrapper from steady polling while idle.
 
     ``max_iterations`` is an injection seam for tests — leave None in
     production for an unbounded loop. ``spawn_fn`` + ``sleep_fn`` are
@@ -383,6 +388,7 @@ def run_supervisor(
         except OSError as exc:
             logger.error("cloud_worker: spawn failed: %s", exc)
             state.crash_count += 1
+            state.clean_exit_count = 0
             state.total_crashes += 1
             delay = _compute_backoff(
                 state.crash_count,
@@ -479,7 +485,10 @@ def run_supervisor(
             break
 
         if returncode == 0:
-            delay = idle_backoff
+            delay = _compute_backoff(
+                state.clean_exit_count,
+                base=idle_backoff, mult=backoff_mult, ceiling=max_backoff,
+            )
         else:
             delay = _compute_backoff(
                 state.crash_count,

--- a/tests/test_cloud_worker.py
+++ b/tests/test_cloud_worker.py
@@ -123,7 +123,7 @@ def test_state_summary_includes_counters():
 
 
 def test_supervisor_clean_exit_uses_idle_backoff(tmp_path):
-    """Subprocess exits 0 → sleep = idle_backoff (not crash_backoff)."""
+    """First clean exit sleeps idle_backoff (not crash_backoff)."""
     sleep_calls, sleep_fn = _make_sleep_recorder()
 
     def spawn(universe):
@@ -139,9 +139,29 @@ def test_supervisor_clean_exit_uses_idle_backoff(tmp_path):
     )
     assert state.total_clean_exits == 2
     assert state.total_crashes == 0
-    # Both iterations sleep idle_backoff after clean exit.
     assert 7.0 in sleep_calls
     assert 999.0 not in sleep_calls
+
+
+def test_supervisor_consecutive_clean_exits_back_off(tmp_path):
+    """Idle universe-cycle exits should not respawn at a fixed short cadence."""
+    sleep_calls, sleep_fn = _make_sleep_recorder()
+
+    def spawn(universe):
+        return FakeProc(returncode=0, steps_until_exit=0)
+
+    state = cw.run_supervisor(
+        tmp_path,
+        idle_backoff=10.0,
+        backoff_mult=2.0,
+        max_backoff=45.0,
+        max_iterations=4,
+        spawn_fn=spawn,
+        sleep_fn=sleep_fn,
+    )
+
+    assert state.total_clean_exits == 4
+    assert sleep_calls == [10.0, 20.0, 40.0, 45.0]
 
 
 def test_supervisor_crash_uses_exponential_backoff(tmp_path):
@@ -201,6 +221,33 @@ def test_supervisor_crash_followed_by_clean_resets_backoff(tmp_path):
     )
 
 
+def test_supervisor_crash_resets_idle_backoff(tmp_path):
+    """Crash recovery should not inherit the idle no-work backoff streak."""
+    sleep_calls, sleep_fn = _make_sleep_recorder()
+    rc_sequence = [0, 0, 1, 0]
+    iter_idx = {"i": 0}
+
+    def spawn(universe):
+        rc = rc_sequence[iter_idx["i"]]
+        iter_idx["i"] += 1
+        return FakeProc(returncode=rc, steps_until_exit=0)
+
+    state = cw.run_supervisor(
+        tmp_path,
+        idle_backoff=3.0,
+        crash_backoff=11.0,
+        backoff_mult=2.0,
+        max_backoff=100.0,
+        max_iterations=4,
+        spawn_fn=spawn,
+        sleep_fn=sleep_fn,
+    )
+
+    assert state.total_clean_exits == 3
+    assert state.total_crashes == 1
+    assert sleep_calls == [3.0, 6.0, 11.0, 3.0]
+
+
 def test_supervisor_max_iterations_honored(tmp_path):
     sleep_calls, sleep_fn = _make_sleep_recorder()
 
@@ -237,6 +284,33 @@ def test_supervisor_spawn_failure_counted_as_crash(tmp_path):
     assert state.total_crashes == 3
     # Backoff magnitudes: 3, 6, 12.
     assert [d for d in sleep_calls if d in (3.0, 6.0, 12.0)] == [3.0, 6.0, 12.0]
+
+
+def test_supervisor_spawn_failure_resets_idle_backoff(tmp_path):
+    """Spawn failures are crash-path events and reset idle no-work backoff."""
+    sleep_calls, sleep_fn = _make_sleep_recorder()
+    outcomes = iter(["clean", "clean", "spawn-fail", "clean"])
+
+    def spawn(universe):
+        outcome = next(outcomes)
+        if outcome == "spawn-fail":
+            raise OSError("simulated spawn failure")
+        return FakeProc(returncode=0, steps_until_exit=0)
+
+    state = cw.run_supervisor(
+        tmp_path,
+        idle_backoff=3.0,
+        crash_backoff=11.0,
+        backoff_mult=2.0,
+        max_backoff=100.0,
+        max_iterations=4,
+        spawn_fn=spawn,
+        sleep_fn=sleep_fn,
+    )
+
+    assert state.total_clean_exits == 3
+    assert state.total_crashes == 1
+    assert sleep_calls == [3.0, 6.0, 11.0, 3.0]
 
 
 # ---- env construction ---------------------------------------------------

--- a/workflow/cloud_worker.py
+++ b/workflow/cloud_worker.py
@@ -294,6 +294,7 @@ class SupervisorState:
 
     def __init__(self) -> None:
         self.crash_count = 0
+        self.clean_exit_count = 0
         self.total_spawns = 0
         self.total_clean_exits = 0
         self.total_crashes = 0
@@ -302,9 +303,11 @@ class SupervisorState:
         self.total_spawns += 1
         if returncode == 0:
             self.crash_count = 0
+            self.clean_exit_count += 1
             self.total_clean_exits += 1
         else:
             self.crash_count += 1
+            self.clean_exit_count = 0
             self.total_crashes += 1
 
     def summary(self) -> str:
@@ -335,7 +338,9 @@ def run_supervisor(
       1. Spawn fantasy_daemon against the universe.
       2. Wait for it to exit.
       3. Record exit as clean or crash.
-      4. Sleep idle_backoff (clean) or crash_backoff*mult^(crashes-1) (crash).
+      4. Sleep with exponential backoff after consecutive clean exits or
+         crashes. Clean exits usually mean no active work; backing them off
+         prevents the universe-cycle wrapper from steady polling while idle.
 
     ``max_iterations`` is an injection seam for tests — leave None in
     production for an unbounded loop. ``spawn_fn`` + ``sleep_fn`` are
@@ -383,6 +388,7 @@ def run_supervisor(
         except OSError as exc:
             logger.error("cloud_worker: spawn failed: %s", exc)
             state.crash_count += 1
+            state.clean_exit_count = 0
             state.total_crashes += 1
             delay = _compute_backoff(
                 state.crash_count,
@@ -479,7 +485,10 @@ def run_supervisor(
             break
 
         if returncode == 0:
-            delay = idle_backoff
+            delay = _compute_backoff(
+                state.clean_exit_count,
+                base=idle_backoff, mult=backoff_mult, ceiling=max_backoff,
+            )
         else:
             delay = _compute_backoff(
                 state.crash_count,


### PR DESCRIPTION
Fixes #736

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-091-universe-cycle-wrapper-polls-every-22-seconds-when-no-active.md`
- GitHub issue: #736
- Branch task: `auto-change/issue-736`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.