### PR TITLE
[auto-change] WIKI-PATCH: PR-102: Inventory / ambient-status / "what I'm working on" content belongs in the brain, not git+PRs — local AIs opening PRs for non-patch content clogs the queue; loop is for patches; canary: chore-branch PRs #158/#162/#164 that only touched .agents/worktrees.md inventory

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auto_ship_pr.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auto_ship_pr.py
@@ -26,6 +26,14 @@ TOKEN_ENV_VARS = ("GH_TOKEN", "GITHUB_TOKEN")
 
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _AUTO_CHANGE_BRANCH_RE = re.compile(r"^auto-change/[A-Za-z0-9._/-]+$")
+_AMBIENT_ONLY_PR_PATHS = frozenset(
+    {
+        ".agents/activity.log",
+        ".agents/worktrees.md",
+        "REFLECTION.md",
+        "STATUS.md",
+    }
+)
 
 JsonPost = Callable[[str, str, dict[str, Any]], tuple[int, dict[str, Any]]]
 JsonGet = Callable[[str, str], tuple[int, dict[str, Any]]]
@@ -197,6 +205,28 @@ def _head_is_current_with_base(compare: dict[str, Any]) -> bool:
     except (TypeError, ValueError):
         return False
     return behind_by == 0 and status in {"ahead", "identical"}
