### PR TITLE
[auto-change] WIKI-PATCH: PR-100: User-chatbot GitHub credit bridge + tiered identity-linking + host-as-current-author reconciliation — v0 ships end-to-end so user-chatbot-filed patches result in real GitHub contribution-graph credit for those users; host stops being credited for AI-only work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -567,7 +567,9 @@ the process was launched from.
 | `UNIVERSE_SERVER_HOST_USER` | Host-identity username used when a request is claimed by the box running the daemon (as opposed to an individual operator). | `host`. |
 | `UNIVERSE_SERVER_AUTH` | Auth mode. `"true"` / `"1"` enables OAuth-gated MCP. Disabled by default for single-operator dev. | `false`. |
 | `UNIVERSE_SERVER_PORT` | Port used by `workflow.auth.wellknown` when emitting OAuth metadata URLs. | `8001`. |
-| `WORKFLOW_GIT_AUTHOR` | Verbatim override for git commit author (e.g. `"Workflow User <user@users.noreply.workflow.local>"`). Highest precedence; falls through to `UNIVERSE_SERVER_USER`-derived synthetic. | Unset (synthetic from `UNIVERSE_SERVER_USER`). |
+| `WORKFLOW_GITHUB_AUTHOR_LOGIN` + `WORKFLOW_GITHUB_AUTHOR_ID` | Request-linked GitHub identity for commit authorship. When both are valid, emits `<id>+<login>@users.noreply.github.com` so user-chatbot-filed patches can receive GitHub contribution-graph credit instead of the host/bot. | Unset. |
+| `WORKFLOW_GIT_AUTHOR` | Verbatim override for git commit author (e.g. `"Workflow User <user@users.noreply.workflow.local>"`). Used when no request-linked GitHub author is present. | Unset. |
+| `WORKFLOW_GITHUB_USERNAME` + `WORKFLOW_GITHUB_USER_ID` | Process-default GitHub identity for local/dev runs, using GitHub noreply author format. Lower precedence than `WORKFLOW_GIT_AUTHOR`; higher than synthetic `UNIVERSE_SERVER_USER`. | Unset. |
 
 ### Feature flags
 

--- a/docs/planning/phase7_4_identity_wiring_scope.md
+++ b/docs/planning/phase7_4_identity_wiring_scope.md
@@ -35,7 +35,21 @@ strings.
 
 ## 2. Commit author format — recommendation
 
