### PR TITLE
[auto-change] WIKI-PATCH: PR-099: In-queue + chatbot-side patch-request dedupe — filing-time Jaccard is not enough; loop must reconcile duplicate patch-requests while they sit in queue, and chatbots filing new requests must detect in-queue dupes before filing

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
@@ -132,8 +132,8 @@ framing.
     proposal. Do not coerce these into bug wording just to enter the
     community loop.
     Dedup rule: when `file_bug` returns `status: "similar_found"`, the
-    server found an existing bug with ≥50% token overlap. Default to
-    `wiki action=cosign_bug bug_id=<top similar bug_id>
+    server found an existing or queued filing with ≥50% token overlap.
+    Default to `wiki action=cosign_bug bug_id=<top similar bug_id>
     reporter_context="<what you observed + your context>"` instead of
     filing a duplicate. Only use `force_new=true` when the symptom is
     materially different — explain the difference in `observed`.

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1590,6 +1590,46 @@ def _scan_existing_bugs(bugs_dir: Path) -> list[dict[str, Any]]:
     return results
 
 
+def _scan_queued_filings(universe_path: Path, kind: str) -> list[dict[str, Any]]:
+    """Return active queued filings of the requested kind from BranchTask queue."""
+    try:
+        from workflow.branch_tasks import read_queue
+        from workflow.bug_investigation import REQUEST_TYPE_BUG_INVESTIGATION
+    except Exception:  # noqa: BLE001 - queue dedupe is best-effort for filing.
+        return []
+
+    results: list[dict[str, Any]] = []
+    try:
+        queue = read_queue(universe_path)
+    except Exception as exc:  # noqa: BLE001 - corrupt queue should not block filing.
+        _logger_wiki.warning("file_bug queued filing scan failed: %s", exc)
+        return []
+
+    for task in queue:
+        if task.request_type != REQUEST_TYPE_BUG_INVESTIGATION:
+            continue
+        if task.status not in {"pending", "running"}:
+            continue
+        inputs = task.inputs if isinstance(task.inputs, dict) else {}
+        if str(inputs.get("kind") or "bug").strip().lower() != kind:
+            continue
+        bug_id = str(inputs.get("bug_id") or "").strip()
+        title = str(inputs.get("title") or "").strip()
+        observed = str(inputs.get("observed") or "").strip()
+        if not bug_id and not title and not observed:
+            continue
+        results.append({
+            "bug_id": bug_id or task.branch_task_id,
+            "title": title,
+            "status": task.status,
+            "haystack_tokens": _bug_token_set(title + " " + observed[:300]),
+            "path": "",
+            "source": "queue",
+            "dispatcher_request_id": task.branch_task_id,
+        })
+    return results
+
+
 def _wiki_cosign_bug(
     bug_id: str = "",
     reporter_context: str = "",
@@ -1739,14 +1779,18 @@ def _wiki_file_bug(
 
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     slug = _slugify_title(title)
+    universe_id = _default_universe()
+    universe_path = _universe_dir(universe_id)
 
     # Dedup check: scan existing filings of THIS kind for Jaccard similarity
-    # ≥ threshold. Per-kind only — a feature-request shouldn't dedup against
-    # a bug because they're different work surfaces; same title may
-    # legitimately exist as both. Skip when force_new=True.
+    # ≥ threshold, including active queued filings that may not have completed
+    # yet. Per-kind only — a feature-request shouldn't dedup against a bug
+    # because they're different work surfaces; same title may legitimately
+    # exist as both. Skip when force_new=True.
     if not force_new:
         query_tokens = _bug_token_set(title + " " + (observed or ""))
         existing = _scan_existing_bugs(pages_dir)
+        existing.extend(_scan_queued_filings(universe_path, effective_kind))
         scored = []
         for entry in existing:
             sim = _jaccard(query_tokens, entry["haystack_tokens"])
@@ -1760,6 +1804,7 @@ def _wiki_file_bug(
                     "title": e["title"],
                     "similarity": round(s, 3),
                     "status": e["status"],
+                    "source": e.get("source", "wiki"),
                 }
                 for s, e in scored[:3]
             ]
@@ -1835,8 +1880,6 @@ def _wiki_file_bug(
             "repro": repro,
             "workaround": workaround,
         }
-        universe_id = _default_universe()
-        universe_path = _universe_dir(universe_id)
         # Pre-write trigger receipt (status=pending). Read canonical branch_def_id
         # from env so the receipt records what we *expected* to invoke even if the
         # enqueue helper rejects.

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/bug_investigation.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/bug_investigation.py
@@ -69,6 +69,49 @@ def _format_request_text(payload: dict) -> str:
     return "\n".join(lines).strip()
 
 
+def _request_tokens(text: str) -> set[str]:
+    return {w for w in re.sub(r"[^a-z0-9]+", " ", text.lower()).split() if len(w) > 2}
+
+
+def _request_jaccard(a: set[str], b: set[str]) -> float:
+    if not a and not b:
+        return 1.0
+    union = a | b
+    return len(a & b) / len(union) if union else 0.0
+
+
+def _find_similar_queued_patch_request(base_path: "Path | str", payload: dict) -> str | None:
+    """Return an active duplicate patch-request BranchTask id, if one exists."""
+    if str(payload.get("kind") or "").strip().lower() != "patch_request":
+        return None
+
+    from workflow.branch_tasks import TERMINAL_STATUSES, read_queue
+
+    query_tokens = _request_tokens(
+        str(payload.get("title") or "") + " " + str(payload.get("observed") or "")
+    )
+    try:
+        queue = read_queue(Path(base_path))
+    except Exception as exc:  # noqa: BLE001 - enqueue should still proceed.
+        _logger.warning("queued patch-request dedupe scan failed: %s", exc)
+        return None
+
+    for task in queue:
+        if task.request_type != REQUEST_TYPE_BUG_INVESTIGATION:
+            continue
+        if task.status in TERMINAL_STATUSES:
+            continue
+        inputs = task.inputs if isinstance(task.inputs, dict) else {}
+        if str(inputs.get("kind") or "").strip().lower() != "patch_request":
+            continue
+        haystack_tokens = _request_tokens(
+            str(inputs.get("title") or "") + " " + str(inputs.get("observed") or "")
+        )
+        if _request_jaccard(query_tokens, haystack_tokens) >= 0.5:
+            return task.branch_task_id
+    return None
+
+
 def format_investigation_comment(
     run_id: str = "",
     status: str = "queued",
@@ -235,13 +278,23 @@ def enqueue_investigation_request(
     import uuid
     base = Path(base_path)
     uid = universe_id or base.name
+    payload = build_run_payload(bug_ref)
+    existing_request_id = _find_similar_queued_patch_request(base, payload)
+    if existing_request_id:
+        _logger.info(
+            "enqueue_investigation_request | %s | deduped_to=%s",
+            bug_ref.get("bug_id", "?"),
+            existing_request_id,
+        )
+        return existing_request_id
+
     request_id = str(uuid.uuid4())
 
     task = BranchTask(
         branch_task_id=request_id,
         branch_def_id=canonical_branch_def_id,
         universe_id=uid,
-        inputs=build_run_payload(bug_ref),
+        inputs=payload,
         trigger_source="owner_queued",
         priority_weight=float(priority),
         queued_at=datetime.now(timezone.utc).isoformat(),

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -958,11 +958,12 @@ def wiki(
     When the user asks to file a bug, patch request, feature request, or
     design proposal, call `file_bug` directly with the matching `kind`
     (`bug`, `patch_request`, `feature`, or `design`). `file_bug` already
-    does Jaccard duplicate detection server-side; you do NOT need to search/list/read
-    the wiki before filing. Before filing, check current repo/PLAN.md
-    context via `community_change_context` or direct repo browsing; the
-    source repo is https://github.com/Jonnyton/Workflow and PLAN.md is
-    canonical design/scoping truth. If a similar filing exists,
+    does Jaccard duplicate detection server-side, including active queued
+    filings; you do NOT need to search/list/read the wiki before filing.
+    Before filing, check current repo/PLAN.md context via
+    `community_change_context` or direct repo browsing; the source repo is
+    https://github.com/Jonnyton/Workflow and PLAN.md is canonical
+    design/scoping truth. If a similar filing exists,
     it returns status="similar_found" with the existing match.
 
     Args:

--- a/tests/test_bug_investigation_dispatcher.py
+++ b/tests/test_bug_investigation_dispatcher.py
@@ -106,6 +106,45 @@ class TestEnqueueInvestigationRequest:
         queue = read_queue(tmp_path)
         assert queue[0].universe_id == "override-universe"
 
+    def test_duplicate_pending_patch_request_reuses_existing_queue_task(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.delenv("WORKFLOW_REQUEST_TYPE_PRIORITIES", raising=False)
+        append_task(
+            tmp_path,
+            BranchTask(
+                branch_task_id="queued-pr-task",
+                branch_def_id="branch-abc",
+                universe_id="u1",
+                request_type=REQUEST_TYPE_BUG_INVESTIGATION,
+                status="pending",
+                inputs={
+                    "bug_id": "PR-099",
+                    "kind": "patch_request",
+                    "title": "In queue chatbot side patch request dedupe",
+                    "observed": "Filing-time Jaccard misses queued patch requests",
+                },
+            ),
+        )
+
+        request_id = enqueue_investigation_request(
+            bug_ref={
+                "bug_id": "PR-100",
+                "kind": "patch_request",
+                "title": "In queue chatbot side patch request dedupe",
+                "observed": (
+                    "Filing-time Jaccard misses queued patch requests before filing"
+                ),
+            },
+            canonical_branch_def_id="branch-abc",
+            base_path=tmp_path,
+            universe_id="u1",
+        )
+
+        queue = read_queue(tmp_path)
+        assert request_id == "queued-pr-task"
+        assert [task.branch_task_id for task in queue] == ["queued-pr-task"]
+
 
 # ── prefers_request_type / get_request_type_priorities ────────────────────────
 

--- a/tests/test_wiki_file_bug_dedup.py
+++ b/tests/test_wiki_file_bug_dedup.py
@@ -269,6 +269,44 @@ def test_file_bug_unrelated_query_does_not_trigger_similar_found(wiki_env):
     )
 
 
+def test_patch_request_dedup_checks_pending_queue(wiki_env, tmp_path, monkeypatch):
+    """Patch requests already queued must block duplicate chatbot filings."""
+    from workflow.branch_tasks import BranchTask, append_task
+
+    universe_dir = tmp_path / "default-universe"
+    universe_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "default-universe")
+
+    append_task(
+        universe_dir,
+        BranchTask(
+            branch_task_id="queued-pr-task",
+            branch_def_id="change-loop",
+            universe_id="default-universe",
+            request_type="bug_investigation",
+            status="pending",
+            inputs={
+                "bug_id": "PR-099",
+                "kind": "patch_request",
+                "title": "In queue chatbot side patch request dedupe",
+                "observed": "Filing-time Jaccard misses queued patch requests",
+            },
+        ),
+    )
+
+    result = _file_bug(
+        wiki_env,
+        kind="patch_request",
+        title="In queue chatbot side patch request dedupe",
+        observed="Filing-time Jaccard misses queued patch requests before filing",
+    )
+
+    assert result["status"] == "similar_found"
+    assert result["bug_id"] is None
+    assert result["similar"][0]["bug_id"] == "PR-099"
+    assert result["similar"][0]["source"] == "queue"
+
+
 # ── Task #42: threshold edge-cases + adversarial depth ────────────────────────
 
 

--- a/workflow/api/prompts.py
+++ b/workflow/api/prompts.py
@@ -132,8 +132,8 @@ framing.
     proposal. Do not coerce these into bug wording just to enter the
     community loop.
     Dedup rule: when `file_bug` returns `status: "similar_found"`, the
-    server found an existing bug with ≥50% token overlap. Default to
-    `wiki action=cosign_bug bug_id=<top similar bug_id>
+    server found an existing or queued filing with ≥50% token overlap.
+    Default to `wiki action=cosign_bug bug_id=<top similar bug_id>
     reporter_context="<what you observed + your context>"` instead of
     filing a duplicate. Only use `force_new=true` when the symptom is
     materially different — explain the difference in `observed`.

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1590,6 +1590,46 @@ def _scan_existing_bugs(bugs_dir: Path) -> list[dict[str, Any]]:
     return results
 
 
