### PR TITLE
Allow checker workflows to mark PRs

### DIFF
--- a/.github/workflows/auto-check-pr.yml
+++ b/.github/workflows/auto-check-pr.yml
@@ -29,7 +29,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: auto-check-pr-${{ inputs.pr_number }}

--- a/.github/workflows/community-loop-watch.yml
+++ b/.github/workflows/community-loop-watch.yml
@@ -30,7 +30,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
   actions: write
 
 concurrency:

--- a/tests/test_auto_check_workflow.py
+++ b/tests/test_auto_check_workflow.py
@@ -38,7 +38,17 @@ def test_auto_check_has_checker_permissions_not_writer_permissions():
 
     assert permissions.get("contents") == "read"
     assert permissions.get("issues") == "write"
-    assert permissions.get("pull-requests") == "read"
+    assert permissions.get("pull-requests") == "write"
+
+
+def test_community_watch_can_mark_checker_prs_without_content_write():
+    wf = yaml.safe_load(COMMUNITY_WATCH.read_text(encoding="utf-8"))
+    permissions = wf.get("permissions", {})
+
+    assert permissions.get("contents") == "read"
+    assert permissions.get("issues") == "write"
+    assert permissions.get("pull-requests") == "write"
+    assert permissions.get("actions") == "write"
 
 
 def test_auto_check_codex_lane_posts_structured_verdict_marker():

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -97,10 +97,10 @@ def test_list_open_prs_by_closing_issue_maps_linked_prs(monkeypatch):
     assert result[568][0]["number"] == 598
 
 
-def test_community_loop_watch_workflow_can_read_pull_requests():
+def test_community_loop_watch_workflow_can_mark_pull_requests():
     workflow = Path(".github/workflows/community-loop-watch.yml").read_text(encoding="utf-8")
 
-    assert "pull-requests: read" in workflow
+    assert "pull-requests: write" in workflow
 
 
 def test_workflow_stage_ignores_neutral_skipped_runs(monkeypatch):


### PR DESCRIPTION
## Summary

Follow-up to #733 after the first live #720 cascade.

#733 successfully dispatched `auto-check-pr.yml` for #720. The checker worker ran Codex and produced a real `send_back` verdict, but posting that verdict comment failed with GitHub 403:

`Resource not accessible by integration` on `POST /repos/Jonnyton/Workflow/issues/720/comments`.

The response advertised accepted permissions `issues=write; pull_requests=write`. The workflows only had `pull-requests: read`, so this patch grants the PR write permission needed to comment/label PRs while keeping `contents: read`.

## Changes

- `auto-check-pr.yml`: `pull-requests: read` -> `pull-requests: write`
- `community-loop-watch.yml`: `pull-requests: read` -> `pull-requests: write`
- update static tests so the permissions needed for checker dispatch/commenting are locked in

## Verification

- `python -m pytest tests/test_auto_check_workflow.py tests/test_community_loop_watch.py tests/test_merge_readiness.py -q` => 54 passed, 8 warnings
- `python -m ruff check tests/test_auto_check_workflow.py tests/test_community_loop_watch.py` => all checks passed
- YAML parse smoke confirms both workflow permission maps

Local actionlint is not installed; CI actionlint remains the gate.

## Note on #720

The first checker worker found a blocking issue on #720: `create_streamable_http_app()` returns `_MCPDiscoveryMiddleware`, which does not preserve the existing Starlette app contract expected by `tests/test_universe_server_directory_app.py` (`app.routes` / `app.state.*`). This PR does not amend #720; it fixes the loop so the checker verdict can be posted by the worker instead of being lost to token permissions.