### PR TITLE
[auto-change] BUG-077: PR-103b: Mark's lane slice 2 — release_ship_validator records auto_ship_ledger.record_attempt on each call behind validation-passed AND feature-flag gate; still does not open PR

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/auto_ship_actions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/auto_ship_actions.py
@@ -3,8 +3,9 @@
 Exposes the auto-ship dry-run validator as a callable MCP action so the
 loop's release_safety_gate prompt (and chatbots / canaries) can reach it
 via tool. Pure-Python wrapper; the only IO beyond JSON parse happens when
-``record_in_ledger`` is set, in which case the decision is also written
-to ``workflow.auto_ship_ledger`` via ``record_attempt``.
+``record_in_ledger`` is set, validation passes, and the auto-ship feature
+flag is enabled, in which case the decision is also written to
+``workflow.auto_ship_ledger`` via ``record_attempt``.
 
 Sequencing:
 - PR #223 added ``workflow/auto_ship.py`` with ``validate_ship_request`` —
@@ -14,9 +15,10 @@ Sequencing:
   loop's release_safety_gate prompt can now call it.
 - PR #226 added ``workflow.auto_ship_ledger`` (Slice A of option-2 lane).
 - THIS REVISION adds opt-in ledger recording: pass ``record_in_ledger=true``