+
+
+def _ambient_only_changed_paths(compare: dict[str, Any]) -> list[str]:
+    files = compare.get("files")
+    if not isinstance(files, list) or not files:
+        return []
+
+    changed_paths: list[str] = []
+    for item in files:
+        if not isinstance(item, dict):
+            return []
+        filename = str(item.get("filename") or "").strip()
+        previous_filename = str(item.get("previous_filename") or "").strip()
+        if not filename:
+            return []
+        changed_paths.append(filename)
+        if previous_filename:
+            changed_paths.append(previous_filename)
+
+    if changed_paths and all(path in _AMBIENT_ONLY_PR_PATHS for path in changed_paths):
+        return sorted(set(changed_paths))
+    return []
 
 
 def open_auto_ship_pr(
@@ -413,6 +443,34 @@ def open_auto_ship_pr(
         result["base_branch"] = base
         result["compare_status"] = status_text
         result["behind_by"] = behind_by
+        return result
+
+    ambient_paths = _ambient_only_changed_paths(compare_response)
+    if ambient_paths:
+        msg = (
+            "auto-change branch changes only coordination/ambient-status files "
+            f"({', '.join(ambient_paths)}); write this state to the brain/coordination "
+            "surface instead of opening a patch PR."
+        )
+        ledger_error = _mark_attempt(
+            universe_path,
+            attempt_id,
+            ship_status="blocked",
+            error_class="pr_create_non_patch_content",
+            error_message=msg,
+        )
+        result = _error_result(
+            ship_attempt_id=attempt_id,
+            ship_status="blocked",
+            error_class="pr_create_non_patch_content",
+            error_message=msg,
+            would_open_pr=True,
+            dry_run=False,
+            ledger_error=ledger_error,
+        )
+        result["head_branch"] = head
+        result["base_branch"] = base
+        result["changed_paths"] = ambient_paths
         return result
 
     pr_title = title.strip() or f"[auto-change] {attempt.request_id or attempt_id}"

--- a/tests/test_auto_ship_pr.py
+++ b/tests/test_auto_ship_pr.py
@@ -278,6 +278,86 @@ def test_enabled_rejects_stale_head_before_pr_creation(tmp_path):
     assert row.error_class == "pr_create_stale_head"
 
 
+def test_enabled_rejects_ambient_inventory_only_branch(tmp_path):
+    attempt_id = _record(tmp_path)
+    calls = []
+
+    def fake_get(url, token):
+        calls.append(("get", url, token))
+        return 200, {
+            "status": "ahead",
+            "behind_by": 0,
+            "files": [{"filename": ".agents/worktrees.md"}],
+        }
+
+    def should_not_post(url, token, payload):  # pragma: no cover - failure path
+        raise AssertionError("ambient-only branches must not create PRs")
+
+    result = open_auto_ship_pr(
+        universe_path=tmp_path,
+        ship_attempt_id=attempt_id,
+        head_branch="auto-change/issue-999-codex-123",
+        title="[auto-change] BUG-999",
+        create_enabled=True,
+        token="gh-token",
+        get_json=fake_get,
+        post_json=should_not_post,
+    )
+
+    assert result["ship_status"] == "blocked"
+    assert result["error_class"] == "pr_create_non_patch_content"
+    assert result["changed_paths"] == [".agents/worktrees.md"]
+    assert "brain/coordination surface" in result["error_message"]
+    assert calls == [(
+        "get",
+        "https://api.github.com/repos/Jonnyton/Workflow/compare/main...auto-change%2Fissue-999-codex-123",
+        "gh-token",
+    )]
+    row = find_attempt(tmp_path, attempt_id)
+    assert row is not None
+    assert row.ship_status == "blocked"
+    assert row.error_class == "pr_create_non_patch_content"
+
+
+def test_enabled_allows_ambient_file_when_branch_has_patch_content(tmp_path):
+    attempt_id = _record(tmp_path)
+    calls = []
+
+    def fake_get(url, token):
+        calls.append(("get", url, token))
+        return 200, {
+            "status": "ahead",
+            "behind_by": 0,
+            "files": [
+                {"filename": ".agents/worktrees.md"},
+                {"filename": "workflow/auto_ship_pr.py"},
+            ],
+        }
+
+    def fake_post(url, token, payload):
+        calls.append(("post", url, token, payload))
+        return 201, {
+            "html_url": "https://github.com/Jonnyton/Workflow/pull/999",
+            "number": 999,
+            "head": {"sha": "abc123"},
+        }
+
+    result = open_auto_ship_pr(
+        universe_path=tmp_path,
+        ship_attempt_id=attempt_id,
+        head_branch="auto-change/issue-999-codex-123",
+        title="[auto-change] BUG-999",
+        create_enabled=True,
+        token="gh-token",
+        get_json=fake_get,
+        post_json=fake_post,
+    )
+
+    assert result["ship_status"] == "opened"
+    assert result["pr_url"] == "https://github.com/Jonnyton/Workflow/pull/999"
+    assert [call[0] for call in calls] == ["get", "post"]
+
+
 def test_blocked_attempt_is_not_eligible_for_pr_creation(tmp_path):
     attempt_id = _record(
         tmp_path,

--- a/workflow/auto_ship_pr.py
+++ b/workflow/auto_ship_pr.py
@@ -26,6 +26,14 @@ TOKEN_ENV_VARS = ("GH_TOKEN", "GITHUB_TOKEN")
 
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _AUTO_CHANGE_BRANCH_RE = re.compile(r"^auto-change/[A-Za-z0-9._/-]+$")
+_AMBIENT_ONLY_PR_PATHS = frozenset(
+    {
+        ".agents/activity.log",
+        ".agents/worktrees.md",
+        "REFLECTION.md",
+        "STATUS.md",
+    }
+)
 
 JsonPost = Callable[[str, str, dict[str, Any]], tuple[int, dict[str, Any]]]
 JsonGet = Callable[[str, str], tuple[int, dict[str, Any]]]
@@ -197,6 +205,28 @@ def _head_is_current_with_base(compare: dict[str, Any]) -> bool:
     except (TypeError, ValueError):
         return False
     return behind_by == 0 and status in {"ahead", "identical"}
+
+
+def _ambient_only_changed_paths(compare: dict[str, Any]) -> list[str]:
+    files = compare.get("files")
+    if not isinstance(files, list) or not files:
+        return []
+
+    changed_paths: list[str] = []
+    for item in files:
+        if not isinstance(item, dict):
+            return []
+        filename = str(item.get("filename") or "").strip()
+        previous_filename = str(item.get("previous_filename") or "").strip()
+        if not filename:
+            return []
+        changed_paths.append(filename)
+        if previous_filename:
+            changed_paths.append(previous_filename)
+
+    if changed_paths and all(path in _AMBIENT_ONLY_PR_PATHS for path in changed_paths):
+        return sorted(set(changed_paths))
+    return []
 
 
 def open_auto_ship_pr(
@@ -413,6 +443,34 @@ def open_auto_ship_pr(
         result["base_branch"] = base
         result["compare_status"] = status_text
         result["behind_by"] = behind_by
+        return result
+
+    ambient_paths = _ambient_only_changed_paths(compare_response)
+    if ambient_paths:
+        msg = (
+            "auto-change branch changes only coordination/ambient-status files "
+            f"({', '.join(ambient_paths)}); write this state to the brain/coordination "
+            "surface instead of opening a patch PR."
+        )
+        ledger_error = _mark_attempt(
+            universe_path,
+            attempt_id,
+            ship_status="blocked",
+            error_class="pr_create_non_patch_content",
+            error_message=msg,
+        )
+        result = _error_result(
+            ship_attempt_id=attempt_id,
+            ship_status="blocked",
+            error_class="pr_create_non_patch_content",
+            error_message=msg,
+            would_open_pr=True,
+            dry_run=False,
+            ledger_error=ledger_error,
+        )
+        result["head_branch"] = head
+        result["base_branch"] = base
+        result["changed_paths"] = ambient_paths
         return result
 
     pr_title = title.strip() or f"[auto-change] {attempt.request_id or attempt_id}"


### PR DESCRIPTION
Fixes #773

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-102-pr-102-inventory-ambient-status-what-i-m-working-on-content-.md`
- GitHub issue: #773
- Branch task: `auto-change/issue-773`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.