### PR TITLE
feat: add guarded wiki page deletion

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -36,6 +36,23 @@ Format for future entries:
 
 ---
 
+## 2026-05-11 16:15 - create wiki-delete-page
+
+- Provider: codex-gpt5-desktop
+- Branch: codex/wiki-delete-page
+- Lane state: Active lane
+- Worktree: C:\Users\Jonathan\Projects\wf-wiki-delete-page
+- STATUS/Issue/PR: host-directed cleanup after misframed PR-106..115 pages
+- PLAN refs: wiki as coordination surface; 6+5 primitive framing
+- Purpose: expose safe wiki page deletion so mistaken brain pages can be removed instead of preserved.
+- _PURPOSE.md: C:\Users\Jonathan\Projects\wf-wiki-delete-page\_PURPOSE.md
+- Memory refs: pages/notes/handoff-to-codex-pages-as-state-architectural-decision-2026-05-11.md
+- Related implications: retracted PR-106..115 pages; closed GitHub PRs #809/#810/#812-#819
+- Idea feed refs: none
+- Ship/abandon: PR pending; abandon if equivalent safe wiki delete lands first
+
+---
+
 ## 2026-05-07 19:50 - create loop-watch-skip-receipts
 
 - Provider: codex-gpt5-desktop

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -827,6 +827,107 @@ def _wiki_patch(
         return json.dumps({"error": f"Failed to patch: {exc}"})
 
 
+def _resolve_delete_page(page: str) -> tuple[Path | None, str | None, str]:
+    requested = page.strip().replace("\\", "/")
+    if not requested:
+        return None, "page parameter is required.", "error"
+    if requested.startswith("/") or any(part in {"", ".", ".."} for part in requested.split("/")):
+        return None, "page must be a wiki-relative page path or unique slug.", "error"
+
+    clean = requested.removesuffix(".md")
+    if clean.lower() in {"index", "log", "schema"} or requested.lower() in {
+        "index.md",
+        "log.md",
+        "wiki.md",
+    }:
+        return None, "protected wiki anchor pages cannot be deleted.", "protected"
+
+    parts = requested.split("/")
+    if parts[0] in {"pages", "drafts"}:
+        if len(parts) != 3:
+            return None, (
+                "page must be an exact path like pages/<category>/<slug>.md "
+                "or drafts/<category>/<slug>.md."
+            ), "error"
+        base = _wiki_pages_dir() if parts[0] == "pages" else _wiki_drafts_dir()
+        slug = parts[2].removesuffix(".md")
+        if not slug:
+            return None, "page slug is required.", "error"
+        candidate = base / parts[1] / (slug + ".md")
+        if not candidate.exists():
+            return None, f"Page not found: {requested}", "not_found"
+        return candidate, None, ""
+
+    if len(parts) != 1:
+        return None, (
+            "page must be an exact path like pages/<category>/<slug>.md "
+            "or a unique slug."
+        ), "error"
+
+    slug = requested.removesuffix(".md")
+    matches = [
+        path for path in (
+            _find_all_pages(_wiki_pages_dir()) + _find_all_pages(_wiki_drafts_dir())
+        ) if path.stem == slug
+    ]
+    if not matches:
+        return None, f"Page not found: {requested}", "not_found"
+    if len(matches) > 1:
+        return None, (
+            "page slug is ambiguous; use an exact path. Matches: "
+            + ", ".join(_page_rel_path(path) for path in matches)
+        ), "ambiguous"
+    return matches[0], None, ""
+
+
+def _wiki_delete(
+    page: str = "",
+    reason: str = "",
+    expected_sha256: str = "",
+    dry_run: bool = True,
+    **_kwargs: Any,
+) -> str:
+    resolved, error, status = _resolve_delete_page(page)
+    if error or resolved is None:
+        response = {"error": error or "Page not found."}
+        if status:
+            response["status"] = status
+        return json.dumps(response)
+
+    text = _read_text(resolved)
+    old_sha = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    rel = _page_rel_path(resolved)
+    response = {
+        "path": rel,
+        "sha256": old_sha,
+        "total_chars": len(text),
+    }
+
+    if expected_sha256 and expected_sha256 != old_sha:
+        response.update({
+            "error": "content hash mismatch",
+            "status": "conflict",
+            "expected_sha256": expected_sha256,
+            "actual_sha256": old_sha,
+        })
+        return json.dumps(response)
+
+    if dry_run:
+        response.update({"status": "dry_run", "would_delete": True})
+        return json.dumps(response)
+
+    if not reason.strip():
+        return json.dumps({"error": "reason is required when dry_run=false."})
+
+    try:
+        resolved.unlink()
+        _append_wiki_log(f"delete | {rel} | {reason.strip()}")
+        response.update({"status": "deleted"})
+        return json.dumps(response)
+    except OSError as exc:
+        return json.dumps({"error": f"Failed to delete: {exc}"})
+
+
 def _wiki_consolidate(
     similarity_threshold: float = 0.25,
     dry_run: bool = True,
@@ -2038,6 +2139,7 @@ def wiki(
         "lint": _wiki_lint,
         "write": _wiki_write,
         "patch": _wiki_patch,
+        "delete": _wiki_delete,
         "consolidate": _wiki_consolidate,
         "promote": _wiki_promote,
         "ingest": _wiki_ingest,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -31,10 +31,12 @@ import logging
 from contextlib import AsyncExitStack, asynccontextmanager
 from functools import wraps
 from inspect import signature
+from typing import Annotated
 
 import uvicorn
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
+from pydantic import Field
 from starlette.applications import Starlette
 
 from workflow.api.branches import _branch_design_guide_prompt
@@ -945,7 +947,16 @@ def wiki(
     force_new: bool = False,
     bug_id: str = "",
     reporter_context: str = "",
-    changed_since: str = "",
+    changed_since: Annotated[
+        str,
+        Field(
+            description=(
+                'Optional ISO timestamp for action="read" ambient feed and '
+                'required ISO timestamp for action="since"; only pages updated '
+                "after this timestamp are returned."
+            ),
+        ),
+    ] = "",
 ) -> str:
     """Read, write, and manage the cross-project knowledge wiki.
 
@@ -964,13 +975,15 @@ def wiki(
 
     Args:
         action: One of — reads: read, search, since, list, lint;
-            writes: write, patch, consolidate, promote, ingest, supersede,
+            writes: write, patch, delete, consolidate, promote, ingest, supersede,
             sync_projects, file_bug, cosign_bug.
             `search` is lexical best-effort, not a completeness proof; use
             `since` with `changed_since` to review pages updated after a known
             timestamp, then `read` the candidate pages.
         old_text/new_text: For action="patch", exact text to replace server-side.
-        expected_sha256: Optional full-page hash guard for action="patch".
+        expected_sha256: Optional full-page hash guard for action="patch" or
+            action="delete".
+        reason: Required for action="delete" when dry_run=false.
         changed_since: Optional ISO timestamp for action="read" ambient feed
             and required ISO timestamp for action="since"; only pages updated
             after this timestamp are returned.
@@ -1017,7 +1030,7 @@ _mcp_wiki = _register_structured_tool(
     annotations=ToolAnnotations(
         title="Wiki Knowledge Base",
         readOnlyHint=False,
-        destructiveHint=False,
+        destructiveHint=True,
         idempotentHint=False,
         openWorldHint=True,
     ),

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -294,6 +294,81 @@ class TestWikiWrite:
         )
 
 
+class TestWikiDelete:
+    def test_delete_dry_run_default_does_not_delete(self, wiki_dir):
+        target = wiki_dir / "pages" / "projects" / "test-project.md"
+        assert target.exists()
+
+        result = json.loads(wiki("delete", page="pages/projects/test-project.md"))
+
+        assert result["status"] == "dry_run"
+        assert result["would_delete"] is True
+        assert result["path"] == "pages/projects/test-project.md"
+        assert "sha256" in result
+        assert target.exists()
+
+    def test_delete_requires_reason_when_not_dry_run(self, wiki_dir):
+        target = wiki_dir / "pages" / "projects" / "test-project.md"
+
+        result = json.loads(
+            wiki("delete", page="pages/projects/test-project.md", dry_run=False)
+        )
+
+        assert result["error"] == "reason is required when dry_run=false."
+        assert target.exists()
+
+    def test_delete_rejects_hash_mismatch(self, wiki_dir):
+        target = wiki_dir / "pages" / "projects" / "test-project.md"
+
+        result = json.loads(
+            wiki(
+                "delete",
+                page="pages/projects/test-project.md",
+                reason="stale test cleanup",
+                expected_sha256="wrong",
+                dry_run=False,
+            )
+        )
+
+        assert result["status"] == "conflict"
+        assert result["error"] == "content hash mismatch"
+        assert target.exists()
+
+    def test_delete_removes_exact_patch_request_page_and_logs(self, wiki_dir):
+        patch_dir = wiki_dir / "pages" / "patch-requests"
+        patch_dir.mkdir(parents=True)
+        target = patch_dir / "pr-106-bad-filing.md"
+        target.write_text(
+            "---\ntitle: Bad filing\ntype: patch_request\n---\n\nDelete me.\n",
+            encoding="utf-8",
+        )
+
+        dry_run = json.loads(wiki("delete", page="pages/patch-requests/pr-106-bad-filing.md"))
+        result = json.loads(
+            wiki(
+                "delete",
+                page="pages/patch-requests/pr-106-bad-filing.md",
+                reason="misframed patch request",
+                expected_sha256=dry_run["sha256"],
+                dry_run=False,
+            )
+        )
+
+        assert result["status"] == "deleted"
+        assert result["path"] == "pages/patch-requests/pr-106-bad-filing.md"
+        assert not target.exists()
+        assert "misframed patch request" in (wiki_dir / "log.md").read_text(
+            encoding="utf-8"
+        )
+
+    def test_delete_rejects_protected_anchor_page(self, wiki_dir):
+        result = json.loads(wiki("delete", page="index"))
+
+        assert result["status"] == "protected"
+        assert "protected" in result["error"]
+        assert (wiki_dir / "index.md").exists()
+
+
 class TestWikiPromote:
     def test_promote_valid_draft(self, wiki_dir):
         # Write a draft with valid frontmatter and wikilinks

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -827,6 +827,107 @@ def _wiki_patch(
         return json.dumps({"error": f"Failed to patch: {exc}"})
 
 
+def _resolve_delete_page(page: str) -> tuple[Path | None, str | None, str]:
+    requested = page.strip().replace("\\", "/")
+    if not requested:
+        return None, "page parameter is required.", "error"
+    if requested.startswith("/") or any(part in {"", ".", ".."} for part in requested.split("/")):
+        return None, "page must be a wiki-relative page path or unique slug.", "error"
+
+    clean = requested.removesuffix(".md")
+    if clean.lower() in {"index", "log", "schema"} or requested.lower() in {
+        "index.md",
+        "log.md",
+        "wiki.md",
+    }:
+        return None, "protected wiki anchor pages cannot be deleted.", "protected"
+
+    parts = requested.split("/")
+    if parts[0] in {"pages", "drafts"}:
+        if len(parts) != 3:
+            return None, (
+                "page must be an exact path like pages/<category>/<slug>.md "
+                "or drafts/<category>/<slug>.md."
+            ), "error"
+        base = _wiki_pages_dir() if parts[0] == "pages" else _wiki_drafts_dir()
+        slug = parts[2].removesuffix(".md")
+        if not slug:
+            return None, "page slug is required.", "error"
+        candidate = base / parts[1] / (slug + ".md")
+        if not candidate.exists():
+            return None, f"Page not found: {requested}", "not_found"
+        return candidate, None, ""
+
+    if len(parts) != 1:
+        return None, (
+            "page must be an exact path like pages/<category>/<slug>.md "
+            "or a unique slug."
+        ), "error"
+
+    slug = requested.removesuffix(".md")
+    matches = [
+        path for path in (
+            _find_all_pages(_wiki_pages_dir()) + _find_all_pages(_wiki_drafts_dir())
+        ) if path.stem == slug
+    ]
+    if not matches:
+        return None, f"Page not found: {requested}", "not_found"
+    if len(matches) > 1:
+        return None, (
+            "page slug is ambiguous; use an exact path. Matches: "
+            + ", ".join(_page_rel_path(path) for path in matches)
+        ), "ambiguous"
+    return matches[0], None, ""
+
+
+def _wiki_delete(
+    page: str = "",
+    reason: str = "",
+    expected_sha256: str = "",
+    dry_run: bool = True,
+    **_kwargs: Any,
+) -> str:
+    resolved, error, status = _resolve_delete_page(page)
+    if error or resolved is None:
+        response = {"error": error or "Page not found."}
+        if status:
+            response["status"] = status
+        return json.dumps(response)
+
+    text = _read_text(resolved)
+    old_sha = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    rel = _page_rel_path(resolved)
+    response = {
+        "path": rel,
+        "sha256": old_sha,
+        "total_chars": len(text),
+    }
+
+    if expected_sha256 and expected_sha256 != old_sha:
+        response.update({
+            "error": "content hash mismatch",
+            "status": "conflict",
+            "expected_sha256": expected_sha256,
+            "actual_sha256": old_sha,
+        })
+        return json.dumps(response)
+
+    if dry_run:
+        response.update({"status": "dry_run", "would_delete": True})
+        return json.dumps(response)
+
+    if not reason.strip():
+        return json.dumps({"error": "reason is required when dry_run=false."})
+
+    try:
+        resolved.unlink()
+        _append_wiki_log(f"delete | {rel} | {reason.strip()}")
+        response.update({"status": "deleted"})
+        return json.dumps(response)
+    except OSError as exc:
+        return json.dumps({"error": f"Failed to delete: {exc}"})
+
+
 def _wiki_consolidate(
     similarity_threshold: float = 0.25,
     dry_run: bool = True,
@@ -2038,6 +2139,7 @@ def wiki(
         "lint": _wiki_lint,
         "write": _wiki_write,
         "patch": _wiki_patch,
+        "delete": _wiki_delete,
         "consolidate": _wiki_consolidate,
         "promote": _wiki_promote,
         "ingest": _wiki_ingest,

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -31,10 +31,12 @@ import logging
 from contextlib import AsyncExitStack, asynccontextmanager
 from functools import wraps
 from inspect import signature
+from typing import Annotated
 
 import uvicorn
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
+from pydantic import Field
 from starlette.applications import Starlette
 
 from workflow.api.branches import _branch_design_guide_prompt
@@ -945,7 +947,16 @@ def wiki(
     force_new: bool = False,
     bug_id: str = "",
     reporter_context: str = "",
-    changed_since: str = "",
+    changed_since: Annotated[
+        str,
+        Field(
+            description=(
+                'Optional ISO timestamp for action="read" ambient feed and '
+                'required ISO timestamp for action="since"; only pages updated '
+                "after this timestamp are returned."
+            ),
+        ),
+    ] = "",
 ) -> str:
     """Read, write, and manage the cross-project knowledge wiki.
 
@@ -964,13 +975,15 @@ def wiki(
 
     Args:
         action: One of — reads: read, search, since, list, lint;
-            writes: write, patch, consolidate, promote, ingest, supersede,
+            writes: write, patch, delete, consolidate, promote, ingest, supersede,
             sync_projects, file_bug, cosign_bug.
             `search` is lexical best-effort, not a completeness proof; use
             `since` with `changed_since` to review pages updated after a known
             timestamp, then `read` the candidate pages.
         old_text/new_text: For action="patch", exact text to replace server-side.
-        expected_sha256: Optional full-page hash guard for action="patch".
+        expected_sha256: Optional full-page hash guard for action="patch" or
+            action="delete".
+        reason: Required for action="delete" when dry_run=false.
         changed_since: Optional ISO timestamp for action="read" ambient feed
             and required ISO timestamp for action="since"; only pages updated
             after this timestamp are returned.
@@ -1017,7 +1030,7 @@ _mcp_wiki = _register_structured_tool(
     annotations=ToolAnnotations(
         title="Wiki Knowledge Base",
         readOnlyHint=False,
-        destructiveHint=False,
+        destructiveHint=True,
         idempotentHint=False,
         openWorldHint=True,
     ),


### PR DESCRIPTION
## Summary

Adds a guarded wiki `delete` action so mistaken brain pages can be removed instead of preserved as superseded/retraction wrappers.

Shape:
- dry-run by default, returns current SHA and path
- `reason` required for actual deletion
- optional `expected_sha256` guard for destructive execution
- exact `pages/<category>/<slug>.md` / `drafts/<category>/<slug>.md` paths supported, including `pages/patch-requests/*`
- protected anchors (`index`, `log`, `schema`/`WIKI.md`) cannot be deleted
- canonical and Claude plugin mirror updated

## Context

This is the narrow fix for the PR-106..115 cleanup issue. It does not move wiki pages into SQLite State; the filesystem-backed wiki remains intact for Obsidian/external editor workflows.

## Verification

- `python -m pytest tests/test_wiki_tools.py -q` -> 75 passed
- `python -m ruff check workflow/api/wiki.py workflow/universe_server.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py tests/test_wiki_tools.py` -> passed