-  to record every validator outcome (passed → ship_status="skipped" row,
-  blocked → ship_status="blocked" row with violations encoded). Recording
-  is OFF by default so existing PR #224 callers keep their exact shape.
+  to record passed validator outcomes as ``ship_status="skipped"`` rows
+  when ``WORKFLOW_AUTO_SHIP_PR_CREATE_ENABLED`` is explicitly truthy.
+  Recording is OFF by default so existing PR #224 callers keep their exact
+  shape.
 - PR #243 / slice #3 adds ``open_auto_ship_pr``: a feature-flagged PR-open
   action that takes an existing passed ledger row and opens a PR from an
   ``auto-change/*`` branch only when ``WORKFLOW_AUTO_SHIP_PR_CREATE_ENABLED``
@@ -45,6 +47,21 @@ def _record_in_ledger_enabled(value: Any) -> bool:
     if isinstance(value, str):
         return value.strip().lower() not in _FALSEY_RECORD_FLAGS
     return bool(value)
+
+
+def _auto_ship_record_gate_enabled() -> bool:
+    """Return whether passed validations may create ledger rows.
+
+    This intentionally shares the PR-create feature flag without opening
+    PRs here. The validator action remains ledger-only; PR creation still
+    lives behind the separate ``open_auto_ship_pr`` action.
+    """
+    try:
+        from workflow.auto_ship_pr import pr_create_enabled
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("auto-ship record gate import failed: %s", exc)
+        return False
+    return pr_create_enabled()
 
 
 def _maybe_record_attempt(
@@ -112,19 +129,20 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
 
     Args (passed via kwargs from the extensions dispatch):
         body_json: JSON-serialized coding_packet to validate. Required.
-        record_in_ledger (optional, default False): when truthy, the
-            decision is also written to the auto-ship ledger as a single
-            row. The response gains a ``ship_attempt_id`` field (the
-            new row's id) and, on write failure, a ``ledger_error`` field
-            describing what went wrong. The validator decision is
+        record_in_ledger (optional, default False): when truthy, validation
+            passes, and ``WORKFLOW_AUTO_SHIP_PR_CREATE_ENABLED`` is truthy,
+            the decision is also written to the auto-ship ledger as a
+            single row. The response gains a ``ship_attempt_id`` field
+            (the new row's id) and, on write failure, a ``ledger_error``
+            field describing what went wrong. The validator decision is
             returned regardless of ledger outcome.
-        universe_id (optional): when ``record_in_ledger`` is truthy,
+        universe_id (optional): when a ledger row will be recorded,
             the universe whose data dir to write to. Defaults to
             ``_default_universe()``.
         request_id, parent_run_id, child_run_id, branch_def_id,
         release_gate_result, ship_class, stable_evidence_handle,
         changed_paths_json (optional): call-site context propagated
-            into the ledger row when ``record_in_ledger`` is truthy.
+            into the ledger row when recording is gated on.
             All default to empty strings / empty list. The validator
             does not read these — they are pure ledger metadata so the
             audit trail can be joined back to the parent run.
@@ -133,7 +151,7 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
         JSON-serialized ship_decision dict. Shape per
         ``workflow.auto_ship.validate_ship_request`` docstring:
         ``{ship_status, would_open_pr, validation_result, violations,
-        rollback_handle, dry_run}``. When ``record_in_ledger`` is truthy,
+        rollback_handle, dry_run}``. When recording is gated on,
         the response is augmented with ``ship_attempt_id`` (str | null)
         and may include ``ledger_error`` (str) if the write failed.
 
@@ -174,6 +192,12 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
     # the response is exactly the validator's decision dict, byte-for-byte
     # identical to PR #224.
     if not _record_in_ledger_enabled(kwargs.get("record_in_ledger")):
+        return json.dumps(decision)
+
+    if (
+        decision.get("validation_result") != "passed"
+        or not _auto_ship_record_gate_enabled()
+    ):
         return json.dumps(decision)
 
     # Resolve call-site context for the ledger row. All optional with

--- a/tests/test_validate_ship_packet_action.py
+++ b/tests/test_validate_ship_packet_action.py
@@ -145,9 +145,11 @@ class TestDispatchIntegration:
         monkeypatch,
     ):
         from workflow.auto_ship_ledger import read_attempts
+        from workflow.auto_ship_pr import PR_CREATE_FLAG
 
         monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
         monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "default-uni")
+        monkeypatch.setenv(PR_CREATE_FLAG, "true")
         universe = tmp_path / "ledger-uni"
         universe.mkdir(parents=True, exist_ok=True)
         packet = {
@@ -205,9 +207,11 @@ class TestDispatchIntegration:
         """The public MCP wrapper forwards ledger fields to the action."""
         from workflow import universe_server as us
         from workflow.auto_ship_ledger import read_attempts
+        from workflow.auto_ship_pr import PR_CREATE_FLAG
 
         monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
         monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "default-uni")
+        monkeypatch.setenv(PR_CREATE_FLAG, "true")
         universe = tmp_path / "wrapper-uni"
         universe.mkdir(parents=True, exist_ok=True)
         packet = {
@@ -311,11 +315,11 @@ class TestLedgerRecording:
     is opt-in: when omitted (or falsy) the response is byte-identical
     to the pre-wire-up behavior (no extra keys, no IO).
 
-    When opt-in, every validator outcome — passed OR blocked — produces
-    one row in the ledger keyed by ``ship_attempt_id``, and the response
-    is augmented with that id. Failure to write the row surfaces as
-    ``ledger_error`` so callers see the problem without losing the
-    decision payload.
+    When opt-in, a passed validator outcome produces one row in the
+    ledger only while the auto-ship feature flag is enabled. Blocked
+    outcomes and disabled flags remain dry-run-only and do not open PRs.
+    Failure to write a requested row surfaces as ``ledger_error`` so
+    callers see the problem without losing the decision payload.
     """
 
     @staticmethod
@@ -345,6 +349,11 @@ class TestLedgerRecording:
         (Path(tmp_path) / name).mkdir(parents=True, exist_ok=True)
         return Path(tmp_path) / name
 
+    @staticmethod
+    def _enable_record_gate(monkeypatch):
+        from workflow.auto_ship_pr import PR_CREATE_FLAG
+        monkeypatch.setenv(PR_CREATE_FLAG, "true")
+
     def test_record_off_response_is_byte_identical_to_pr224(self, tmp_path, monkeypatch):
         self._setup_universe(tmp_path, monkeypatch)
         from workflow.auto_ship_ledger import read_attempts
@@ -360,6 +369,13 @@ class TestLedgerRecording:
     def test_record_on_passed_writes_skipped_row(self, tmp_path, monkeypatch):
         u = self._setup_universe(tmp_path, monkeypatch)
         from workflow.auto_ship_ledger import read_attempts
+        self._enable_record_gate(monkeypatch)
+        monkeypatch.setattr(
+            "workflow.auto_ship_pr.open_auto_ship_pr",
+            lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("validate_ship_packet must not open a PR")
+            ),
+        )
         result = json.loads(_action_validate_ship_packet({
             "body_json": json.dumps(self._packet()),
             "record_in_ledger": True,
@@ -387,9 +403,31 @@ class TestLedgerRecording:
         # Rollback handle carried from validator's rollback_handle
         assert row.rollback_handle.startswith("revert:")
 
-    def test_record_on_blocked_writes_blocked_row_with_violations(self, tmp_path, monkeypatch):
+    def test_record_on_disabled_feature_flag_skips_ledger(self, tmp_path, monkeypatch):
         u = self._setup_universe(tmp_path, monkeypatch)
         from workflow.auto_ship_ledger import read_attempts
+        from workflow.auto_ship_pr import PR_CREATE_FLAG
+        monkeypatch.delenv(PR_CREATE_FLAG, raising=False)
+
+        result = json.loads(_action_validate_ship_packet({
+            "body_json": json.dumps(self._packet()),
+            "record_in_ledger": True,
+            "request_id": "REQ-FLAG-OFF",
+        }))
+        assert result.get("ledger_error") is None
+        assert "ship_attempt_id" not in result
+        assert result["validation_result"] == "passed"
+        assert result["would_open_pr"] is True
+        assert read_attempts(u) == []
+
+    def test_record_on_blocked_validation_skips_ledger_even_when_flag_enabled(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        u = self._setup_universe(tmp_path, monkeypatch)
+        from workflow.auto_ship_ledger import read_attempts
+        self._enable_record_gate(monkeypatch)
         result = json.loads(_action_validate_ship_packet({
             "body_json": json.dumps(self._packet(release_gate_result="HOLD")),
             "record_in_ledger": True,
@@ -397,14 +435,11 @@ class TestLedgerRecording:
         }))
         assert result.get("ledger_error") is None
         rows = read_attempts(u)
-        assert len(rows) == 1
-        row = rows[0]
-        assert row.ship_status == "blocked"
-        assert row.would_open_pr is False
-        assert "release_gate_not_approved" in row.error_class
-        # error_message is the violations payload as JSON
-        violations = json.loads(row.error_message)
-        assert any(v["rule_id"] == "release_gate_not_approved" for v in violations)
+        assert rows == []
+        assert "ship_attempt_id" not in result
+        assert result["validation_result"] == "blocked"
+        assert result["would_open_pr"] is False
+        assert any(v["rule_id"] == "release_gate_not_approved" for v in result["violations"])
 
     def test_explicit_universe_id_overrides_default(self, tmp_path, monkeypatch):
         from pathlib import Path
@@ -412,6 +447,7 @@ class TestLedgerRecording:
         from workflow.auto_ship_ledger import read_attempts
         monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
         monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "default-uni")
+        self._enable_record_gate(monkeypatch)
         (Path(tmp_path) / "default-uni").mkdir(parents=True, exist_ok=True)
         (Path(tmp_path) / "other-uni").mkdir(parents=True, exist_ok=True)
 
@@ -429,6 +465,7 @@ class TestLedgerRecording:
     def test_string_truthy_record_flag_enables_recording(self, tmp_path, monkeypatch):
         u = self._setup_universe(tmp_path, monkeypatch)
         from workflow.auto_ship_ledger import read_attempts
+        self._enable_record_gate(monkeypatch)
         result = json.loads(_action_validate_ship_packet({
             "body_json": json.dumps(self._packet()),
             "record_in_ledger": "true",
@@ -451,6 +488,7 @@ class TestLedgerRecording:
     def test_changed_paths_json_kwarg_overrides_packet_paths(self, tmp_path, monkeypatch):
         u = self._setup_universe(tmp_path, monkeypatch)
         from workflow.auto_ship_ledger import read_attempts
+        self._enable_record_gate(monkeypatch)
         json.loads(_action_validate_ship_packet({
             "body_json": json.dumps(self._packet(
                 changed_paths=["docs/autoship-canaries/from-packet.md"],
@@ -473,6 +511,7 @@ class TestLedgerRecording:
     def test_malformed_changed_paths_json_falls_back_to_packet(self, tmp_path, monkeypatch):
         u = self._setup_universe(tmp_path, monkeypatch)
         from workflow.auto_ship_ledger import read_attempts
+        self._enable_record_gate(monkeypatch)
         json.loads(_action_validate_ship_packet({
             "body_json": json.dumps(self._packet(changed_paths=["docs/autoship-canaries/x.md"])),
             "record_in_ledger": True,
@@ -488,6 +527,7 @@ class TestLedgerRecording:
         blocks acceptance and surfaces ledger_error."""
         monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
         monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "")
+        self._enable_record_gate(monkeypatch)
         # No universe directories exist; helper falls back to "default-universe"
         # which doesn't exist as a dir. record_attempt creates it via mkdir —
         # so we instead force a path-traversal validation error.
@@ -524,6 +564,7 @@ class TestLedgerRecording:
 
         monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
         monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "default-uni")
+        self._enable_record_gate(monkeypatch)
         (tmp_path / "default-uni").mkdir(parents=True, exist_ok=True)
 
         result = json.loads(_extensions_impl(
@@ -547,6 +588,7 @@ class TestLedgerRecording:
         trail rather than collapsing identical packets."""
         u = self._setup_universe(tmp_path, monkeypatch)
         from workflow.auto_ship_ledger import read_attempts
+        self._enable_record_gate(monkeypatch)
         result_a = json.loads(_action_validate_ship_packet({
             "body_json": json.dumps(self._packet()),
             "record_in_ledger": True,

--- a/workflow/api/auto_ship_actions.py
+++ b/workflow/api/auto_ship_actions.py
@@ -3,8 +3,9 @@
 Exposes the auto-ship dry-run validator as a callable MCP action so the
 loop's release_safety_gate prompt (and chatbots / canaries) can reach it
 via tool. Pure-Python wrapper; the only IO beyond JSON parse happens when
-``record_in_ledger`` is set, in which case the decision is also written
-to ``workflow.auto_ship_ledger`` via ``record_attempt``.
+``record_in_ledger`` is set, validation passes, and the auto-ship feature
+flag is enabled, in which case the decision is also written to
+``workflow.auto_ship_ledger`` via ``record_attempt``.
 
 Sequencing:
 - PR #223 added ``workflow/auto_ship.py`` with ``validate_ship_request`` —
@@ -14,9 +15,10 @@ Sequencing:
   loop's release_safety_gate prompt can now call it.
 - PR #226 added ``workflow.auto_ship_ledger`` (Slice A of option-2 lane).
 - THIS REVISION adds opt-in ledger recording: pass ``record_in_ledger=true``
-  to record every validator outcome (passed → ship_status="skipped" row,
-  blocked → ship_status="blocked" row with violations encoded). Recording
-  is OFF by default so existing PR #224 callers keep their exact shape.
+  to record passed validator outcomes as ``ship_status="skipped"`` rows
+  when ``WORKFLOW_AUTO_SHIP_PR_CREATE_ENABLED`` is explicitly truthy.
+  Recording is OFF by default so existing PR #224 callers keep their exact
+  shape.
 - PR #243 / slice #3 adds ``open_auto_ship_pr``: a feature-flagged PR-open
   action that takes an existing passed ledger row and opens a PR from an
   ``auto-change/*`` branch only when ``WORKFLOW_AUTO_SHIP_PR_CREATE_ENABLED``
@@ -45,6 +47,21 @@ def _record_in_ledger_enabled(value: Any) -> bool:
     if isinstance(value, str):
         return value.strip().lower() not in _FALSEY_RECORD_FLAGS
     return bool(value)
+
+
+def _auto_ship_record_gate_enabled() -> bool:
+    """Return whether passed validations may create ledger rows.
+
+    This intentionally shares the PR-create feature flag without opening
+    PRs here. The validator action remains ledger-only; PR creation still
+    lives behind the separate ``open_auto_ship_pr`` action.
+    """
+    try:
+        from workflow.auto_ship_pr import pr_create_enabled
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("auto-ship record gate import failed: %s", exc)
+        return False
+    return pr_create_enabled()
 
 
 def _maybe_record_attempt(
@@ -112,19 +129,20 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
 
     Args (passed via kwargs from the extensions dispatch):
         body_json: JSON-serialized coding_packet to validate. Required.
-        record_in_ledger (optional, default False): when truthy, the
-            decision is also written to the auto-ship ledger as a single
-            row. The response gains a ``ship_attempt_id`` field (the
-            new row's id) and, on write failure, a ``ledger_error`` field
-            describing what went wrong. The validator decision is
+        record_in_ledger (optional, default False): when truthy, validation
+            passes, and ``WORKFLOW_AUTO_SHIP_PR_CREATE_ENABLED`` is truthy,
+            the decision is also written to the auto-ship ledger as a
+            single row. The response gains a ``ship_attempt_id`` field
+            (the new row's id) and, on write failure, a ``ledger_error``
+            field describing what went wrong. The validator decision is
             returned regardless of ledger outcome.
-        universe_id (optional): when ``record_in_ledger`` is truthy,
+        universe_id (optional): when a ledger row will be recorded,
             the universe whose data dir to write to. Defaults to
             ``_default_universe()``.
         request_id, parent_run_id, child_run_id, branch_def_id,
         release_gate_result, ship_class, stable_evidence_handle,
         changed_paths_json (optional): call-site context propagated
-            into the ledger row when ``record_in_ledger`` is truthy.
+            into the ledger row when recording is gated on.
             All default to empty strings / empty list. The validator
             does not read these — they are pure ledger metadata so the
             audit trail can be joined back to the parent run.
@@ -133,7 +151,7 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
         JSON-serialized ship_decision dict. Shape per
         ``workflow.auto_ship.validate_ship_request`` docstring:
         ``{ship_status, would_open_pr, validation_result, violations,
-        rollback_handle, dry_run}``. When ``record_in_ledger`` is truthy,
+        rollback_handle, dry_run}``. When recording is gated on,
         the response is augmented with ``ship_attempt_id`` (str | null)
         and may include ``ledger_error`` (str) if the write failed.
 
@@ -174,6 +192,12 @@ def _action_validate_ship_packet(kwargs: dict[str, Any]) -> str:
     # the response is exactly the validator's decision dict, byte-for-byte
     # identical to PR #224.
     if not _record_in_ledger_enabled(kwargs.get("record_in_ledger")):
+        return json.dumps(decision)
+
+    if (
+        decision.get("validation_result") != "passed"
+        or not _auto_ship_record_gate_enabled()
+    ):
         return json.dumps(decision)
 
     # Resolve call-site context for the ledger row. All optional with


### PR DESCRIPTION
Fixes #770

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-077-pr-103b-mark-s-lane-slice-2-release-ship-validator-records-a.md`
- GitHub issue: #770
- Branch task: `auto-change/issue-770`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.