### PR TITLE
[auto-change] WIKI-PATCH: PR-115: Import should be a user-composable Node-graph (Import-as-Node-graph) — source-handlers are forkable Nodes, not curated source_kind enum

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_wiki.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Any
 
 SCHEMA_VERSION = 1
-VALID_SIGNAL_SOURCES = {"node", "gate", "manual"}
 VALID_SIGNAL_OUTCOMES = {"passed", "failed", "blocked", "cancelled", "unknown"}
 
 
@@ -25,6 +24,13 @@ def _utc_now() -> datetime:
 def _safe_slug(value: str, *, fallback: str = "item") -> str:
     slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.strip()).strip("-._").lower()
     return slug[:96] or fallback
+
+
+def _normalize_source_kind(source_kind: str) -> str:
+    kind = _safe_slug(source_kind, fallback="")
+    if not kind:
+        raise ValueError("source_kind is required")
+    return kind
 
 
 def daemon_wiki_root(base_path: str | Path, daemon_id: str) -> Path:
@@ -84,8 +90,9 @@ evidence, and more reliable across nodes and gates.
 ## Layers
 
 - `raw/signals/`: immutable records from passed, failed, blocked, or cancelled
-  nodes and gates. Do not edit these files after recording; the memory governor
-  may compact older raw signals after they have been summarized.
+  graph source handlers, including nodes and gates. Do not edit these files
+  after recording; the memory governor may compact older raw signals after they
+  have been summarized.
 - `pages/`: maintained synthesis pages. Update these when new signals change
   what the daemon has learned.
 - `pages/brain/review.md`: curated review of promoted mini-brain entries.
@@ -388,12 +395,10 @@ def record_daemon_signal(
     metadata: dict[str, Any] | None = None,
     recorded_at: datetime | None = None,
 ) -> dict[str, Any]:
-    """Record an immutable learning signal from a node, gate, or manual note."""
+    """Record an immutable learning signal from any graph source handler."""
     from workflow.daemon_registry import get_daemon
 
-    kind = source_kind.strip().lower()
-    if kind not in VALID_SIGNAL_SOURCES:
-        raise ValueError(f"source_kind must be one of {sorted(VALID_SIGNAL_SOURCES)}")
+    kind = _normalize_source_kind(source_kind)
     normalized_outcome = outcome.strip().lower() or "unknown"
     if normalized_outcome not in VALID_SIGNAL_OUTCOMES:
         raise ValueError(

--- a/tests/test_daemon_wiki.py
+++ b/tests/test_daemon_wiki.py
@@ -81,6 +81,32 @@ def test_record_daemon_signal_writes_raw_signal_digest_and_log(tmp_path) -> None
     assert "signal | node:node-123 | failed" in log.read_text(encoding="utf-8")
 
 
+def test_record_daemon_signal_accepts_forkable_source_handler_node(tmp_path) -> None:
+    daemon = _soul_daemon(tmp_path)
+
+    signal = daemon_wiki.record_daemon_signal(
+        tmp_path,
+        daemon_id=daemon["daemon_id"],
+        source_kind="Import.Fetch URL",
+        source_id="handler/node 42",
+        outcome="passed",
+        summary="Imported a source through a forkable handler node.",
+    )
+
+    raw_path = Path(signal["signal_path"])
+    root = daemon_wiki.daemon_wiki_root(tmp_path, daemon["daemon_id"])
+    digest = root / "pages" / "signals" / "learning-signals.md"
+
+    assert signal["source_kind"] == "import.fetch-url"
+    assert raw_path.name.endswith("-import.fetch-url-handler-node-42-passed.md")
+    raw_text = raw_path.read_text(encoding="utf-8")
+    assert "source_kind: import.fetch-url" in raw_text
+    assert "Import.Fetch URL" not in raw_text
+    assert "import.fetch-url | passed | handler/node 42" in digest.read_text(
+        encoding="utf-8"
+    )
+
+
 def test_record_daemon_signal_rejects_soulless_daemon(tmp_path) -> None:
     daemon = daemon_registry.create_daemon(
         tmp_path,

--- a/workflow/daemon_wiki.py
+++ b/workflow/daemon_wiki.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Any
 
 SCHEMA_VERSION = 1
-VALID_SIGNAL_SOURCES = {"node", "gate", "manual"}
 VALID_SIGNAL_OUTCOMES = {"passed", "failed", "blocked", "cancelled", "unknown"}
 
 
@@ -25,6 +24,13 @@ def _utc_now() -> datetime:
 def _safe_slug(value: str, *, fallback: str = "item") -> str:
     slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.strip()).strip("-._").lower()
     return slug[:96] or fallback
+
+
+def _normalize_source_kind(source_kind: str) -> str:
+    kind = _safe_slug(source_kind, fallback="")
+    if not kind:
+        raise ValueError("source_kind is required")
+    return kind
 
 
 def daemon_wiki_root(base_path: str | Path, daemon_id: str) -> Path:
@@ -84,8 +90,9 @@ evidence, and more reliable across nodes and gates.
 ## Layers
 
 - `raw/signals/`: immutable records from passed, failed, blocked, or cancelled
-  nodes and gates. Do not edit these files after recording; the memory governor
-  may compact older raw signals after they have been summarized.
+  graph source handlers, including nodes and gates. Do not edit these files
+  after recording; the memory governor may compact older raw signals after they
+  have been summarized.
 - `pages/`: maintained synthesis pages. Update these when new signals change
   what the daemon has learned.
 - `pages/brain/review.md`: curated review of promoted mini-brain entries.
@@ -388,12 +395,10 @@ def record_daemon_signal(
     metadata: dict[str, Any] | None = None,
     recorded_at: datetime | None = None,
 ) -> dict[str, Any]:
-    """Record an immutable learning signal from a node, gate, or manual note."""
+    """Record an immutable learning signal from any graph source handler."""
     from workflow.daemon_registry import get_daemon
 
-    kind = source_kind.strip().lower()
-    if kind not in VALID_SIGNAL_SOURCES:
-        raise ValueError(f"source_kind must be one of {sorted(VALID_SIGNAL_SOURCES)}")
+    kind = _normalize_source_kind(source_kind)
     normalized_outcome = outcome.strip().lower() or "unknown"
     if normalized_outcome not in VALID_SIGNAL_OUTCOMES:
         raise ValueError(


### PR DESCRIPTION
Fixes #807

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-115-pr-115-import-should-be-a-user-composable-node-graph-import-.md`
- GitHub issue: #807
- Branch task: `auto-change/issue-807`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.