### PR TITLE
[auto-change] BUG-078: PR-103c: Mark's lane slice 3 — release_ship_validator calls open_auto_ship_pr when validate=valid AND ledger recorded AND WORKFLOW_AUTO_SHIP_PR_CREATE_ENABLED=1; Loop B starts producing PRs at parity with Loop A

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/auto_ship_actions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/auto_ship_actions.py
@@ -232,6 +232,48 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
         })
         augmented["violations"] = violations
         augmented["ledger_error"] = ledger_error
+        return json.dumps(augmented)
+
+    if (
+        decision.get("validation_result") == "passed"
+        and decision.get("would_open_pr") is True
+        and ship_attempt_id
+    ):
+        try:
+            from workflow.auto_ship_pr import open_auto_ship_pr, pr_create_enabled
+        except Exception as exc:  # noqa: BLE001
+            augmented["pr_create_error_class"] = type(exc).__name__
+            augmented["pr_create_error_message"] = (
+                f"auto-ship PR helper import failed: {exc}"
+            )
+            return json.dumps(augmented)
+
+        if pr_create_enabled():
+            head_branch = str(kwargs.get("head_branch") or "").strip()
+            universe_path, error = _resolve_universe_path(
+                str(kwargs.get("universe_id") or "")
+            )
+            if error:
+                augmented["pr_create_error_class"] = "universe_resolve_failed"
+                augmented["pr_create_error_message"] = error
+                return json.dumps(augmented)
+
+            try:
+                pr_result = open_auto_ship_pr(
+                    universe_path=universe_path,
+                    ship_attempt_id=ship_attempt_id,
+                    head_branch=head_branch,
+                    title=str(kwargs.get("title") or ""),
+                    body=str(kwargs.get("body") or ""),
+                    base_branch=str(kwargs.get("base_branch") or "main"),
+                )
+            except Exception as exc:  # noqa: BLE001 - keep MCP response JSON
+                augmented["pr_create_error_class"] = type(exc).__name__
+                augmented["pr_create_error_message"] = (
+                    f"open_auto_ship_pr raised: {exc}"
+                )
+                return json.dumps(augmented)
+            return json.dumps(pr_result)
     return json.dumps(augmented)
 
 

--- a/tests/test_validate_ship_packet_action.py
+++ b/tests/test_validate_ship_packet_action.py
@@ -280,6 +280,94 @@ class TestDispatchIntegration:
         assert row is not None
         assert row.error_class == "pr_create_disabled"
 
