### PR TITLE
[auto-change] BUG-079: PatchRequestDefaultFilingSurface — patch_request as default user/chatbot filing frame; bug as subtype, not container

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
@@ -125,12 +125,12 @@ framing.
     continue the user's task; the log is how the host fixes the bug.
     User-caused errors (invalid args, missing universe, etc.) are not
     bugs — don't log those.
-    Non-defect platform changes are not bugs. File them through the same
-    action with the matching `kind`: use `kind=patch_request` for a
-    concrete code/config/docs patch request, `kind=feature` for a new
-    capability request, and `kind=design` for an architecture or policy
-    proposal. Do not coerce these into bug wording just to enter the
-    community loop.
+    The default filing frame is `patch_request`: use it for concrete
+    code/config/docs changes. Bug is a subtype, not the container; use
+    `kind=bug` only for confirmed server defects. File new capabilities as
+    `kind=feature` and architecture or policy proposals as `kind=design`.
+    Do not coerce non-defects into bug wording just to enter the community
+    loop.
     Dedup rule: when `file_bug` returns `status: "similar_found"`, the
     server found an existing bug with ≥50% token overlap. Default to
     `wiki action=cosign_bug bug_id=<top similar bug_id>

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1424,8 +1424,9 @@ _VALID_SEVERITIES = ("critical", "major", "minor", "cosmetic")
 
 # Per-kind routing: kind -> (category-dir-name, ID-prefix). Each prefix has its
 # own independent NNN counter. New filings route per kind; existing pages stay
-# put (no migration). Default kind="bug" preserves the historical pages/bugs/
-# location and BUG-NNN sequence — backward-compat clean.
+# put (no migration). Default kind="patch_request" makes the community patch
+# request lane the default filing frame; explicit kind="bug" still preserves
+# the historical pages/bugs/ location and BUG-NNN sequence for real defects.
 _KIND_ROUTING: dict[str, tuple[str, str]] = {
     "bug":           (_BUGS_CATEGORY,           "BUG"),
     "feature":       (_KIND_FEATURES_DIR,       "FEAT"),
@@ -1486,7 +1487,7 @@ def _render_bug_markdown(
     expected: str,
     workaround: str,
     first_seen_date: str,
-    kind: str = "bug",
+    kind: str = "patch_request",
     extra_tags: list[str] | None = None,
 ) -> str:
     comp_tag = component.split(".")[0] if component else "unknown"
@@ -1685,7 +1686,7 @@ def _wiki_file_bug(
     observed: str = "",
     expected: str = "",
     workaround: str = "",
-    kind: str = "bug",
+    kind: str = "patch_request",
     tags: str = "",
     force_new: bool = False,
     verbose: bool = False,
@@ -1693,10 +1694,10 @@ def _wiki_file_bug(
 ) -> str:
     """File a bug, feature request, design proposal, or patch request.
 
-    ``kind`` defaults to "bug"; set to "feature", "design", or
-    "patch_request" for non-bug filings. All kinds use the same request
-    pipeline — navigator vets before dev implements (design-participation
-    rule).
+    ``kind`` defaults to "patch_request"; set to "bug" only for confirmed
+    defects, or to "feature" / "design" for those request subtypes. All kinds
+    use the same request pipeline — navigator vets before dev implements
+    (design-participation rule).
 
     Bypasses the draft-gate — filings land in pages/ immediately
     for host triage. ID is server-assigned via _next_bug_id. Atomic
@@ -1722,7 +1723,7 @@ def _wiki_file_bug(
             "error": f"Invalid severity '{severity}'.",
             "valid": list(_VALID_SEVERITIES),
         })
-    effective_kind = kind.strip().lower() if kind else "bug"
+    effective_kind = kind.strip().lower() if kind else "patch_request"
     if effective_kind not in _VALID_BUG_KINDS:
         return json.dumps({
             "error": f"Invalid kind '{kind}'.",
@@ -1989,7 +1990,7 @@ def wiki(
     observed: str = "",
     expected: str = "",
     workaround: str = "",
-    kind: str = "bug",
+    kind: str = "patch_request",
     tags: str = "",
     force_new: bool = False,
     bug_id: str = "",

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
@@ -406,7 +406,7 @@ def write_page(
     new_text: str = "",
     expected_sha256: str = "",
     title: str = "",
-    kind: str = "",
+    kind: str = "patch_request",
     component: str = "",
     severity: str = "",
     repro: str = "",
@@ -430,7 +430,8 @@ def write_page(
         new_text: Replacement text for a targeted page patch.
         expected_sha256: Optional full-page hash guard for patches.
         title: Filing title when creating a bug, patch, feature, or design page.
-        kind: Filing kind: bug, patch_request, feature, or design.
+        kind: Filing kind: bug, patch_request, feature, or design. Defaults
+            to patch_request; pass bug only for confirmed defects.
         component: Optional affected component for filed issues.
         severity: Optional severity for filed issues.
         repro: Optional reproduction notes for filed issues.

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -940,7 +940,7 @@ def wiki(
     observed: str = "",
     expected: str = "",
     workaround: str = "",
-    kind: str = "bug",
+    kind: str = "patch_request",
     tags: str = "",
     force_new: bool = False,
     bug_id: str = "",
@@ -957,7 +957,9 @@ def wiki(
 
     When the user asks to file a bug, patch request, feature request, or
     design proposal, call `file_bug` directly with the matching `kind`
-    (`bug`, `patch_request`, `feature`, or `design`). `file_bug` already
+    (`bug`, `patch_request`, `feature`, or `design`). The default filing
+    frame is `patch_request`; use `kind="bug"` only for confirmed defects.
+    `file_bug` already
     does Jaccard duplicate detection server-side; you do NOT need to search/list/read
     the wiki before filing. Before filing, check current repo/PLAN.md
     context via `community_change_context` or direct repo browsing; the

--- a/tests/test_api_wiki.py
+++ b/tests/test_api_wiki.py
@@ -553,6 +553,22 @@ def test_wiki_file_bug_rejects_invalid_severity(wiki_env):
     assert set(res["valid"]) == set(_VALID_SEVERITIES)
 
 
+def test_wiki_file_bug_defaults_to_patch_request_surface(wiki_env):
+    res = json.loads(
+        wiki(
+            action="file_bug",
+            component="community.filing",
+            severity="minor",
+            title="Default filing frame is patch request",
+            force_new=True,
+        )
+    )
+    assert res["status"] == "filed"
+    assert res["kind"] == "patch_request"
+    assert res["bug_id"].startswith("PR-")
+    assert res["path"].startswith("pages/patch-requests/")
+
+
 def test_wiki_file_bug_files_clean_when_no_dups(wiki_env):
     res = json.loads(
         wiki(
@@ -560,6 +576,7 @@ def test_wiki_file_bug_files_clean_when_no_dups(wiki_env):
             component="universe.inspect",
             severity="minor",
             title="A unique never-seen title aardvark zeppelin",
+            kind="bug",
             observed="aardvark",
             expected="zeppelin",
             force_new=True,
@@ -587,6 +604,7 @@ def test_wiki_file_bug_queued_investigation_returns_branch_task_lease_shape(
             component="loop",
             severity="major",
             title="Lease metadata response shape",
+            kind="bug",
             observed="queued task lacks visible lease metadata",
             force_new=True,
             verbose=True,
@@ -609,6 +627,7 @@ def test_wiki_file_bug_dedup_returns_similar_found(wiki_env):
         severity="minor",
         title="Connector returns wrong universe id on inspect",
         observed="inspect returned the wrong universe id under load",
+        kind="bug",
     )
     json.loads(wiki(**base, force_new=True))
     dup = json.loads(wiki(**base))  # no force_new — should dedup
@@ -644,6 +663,7 @@ def test_wiki_cosign_bug_appends_to_existing_filing(wiki_env):
             severity="minor",
             title="The cosign smoke test bug uniquely worded",
             observed="something broke uniquely",
+            kind="bug",
             force_new=True,
         )
     )

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -656,6 +656,7 @@ class TestWikiFileBugDispatch:
                 component="extensions.patch_branch",
                 severity="major",
                 title="Widget explodes on save",
+                kind="bug",
                 repro="Click save",
                 observed="500 error",
                 expected="200 ok",
@@ -677,6 +678,7 @@ class TestWikiFileBugDispatch:
                 component="wiki-mcp",
                 severity="minor",
                 title="Tagged schema regression",
+                kind="bug",
                 tags="schema, regression",
                 force_new=True,
             )
@@ -714,6 +716,7 @@ class TestWikiFileBugDispatch:
                     component="x",
                     severity="minor",
                     title="collision test",
+                    kind="bug",
                 )
             )
         assert out["status"] == "filed"
@@ -751,7 +754,7 @@ class TestWikiMCPRegistration:
         wiki_tool = next(t for t in tools if t.name == "wiki")
         properties = wiki_tool.parameters["properties"]
 
-        assert properties["kind"] == {"default": "bug", "type": "string"}
+        assert properties["kind"] == {"default": "patch_request", "type": "string"}
         assert "kind" not in wiki_tool.parameters["required"]
 
     def test_wiki_since_changed_since_field_is_in_mcp_schema(self):

--- a/workflow/api/prompts.py
+++ b/workflow/api/prompts.py
@@ -125,12 +125,12 @@ framing.
     continue the user's task; the log is how the host fixes the bug.
     User-caused errors (invalid args, missing universe, etc.) are not
     bugs — don't log those.
-    Non-defect platform changes are not bugs. File them through the same
-    action with the matching `kind`: use `kind=patch_request` for a
-    concrete code/config/docs patch request, `kind=feature` for a new
-    capability request, and `kind=design` for an architecture or policy
-    proposal. Do not coerce these into bug wording just to enter the
-    community loop.
+    The default filing frame is `patch_request`: use it for concrete
+    code/config/docs changes. Bug is a subtype, not the container; use
+    `kind=bug` only for confirmed server defects. File new capabilities as
+    `kind=feature` and architecture or policy proposals as `kind=design`.
+    Do not coerce non-defects into bug wording just to enter the community
+    loop.
     Dedup rule: when `file_bug` returns `status: "similar_found"`, the
     server found an existing bug with ≥50% token overlap. Default to
     `wiki action=cosign_bug bug_id=<top similar bug_id>

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1424,8 +1424,9 @@ _VALID_SEVERITIES = ("critical", "major", "minor", "cosmetic")
 
 # Per-kind routing: kind -> (category-dir-name, ID-prefix). Each prefix has its
 # own independent NNN counter. New filings route per kind; existing pages stay
