### PR TITLE
[auto-change] WIKI-PATCH: extensions action=list_branches surfaces 35 unpublished smoke/probe/test branches alongside 4 published branches; no way for fresh-user chatbot to filter to "forkable production-ready branches" — friction surfaced during user-onboarding scout 2026-05-10

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -375,10 +375,13 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
     from workflow.api.engine_helpers import _current_actor
     from workflow.daemon_server import list_branch_definitions
 
+    published_only = bool(kwargs.get("published_only", False))
+
     # Phase 6.2.2 — visibility-aware listing. Viewer sees public
     # Branches and any private Branches they authored.
     rows = list_branch_definitions(
         _base_path(),
+        published_only=published_only,
         domain_id=kwargs.get("domain_id", ""),
         author=kwargs.get("author", ""),
         goal_id=kwargs.get("goal_id", ""),
@@ -392,6 +395,8 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
 
     summaries = []
     for r in rows:
+        if published_only and not r.get("published", False):
+            continue
         node_defs = r.get("node_defs", [])
         has_sandbox_nodes = any(nd.get("requires_sandbox") for nd in node_defs)
         if rs_filter == "none" and has_sandbox_nodes:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
@@ -276,6 +276,7 @@ def _extensions_impl(
     node_ref_json: str = "",
     intent: str = "",
     node_query: str = "",
+    published_only: bool = False,
     force: bool = False,
     project_id: str = "",
     key: str = "",
@@ -394,6 +395,7 @@ def _extensions_impl(
         "intent": intent,
         "query": node_query,
         "limit": limit,
+        "published_only": published_only,
         "force": force,
     }
     if node_ref_json:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -517,6 +517,7 @@ def extensions(
     node_ref_json: str = "",
     intent: str = "",
     node_query: str = "",
+    published_only: bool = False,
     force: bool = False,
     project_id: str = "",
     key: str = "",
@@ -598,6 +599,8 @@ def extensions(
     describe_branch, get_branch, run_branch, get_run, wait_for_run,
     judge_run, publish_version, schedule_branch, fork_tree, and search_nodes.
     Pass `action` plus the matching ids or JSON payload fields.
+    Use `published_only=True` with list_branches to show production-ready
+    Branches instead of drafts, probes, and smoke-test branches.
     """
     return _extensions_impl(
         action=action,
@@ -646,6 +649,7 @@ def extensions(
         node_ref_json=node_ref_json,
         intent=intent,
         node_query=node_query,
+        published_only=published_only,
         force=force,
         project_id=project_id,
         key=key,

--- a/tests/test_branch_authoring_actions.py
+++ b/tests/test_branch_authoring_actions.py
@@ -69,6 +69,38 @@ def test_list_branches_returns_summaries(branch_env):
     assert all("node_count" in b for b in listing["branches"])
 
 
+def test_list_branches_published_only_filter(branch_env):
+    us, _ = branch_env
+    spec = {
+        "name": "Published",
+        "entry_point": "ready",
+        "node_defs": [{
+            "node_id": "ready",
+            "display_name": "Ready",
+            "prompt_template": "Do the work.",
+        }],
+        "edges": [
+            {"from": "START", "to": "ready"},
+            {"from": "ready", "to": "END"},
+        ],
+        "state_schema": [{"name": "x", "type": "str"}],
+    }
+    published = _call(us, "build_branch", spec_json=json.dumps(spec))
+    _call(us, "create_branch", name="Probe draft")
+    patched = _call(
+        us,
+        "patch_branch",
+        branch_def_id=published["branch_def_id"],
+        changes_json=json.dumps([{"op": "set_published", "published": True}]),
+    )
+    assert patched.get("status") != "rejected", patched
+
+    listing = _call(us, "list_branches", published_only=True)
+    assert listing["count"] == 1
+    assert listing["branches"][0]["name"] == "Published"
+    assert listing["branches"][0]["published"] is True
+
+
 def test_list_branches_node_count_matches_node_defs_length(branch_env):
     """list_branches.node_count must equal get_branch.node_defs length.
 

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -375,10 +375,13 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
     from workflow.api.engine_helpers import _current_actor
     from workflow.daemon_server import list_branch_definitions
 
+    published_only = bool(kwargs.get("published_only", False))
+
     # Phase 6.2.2 — visibility-aware listing. Viewer sees public
     # Branches and any private Branches they authored.
     rows = list_branch_definitions(
         _base_path(),
+        published_only=published_only,
         domain_id=kwargs.get("domain_id", ""),
         author=kwargs.get("author", ""),
         goal_id=kwargs.get("goal_id", ""),
@@ -392,6 +395,8 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
 
     summaries = []
     for r in rows:
+        if published_only and not r.get("published", False):
+            continue
         node_defs = r.get("node_defs", [])
         has_sandbox_nodes = any(nd.get("requires_sandbox") for nd in node_defs)
         if rs_filter == "none" and has_sandbox_nodes:

--- a/workflow/api/extensions.py
+++ b/workflow/api/extensions.py
@@ -276,6 +276,7 @@ def _extensions_impl(
     node_ref_json: str = "",
     intent: str = "",
     node_query: str = "",
+    published_only: bool = False,
     force: bool = False,
     project_id: str = "",
     key: str = "",
@@ -394,6 +395,7 @@ def _extensions_impl(
         "intent": intent,
         "query": node_query,
         "limit": limit,
+        "published_only": published_only,
         "force": force,
     }
     if node_ref_json:

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -517,6 +517,7 @@ def extensions(
     node_ref_json: str = "",
     intent: str = "",
     node_query: str = "",
+    published_only: bool = False,
     force: bool = False,
     project_id: str = "",
     key: str = "",
@@ -598,6 +599,8 @@ def extensions(
     describe_branch, get_branch, run_branch, get_run, wait_for_run,
     judge_run, publish_version, schedule_branch, fork_tree, and search_nodes.
     Pass `action` plus the matching ids or JSON payload fields.
+    Use `published_only=True` with list_branches to show production-ready
+    Branches instead of drafts, probes, and smoke-test branches.
     """
     return _extensions_impl(
         action=action,
@@ -646,6 +649,7 @@ def extensions(
         node_ref_json=node_ref_json,
         intent=intent,
         node_query=node_query,
+        published_only=published_only,
         force=force,
         project_id=project_id,
         key=key,


### PR DESCRIPTION
Fixes #745

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-094-extensions-action-list-branches-surfaces-35-unpublished-smok.md`
- GitHub issue: #745
- Branch task: `auto-change/issue-745`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.