### PR TITLE
[auto-change] BUG-076: file_bug defaults patch-request-shaped filings into bug kind; add explicit kind selector or patch_request filing path

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -31,6 +31,7 @@ import logging
 from contextlib import AsyncExitStack, asynccontextmanager
 from functools import wraps
 from inspect import signature
+from typing import Literal
 
 import uvicorn
 from fastmcp import FastMCP
@@ -940,7 +941,7 @@ def wiki(
     observed: str = "",
     expected: str = "",
     workaround: str = "",
-    kind: str = "bug",
+    kind: Literal["bug", "patch_request", "feature", "design"] = "bug",
     tags: str = "",
     force_new: bool = False,
     bug_id: str = "",

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -751,7 +751,11 @@ class TestWikiMCPRegistration:
         wiki_tool = next(t for t in tools if t.name == "wiki")
         properties = wiki_tool.parameters["properties"]
 
-        assert properties["kind"] == {"default": "bug", "type": "string"}
+        assert properties["kind"] == {
+            "default": "bug",
+            "enum": ["bug", "patch_request", "feature", "design"],
+            "type": "string",
+        }
         assert "kind" not in wiki_tool.parameters["required"]
 
     def test_wiki_since_changed_since_field_is_in_mcp_schema(self):

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -31,6 +31,7 @@ import logging
 from contextlib import AsyncExitStack, asynccontextmanager
 from functools import wraps
 from inspect import signature
+from typing import Literal
 
 import uvicorn
 from fastmcp import FastMCP
@@ -940,7 +941,7 @@ def wiki(
     observed: str = "",
     expected: str = "",
     workaround: str = "",
-    kind: str = "bug",
+    kind: Literal["bug", "patch_request", "feature", "design"] = "bug",
     tags: str = "",
     force_new: bool = False,
     bug_id: str = "",


### PR DESCRIPTION
Fixes #769

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-076-file-bug-defaults-patch-request-shaped-filings-into-bug-kind.md`
- GitHub issue: #769
- Branch task: `auto-change/issue-769`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.