### PR TITLE
fix: preflight deploy disk pressure

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -196,6 +196,58 @@ jobs:
                sudo install -m 0644 -o root -g root /tmp/workflow-daemon.service /etc/systemd/system/workflow-daemon.service; \
                sudo systemctl daemon-reload"
 
+      - name: Preflight droplet disk before image pull
+        id: disk-preflight
+        run: |
+          # A full root volume can make both the forward deploy and the rollback
+          # fail while the live daemon is already down. Reclaim disposable state
+          # before touching WORKFLOW_IMAGE or pulling the new image.
+          ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
+              "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
+              'sudo bash -s' <<'SH'
+          set -euo pipefail
+
+          threshold=85
+          fail_threshold=90
+
+          max_disk_pct() {
+            max=0
+            for path in / /var/lib/docker /data; do
+              [ -e "$path" ] || continue
+              pct="$(df -P "$path" | awk 'NR==2 {gsub("%", "", $5); print $5}')"
+              case "$pct" in
+                ''|*[!0-9]*) pct=0 ;;
+              esac
+              if [ "$pct" -gt "$max" ]; then
+                max="$pct"
+              fi
+            done
+            echo "$max"
+          }
+
+          echo "disk preflight before cleanup:"
+          df -h / /var/lib/docker /data 2>&1 || true
+
+          before="$(max_disk_pct)"
+          if [ "$before" -ge "$threshold" ]; then
+            echo "::warning::disk usage ${before}% >= ${threshold}%; pruning disposable Docker/build/journal state before deploy"
+            docker system prune -af 2>&1 | tail -80 || true
+            docker builder prune -af 2>&1 | tail -80 || true
+            journalctl --vacuum-time=3d 2>&1 | tail -20 || true
+          else
+            echo "disk usage ${before}% < ${threshold}%; no pre-deploy prune needed"
+          fi
+
+          echo "disk preflight after cleanup:"
+          df -h / /var/lib/docker /data 2>&1 || true
+
+          after="$(max_disk_pct)"
+          if [ "$after" -ge "$fail_threshold" ]; then
+            echo "::error::disk usage still ${after}% >= ${fail_threshold}% after prune; refusing deploy before image pull/restart"
+            exit 1
+          fi
+          SH
+
       - name: Deploy new image
         id: deploy
         env:

--- a/tests/test_deploy_prod_workflow.py
+++ b/tests/test_deploy_prod_workflow.py
@@ -10,6 +10,7 @@ Covers:
   (g) Rollback step present and conditioned on failure
   (h) CF Access gate step blocks deploy on 200 (Access broken); advisory on tunnel-down
   (i) Optional Codex subscription auth bundle is synced without API-key fallback
+  (j) Droplet disk pressure is pruned before image pull/restart
 """
 
 from __future__ import annotations
@@ -256,6 +257,46 @@ def test_deploy_syncs_runtime_compose_and_systemd_files():
     assert "/etc/systemd/system/workflow-daemon.service" in run_script
     assert "systemctl daemon-reload" in run_script
     assert "vector-entrypoint.sh" in run_script
+
+
+# ---------------------------------------------------------------------------
+# (j) Disk preflight before image pull/restart
+# ---------------------------------------------------------------------------
+
+
+def test_disk_preflight_runs_before_deploy_image_pull():
+    wf = _load()
+    steps = _steps(wf)
+    names = [s.get("name", "") for s in steps]
+    preflight_idx = next(
+        i for i, name in enumerate(names)
+        if name == "Preflight droplet disk before image pull"
+    )
+    deploy_idx = next(
+        i for i, step in enumerate(steps)
+        if step.get("id") == "deploy"
+    )
+
+    assert preflight_idx < deploy_idx, (
+        "disk preflight must happen before WORKFLOW_IMAGE is changed, "
+        "docker pull runs, or systemd restart can take the live daemon down"
+    )
+
+
+def test_disk_preflight_prunes_disposable_state_and_fails_before_restart():
+    wf = _load()
+    step = next(
+        s for s in _steps(wf)
+        if s.get("name") == "Preflight droplet disk before image pull"
+    )
+    run_script = step.get("run", "") or ""
+
+    assert "df -h / /var/lib/docker /data" in run_script
+    assert "docker system prune -af" in run_script
+    assert "docker builder prune -af" in run_script
+    assert "journalctl --vacuum-time=3d" in run_script
+    assert "fail_threshold=90" in run_script
+    assert "refusing deploy before image pull/restart" in run_script
 
 
 def test_deploy_scrubs_stdio_only_workflow_universe_from_cloud_env():


### PR DESCRIPTION
## Summary
- Adds a deploy-prod preflight step that checks `/`, `/var/lib/docker`, and `/data` before changing `WORKFLOW_IMAGE` or pulling the new image.
- If any checked path is at or above 85% usage, it prunes disposable Docker system state, builder cache, and old journal entries.
- If disk is still at or above 90% after pruning, deploy fails before image pull/restart so the current daemon stays up and rollback is not made impossible by a full disk.

## Outage link
- Follow-up to #833 / deploy-prod run 25721061895: P0 auto-triage found root disk at 100%, repaired via emergency prune, and a known-good redeploy passed.
- #832 is still red for writer/checker queue reasons, but production deploy and P0 incident stages are green after recovery.

## Verification
- python -m pytest tests/test_deploy_prod_workflow.py -q (26 passed)
- python -m pytest tests/test_deploy_prod_workflow.py tests/test_p0_triage_workflow.py tests/test_disk_autoprune.py -q (53 passed)
- YAML parse of .github/workflows/deploy-prod.yml passed
- git diff --check passed

## Local caveat
- Local actionlint is not installed; the pre-commit hook skipped it and CI should run the normal workflow lint gate.