+def _scan_queued_filings(universe_path: Path, kind: str) -> list[dict[str, Any]]:
+    """Return active queued filings of the requested kind from BranchTask queue."""
+    try:
+        from workflow.branch_tasks import read_queue
+        from workflow.bug_investigation import REQUEST_TYPE_BUG_INVESTIGATION
+    except Exception:  # noqa: BLE001 - queue dedupe is best-effort for filing.
+        return []
+
+    results: list[dict[str, Any]] = []
+    try:
+        queue = read_queue(universe_path)
+    except Exception as exc:  # noqa: BLE001 - corrupt queue should not block filing.
+        _logger_wiki.warning("file_bug queued filing scan failed: %s", exc)
+        return []
+
+    for task in queue:
+        if task.request_type != REQUEST_TYPE_BUG_INVESTIGATION:
+            continue
+        if task.status not in {"pending", "running"}:
+            continue
+        inputs = task.inputs if isinstance(task.inputs, dict) else {}
+        if str(inputs.get("kind") or "bug").strip().lower() != kind:
+            continue
+        bug_id = str(inputs.get("bug_id") or "").strip()
+        title = str(inputs.get("title") or "").strip()
+        observed = str(inputs.get("observed") or "").strip()
+        if not bug_id and not title and not observed:
+            continue
+        results.append({
+            "bug_id": bug_id or task.branch_task_id,
+            "title": title,
+            "status": task.status,
+            "haystack_tokens": _bug_token_set(title + " " + observed[:300]),
+            "path": "",
+            "source": "queue",
+            "dispatcher_request_id": task.branch_task_id,
+        })
+    return results
+
+
 def _wiki_cosign_bug(
     bug_id: str = "",
     reporter_context: str = "",
@@ -1739,14 +1779,18 @@ def _wiki_file_bug(
 
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     slug = _slugify_title(title)
+    universe_id = _default_universe()
+    universe_path = _universe_dir(universe_id)
 
     # Dedup check: scan existing filings of THIS kind for Jaccard similarity
-    # ≥ threshold. Per-kind only — a feature-request shouldn't dedup against
-    # a bug because they're different work surfaces; same title may
-    # legitimately exist as both. Skip when force_new=True.
+    # ≥ threshold, including active queued filings that may not have completed
+    # yet. Per-kind only — a feature-request shouldn't dedup against a bug
+    # because they're different work surfaces; same title may legitimately
+    # exist as both. Skip when force_new=True.
     if not force_new:
         query_tokens = _bug_token_set(title + " " + (observed or ""))
         existing = _scan_existing_bugs(pages_dir)
+        existing.extend(_scan_queued_filings(universe_path, effective_kind))
         scored = []
         for entry in existing:
             sim = _jaccard(query_tokens, entry["haystack_tokens"])
@@ -1760,6 +1804,7 @@ def _wiki_file_bug(
                     "title": e["title"],
                     "similarity": round(s, 3),
                     "status": e["status"],
+                    "source": e.get("source", "wiki"),
                 }
                 for s, e in scored[:3]
             ]
@@ -1835,8 +1880,6 @@ def _wiki_file_bug(
             "repro": repro,
             "workaround": workaround,
         }
-        universe_id = _default_universe()
-        universe_path = _universe_dir(universe_id)
         # Pre-write trigger receipt (status=pending). Read canonical branch_def_id
         # from env so the receipt records what we *expected* to invoke even if the
         # enqueue helper rejects.

--- a/workflow/bug_investigation.py
+++ b/workflow/bug_investigation.py
@@ -69,6 +69,49 @@ def _format_request_text(payload: dict) -> str:
     return "\n".join(lines).strip()
 
 
+def _request_tokens(text: str) -> set[str]:
+    return {w for w in re.sub(r"[^a-z0-9]+", " ", text.lower()).split() if len(w) > 2}
+
+
+def _request_jaccard(a: set[str], b: set[str]) -> float:
+    if not a and not b:
+        return 1.0
+    union = a | b
+    return len(a & b) / len(union) if union else 0.0
+
+
+def _find_similar_queued_patch_request(base_path: "Path | str", payload: dict) -> str | None:
+    """Return an active duplicate patch-request BranchTask id, if one exists."""
+    if str(payload.get("kind") or "").strip().lower() != "patch_request":
+        return None
+
+    from workflow.branch_tasks import TERMINAL_STATUSES, read_queue
+
+    query_tokens = _request_tokens(
+        str(payload.get("title") or "") + " " + str(payload.get("observed") or "")
+    )
+    try:
+        queue = read_queue(Path(base_path))
+    except Exception as exc:  # noqa: BLE001 - enqueue should still proceed.
+        _logger.warning("queued patch-request dedupe scan failed: %s", exc)
+        return None
+
+    for task in queue:
+        if task.request_type != REQUEST_TYPE_BUG_INVESTIGATION:
+            continue
+        if task.status in TERMINAL_STATUSES:
+            continue
+        inputs = task.inputs if isinstance(task.inputs, dict) else {}
+        if str(inputs.get("kind") or "").strip().lower() != "patch_request":
+            continue
+        haystack_tokens = _request_tokens(
+            str(inputs.get("title") or "") + " " + str(inputs.get("observed") or "")
+        )
+        if _request_jaccard(query_tokens, haystack_tokens) >= 0.5:
+            return task.branch_task_id
+    return None
+
+
 def format_investigation_comment(
     run_id: str = "",
     status: str = "queued",
@@ -235,13 +278,23 @@ def enqueue_investigation_request(
     import uuid
     base = Path(base_path)
     uid = universe_id or base.name
+    payload = build_run_payload(bug_ref)
+    existing_request_id = _find_similar_queued_patch_request(base, payload)
+    if existing_request_id:
+        _logger.info(
+            "enqueue_investigation_request | %s | deduped_to=%s",
+            bug_ref.get("bug_id", "?"),
+            existing_request_id,
+        )
+        return existing_request_id
+
     request_id = str(uuid.uuid4())
 
     task = BranchTask(
         branch_task_id=request_id,
         branch_def_id=canonical_branch_def_id,
         universe_id=uid,
-        inputs=build_run_payload(bug_ref),
+        inputs=payload,
         trigger_source="owner_queued",
         priority_weight=float(priority),
         queued_at=datetime.now(timezone.utc).isoformat(),

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -958,11 +958,12 @@ def wiki(
     When the user asks to file a bug, patch request, feature request, or
     design proposal, call `file_bug` directly with the matching `kind`
     (`bug`, `patch_request`, `feature`, or `design`). `file_bug` already
-    does Jaccard duplicate detection server-side; you do NOT need to search/list/read
-    the wiki before filing. Before filing, check current repo/PLAN.md
-    context via `community_change_context` or direct repo browsing; the
-    source repo is https://github.com/Jonnyton/Workflow and PLAN.md is
-    canonical design/scoping truth. If a similar filing exists,
+    does Jaccard duplicate detection server-side, including active queued
+    filings; you do NOT need to search/list/read the wiki before filing.
+    Before filing, check current repo/PLAN.md context via
+    `community_change_context` or direct repo browsing; the source repo is
+    https://github.com/Jonnyton/Workflow and PLAN.md is canonical
+    design/scoping truth. If a similar filing exists,
     it returns status="similar_found" with the existing match.
 
     Args:


### PR DESCRIPTION
Fixes #760

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-099-pr-099-in-queue-chatbot-side-patch-request-dedupe-filing-tim.md`
- GitHub issue: #760
- Branch task: `auto-change/issue-760`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.