### PR TITLE
[auto-change] BUG-075: PR-103a: Mark's lane slice 1 — release_safety_gate adds validate_ship_packet dry-run call; returns validation result in release_gate_result; does not yet record ledger or open PR

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/auto_ship_actions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/auto_ship_actions.py
@@ -21,9 +21,11 @@ Sequencing:
   action that takes an existing passed ledger row and opens a PR from an
   ``auto-change/*`` branch only when ``WORKFLOW_AUTO_SHIP_PR_CREATE_ENABLED``
   is explicitly enabled. It does not auto-merge.
-- A future loop-content PR (Mark's lane) updates change_loop_v1's
-  release_safety_gate to call this action with ``record_in_ledger=true``
-  and emit APPROVE_AUTO_SHIP only when ``would_open_pr`` is True.
+- PR-103a / Mark's lane slice 1 lets change_loop_v1's release_safety_gate
+  call this action in dry-run mode with ``return_release_gate_result=true``.
+  That returns a structured ``release_gate_result`` verdict without recording
+  to the ledger or opening a PR. A later slice can opt into
+  ``record_in_ledger=true``.
 
 Phase 2A is wrapper only — no behavior change to any current path until
 a caller opts in. The action exists; nothing in the loop or substrate
@@ -118,6 +120,12 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
             new row's id) and, on write failure, a ``ledger_error`` field
             describing what went wrong. The validator decision is
             returned regardless of ledger outcome.
+        return_release_gate_result (optional, default False): when truthy,
+            augment the dry-run response with a release-gate verdict derived
+            from validation: ``APPROVE_AUTO_SHIP`` when the packet passed and
+            would open a PR, otherwise ``HOLD``. This is for release_safety_gate
+            callers that need to return a structured ``release_gate_result``
+            while still leaving ledger recording and PR creation disabled.
         universe_id (optional): when ``record_in_ledger`` is truthy,
             the universe whose data dir to write to. Defaults to
             ``_default_universe()``.
@@ -170,10 +178,21 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
             "exception_class": type(exc).__name__,
         })
 
-    # Phase 2A behavior preserved: when ledger recording is not requested,
+    # Phase 2A behavior preserved: when no opt-in sidecar fields are requested,
     # the response is exactly the validator's decision dict, byte-for-byte
     # identical to PR #224.
     if not _record_in_ledger_enabled(kwargs.get("record_in_ledger")):
+        if _record_in_ledger_enabled(kwargs.get("return_release_gate_result")):
+            augmented = dict(decision)
+            augmented["release_gate_result"] = (
+                "APPROVE_AUTO_SHIP"
+                if (
+                    decision.get("validation_result") == "passed"
+                    and decision.get("would_open_pr") is True
+                )
+                else "HOLD"
+            )
+            return json.dumps(augmented)
         return json.dumps(decision)
 
     # Resolve call-site context for the ledger row. All optional with

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
@@ -348,6 +348,7 @@ def _extensions_impl(
     ship_class: str = "",
     changed_paths_json: str = "",
     stable_evidence_handle: str = "",
+    return_release_gate_result: bool = False,
 ) -> str:
     """Pattern A2 body — see ``workflow.universe_server.extensions`` for the
     chatbot-facing docstring. Behavior is identical; the decorator wrapper
@@ -580,6 +581,7 @@ def _extensions_impl(
             "ship_class": ship_class,
             "changed_paths_json": changed_paths_json,
             "stable_evidence_handle": stable_evidence_handle,
+            "return_release_gate_result": return_release_gate_result,
             "ship_attempt_id": ship_attempt_id,
             "head_branch": head_branch,
             "title": title,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -589,6 +589,7 @@ def extensions(
     ship_class: str = "",
     changed_paths_json: str = "",
     stable_evidence_handle: str = "",
+    return_release_gate_result: bool = False,
 ) -> str:
     """Workflow-builder surface: design, edit, run, judge custom AI graphs.
 
@@ -721,6 +722,7 @@ def extensions(
         ship_class=ship_class,
         changed_paths_json=changed_paths_json,
         stable_evidence_handle=stable_evidence_handle,
+        return_release_gate_result=return_release_gate_result,
     )
 
 

--- a/tests/test_validate_ship_packet_action.py
+++ b/tests/test_validate_ship_packet_action.py
@@ -70,6 +70,73 @@ class TestHandlerLayer:
         assert result["dry_run"] is True
         assert result["ship_status"] == "skipped"
 
+    def test_release_gate_result_mode_returns_dry_run_verdict_without_side_effects(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        from workflow.auto_ship_ledger import read_attempts
+
+        monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "test-uni")
+        universe = tmp_path / "test-uni"
+        universe.mkdir()
+        packet = {
+            "release_gate_result": "APPROVE_AUTO_SHIP",
+            "ship_class": "docs_canary",
+            "child_keep_reject_decision": "KEEP",
+            "coding_packet": {"status": "KEEP_READY"},
+            "child_score": 9.5,
+            "risk_level": "low",
+            "blocked_execution_record": {},
+            "stable_evidence_handle": "child_run:b:r",
+            "automation_claim_status": "child_attached_with_handle",
+            "rollback_plan": "Revert commit <sha>",
+            "changed_paths": ["docs/autoship-canaries/x.md"],
+            "diff": "+ added\n",
+        }
+
+        result = json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps(packet),
+            "return_release_gate_result": True,
+        }))
+
+        assert result["validation_result"] == "passed"
+        assert result["release_gate_result"] == "APPROVE_AUTO_SHIP"
+        assert result["would_open_pr"] is True
+        assert result["dry_run"] is True
+        assert "ship_attempt_id" not in result
+        assert read_attempts(universe) == []
+
+    def test_release_gate_result_mode_holds_blocked_dry_run(self):
+        packet = {
+            "release_gate_result": "APPROVE_AUTO_SHIP",
+            "ship_class": "docs_canary",
+            "child_keep_reject_decision": "KEEP",
+            "coding_packet": {"status": "KEEP_READY"},
+            "child_score": 9.5,
+            "risk_level": "low",
+            "blocked_execution_record": {},
+            "stable_evidence_handle": "child_run:b:r",
+            "automation_claim_status": "child_attached_with_handle",
+            "rollback_plan": "Revert commit <sha>",
+            "changed_paths": ["workflow/api/unsafe.py"],
+            "diff": "+ unsafe\n",
+        }
+
+        result = json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps(packet),
+            "return_release_gate_result": True,
+        }))
+
+        assert result["validation_result"] == "blocked"
+        assert result["release_gate_result"] == "HOLD"
+        assert result["would_open_pr"] is False
+        assert any(
+            violation["rule_id"] == "changed_path_forbidden_prefix"
+            for violation in result["violations"]
+        )
+
     def test_blocked_packet_returns_decision_dict_with_violations(self):
         packet = {
             "release_gate_result": "HOLD",  # NOT approved
@@ -108,6 +175,7 @@ class TestDispatchIntegration:
             "ship_class",
             "changed_paths_json",
             "stable_evidence_handle",
+            "return_release_gate_result",
         ):
             assert name in params
 
@@ -132,6 +200,31 @@ class TestDispatchIntegration:
         )
         result = json.loads(result_str)
         assert result["validation_result"] == "passed"
+
+    def test_action_dispatch_forwards_release_gate_result_mode(self):
+        packet = {
+            "release_gate_result": "APPROVE_AUTO_SHIP",
+            "ship_class": "docs_canary",
+            "child_keep_reject_decision": "KEEP",
+            "coding_packet": {"status": "KEEP_READY"},
+            "child_score": 9.5,
+            "risk_level": "low",
+            "blocked_execution_record": {},
+            "stable_evidence_handle": "child_run:b:r",
+            "automation_claim_status": "child_attached_with_handle",
+            "rollback_plan": "Revert commit <sha>",
+            "changed_paths": ["docs/autoship-canaries/x.md"],
+            "diff": "+ x\n",
+        }
+        result_str = _extensions_impl(
+            action="validate_ship_packet",
+            body_json=json.dumps(packet),
+            return_release_gate_result=True,
+        )
+        result = json.loads(result_str)
+        assert result["validation_result"] == "passed"
+        assert result["release_gate_result"] == "APPROVE_AUTO_SHIP"
+        assert "ship_attempt_id" not in result
 
     def test_action_with_no_body_json_routes_and_errors_at_handler(self):
         result_str = _extensions_impl(action="validate_ship_packet")

--- a/workflow/api/auto_ship_actions.py
+++ b/workflow/api/auto_ship_actions.py
@@ -21,9 +21,11 @@ Sequencing:
   action that takes an existing passed ledger row and opens a PR from an
   ``auto-change/*`` branch only when ``WORKFLOW_AUTO_SHIP_PR_CREATE_ENABLED``
   is explicitly enabled. It does not auto-merge.
-- A future loop-content PR (Mark's lane) updates change_loop_v1's
-  release_safety_gate to call this action with ``record_in_ledger=true``
-  and emit APPROVE_AUTO_SHIP only when ``would_open_pr`` is True.
+- PR-103a / Mark's lane slice 1 lets change_loop_v1's release_safety_gate
+  call this action in dry-run mode with ``return_release_gate_result=true``.
+  That returns a structured ``release_gate_result`` verdict without recording
+  to the ledger or opening a PR. A later slice can opt into
+  ``record_in_ledger=true``.
 
 Phase 2A is wrapper only — no behavior change to any current path until
 a caller opts in. The action exists; nothing in the loop or substrate
@@ -118,6 +120,12 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
             new row's id) and, on write failure, a ``ledger_error`` field
             describing what went wrong. The validator decision is
             returned regardless of ledger outcome.
+        return_release_gate_result (optional, default False): when truthy,
+            augment the dry-run response with a release-gate verdict derived
+            from validation: ``APPROVE_AUTO_SHIP`` when the packet passed and
+            would open a PR, otherwise ``HOLD``. This is for release_safety_gate
+            callers that need to return a structured ``release_gate_result``
+            while still leaving ledger recording and PR creation disabled.
         universe_id (optional): when ``record_in_ledger`` is truthy,
             the universe whose data dir to write to. Defaults to
             ``_default_universe()``.
@@ -170,10 +178,21 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
             "exception_class": type(exc).__name__,
         })
 
-    # Phase 2A behavior preserved: when ledger recording is not requested,
+    # Phase 2A behavior preserved: when no opt-in sidecar fields are requested,
     # the response is exactly the validator's decision dict, byte-for-byte
     # identical to PR #224.
     if not _record_in_ledger_enabled(kwargs.get("record_in_ledger")):
+        if _record_in_ledger_enabled(kwargs.get("return_release_gate_result")):
+            augmented = dict(decision)
+            augmented["release_gate_result"] = (
+                "APPROVE_AUTO_SHIP"
+                if (
+                    decision.get("validation_result") == "passed"
+                    and decision.get("would_open_pr") is True
+                )
+                else "HOLD"
+            )
+            return json.dumps(augmented)
         return json.dumps(decision)
 
     # Resolve call-site context for the ledger row. All optional with

--- a/workflow/api/extensions.py
+++ b/workflow/api/extensions.py
@@ -348,6 +348,7 @@ def _extensions_impl(
     ship_class: str = "",
     changed_paths_json: str = "",
     stable_evidence_handle: str = "",
+    return_release_gate_result: bool = False,
 ) -> str:
     """Pattern A2 body — see ``workflow.universe_server.extensions`` for the
     chatbot-facing docstring. Behavior is identical; the decorator wrapper
@@ -580,6 +581,7 @@ def _extensions_impl(
             "ship_class": ship_class,
             "changed_paths_json": changed_paths_json,
             "stable_evidence_handle": stable_evidence_handle,
+            "return_release_gate_result": return_release_gate_result,
             "ship_attempt_id": ship_attempt_id,
             "head_branch": head_branch,
             "title": title,

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -589,6 +589,7 @@ def extensions(
     ship_class: str = "",
     changed_paths_json: str = "",
     stable_evidence_handle: str = "",
+    return_release_gate_result: bool = False,
 ) -> str:
     """Workflow-builder surface: design, edit, run, judge custom AI graphs.
 
@@ -721,6 +722,7 @@ def extensions(
         ship_class=ship_class,
         changed_paths_json=changed_paths_json,
         stable_evidence_handle=stable_evidence_handle,
+        return_release_gate_result=return_release_gate_result,
     )
 
 


### PR DESCRIPTION
Fixes #768

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-075-pr-103a-mark-s-lane-slice-1-release-safety-gate-adds-validat.md`
- GitHub issue: #768
- Branch task: `auto-change/issue-768`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.