-# put (no migration). Default kind="bug" preserves the historical pages/bugs/
-# location and BUG-NNN sequence — backward-compat clean.
+# put (no migration). Default kind="patch_request" makes the community patch
+# request lane the default filing frame; explicit kind="bug" still preserves
+# the historical pages/bugs/ location and BUG-NNN sequence for real defects.
 _KIND_ROUTING: dict[str, tuple[str, str]] = {
     "bug":           (_BUGS_CATEGORY,           "BUG"),
     "feature":       (_KIND_FEATURES_DIR,       "FEAT"),
@@ -1486,7 +1487,7 @@ def _render_bug_markdown(
     expected: str,
     workaround: str,
     first_seen_date: str,
-    kind: str = "bug",
+    kind: str = "patch_request",
     extra_tags: list[str] | None = None,
 ) -> str:
     comp_tag = component.split(".")[0] if component else "unknown"
@@ -1685,7 +1686,7 @@ def _wiki_file_bug(
     observed: str = "",
     expected: str = "",
     workaround: str = "",
-    kind: str = "bug",
+    kind: str = "patch_request",
     tags: str = "",
     force_new: bool = False,
     verbose: bool = False,
@@ -1693,10 +1694,10 @@ def _wiki_file_bug(
 ) -> str:
     """File a bug, feature request, design proposal, or patch request.
 
-    ``kind`` defaults to "bug"; set to "feature", "design", or
-    "patch_request" for non-bug filings. All kinds use the same request
-    pipeline — navigator vets before dev implements (design-participation
-    rule).
+    ``kind`` defaults to "patch_request"; set to "bug" only for confirmed
+    defects, or to "feature" / "design" for those request subtypes. All kinds
+    use the same request pipeline — navigator vets before dev implements
+    (design-participation rule).
 
     Bypasses the draft-gate — filings land in pages/ immediately
     for host triage. ID is server-assigned via _next_bug_id. Atomic
@@ -1722,7 +1723,7 @@ def _wiki_file_bug(
             "error": f"Invalid severity '{severity}'.",
             "valid": list(_VALID_SEVERITIES),
         })
-    effective_kind = kind.strip().lower() if kind else "bug"
+    effective_kind = kind.strip().lower() if kind else "patch_request"
     if effective_kind not in _VALID_BUG_KINDS:
         return json.dumps({
             "error": f"Invalid kind '{kind}'.",
@@ -1989,7 +1990,7 @@ def wiki(
     observed: str = "",
     expected: str = "",
     workaround: str = "",
-    kind: str = "bug",
+    kind: str = "patch_request",
     tags: str = "",
     force_new: bool = False,
     bug_id: str = "",

--- a/workflow/directory_server.py
+++ b/workflow/directory_server.py
@@ -406,7 +406,7 @@ def write_page(
     new_text: str = "",
     expected_sha256: str = "",
     title: str = "",
-    kind: str = "",
+    kind: str = "patch_request",
     component: str = "",
     severity: str = "",
     repro: str = "",
@@ -430,7 +430,8 @@ def write_page(
         new_text: Replacement text for a targeted page patch.
         expected_sha256: Optional full-page hash guard for patches.
         title: Filing title when creating a bug, patch, feature, or design page.
-        kind: Filing kind: bug, patch_request, feature, or design.
+        kind: Filing kind: bug, patch_request, feature, or design. Defaults
+            to patch_request; pass bug only for confirmed defects.
         component: Optional affected component for filed issues.
         severity: Optional severity for filed issues.
         repro: Optional reproduction notes for filed issues.

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -940,7 +940,7 @@ def wiki(
     observed: str = "",
     expected: str = "",
     workaround: str = "",
-    kind: str = "bug",
+    kind: str = "patch_request",
     tags: str = "",
     force_new: bool = False,
     bug_id: str = "",
@@ -957,7 +957,9 @@ def wiki(
 
     When the user asks to file a bug, patch request, feature request, or
     design proposal, call `file_bug` directly with the matching `kind`
-    (`bug`, `patch_request`, `feature`, or `design`). `file_bug` already
+    (`bug`, `patch_request`, `feature`, or `design`). The default filing
+    frame is `patch_request`; use `kind="bug"` only for confirmed defects.
+    `file_bug` already
     does Jaccard duplicate detection server-side; you do NOT need to search/list/read
     the wiki before filing. Before filing, check current repo/PLAN.md
     context via `community_change_context` or direct repo browsing; the


### PR DESCRIPTION
Fixes #777

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-079-patchrequestdefaultfilingsurface-patch-request-as-default-us.md`
- GitHub issue: #777
- Branch task: `auto-change/issue-777`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.