-**Take option 3 (GitHub-style noreply composite). Format:**
+**Updated by PR-100 v0 (2026-05-11):** take a tiered author format.
+When a request has a linked GitHub identity, emit GitHub's public
+noreply author form:
+
+```
+{login} <{github_user_id}+{login}@users.noreply.github.com>
+```
+
+This is the only v0 path intended to produce real GitHub contribution-graph
+credit for user-chatbot-filed patches. It requires both
+`WORKFLOW_GITHUB_AUTHOR_LOGIN` and `WORKFLOW_GITHUB_AUTHOR_ID`; incomplete
+or invalid linked identity falls through instead of guessing.
+
+When no linked GitHub identity is present, keep the original synthetic
+Workflow-local fallback:
 
 ```
 Workflow User <{slug}@users.noreply.workflow.local>
@@ -48,27 +62,25 @@ to `anonymous` when the actor is empty, "anonymous", or unsafe.
 
 | Actor | Commit author |
 |-------|---------------|
+| linked `alice` + GitHub id `123456` | `alice <123456+alice@users.noreply.github.com>` |
 | `alice` (env var) | `Workflow User <alice@users.noreply.workflow.local>` |
 | `"Alice Smith"` | `Workflow User <alice-smith@users.noreply.workflow.local>` |
 | (empty / unset) | `Workflow User <anonymous@users.noreply.workflow.local>` |
 | `"anonymous"` | `Workflow User <anonymous@users.noreply.workflow.local>` |
 
-**Why this over options 1 and 2:**
+**Why this tier over options 1 and 2:**
 
 - **Always well-formed.** `git commit --author=` is picky about
   `Name <email>` shape; opaque free-form actor strings (option 2
   literal) can fail silently or produce junk. Wrapping in a fixed
   template eliminates a whole failure mode.
-- **Preserves attribution.** Unlike option 1 (single daemon
-  identity), `git log --author=alice` still works and `git blame`
-  still tells the truth about who did what.
+- **Preserves attribution.** Unlike option 1 (single daemon identity),
+  linked users receive GitHub-recognized authorship, and unlinked users
+  still produce searchable synthetic authorship.
 - **Never claims GitHub identity it can't prove.** The
-  `users.noreply.workflow.local` TLD cannot resolve and cannot be a
-  real GitHub account. On public repos this is important — we
-  don't want the daemon to accidentally emit `alice@example.com`
-  and attribute a commit to someone who hasn't authorized it. If
-  a user wants their real GitHub identity on commits, they pass it
-  via the explicit config knob (§5).
+  `users.noreply.github.com` path only activates with both login and
+  numeric GitHub user id. The synthetic `users.noreply.workflow.local`
+  fallback cannot resolve and cannot be a real GitHub account.
 
 **Non-email display name** ("Workflow User") is deliberate: it
 makes "this commit came from the Workflow daemon on behalf of an
@@ -76,9 +88,11 @@ actor" legible in `git log --oneline`'s author column without the
 user having to read the email. The daemon is a participating
 author; the actor is encoded in the email local part.
 
-**Escape hatch for users who want full GitHub attribution:**
-`WORKFLOW_GIT_AUTHOR` env var (§5) overrides the composite format
-entirely and accepts a raw `"Alice <alice@real.email>"` string.
+**Escape hatch for users who want a raw author string:**
+`WORKFLOW_GIT_AUTHOR` env var (§5) overrides the synthetic composite
+format and accepts a raw `"Alice <alice@real.email>"` string. Request-linked
+GitHub author env wins over this host/process override so a chatbot-filed
+patch can credit the requesting user instead of the host.
 
 ## 3. Anonymous / session-less fallback
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/identity.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/identity.py
@@ -6,13 +6,19 @@ verification, no per-branch override. That's a later follow-up.
 
 Resolution order (first hit wins):
 
-1. ``WORKFLOW_GIT_AUTHOR`` env var — verbatim override. The user
+1. ``WORKFLOW_GITHUB_AUTHOR_LOGIN`` + ``WORKFLOW_GITHUB_AUTHOR_ID`` —
+   request-linked GitHub identity. Emits GitHub's public noreply format,
+   which can count for contribution-graph credit when the linked account
+   has noreply enabled.
+2. ``WORKFLOW_GIT_AUTHOR`` env var — verbatim override. The user
    takes responsibility for the format. Useful for "I want my real
    email on these commits, I know what I'm doing" cases.
-2. The ``actor`` argument (if truthy) or ``UNIVERSE_SERVER_USER`` env
+3. ``WORKFLOW_GITHUB_USERNAME`` + ``WORKFLOW_GITHUB_USER_ID`` — process
+   default GitHub identity for local/dev runs.
+4. The ``actor`` argument (if truthy) or ``UNIVERSE_SERVER_USER`` env
    var, slugified and wrapped into
    ``Workflow User <slug@users.noreply.workflow.local>``.
-3. Fallback slug ``anonymous`` when nothing useful is available.
+5. Fallback slug ``anonymous`` when nothing useful is available.
 
 Using a ``users.noreply.workflow.local`` domain keeps commits
 attributable (the slug identifies which actor made the change) without
@@ -24,12 +30,34 @@ flagged the unverified-email risk; noreply defuses it.
 from __future__ import annotations
 
 import os
+import re
 
 from workflow.catalog.layout import slugify
 
 _DISPLAY_NAME = "Workflow User"
 _NOREPLY_DOMAIN = "users.noreply.workflow.local"
+_GITHUB_NOREPLY_DOMAIN = "users.noreply.github.com"
 _ANONYMOUS_SLUG = "anonymous"
+_GITHUB_LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38}[A-Za-z0-9])?$")
+_GITHUB_ID_RE = re.compile(r"^[1-9][0-9]{0,19}$")
+
+
+def _github_noreply_author(login: str, user_id: str) -> str | None:
+    clean_login = login.strip()
+    clean_id = user_id.strip()
+    if not _GITHUB_LOGIN_RE.fullmatch(clean_login):
+        return None
+    if not _GITHUB_ID_RE.fullmatch(clean_id):
+        return None
+    return f"{clean_login} <{clean_id}+{clean_login}@{_GITHUB_NOREPLY_DOMAIN}>"
+
+
+def _github_author_from_env(login_var: str, id_var: str) -> str | None:
+    login = os.environ.get(login_var, "")
+    user_id = os.environ.get(id_var, "")
+    if not login.strip() or not user_id.strip():
+        return None
+    return _github_noreply_author(login, user_id)
 
 
 def git_author(actor: str | None = None) -> str:
@@ -37,9 +65,23 @@ def git_author(actor: str | None = None) -> str:
 
     See module docstring for resolution order.
     """
+    request_linked = _github_author_from_env(
+        "WORKFLOW_GITHUB_AUTHOR_LOGIN",
+        "WORKFLOW_GITHUB_AUTHOR_ID",
+    )
+    if request_linked:
+        return request_linked
+
     override = os.environ.get("WORKFLOW_GIT_AUTHOR", "").strip()
     if override:
         return override
+
+    process_linked = _github_author_from_env(
+        "WORKFLOW_GITHUB_USERNAME",
+        "WORKFLOW_GITHUB_USER_ID",
+    )
+    if process_linked:
+        return process_linked
 
     raw = (actor or os.environ.get("UNIVERSE_SERVER_USER", "") or "").strip()
     slug = slugify(raw, fallback=_ANONYMOUS_SLUG)

--- a/tests/test_git_author_identity.py
+++ b/tests/test_git_author_identity.py
@@ -3,6 +3,8 @@
 Covers the narrow v1 contract in :mod:`workflow.identity`:
 
 - ``WORKFLOW_GIT_AUTHOR`` env var overrides everything (verbatim).
+- linked GitHub env vars can emit the GitHub noreply format for real
+  contribution-graph credit.
 - Otherwise ``actor`` arg or ``UNIVERSE_SERVER_USER`` → slugged
   ``Workflow User <slug@users.noreply.workflow.local>``.
 - Empty/None/invalid slug → ``anonymous``.
@@ -25,6 +27,10 @@ _DISPLAY = "Workflow User"
 def _clean_identity_env(monkeypatch: pytest.MonkeyPatch):
     """Every test starts without Workflow identity env vars set."""
     monkeypatch.delenv("WORKFLOW_GIT_AUTHOR", raising=False)
+    monkeypatch.delenv("WORKFLOW_GITHUB_AUTHOR_LOGIN", raising=False)
+    monkeypatch.delenv("WORKFLOW_GITHUB_AUTHOR_ID", raising=False)
+    monkeypatch.delenv("WORKFLOW_GITHUB_USERNAME", raising=False)
+    monkeypatch.delenv("WORKFLOW_GITHUB_USER_ID", raising=False)
     monkeypatch.delenv("UNIVERSE_SERVER_USER", raising=False)
     yield
 
@@ -54,6 +60,38 @@ def test_workflow_git_author_env_is_verbatim(monkeypatch):
     )
     monkeypatch.setenv("UNIVERSE_SERVER_USER", "would-be-ignored")
     assert git_author() == "Alice Real <alice@example.com>"
+
+
+def test_request_linked_github_author_uses_noreply_credit_email(monkeypatch):
+    monkeypatch.setenv("WORKFLOW_GITHUB_AUTHOR_LOGIN", "alice")
+    monkeypatch.setenv("WORKFLOW_GITHUB_AUTHOR_ID", "123456")
+    monkeypatch.setenv("WORKFLOW_GIT_AUTHOR", "Host <host@example.com>")
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "host")
+
+    assert git_author() == "alice <123456+alice@users.noreply.github.com>"
+
+
+def test_process_github_author_uses_noreply_when_no_request_author(monkeypatch):
+    monkeypatch.setenv("WORKFLOW_GITHUB_USERNAME", "Bob-Dev")
+    monkeypatch.setenv("WORKFLOW_GITHUB_USER_ID", "987654")
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "host")
+
+    assert git_author() == "Bob-Dev <987654+Bob-Dev@users.noreply.github.com>"
+
+
+def test_invalid_request_linked_github_author_falls_through(monkeypatch):
+    monkeypatch.setenv("WORKFLOW_GITHUB_AUTHOR_LOGIN", "-alice")
+    monkeypatch.setenv("WORKFLOW_GITHUB_AUTHOR_ID", "123456")
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "fallback-user")
+
+    assert git_author() == f"{_DISPLAY} <fallback-user@{_DOMAIN}>"
+
+
+def test_incomplete_request_linked_github_author_falls_through(monkeypatch):
+    monkeypatch.setenv("WORKFLOW_GITHUB_AUTHOR_LOGIN", "alice")
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "fallback-user")
+
+    assert git_author() == f"{_DISPLAY} <fallback-user@{_DOMAIN}>"
 
 
 def test_workflow_git_author_env_strips_surrounding_whitespace(monkeypatch):

--- a/workflow/identity.py
+++ b/workflow/identity.py
@@ -6,13 +6,19 @@ verification, no per-branch override. That's a later follow-up.
 
 Resolution order (first hit wins):
 
-1. ``WORKFLOW_GIT_AUTHOR`` env var — verbatim override. The user
+1. ``WORKFLOW_GITHUB_AUTHOR_LOGIN`` + ``WORKFLOW_GITHUB_AUTHOR_ID`` —
+   request-linked GitHub identity. Emits GitHub's public noreply format,
+   which can count for contribution-graph credit when the linked account
+   has noreply enabled.
+2. ``WORKFLOW_GIT_AUTHOR`` env var — verbatim override. The user
    takes responsibility for the format. Useful for "I want my real
    email on these commits, I know what I'm doing" cases.
-2. The ``actor`` argument (if truthy) or ``UNIVERSE_SERVER_USER`` env
+3. ``WORKFLOW_GITHUB_USERNAME`` + ``WORKFLOW_GITHUB_USER_ID`` — process
+   default GitHub identity for local/dev runs.
+4. The ``actor`` argument (if truthy) or ``UNIVERSE_SERVER_USER`` env
    var, slugified and wrapped into
    ``Workflow User <slug@users.noreply.workflow.local>``.
-3. Fallback slug ``anonymous`` when nothing useful is available.
+5. Fallback slug ``anonymous`` when nothing useful is available.
 
 Using a ``users.noreply.workflow.local`` domain keeps commits
 attributable (the slug identifies which actor made the change) without
@@ -24,12 +30,34 @@ flagged the unverified-email risk; noreply defuses it.
 from __future__ import annotations
 
 import os
+import re
 
 from workflow.catalog.layout import slugify
 
 _DISPLAY_NAME = "Workflow User"
 _NOREPLY_DOMAIN = "users.noreply.workflow.local"
+_GITHUB_NOREPLY_DOMAIN = "users.noreply.github.com"
 _ANONYMOUS_SLUG = "anonymous"
+_GITHUB_LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38}[A-Za-z0-9])?$")
+_GITHUB_ID_RE = re.compile(r"^[1-9][0-9]{0,19}$")
+
+
+def _github_noreply_author(login: str, user_id: str) -> str | None:
+    clean_login = login.strip()
+    clean_id = user_id.strip()
+    if not _GITHUB_LOGIN_RE.fullmatch(clean_login):
+        return None
+    if not _GITHUB_ID_RE.fullmatch(clean_id):
+        return None
+    return f"{clean_login} <{clean_id}+{clean_login}@{_GITHUB_NOREPLY_DOMAIN}>"
+
+
+def _github_author_from_env(login_var: str, id_var: str) -> str | None:
+    login = os.environ.get(login_var, "")
+    user_id = os.environ.get(id_var, "")
+    if not login.strip() or not user_id.strip():
+        return None
+    return _github_noreply_author(login, user_id)
 
 
 def git_author(actor: str | None = None) -> str:
@@ -37,9 +65,23 @@ def git_author(actor: str | None = None) -> str:
 
     See module docstring for resolution order.
     """
+    request_linked = _github_author_from_env(
+        "WORKFLOW_GITHUB_AUTHOR_LOGIN",
+        "WORKFLOW_GITHUB_AUTHOR_ID",
+    )
+    if request_linked:
+        return request_linked
+
     override = os.environ.get("WORKFLOW_GIT_AUTHOR", "").strip()
     if override:
         return override
+
+    process_linked = _github_author_from_env(
+        "WORKFLOW_GITHUB_USERNAME",
+        "WORKFLOW_GITHUB_USER_ID",
+    )
+    if process_linked:
+        return process_linked
 
     raw = (actor or os.environ.get("UNIVERSE_SERVER_USER", "") or "").strip()
     slug = slugify(raw, fallback=_ANONYMOUS_SLUG)


### PR DESCRIPTION
Fixes #762

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-100-pr-100-user-chatbot-github-credit-bridge-tiered-identity-lin.md`
- GitHub issue: #762
- Branch task: `auto-change/issue-762`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.