### PR TITLE
[design-note] WIKI-DESIGN: Promote 6 primitives + 5 MCP handles substrate canonical vocabulary into PLAN.md as foundational project architecture; supersedes PR #662 close-as-superseded; the substrate framing has been locked since 2026-05-06 in feedback memory + canonical wiki concept page but PLAN.md doesn't yet name it; coding sessions reading PLAN.md as the design reference should see it

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -74,6 +74,49 @@ Depth: lead memory `project_user_capability_axis.md`; host matrix `docs/design-n
 
 ---
 
+## Canonical Work Substrate Vocabulary
+
+**Status: canonical as of 2026-05-10.** Workflow's foundational substrate
+vocabulary is six work concepts plus five permissioned MCP handles. Coding
+sessions should use this vocabulary when naming architecture, docs, tool
+metadata, and future design notes unless a narrower domain term is explicitly
+needed.
+
+The six base concepts describe durable work at the graph layer:
+
+| Concept | Meaning |
+|---|---|
+| `Node` | A typed unit of work, judgment, transformation, or evidence capture. |
+| `Edge` | A declared transition between nodes, including conditional routing and review paths. |
+| `State` | The durable typed record a graph reads, writes, reduces, checkpoints, and resumes. |
+| `Scope` | The authority and context boundary for a work item: user, branch, goal, daemon, host, commons, or other bounded surface. |
+| `Run` | An execution attempt with inputs, outputs, provider traces, checkpoints, and evidence. |
+| `Trigger` | The event or schedule that asks Workflow to start, resume, replay, or route work. |
+
+The five MCP handles describe the small permissioned control surface agents use
+to inspect and act on those concepts:
+
+| Handle | Authority |
+|---|---|
+| `read.graph` | Inspect graph structure, state summaries, lineage, runs, and public metadata. |
+| `write.graph` | Propose or mutate graph definitions, state, scopes, edges, and work artifacts under the caller's authority. |
+| `run.graph` | Start, resume, cancel, replay, or otherwise control graph execution within the caller's scope and confirmation policy. |
+| `read.page` | Read wiki, commons, docs, request, and explanation pages that contextualize the graph. |
+| `write.page` | Draft or update wiki, commons, docs, request, and explanation pages through the same reviewable artifact path. |
+
+These names are substrate vocabulary, not a mandate that every runtime function
+or MCP tool be named exactly this way. Concrete tool names may remain
+client-shaped for compatibility, but they should map back to one or more of
+these handles in docs, permission checks, and tool descriptions. The older
+8-engine-primitive framing in
+`docs/design-notes/2026-04-26-engine-primitive-substrate.md` remains a useful
+historical pressure test over implementation modules; it is no longer the
+canonical primitive count for project architecture. The canonical source for
+the promotion rationale is
+`docs/design-notes/proposed/2026-05-10-promote-work-substrate-vocabulary.md`.
+
+---
+
 ## Cross-Cutting Principles
 
 **Agentic hybrid search is memory.** Durable memory is a policy over multiple stores (KG traversal, vector similarity, hierarchical summaries, notes, world-state, direct tool calls). No single backend owns truth. Routing matters more than any one store.

--- a/STATUS.md
+++ b/STATUS.md
@@ -47,5 +47,5 @@ Run `python scripts/claim_check.py --provider <name>` before claiming. Claim by 
 1. **Current uptime priority 2026-05-02 22:10Z:** Community patch loop ALIVE end-to-end. Substrate stack PASS: FEAT-004 trigger receipts + FEAT-006 provider diagnostics + BUG-009 dispatcher pickup + #205 claim-grace + BUG-045A child spawn. First successful end-to-end run BUG-050 (parent dee755 + child 1cdbd3) at 21:55-21:59. Bottleneck moved from substrate to loop-content (BUG-051: stale caution language in coding_packet/release_gate prompts) + auto-ship policy authoring (PR #198 spec). PR #198 + #206 are design-only, ready to land.
 
 2. **Five Scoping Rules now in PLAN.md** (2026-04-28): minimal-primitives / community-build-over-platform / privacy-via-community-composition / commons-first-architecture / user-capability-axis. Cross-provider source. Depth in lead memory.
-3. **Decision pile awaiting host:** primitive-set §7 + engine substrate §7 + Tomas + A.1 unpack §7 + Phase 6 db rename + parked Q D.
+3. **Decision pile awaiting host:** Tomas + A.1 unpack §7 + Phase 6 db rename + parked Q D.
 4. **No-shims-ever**, platform responsibility model, and public-surface probes after DNS/tunnel/Worker/connector changes are active.

--- a/docs/design-notes/proposed/2026-05-10-promote-work-substrate-vocabulary.md
+++ b/docs/design-notes/proposed/2026-05-10-promote-work-substrate-vocabulary.md
@@ -1,0 +1,84 @@
+---
+title: Promote Work Substrate Vocabulary
+date: 2026-05-10
+author: codex-wiki-design
+status: proposed
+request_id: WIKI-DESIGN
+github_issue: 755
+wiki_source: pages/patch-requests/pr-098-promote-6-primitives-5-mcp-handles-substrate-canonical-vocab.md
+scope: design-only; no runtime code in this branch
+supersedes:
+  - PR #662 close-as-superseded framing
+builds_on:
+  - docs/notes/2026-05-06-work-primitive-industry-framing.md
+  - docs/design-notes/2026-04-26-engine-primitive-substrate.md
+  - PLAN.md#scoping-rules
+  - PLAN.md#api-and-mcp-interface
+---
+
+# Promote Work Substrate Vocabulary
+
+## Recommendation
+
+Promote the six substrate concepts plus five MCP handles into `PLAN.md` as
+canonical project architecture:
+
+- Concepts: `Node`, `Edge`, `State`, `Scope`, `Run`, `Trigger`.
+- Handles: `read.graph`, `write.graph`, `run.graph`, `read.page`,
+  `write.page`.
+
+This is a vocabulary and architecture change only. It does not add runtime MCP
+actions, change tool registration, or require plugin rebuilds.
+
+## Rationale
+
+The substrate framing has been stable in feedback memory and the promoted wiki
+concept page since 2026-05-06, but `PLAN.md` is the design reference new
+coding sessions read first. Leaving the vocabulary only in wiki memory and a
+docs/ops note makes the project look split between the older 8-engine
+primitive pressure test and the newer 6+5 work-substrate language.
+
+The useful distinction is:
+
+- The six concepts describe durable work at the graph layer.
+- The five handles describe permissioned ways an agent or chatbot can inspect
+  and act on that work through MCP-compatible surfaces.
+- Existing modules and tools can keep compatibility names, but design docs,
+  permission checks, and future tool descriptions should be able to map back to
+  this vocabulary.
+
+## Scope
+
+In scope:
+
+- Add a concise canonical section to `PLAN.md`.
+- Reference this note from `PLAN.md`.
+- Mark the older 8-engine-primitive note as historical pressure-test framing,
+  not the canonical primitive count.
+
+Out of scope:
+
+- Runtime MCP tool renames or new actions.
+- Permission implementation changes.
+- Rewriting community-authored branches or PR #662 content.
+- Changing `workflow/*` runtime code or plugin mirrors.
+
+## Compatibility
+
+The older `docs/design-notes/2026-04-26-engine-primitive-substrate.md` remains
+useful because it mapped implementation modules and proved compositional
+coverage. This promotion narrows what future contributors should call
+foundational architecture. If future work needs implementation-specific
+subsystems such as provider routing, retrieval, catalog, dispatcher, or
+evaluation, those should be described as implementations or compositions of
+the six concepts and five handles unless a new irreducible concept passes the
+scoping rules.
+
+## Verification
+
+Because this is documentation-only:
+
+- No Python files are touched.
+- No runtime tests or plugin rebuild are required.
+- Review should confirm `PLAN.md` now exposes the canonical vocabulary and does
+  not imply new MCP actions exist today.


### PR DESCRIPTION
Fixes #755

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-098-promote-6-primitives-5-mcp-handles-substrate-canonical-vocab.md`
- GitHub issue: #755
- Branch task: `design-note-draft/issue-755`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.