### PR TITLE
Classify expired Codex auth in auto-fix loop

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -421,15 +421,20 @@ jobs:
                 color: 'd93f0b',
                 description: 'Automated writer auth exists, but the selected provider returned quota/capacity exhaustion.',
               },
-              {
-                name: 'auto-fix-writer-failed',
-                color: 'd93f0b',
-                description: 'Automated writer auth existed, but the selected writer failed before opening a PR.',
-              },
-              {
-                name: 'auto-fix-claude-subscription-missing',
-                color: 'd93f0b',
-                description: 'Preferred subscription-backed Claude Code OAuth token was not visible to GitHub Actions.',
+                {
+                  name: 'auto-fix-writer-failed',
+                  color: 'd93f0b',
+                  description: 'Automated writer auth existed, but the selected writer failed before opening a PR.',
+                },
+                {
+                  name: 'auto-fix-auth-expired',
+                  color: 'd93f0b',
+                  description: 'Subscription-backed writer auth was visible but expired or revoked at invocation time.',
+                },
+                {
+                  name: 'auto-fix-claude-subscription-missing',
+                  color: 'd93f0b',
+                  description: 'Preferred subscription-backed Claude Code OAuth token was not visible to GitHub Actions.',
               },
               {
                 name: 'auto-fix-codex-subscription-missing',
@@ -660,7 +665,13 @@ jobs:
             const issueLabels = (issue.labels || []).map((label) => (
               typeof label === 'string' ? label : label.name
             ));
-            const labelsToClear = ['needs-human', 'auto-fix-auth-missing', 'auto-fix-provider-exhausted'];
+            const labelsToClear = [
+              'needs-human',
+              'auto-fix-auth-missing',
+              'auto-fix-auth-expired',
+              'auto-fix-provider-exhausted',
+              'auto-fix-writer-failed',
+            ];
             if ('${{ steps.auth.outputs.has_claude_oauth }}' === 'true') {
               labelsToClear.push('auto-fix-claude-subscription-missing');
             }
@@ -904,7 +915,8 @@ jobs:
           fi
           unset WORKFLOW_PUSH_TOKEN
 
-          codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --cd "$GITHUB_WORKSPACE" --output-last-message "$RUNNER_TEMP/codex-last-message.md" - <<'PROMPT'
+          prompt_file="$RUNNER_TEMP/codex-prompt.md"
+          cat > "$prompt_file" <<'PROMPT'
           You are handling a community change request in the Workflow repository.
 
           Request ID: ${{ steps.meta.outputs.request_id }}
@@ -935,6 +947,35 @@ jobs:
           working tree unchanged and explain why in your final message. Do not guess.
           PROMPT
 
+          codex_log="$RUNNER_TEMP/codex-exec.log"
+          set +e
+          codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --cd "$GITHUB_WORKSPACE" --output-last-message "$RUNNER_TEMP/codex-last-message.md" - < "$prompt_file" 2>&1 | tee "$codex_log"
+          codex_status=${PIPESTATUS[0]}
+          set -e
+          if [[ "$codex_status" -ne 0 ]]; then
+            auth_expired=false
+            if grep -Eiq 'refresh_token_reused|token_expired|invalid_grant|auth[^[:space:]]*[[:space:]-]*(expired|revoked)|login required|not logged in' "$codex_log"; then
+              auth_expired=true
+            fi
+            _delim="EOF_$(tr -d '-' < /proc/sys/kernel/random/uuid)"
+            {
+              echo "changed=false"
+              echo "no_change_reason="
+              echo "push_blocked=false"
+              echo "push_block_reason="
+              echo "auth_expired=${auth_expired}"
+              echo "last_message<<${_delim}"
+              if [ -s "$RUNNER_TEMP/codex-last-message.md" ]; then
+                head -c 4000 "$RUNNER_TEMP/codex-last-message.md"
+              else
+                head -c 4000 "$codex_log"
+              fi
+              echo
+              echo "${_delim}"
+            } >> "$GITHUB_OUTPUT"
+            exit "$codex_status"
+          fi
+
           if [ -z "$(git status --porcelain)" ]; then
             reason="blocked"
             message_file="$RUNNER_TEMP/codex-last-message.md"
@@ -948,6 +989,7 @@ jobs:
             {
               echo "changed=false"
               echo "no_change_reason=${reason}"
+              echo "auth_expired=false"
               echo "last_message<<${_delim}"
               if [ -s "$message_file" ]; then
                 head -c 4000 "$message_file"
@@ -1013,6 +1055,7 @@ jobs:
               echo "no_change_reason="
               echo "push_blocked=false"
               echo "push_block_reason="
+              echo "auth_expired=false"
               echo "last_message<<${_delim}"
               head -c 4000 "$verification_log"
               echo
@@ -1038,6 +1081,7 @@ jobs:
                 echo "no_change_reason="
                 echo "push_blocked=true"
                 echo "push_block_reason=github_actions_workflow_permission_missing"
+                echo "auth_expired=false"
               } >> "$GITHUB_OUTPUT"
               exit 0
             fi
@@ -1048,6 +1092,7 @@ jobs:
             echo "no_change_reason="
             echo "push_blocked=false"
             echo "push_block_reason="
+            echo "auth_expired=false"
           } >> "$GITHUB_OUTPUT"
 
       - name: Create Codex PR
@@ -1549,6 +1594,7 @@ jobs:
           CODEX_PR_BLOCK_REASON: ${{ steps.codex-pr-create.outputs.block_reason }}
           CODEX_PUSH_BLOCKED: ${{ steps.codex-subscription.outputs.push_blocked }}
           CODEX_PUSH_BLOCK_REASON: ${{ steps.codex-subscription.outputs.push_block_reason }}
+          CODEX_AUTH_EXPIRED: ${{ steps.codex-subscription.outputs.auth_expired }}
           WIKI_PATH: ${{ steps.meta.outputs.wiki_path }}
           EXPECTED_BRANCH_TASK: ${{ steps.meta.outputs.expected_branch_task }}
           CLAUDE_OUTCOME: ${{ steps.claude-oauth.outcome }}
@@ -1606,10 +1652,13 @@ jobs:
             const codexPrBlockReason = process.env.CODEX_PR_BLOCK_REASON || '';
             const codexPushBlocked = process.env.CODEX_PUSH_BLOCKED === 'true';
             const codexPushBlockReason = process.env.CODEX_PUSH_BLOCK_REASON || '';
+            const codexAuthExpired = process.env.CODEX_AUTH_EXPIRED === 'true';
             const claudeWriterFailed = mode === 'claude_oauth' && process.env.CLAUDE_OUTCOME === 'failure';
             const codexWriterFailed = mode === 'codex_subscription' && process.env.CODEX_OUTCOME === 'failure';
             const writerFailed = claudeWriterFailed || codexWriterFailed;
-            const terminalOutcome = writerFailed
+            const terminalOutcome = codexAuthExpired
+              ? 'writer-auth-expired-before-pr'
+              : writerFailed
               ? 'writer-failed-before-pr'
               : codexPushBlocked
                 ? 'branch-push-blocked'
@@ -1619,11 +1668,18 @@ jobs:
                     ? `no-change-${codexNoChangeReason}`
                     : 'no-pr-artifact-created';
             const labels = ['needs-human'];
-            if (codexNoChangeReason || codexPrBlocked || codexPushBlocked || writerFailed) {
+            if (codexNoChangeReason || codexPrBlocked || codexPushBlocked || (writerFailed && !codexAuthExpired)) {
               labels.push('auto-fix-reviewed');
             }
             if (writerFailed) {
               labels.push('auto-fix-writer-failed');
+            }
+            if (codexAuthExpired) {
+              labels.push(
+                'auto-fix-auth-missing',
+                'auto-fix-codex-subscription-missing',
+                'auto-fix-auth-expired',
+              );
             }
             if (codexNoChangeReason) {
               labels.push('auto-fix-blocked');
@@ -1688,6 +1744,9 @@ jobs:
                   : '',
                 codexPushBlocked && codexPushBlockReason === 'github_actions_workflow_permission_missing'
                   ? 'Configure `WORKFLOW_PUSH_TOKEN` with repo Contents write, Workflows write, and Pull requests write so automated workflow-file branches can push and loop-created PRs can trigger checks.'
+                  : '',
+                codexAuthExpired
+                  ? 'Remaining blocker: refresh `WORKFLOW_CODEX_AUTH_JSON_B64`; the auth bundle is visible but expired or revoked.'
                   : '',
                 codexPrBlocked && branch
                   ? `Auto-fix branch: https://github.com/${context.repo.owner}/${context.repo.repo}/tree/${branch}`

--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -60,6 +60,8 @@ AUTH_MISSING_LABEL = "auto-fix-auth-missing"
 CLAUDE_SUBSCRIPTION_MISSING_LABEL = "auto-fix-claude-subscription-missing"
 CODEX_SUBSCRIPTION_MISSING_LABEL = "auto-fix-codex-subscription-missing"
 PROVIDER_EXHAUSTED_LABEL = "auto-fix-provider-exhausted"
+WRITER_FAILED_LABEL = "auto-fix-writer-failed"
+AUTH_EXPIRED_LABEL = "auto-fix-auth-expired"
 READY_FOR_CHECKER_LABEL = "ready_for_checker"
 CHECKER_CODEX_LABEL = "checker:codex"
 CHECKER_CLAUDE_LABEL = "checker:claude"
@@ -806,6 +808,8 @@ def queue_stage(
     missing_codex_subscription: list[dict[str, Any]] = []
     auth_missing: list[dict[str, Any]] = []
     provider_exhausted: list[dict[str, Any]] = []
+    writer_failed: list[dict[str, Any]] = []
+    auth_expired: list[dict[str, Any]] = []
     pr_blocked: list[dict[str, Any]] = []
     branch_push_blocked: list[dict[str, Any]] = []
     reviewed_terminal: list[dict[str, Any]] = []
@@ -828,6 +832,8 @@ def queue_stage(
             labels.isdisjoint(TERMINAL_REVIEW_LABELS)
             or PR_BLOCKED_LABEL in labels
             or BRANCH_PUSH_BLOCKED_LABEL in labels
+            or WRITER_FAILED_LABEL in labels
+            or AUTH_EXPIRED_LABEL in labels
         ):
             needs_human.append(issue)
             if CLAUDE_SUBSCRIPTION_MISSING_LABEL in labels:
@@ -842,6 +848,10 @@ def queue_stage(
                 branch_push_blocked.append(issue)
             if PROVIDER_EXHAUSTED_LABEL in labels:
                 provider_exhausted.append(issue)
+            if WRITER_FAILED_LABEL in labels:
+                writer_failed.append(issue)
+            if AUTH_EXPIRED_LABEL in labels:
+                auth_expired.append(issue)
         elif COMPLETE_LABEL in labels or not labels.isdisjoint(TERMINAL_REVIEW_LABELS):
             reviewed_terminal.append(issue)
         elif AWAIT_PRIMITIVE_LAYER_LABEL in labels:
@@ -885,6 +895,8 @@ def queue_stage(
         "branch_push_blocked": [issue.get("number") for issue in branch_push_blocked],
         "pr_blocked": [issue.get("number") for issue in pr_blocked],
         "provider_exhausted": [issue.get("number") for issue in provider_exhausted],
+        "writer_failed": [issue.get("number") for issue in writer_failed],
+        "auth_expired": [issue.get("number") for issue in auth_expired],
         "pending": [issue.get("number") for issue in pending],
         "old_pending": [issue.get("number") for issue in old_pending],
         "await_primitive_layer": [issue.get("number") for issue in await_primitive_layer],
@@ -923,8 +935,12 @@ def queue_stage(
             root_cause = "Claude subscription OAuth is not visible to GitHub Actions"
         elif missing_codex_subscription:
             root_cause = "Codex subscription auth bundle is not visible to GitHub Actions"
+        elif auth_expired:
+            root_cause = "subscription-backed writer auth is visible but expired or revoked"
         elif auth_missing:
             root_cause = "approved subscription-backed writer auth is missing"
+        elif writer_failed:
+            root_cause = "approved writer failed before opening a PR"
         elif provider_exhausted:
             root_cause = "approved writer provider returned quota/capacity exhaustion"
         pending_clause = (

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -387,6 +387,18 @@ def test_codex_subscription_step_uses_codex_cli(wf):
     assert "OPENAI_API_KEY" in run_script and "unset OPENAI_API_KEY" in run_script
 
 
+def test_codex_subscription_step_classifies_expired_auth(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    codex_step = next((s for s in steps if s.get("id") == "codex-subscription"), None)
+    assert codex_step is not None, "Must have a Codex subscription writer step"
+    run_script = codex_step.get("run", "")
+    assert "codex-exec.log" in run_script
+    assert "codex_status=${PIPESTATUS[0]}" in run_script
+    assert "refresh_token_reused" in run_script
+    assert "token_expired" in run_script
+    assert "auth_expired=${auth_expired}" in run_script
+
+
 def test_codex_subscription_step_uses_workflow_push_token_for_git_push(wf):
     steps = wf["jobs"]["fix"]["steps"]
     codex_step = next((s for s in steps if s.get("id") == "codex-subscription"), None)
@@ -938,3 +950,33 @@ def test_pr_blocked_label_is_defined(wf):
     assert "GitHub blocked Actions from pushing the branch" in script
     assert "auto-fix-writer-failed" in script
     assert "selected writer failed before opening a PR" in script
+    assert "auto-fix-auth-expired" in script
+    assert "expired or revoked" in script
+
+
+def test_retry_clears_stale_writer_failure_labels(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    clear_step = next(
+        (s for s in steps if s.get("name") == "Clear auth-missing block when auth is visible"),
+        None,
+    )
+    assert clear_step is not None, "Must clear stale failure labels before retry"
+    script = str(clear_step.get("with", {}).get("script", ""))
+    assert "auto-fix-auth-expired" in script
+    assert "auto-fix-writer-failed" in script
+
+
+def test_expired_codex_auth_stays_human_visible_not_reviewed_terminal(wf):
+    steps = wf["jobs"]["fix"]["steps"]
+    no_pr_step = next(
+        (s for s in steps if s.get("name") == "Mark needs-human if no PR opened"),
+        None,
+    )
+    assert no_pr_step is not None, "Must mark no-PR outcomes"
+    env = str(no_pr_step.get("env", {}))
+    script = str(no_pr_step.get("with", {}).get("script", ""))
+    assert "CODEX_AUTH_EXPIRED" in env
+    assert "writer-auth-expired-before-pr" in script
+    assert "writerFailed && !codexAuthExpired" in script
+    assert "auto-fix-auth-expired" in script
+    assert "Remaining blocker: refresh `WORKFLOW_CODEX_AUTH_JSON_B64`" in script

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -784,6 +784,45 @@ def test_queue_stage_counts_pr_blocked_issue_as_needs_human(monkeypatch):
     assert "PR creation was blocked" in stage["summary"]
 
 
+def test_queue_stage_counts_expired_auth_issue_as_needs_human(monkeypatch):
+    now = dt.datetime(2026, 5, 10, 9, 20, tzinfo=dt.timezone.utc)
+
+    def fake_list_loop_issues(*_args, **_kwargs):
+        return [
+            {
+                "number": 745,
+                "title": "Codex auth bundle expired before PR creation",
+                "created_at": "2026-05-10T08:28:00Z",
+                "html_url": "https://example.test/issues/745",
+                "labels": [
+                    {"name": watch.BLOCKED_LABEL},
+                    {"name": watch.ATTEMPTED_LABEL},
+                    {"name": watch.REVIEWED_LABEL},
+                    {"name": watch.WRITER_FAILED_LABEL},
+                    {"name": watch.AUTH_EXPIRED_LABEL},
+                ],
+            }
+        ]
+
+    monkeypatch.setattr(watch, "list_loop_issues", fake_list_loop_issues)
+
+    stage = watch.queue_stage(
+        "owner/repo",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+        now=now,
+        max_pending_age_min=45,
+    )
+
+    assert stage["status"] == "red"
+    assert stage["details"]["needs_human"] == [745]
+    assert stage["details"]["writer_failed"] == [745]
+    assert stage["details"]["auth_expired"] == [745]
+    assert stage["details"]["reviewed_terminal"] == []
+    assert "expired or revoked" in stage["summary"]
+
+
 def test_queue_stage_summarizes_mixed_permission_blocks(monkeypatch):
     now = dt.datetime(2026, 5, 5, 21, 20, tzinfo=dt.timezone.utc)
 


### PR DESCRIPTION
## Summary
- classifies expired/revoked Codex auth separately from missing auth in `auto-fix-bug.yml`
- keeps expired-auth writer failures human-visible instead of marking them `auto-fix-reviewed`
- teaches `community_loop_watch.py` to report expired auth / writer-failed queues as active red blockers

## Context
Cowork's fresh-user scout found PR-093/#744 and PR-094/#745 were correctly filed, but both hit stale `WORKFLOW_CODEX_AUTH_JSON_B64` and failed before creating healthy PRs. The immediate credential refresh has already produced child PRs #748 and #750; this PR prevents that failure mode from being hidden next time.

## Verification
- `python -m pytest tests/test_auto_fix_workflow.py tests/test_community_loop_watch.py -q` -> 107 passed, 8 warnings
- `python -m ruff check scripts/community_loop_watch.py tests/test_auto_fix_workflow.py tests/test_community_loop_watch.py` -> pass
- `git diff --check` -> pass

Related: #744, #745, #747