+    def test_validate_ship_packet_opens_pr_when_enabled_after_ledger_record(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Regression for BUG-078: Loop B's validator action should bridge
+        directly into PR creation once validation passed and the ledger row
+        exists, matching Loop A's auto-change PR behavior.
+        """
+        from workflow.auto_ship_ledger import find_attempt
+        from workflow.auto_ship_pr import PR_CREATE_FLAG
+
+        monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "ship-uni")
+        monkeypatch.setenv(PR_CREATE_FLAG, "1")
+        monkeypatch.setenv("GH_TOKEN", "gh-token")
+        universe = tmp_path / "ship-uni"
+        universe.mkdir(parents=True, exist_ok=True)
+
+        calls = []
+
+        def fake_get(url, token):
+            calls.append(("get", url, token))
+            return 200, {"status": "ahead", "behind_by": 0}
+
+        def fake_post(url, token, payload):
+            calls.append(("post", url, token, payload))
+            return 201, {
+                "html_url": "https://github.com/Jonnyton/Workflow/pull/780",
+                "number": 780,
+                "head": {"sha": "abc780"},
+            }
+
+        monkeypatch.setattr("workflow.auto_ship_pr._get_github_json", fake_get)
+        monkeypatch.setattr("workflow.auto_ship_pr._post_github_json", fake_post)
+        packet = {
+            "release_gate_result": "APPROVE_AUTO_SHIP",
+            "ship_class": "docs_canary",
+            "child_keep_reject_decision": "KEEP",
+            "coding_packet": {"status": "KEEP_READY"},
+            "child_score": 9.5,
+            "risk_level": "low",
+            "blocked_execution_record": {},
+            "stable_evidence_handle": "child_run:b:r",
+            "automation_claim_status": "child_attached_with_handle",
+            "rollback_plan": "Revert commit <sha>",
+            "changed_paths": ["docs/autoship-canaries/bug-078.md"],
+            "diff": "+ x\n",
+        }
+
+        result = json.loads(_extensions_impl(
+            action="validate_ship_packet",
+            body_json=json.dumps(packet),
+            record_in_ledger=True,
+            universe_id="ship-uni",
+            request_id="BUG-078",
+            parent_run_id="parent-run",
+            child_run_id="child-run",
+            branch_def_id="change_loop_v1",
+            head_branch="auto-change/issue-771-codex-25647817292",
+            title="[auto-change] BUG-078",
+            pr_body="Auto-ship BUG-078",
+        ))
+
+        assert result["ship_status"] == "opened"
+        assert result["validation_result"] == "passed"
+        assert result["would_open_pr"] is True
+        assert result["dry_run"] is False
+        assert result["pr_url"] == "https://github.com/Jonnyton/Workflow/pull/780"
+        assert result["commit_sha"] == "abc780"
+        assert calls[0][0] == "get"
+        assert calls[1] == (
+            "post",
+            "https://api.github.com/repos/Jonnyton/Workflow/pulls",
+            "gh-token",
+            {
+                "title": "[auto-change] BUG-078",
+                "head": "auto-change/issue-771-codex-25647817292",
+                "base": "main",
+                "body": "Auto-ship BUG-078",
+                "draft": False,
+            },
+        )
+        row = find_attempt(universe, result["ship_attempt_id"])
+        assert row is not None
+        assert row.ship_status == "opened"
+        assert row.pr_url == "https://github.com/Jonnyton/Workflow/pull/780"
+
 
 # ── Wrapper resilience ─────────────────────────────────────────────────────
 

--- a/workflow/api/auto_ship_actions.py
+++ b/workflow/api/auto_ship_actions.py
@@ -232,6 +232,48 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
         })
         augmented["violations"] = violations
         augmented["ledger_error"] = ledger_error
+        return json.dumps(augmented)
+
+    if (
+        decision.get("validation_result") == "passed"
+        and decision.get("would_open_pr") is True
+        and ship_attempt_id
+    ):
+        try:
+            from workflow.auto_ship_pr import open_auto_ship_pr, pr_create_enabled
+        except Exception as exc:  # noqa: BLE001
+            augmented["pr_create_error_class"] = type(exc).__name__
+            augmented["pr_create_error_message"] = (
+                f"auto-ship PR helper import failed: {exc}"
+            )
+            return json.dumps(augmented)
+
+        if pr_create_enabled():
+            head_branch = str(kwargs.get("head_branch") or "").strip()
+            universe_path, error = _resolve_universe_path(
+                str(kwargs.get("universe_id") or "")
+            )
+            if error:
+                augmented["pr_create_error_class"] = "universe_resolve_failed"
+                augmented["pr_create_error_message"] = error
+                return json.dumps(augmented)
+
+            try:
+                pr_result = open_auto_ship_pr(
+                    universe_path=universe_path,
+                    ship_attempt_id=ship_attempt_id,
+                    head_branch=head_branch,
+                    title=str(kwargs.get("title") or ""),
+                    body=str(kwargs.get("body") or ""),
+                    base_branch=str(kwargs.get("base_branch") or "main"),
+                )
+            except Exception as exc:  # noqa: BLE001 - keep MCP response JSON
+                augmented["pr_create_error_class"] = type(exc).__name__
+                augmented["pr_create_error_message"] = (
+                    f"open_auto_ship_pr raised: {exc}"
+                )
+                return json.dumps(augmented)
+            return json.dumps(pr_result)
     return json.dumps(augmented)
 
 


### PR DESCRIPTION
Fixes #771

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-078-pr-103c-mark-s-lane-slice-3-release-ship-validator-calls-ope.md`
- GitHub issue: #771
- Branch task: `auto-change/issue-771`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.