### PR TITLE
[auto-change] WIKI-PATCH: PR-104: Filing-time primitives-compose check — chatbot proposing new MCP action / primitive must first demonstrate the proposed function cannot be composed from existing 6+5 primitives; catches "violates 6+5 minimality" class at filing time before writer wastes a cycle

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
@@ -131,6 +131,17 @@ framing.
     capability request, and `kind=design` for an architecture or policy
     proposal. Do not coerce these into bug wording just to enter the
     community loop.
+    Primitive minimality gate: before filing any request that proposes a
+    new MCP action, new primitive, new tool, or convenience wrapper,
+    first make the composition proof explicit. Try to compose the user's
+    requested function from PLAN.md's minimal primitive surfaces: the
+    current 5+2 tool primitives, the E1-E8 engine substrate, and the
+    wiki `composition-patterns` catalog. If a competent chatbot could
+    compose the behavior from existing primitives in fewer than five
+    reasoning steps, do not file a platform-code request; document or
+    point to the composition pattern instead. File only when the proof
+    shows a structural gap, and include the failed composition attempt
+    in `observed` or `reporter_context`.
     Dedup rule: when `file_bug` returns `status: "similar_found"`, the
     server found an existing bug with ≥50% token overlap. Default to
     `wiki action=cosign_bug bug_id=<top similar bug_id>

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -962,8 +962,12 @@ def wiki(
     the wiki before filing. Before filing, check current repo/PLAN.md
     context via `community_change_context` or direct repo browsing; the
     source repo is https://github.com/Jonnyton/Workflow and PLAN.md is
-    canonical design/scoping truth. If a similar filing exists,
-    it returns status="similar_found" with the existing match.
+    canonical design/scoping truth. If the filing proposes a new MCP action,
+    primitive, tool, or convenience wrapper, include a composition proof:
+    show why it cannot be composed from the 5+2 tool primitives, the E1-E8
+    engine substrate, and the wiki `composition-patterns` catalog. If a
+    similar filing exists, it returns status="similar_found" with the
+    existing match.
 
     Args:
         action: One of — reads: read, search, since, list, lint;

--- a/tests/test_universe_server_framing.py
+++ b/tests/test_universe_server_framing.py
@@ -128,6 +128,22 @@ def test_wiki_tool_description_nudges_plan_check_before_filing() -> None:
     assert "community_change_context" in text
 
 
+def test_wiki_tool_description_requires_primitive_composition_check() -> None:
+    """WIKI-PATCH PR-104: proposed new actions/primitives must show they
+    cannot be composed from the existing minimal primitive surfaces.
+    """
+    tool = next(t for t in _list_tools() if t.name == "wiki")
+    text = tool.description or ""
+    lower = text.lower()
+
+    assert "new mcp action" in lower
+    assert "primitive" in lower
+    assert "composition proof" in lower
+    assert "5+2" in text
+    assert "e1-e8" in lower
+    assert "composition-patterns" in lower
+
+
 def test_universe_tool_description_is_general_not_fiction_only() -> None:
     """#28 post-4ef0769 (universe docstring trimmed to ≤6 lines + Args):
     the multi-domain example list moved to control_station prompt (which
@@ -218,6 +234,24 @@ def test_control_station_tells_chatbots_to_check_repo_plan_before_filing() -> No
     assert "community_change_context" in text
     assert "daemon mini-brain" in lower
     assert re.search(r"not a mirror of the rest of the\s+repository", lower)
+
+
+def test_control_station_requires_primitive_composition_check_before_filing() -> None:
+    """WIKI-PATCH PR-104: filing guidance should reject convenience
+    primitives unless the chatbot records a failed composition attempt.
+    """
+    from workflow.api.prompts import _CONTROL_STATION_PROMPT
+
+    text = _CONTROL_STATION_PROMPT
+    lower = text.lower()
+
+    assert "new mcp action" in lower
+    assert "new primitive" in lower
+    assert "composition proof" in lower
+    assert "5+2" in text
+    assert "e1-e8" in lower
+    assert "composition-patterns" in lower
+    assert "competent chatbot" in lower
 
 
 def test_extension_guide_prompt_points_to_control_station() -> None:

--- a/workflow/api/prompts.py
+++ b/workflow/api/prompts.py
@@ -131,6 +131,17 @@ framing.
     capability request, and `kind=design` for an architecture or policy
     proposal. Do not coerce these into bug wording just to enter the
     community loop.
+    Primitive minimality gate: before filing any request that proposes a
+    new MCP action, new primitive, new tool, or convenience wrapper,
+    first make the composition proof explicit. Try to compose the user's
+    requested function from PLAN.md's minimal primitive surfaces: the
+    current 5+2 tool primitives, the E1-E8 engine substrate, and the
+    wiki `composition-patterns` catalog. If a competent chatbot could
+    compose the behavior from existing primitives in fewer than five
+    reasoning steps, do not file a platform-code request; document or
+    point to the composition pattern instead. File only when the proof
+    shows a structural gap, and include the failed composition attempt
+    in `observed` or `reporter_context`.
     Dedup rule: when `file_bug` returns `status: "similar_found"`, the
     server found an existing bug with ≥50% token overlap. Default to
     `wiki action=cosign_bug bug_id=<top similar bug_id>

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -962,8 +962,12 @@ def wiki(
     the wiki before filing. Before filing, check current repo/PLAN.md
     context via `community_change_context` or direct repo browsing; the
     source repo is https://github.com/Jonnyton/Workflow and PLAN.md is
-    canonical design/scoping truth. If a similar filing exists,
-    it returns status="similar_found" with the existing match.
+    canonical design/scoping truth. If the filing proposes a new MCP action,
+    primitive, tool, or convenience wrapper, include a composition proof:
+    show why it cannot be composed from the 5+2 tool primitives, the E1-E8
+    engine substrate, and the wiki `composition-patterns` catalog. If a
+    similar filing exists, it returns status="similar_found" with the
+    existing match.
 
     Args:
         action: One of — reads: read, search, since, list, lint;


### PR DESCRIPTION
Fixes #774

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-103-pr-104-filing-time-primitives-compose-check-chatbot-proposin.md`
- GitHub issue: #774
- Branch task: `auto-change/issue-774`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.