### PR TITLE
[auto-change] WIKI-PATCH: PR-101: PLAN.md locked-mirror into brain + repo URL embedded for user-chatbots + filing-time nudge to check repo — user-chatbots need to know the repo exists and check PLAN.md before filing, but the brain does NOT mirror the rest of the repo

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
@@ -105,6 +105,16 @@ framing.
     to assert fabricated history as this user's lived experience.
 12. File server defects and platform change requests to the wiki; don't
     silently work around them.
+    Repository context matters before filing. Workflow's source repo is
+    https://github.com/Jonnyton/Workflow, and PLAN.md is the canonical
+    design/scoping reference. Before filing a bug, patch request,
+    feature request, or design proposal, check current repo/PLAN.md
+    context: use `community_change_context` for live community-loop
+    context and relevant PLAN sections, or inspect the repository
+    directly if your client has browsing/repo tools. Do not use stale
+    chat memory as the source of truth. The daemon mini-brain may carry
+    locked PLAN.md context, but it is not a mirror of the rest of the
+    repository.
     When any tool against this connector returns a malformed result,
     silent corruption, schema mismatch, or obvious misbehavior, file a
     bug via `wiki action=file_bug component=<surface>

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1705,6 +1705,12 @@ def _wiki_file_bug(
     ``force_new`` skips the similarity check and always mints a new id.
     When omitted, a Jaccard similarity ≥ 0.5 against an existing bug's
     title+body returns {status: "similar_found"} instead of filing.
+
+    Chatbot callers should check current repository/PLAN.md context before
+    filing platform changes. The source repo is
+    https://github.com/Jonnyton/Workflow; PLAN.md is canonical design and
+    scoping truth. This does not require a wiki duplicate search because the
+    server performs filing deduplication.
     """
     if not title or not component or not severity:
         return json.dumps({

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_brain.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_brain.py
@@ -19,6 +19,17 @@ from typing import Any
 
 SCHEMA_VERSION = 1
 DEFAULT_BRAIN_PACKET_CHARS = 1600
+WORKFLOW_REPOSITORY_URL = "https://github.com/Jonnyton/Workflow"
+LOCKED_PROJECT_CONTEXT = f"""\
+## Locked PLAN.md Mirror
+
+- Repository: {WORKFLOW_REPOSITORY_URL}
+- PLAN.md is canonical design and scoping truth for Workflow.
+- Scoping: minimal primitives, community-build, privacy via composition,
+  commons-first, and the browser/local user-capability axis.
+- Mini-brain mirrors locked PLAN.md context; it is not a mirror of the rest
+  of the repository.
+"""
 
 VALID_MEMORY_KINDS = {
     "semantic",
@@ -940,7 +951,12 @@ def build_daemon_brain_packet(
             f"- State: {entry['promotion_state']} | Visibility: {entry['visibility']}",
             entry["content"],
         ])
-    context, truncated = _truncate_text("\n".join(lines).strip(), budget)
+    raw_context = (
+        LOCKED_PROJECT_CONTEXT.strip()
+        + "\n\n"
+        + "\n".join(lines).strip()
+    )
+    context, truncated = _truncate_text(raw_context, budget)
     with _connect(base_path) as conn:
         _record_event_conn(
             conn,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -959,7 +959,10 @@ def wiki(
     design proposal, call `file_bug` directly with the matching `kind`
     (`bug`, `patch_request`, `feature`, or `design`). `file_bug` already
     does Jaccard duplicate detection server-side; you do NOT need to search/list/read
-    the wiki before filing. If a similar filing exists,
+    the wiki before filing. Before filing, check current repo/PLAN.md
+    context via `community_change_context` or direct repo browsing; the
+    source repo is https://github.com/Jonnyton/Workflow and PLAN.md is
+    canonical design/scoping truth. If a similar filing exists,
     it returns status="similar_found" with the existing match.
 
     Args:

--- a/tests/test_daemon_brain.py
+++ b/tests/test_daemon_brain.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from workflow.daemon_brain import (
@@ -106,6 +107,14 @@ def test_daemon_brain_smoke_roundtrip(tmp_path: Path) -> None:
         daemon_id=ada["daemon_id"],
         query="daemon routing executor identity",
         max_chars=700,
+    )
+    assert "## Locked PLAN.md Mirror" in brain_packet["context"]
+    assert "https://github.com/Jonnyton/Workflow" in brain_packet["context"]
+    assert "PLAN.md" in brain_packet["context"]
+    assert "minimal primitives" in brain_packet["context"]
+    assert re.search(
+        r"not a mirror of the rest\s+of the repository",
+        brain_packet["context"],
     )
     assert first["entry_id"] in brain_packet["context"]
     assert len(brain_packet["context"]) <= 700

--- a/tests/test_universe_server_framing.py
+++ b/tests/test_universe_server_framing.py
@@ -114,6 +114,20 @@ def test_wiki_tool_description_is_not_a_catchall() -> None:
     assert "build / design / create a workflow" in lower or "build a workflow" in lower
 
 
+def test_wiki_tool_description_nudges_plan_check_before_filing() -> None:
+    """WIKI-PATCH PR-101: the filing tool metadata itself should carry the
+    repo/PLAN nudge, not only the long control_station prompt.
+    """
+    tool = next(t for t in _list_tools() if t.name == "wiki")
+    text = tool.description or ""
+    lower = text.lower()
+
+    assert "https://github.com/Jonnyton/Workflow" in text
+    assert "before filing" in lower
+    assert "plan.md" in lower
+    assert "community_change_context" in text
+
+
 def test_universe_tool_description_is_general_not_fiction_only() -> None:
     """#28 post-4ef0769 (universe docstring trimmed to ≤6 lines + Args):
     the multi-domain example list moved to control_station prompt (which
@@ -187,6 +201,23 @@ def test_control_station_routes_daemon_memory_actions() -> None:
         assert action in text
     assert "inputs_json" in text
     assert "daemon_id" in text
+
+
+def test_control_station_tells_chatbots_to_check_repo_plan_before_filing() -> None:
+    """WIKI-PATCH PR-101: user chatbots need the repo URL and a PLAN.md
+    check before filing platform bugs, patches, features, or design proposals.
+    """
+    from workflow.api.prompts import _CONTROL_STATION_PROMPT
+
+    text = _CONTROL_STATION_PROMPT
+    lower = text.lower()
+
+    assert "https://github.com/Jonnyton/Workflow" in text
+    assert "plan.md" in lower
+    assert "before filing" in lower
+    assert "community_change_context" in text
+    assert "daemon mini-brain" in lower
+    assert re.search(r"not a mirror of the rest of the\s+repository", lower)
 
 
 def test_extension_guide_prompt_points_to_control_station() -> None:

--- a/workflow/api/prompts.py
+++ b/workflow/api/prompts.py
@@ -105,6 +105,16 @@ framing.
     to assert fabricated history as this user's lived experience.
 12. File server defects and platform change requests to the wiki; don't
     silently work around them.
+    Repository context matters before filing. Workflow's source repo is
+    https://github.com/Jonnyton/Workflow, and PLAN.md is the canonical
+    design/scoping reference. Before filing a bug, patch request,
+    feature request, or design proposal, check current repo/PLAN.md
+    context: use `community_change_context` for live community-loop
+    context and relevant PLAN sections, or inspect the repository
+    directly if your client has browsing/repo tools. Do not use stale
+    chat memory as the source of truth. The daemon mini-brain may carry
+    locked PLAN.md context, but it is not a mirror of the rest of the
+    repository.
     When any tool against this connector returns a malformed result,
     silent corruption, schema mismatch, or obvious misbehavior, file a
     bug via `wiki action=file_bug component=<surface>

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1705,6 +1705,12 @@ def _wiki_file_bug(
     ``force_new`` skips the similarity check and always mints a new id.
     When omitted, a Jaccard similarity ≥ 0.5 against an existing bug's
     title+body returns {status: "similar_found"} instead of filing.
+
+    Chatbot callers should check current repository/PLAN.md context before
+    filing platform changes. The source repo is
+    https://github.com/Jonnyton/Workflow; PLAN.md is canonical design and
+    scoping truth. This does not require a wiki duplicate search because the
+    server performs filing deduplication.
     """
     if not title or not component or not severity:
         return json.dumps({

--- a/workflow/daemon_brain.py
+++ b/workflow/daemon_brain.py
@@ -19,6 +19,17 @@ from typing import Any
 
 SCHEMA_VERSION = 1
 DEFAULT_BRAIN_PACKET_CHARS = 1600
+WORKFLOW_REPOSITORY_URL = "https://github.com/Jonnyton/Workflow"
+LOCKED_PROJECT_CONTEXT = f"""\
+## Locked PLAN.md Mirror
+
+- Repository: {WORKFLOW_REPOSITORY_URL}
+- PLAN.md is canonical design and scoping truth for Workflow.
+- Scoping: minimal primitives, community-build, privacy via composition,
+  commons-first, and the browser/local user-capability axis.
+- Mini-brain mirrors locked PLAN.md context; it is not a mirror of the rest
+  of the repository.
+"""
 
 VALID_MEMORY_KINDS = {
     "semantic",
@@ -940,7 +951,12 @@ def build_daemon_brain_packet(
             f"- State: {entry['promotion_state']} | Visibility: {entry['visibility']}",
             entry["content"],
         ])
-    context, truncated = _truncate_text("\n".join(lines).strip(), budget)
+    raw_context = (
+        LOCKED_PROJECT_CONTEXT.strip()
+        + "\n\n"
+        + "\n".join(lines).strip()
+    )
+    context, truncated = _truncate_text(raw_context, budget)
     with _connect(base_path) as conn:
         _record_event_conn(
             conn,

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -959,7 +959,10 @@ def wiki(
     design proposal, call `file_bug` directly with the matching `kind`
     (`bug`, `patch_request`, `feature`, or `design`). `file_bug` already
     does Jaccard duplicate detection server-side; you do NOT need to search/list/read
-    the wiki before filing. If a similar filing exists,
+    the wiki before filing. Before filing, check current repo/PLAN.md
+    context via `community_change_context` or direct repo browsing; the
+    source repo is https://github.com/Jonnyton/Workflow and PLAN.md is
+    canonical design/scoping truth. If a similar filing exists,
     it returns status="similar_found" with the existing match.
 
     Args:


### PR DESCRIPTION
Fixes #763

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-101-pr-101-plan-md-locked-mirror-into-brain-repo-url-embedded-fo.md`
- GitHub issue: #763
- Branch task: `auto-change/issue-763`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.