### PR TITLE
[auto-change] WIKI-PATCH: PR-113: Rendering should be a user-composable Node-graph downstream of read.page (Render-as-Node)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
@@ -305,7 +305,7 @@ def run_graph(
     graph_id: str = "",
     recursion_limit_override: int = 0,
 ) -> str:
-    """Run a Workflow graph branch.
+    """Run a Workflow graph branch, including page-derived rendering branches.
 
     Args:
         branch_def_id: Branch definition identifier to run.
@@ -347,7 +347,7 @@ def read_page(
     changed_since: str = "",
     max_results: int = 10,
 ) -> str:
-    """Read or search Workflow wiki pages.
+    """Read or search source pages; not a renderer.
 
     Args:
         page: Optional wiki page slug or path. Empty searches by query.

--- a/tests/test_directory_server.py
+++ b/tests/test_directory_server.py
@@ -148,6 +148,16 @@ def test_directory_read_page_schema_advertises_changed_since() -> None:
     assert "changed_since" not in tool.parameters.get("required", [])
 
 
+def test_directory_contract_keeps_rendering_as_graph_composition() -> None:
+    """PR-113: page rendering is a graph composition, not a read.page mode."""
+
+    tools = {tool.name: tool for tool in _list_tools()}
+
+    assert "source pages" in tools["read.page"].description
+    assert "not a renderer" in tools["read.page"].description
+    assert "page-derived rendering branches" in tools["run.graph"].description
+
+
 def test_directory_status_redacts_operator_diagnostics() -> None:
     redacted = _redact_directory_status({
         "active_host": {

--- a/workflow/directory_server.py
+++ b/workflow/directory_server.py
@@ -305,7 +305,7 @@ def run_graph(
     graph_id: str = "",
     recursion_limit_override: int = 0,
 ) -> str:
-    """Run a Workflow graph branch.
+    """Run a Workflow graph branch, including page-derived rendering branches.
 
     Args:
         branch_def_id: Branch definition identifier to run.
@@ -347,7 +347,7 @@ def read_page(
     changed_since: str = "",
     max_results: int = 10,
 ) -> str:
-    """Read or search Workflow wiki pages.
+    """Read or search source pages; not a renderer.
 
     Args:
         page: Optional wiki page slug or path. Empty searches by query.


### PR DESCRIPTION
Fixes #805

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-113-pr-113-rendering-should-be-a-user-composable-node-graph-down.md`
- GitHub issue: #805
- Branch task: `auto-change/issue-805`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.