### PR TITLE
Fix checkpoint retention disk growth

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -500,3 +500,14 @@ Notes:
   #728 independent-checker observability state.
 - Ship condition: focused tests pass, PR opened for Cowork/Claude review, #720
   can route to a checker worker without manual session assignment.
+
+## Checkpoint Retention - 2026-05-12
+
+- 2026-05-12 create `../wf-checkpoint-retention` on
+  `codex/checkpoint-retention` by codex-gpt5-desktop.
+- Source: production disk triage found `concordance/checkpoints.db` at ~6.5 GiB
+  with 2,915 retained checkpoints and no free-list space.
+- Purpose: cap LangGraph checkpoint retention and surface active-universe
+  checkpoint DB size in storage status before it becomes a disk-full outage.
+- Ship condition: focused tests pass, ruff passes, PR opened for Claude/Cowork
+  review.

--- a/fantasy_daemon/__main__.py
+++ b/fantasy_daemon/__main__.py
@@ -60,6 +60,7 @@ from fantasy_daemon.providers.claude_provider import ClaudeProvider  # noqa: E40
 from fantasy_daemon.providers.codex_provider import CodexProvider  # noqa: E402
 from fantasy_daemon.providers.ollama_provider import OllamaProvider  # noqa: E402
 from fantasy_daemon.providers.router import ProviderRouter  # noqa: E402
+from workflow.checkpointing import apply_configured_checkpoint_retention  # noqa: E402
 
 logger = logging.getLogger("fantasy_author")
 
@@ -1676,6 +1677,26 @@ class DaemonController:
                                 "trigger_source": claimed_task.trigger_source,
                             },
                         )
+                try:
+                    prune_result = apply_configured_checkpoint_retention(
+                        checkpointer,
+                        universe_id,
+                    )
+                    if prune_result and prune_result.checkpoints_deleted:
+                        logger.info(
+                            "checkpoint_retention: thread=%s keep_last=%d "
+                            "deleted_checkpoints=%d deleted_writes=%d",
+                            prune_result.thread_id,
+                            prune_result.keep_last_n,
+                            prune_result.checkpoints_deleted,
+                            prune_result.writes_deleted,
+                        )
+                except Exception:  # noqa: BLE001 — retention is protective
+                    logger.warning(
+                        "checkpoint_retention: pruning failed for %s",
+                        universe_id,
+                        exc_info=True,
+                    )
                 self._cleanup()
 
                 # Handle cross-universe synthesis switch

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
@@ -675,6 +675,11 @@ def get_status(universe_id: str = "") -> str:
         # directory, not at data_dir() root; patch the per-subsystem byte
         # counts using the already-resolved udir.
         if "per_subsystem" in storage_utilization:
+            checkpoint_bytes = path_size_bytes(udir / "checkpoints.db")
+            storage_utilization["per_subsystem"]["checkpoint_db"] = {
+                "bytes": checkpoint_bytes,
+                "path": str(udir / "checkpoints.db"),
+            }
             storage_utilization["per_subsystem"]["activity_log"] = {
                 "bytes": path_size_bytes(udir / "activity.log"),
                 "path": str(udir / "activity.log"),
@@ -683,6 +688,20 @@ def get_status(universe_id: str = "") -> str:
                 "bytes": path_size_bytes(udir / "output"),
                 "path": str(udir / "output"),
             }
+            try:
+                from workflow.storage.caps import subsystem_cap_snapshot
+
+                storage_utilization["subsystem_caps"] = subsystem_cap_snapshot({
+                    "checkpoints": checkpoint_bytes,
+                    "logs": storage_utilization["per_subsystem"]
+                    .get("activity_log", {})
+                    .get("bytes", 0),
+                    "run_artifacts": storage_utilization["per_subsystem"]
+                    .get("run_transcripts", {})
+                    .get("bytes", 0),
+                })
+            except Exception:  # noqa: BLE001 — keep status best-effort
+                pass
     except Exception as exc:  # noqa: BLE001 — best-effort observability
         storage_utilization = {
             "error": "inspect_failed",

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/checkpointing/__init__.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/checkpointing/__init__.py
@@ -9,18 +9,27 @@ create_checkpointer     -- create a SqliteSaver with WAL mode
 compile_all_graphs      -- compile all 4 graphs with a shared checkpointer
 get_checkpoint_history  -- list checkpoints for a thread
 CheckpointRetentionPolicy -- custom retention policy
+prune_checkpoint_history -- direct SQLite retention for large databases
 """
 
 from workflow.checkpointing.sqlite_saver import (
+    DEFAULT_CHECKPOINT_RETENTION_KEEP_LAST,
     CheckpointRetentionPolicy,
+    apply_configured_checkpoint_retention,
     compile_all_graphs,
+    configured_checkpoint_retention_keep_last,
     create_checkpointer,
     get_checkpoint_history,
+    prune_checkpoint_history,
 )
 
 __all__ = [
+    "DEFAULT_CHECKPOINT_RETENTION_KEEP_LAST",
     "CheckpointRetentionPolicy",
+    "apply_configured_checkpoint_retention",
     "compile_all_graphs",
+    "configured_checkpoint_retention_keep_last",
     "create_checkpointer",
     "get_checkpoint_history",
+    "prune_checkpoint_history",
 ]

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/checkpointing/sqlite_saver.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/checkpointing/sqlite_saver.py
@@ -28,6 +28,7 @@ Typical usage
 
 from __future__ import annotations
 
+import os
 import sqlite3
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -39,6 +40,10 @@ from workflow.exceptions import CheckpointError
 
 if TYPE_CHECKING:
     from langgraph.graph.state import CompiledStateGraph
+
+
+DEFAULT_CHECKPOINT_RETENTION_KEEP_LAST = 500
+CHECKPOINT_RETENTION_KEEP_LAST_ENV = "WORKFLOW_CHECKPOINT_RETENTION_KEEP_LAST"
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +263,175 @@ def make_resume_config(
 # ---------------------------------------------------------------------------
 # Checkpoint retention policy
 # ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CheckpointPruneResult:
+    """Summary of a direct SQLite checkpoint-retention pass."""
+
+    thread_id: str
+    keep_last_n: int
+    checkpoints_before: int
+    checkpoints_deleted: int
+    writes_deleted: int
+    namespaces_seen: tuple[str, ...] = ()
+    skipped_reason: str = ""
+
+
+def configured_checkpoint_retention_keep_last() -> int | None:
+    """Return configured checkpoint retention count.
+
+    ``None`` means retention is disabled. The default is intentionally
+    bounded because unbounded LangGraph checkpoint history can fill the
+    daemon host disk. Set ``WORKFLOW_CHECKPOINT_RETENTION_KEEP_LAST=0`` to
+    disable retention for a local diagnostic run.
+    """
+    raw = os.environ.get(CHECKPOINT_RETENTION_KEEP_LAST_ENV, "").strip()
+    if not raw:
+        return DEFAULT_CHECKPOINT_RETENTION_KEEP_LAST
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_CHECKPOINT_RETENTION_KEEP_LAST
+    if value <= 0:
+        return None
+    return value
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    try:
+        return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
+    except sqlite3.Error:
+        return set()
+
+
+def _sqlite_delete_many(
+    conn: sqlite3.Connection,
+    sql: str,
+    params: list[tuple[object, ...]],
+) -> int:
+    if not params:
+        return 0
+    before = conn.total_changes
+    conn.executemany(sql, params)
+    return conn.total_changes - before
+
+
+def prune_checkpoint_history(
+    conn: sqlite3.Connection,
+    thread_id: str,
+    *,
+    keep_last_n: int,
+    checkpoint_ns: str | None = None,
+) -> CheckpointPruneResult:
+    """Prune old LangGraph SQLite checkpoints without loading checkpoint blobs.
+
+    This is the production retention path. It operates directly on the
+    ``checkpoints`` and ``writes`` tables so a multi-GB checkpoint database can
+    be bounded without deserializing every historical checkpoint into process
+    memory. The newest ``keep_last_n`` checkpoints are preserved per namespace.
+    """
+    if keep_last_n < 1:
+        raise ValueError("keep_last_n must be >= 1")
+
+    checkpoint_cols = _table_columns(conn, "checkpoints")
+    if not {"thread_id", "checkpoint_id"}.issubset(checkpoint_cols):
+        return CheckpointPruneResult(
+            thread_id=thread_id,
+            keep_last_n=keep_last_n,
+            checkpoints_before=0,
+            checkpoints_deleted=0,
+            writes_deleted=0,
+            skipped_reason="missing_checkpoints_table",
+        )
+
+    has_checkpoint_ns = "checkpoint_ns" in checkpoint_cols
+    where = "thread_id = ?"
+    params: list[object] = [thread_id]
+    if checkpoint_ns is not None and has_checkpoint_ns:
+        where += " AND checkpoint_ns = ?"
+        params.append(checkpoint_ns)
+
+    ns_select = ", checkpoint_ns" if has_checkpoint_ns else ""
+    rows = conn.execute(
+        f"SELECT rowid, checkpoint_id{ns_select} "
+        f"FROM checkpoints WHERE {where} ORDER BY rowid DESC",
+        tuple(params),
+    ).fetchall()
+    namespaces_seen = tuple(
+        sorted({str(row[2]) for row in rows})
+    ) if has_checkpoint_ns else ()
+
+    grouped: dict[str, list[tuple[int, str, str]]] = {}
+    for row in rows:
+        ns = str(row[2]) if has_checkpoint_ns else ""
+        grouped.setdefault(ns, []).append((int(row[0]), str(row[1]), ns))
+
+    delete_rows: list[tuple[int, str, str]] = []
+    for group_rows in grouped.values():
+        delete_rows.extend(group_rows[keep_last_n:])
+
+    if not delete_rows:
+        return CheckpointPruneResult(
+            thread_id=thread_id,
+            keep_last_n=keep_last_n,
+            checkpoints_before=len(rows),
+            checkpoints_deleted=0,
+            writes_deleted=0,
+            namespaces_seen=namespaces_seen,
+        )
+
+    checkpoint_delete_params = [(rowid,) for rowid, _cp_id, _ns in delete_rows]
+    checkpoints_deleted = _sqlite_delete_many(
+        conn,
+        "DELETE FROM checkpoints WHERE rowid = ?",
+        checkpoint_delete_params,
+    )
+
+    writes_deleted = 0
+    writes_cols = _table_columns(conn, "writes")
+    if {"thread_id", "checkpoint_id"}.issubset(writes_cols):
+        if "checkpoint_ns" in writes_cols:
+            writes_deleted = _sqlite_delete_many(
+                conn,
+                (
+                    "DELETE FROM writes "
+                    "WHERE thread_id = ? AND checkpoint_ns = ? "
+                    "AND checkpoint_id = ?"
+                ),
+                [(thread_id, ns, cp_id) for _rowid, cp_id, ns in delete_rows],
+            )
+        else:
+            writes_deleted = _sqlite_delete_many(
+                conn,
+                "DELETE FROM writes WHERE thread_id = ? AND checkpoint_id = ?",
+                [(thread_id, cp_id) for _rowid, cp_id, _ns in delete_rows],
+            )
+
+    conn.commit()
+    return CheckpointPruneResult(
+        thread_id=thread_id,
+        keep_last_n=keep_last_n,
+        checkpoints_before=len(rows),
+        checkpoints_deleted=checkpoints_deleted,
+        writes_deleted=writes_deleted,
+        namespaces_seen=namespaces_seen,
+    )
+
+
+def apply_configured_checkpoint_retention(
+    checkpointer: SqliteSaver,
+    thread_id: str,
+) -> CheckpointPruneResult | None:
+    """Apply env-configured direct retention to an active SqliteSaver."""
+    keep_last_n = configured_checkpoint_retention_keep_last()
+    if keep_last_n is None:
+        return None
+    return prune_checkpoint_history(
+        checkpointer.conn,
+        thread_id,
+        keep_last_n=keep_last_n,
+    )
 
 
 @dataclass

--- a/scripts/checkpoint_retention.py
+++ b/scripts/checkpoint_retention.py
@@ -1,0 +1,129 @@
+"""Prune LangGraph checkpoint databases under a Workflow data directory.
+
+Use this for one-time maintenance after the runtime retention patch lands.
+Run with the affected daemon stopped if ``--vacuum`` is set; VACUUM rewrites
+the SQLite file to return pruned pages to the filesystem.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from workflow.checkpointing import (  # noqa: E402
+    DEFAULT_CHECKPOINT_RETENTION_KEEP_LAST,
+    prune_checkpoint_history,
+)
+
+
+def find_checkpoint_dbs(data_dir: Path) -> list[Path]:
+    """Return per-universe checkpoint DBs below ``data_dir``."""
+    return sorted(path for path in data_dir.glob("*/checkpoints.db") if path.is_file())
+
+
+def _default_thread_id(data_dir: Path, db_path: Path) -> str:
+    try:
+        return db_path.parent.relative_to(data_dir).parts[0]
+    except ValueError:
+        return db_path.parent.name
+
+
+def prune_db(
+    db_path: Path,
+    *,
+    thread_id: str,
+    keep_last: int,
+    vacuum: bool,
+) -> dict[str, Any]:
+    before_bytes = db_path.stat().st_size if db_path.exists() else 0
+    with sqlite3.connect(str(db_path), timeout=30) as conn:
+        conn.execute("PRAGMA busy_timeout=30000")
+        result = prune_checkpoint_history(
+            conn,
+            thread_id,
+            keep_last_n=keep_last,
+        )
+        if vacuum and result.checkpoints_deleted:
+            conn.execute("VACUUM")
+    after_bytes = db_path.stat().st_size if db_path.exists() else 0
+    return {
+        "path": str(db_path),
+        "thread_id": thread_id,
+        "keep_last": keep_last,
+        "checkpoints_before": result.checkpoints_before,
+        "checkpoints_deleted": result.checkpoints_deleted,
+        "writes_deleted": result.writes_deleted,
+        "bytes_before": before_bytes,
+        "bytes_after": after_bytes,
+        "vacuum": vacuum,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        required=True,
+        help="Workflow data directory containing <universe>/checkpoints.db files.",
+    )
+    parser.add_argument(
+        "--db",
+        type=Path,
+        help="Specific checkpoints.db to prune. Defaults to all under --data-dir.",
+    )
+    parser.add_argument(
+        "--thread-id",
+        help="Thread id for --db. Defaults to the DB parent directory name.",
+    )
+    parser.add_argument(
+        "--keep-last",
+        type=int,
+        default=DEFAULT_CHECKPOINT_RETENTION_KEEP_LAST,
+        help="Recent checkpoints to retain per namespace.",
+    )
+    parser.add_argument(
+        "--vacuum",
+        action="store_true",
+        help="Reclaim filesystem bytes after pruning. Stop the daemon first.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.keep_last < 1:
+        print("--keep-last must be >= 1", file=sys.stderr)
+        return 2
+
+    data_dir = args.data_dir.resolve()
+    dbs = [args.db.resolve()] if args.db else find_checkpoint_dbs(data_dir)
+    results: list[dict[str, Any]] = []
+    for db_path in dbs:
+        if not db_path.exists():
+            results.append({"path": str(db_path), "error": "missing"})
+            continue
+        thread_id = args.thread_id or _default_thread_id(data_dir, db_path)
+        results.append(
+            prune_db(
+                db_path,
+                thread_id=thread_id,
+                keep_last=args.keep_last,
+                vacuum=args.vacuum,
+            )
+        )
+
+    print(json.dumps({"results": results}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -23,8 +23,10 @@ from domains.fantasy_daemon.graphs.scene import build_scene_graph
 from workflow.checkpointing import (
     CheckpointRetentionPolicy,
     compile_all_graphs,
+    configured_checkpoint_retention_keep_last,
     create_checkpointer,
     get_checkpoint_history,
+    prune_checkpoint_history,
 )
 from workflow.checkpointing.sqlite_saver import (
     make_resume_config,
@@ -371,6 +373,172 @@ class TestRetentionPolicy:
 
         # Unmark non-existent is safe
         policy.unmark_named("cp-nonexistent")
+
+
+class TestDirectCheckpointPruning:
+    """Production retention path must avoid loading checkpoint blobs."""
+
+    @staticmethod
+    def _make_tables(conn: sqlite3.Connection) -> None:
+        conn.execute(
+            """
+            CREATE TABLE checkpoints (
+                thread_id TEXT NOT NULL,
+                checkpoint_ns TEXT NOT NULL DEFAULT '',
+                checkpoint_id TEXT NOT NULL,
+                parent_checkpoint_id TEXT,
+                type TEXT,
+                checkpoint BLOB,
+                metadata BLOB,
+                PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id)
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE writes (
+                thread_id TEXT NOT NULL,
+                checkpoint_ns TEXT NOT NULL DEFAULT '',
+                checkpoint_id TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                idx INTEGER NOT NULL,
+                channel TEXT NOT NULL,
+                type TEXT,
+                value BLOB,
+                PRIMARY KEY (
+                    thread_id, checkpoint_ns, checkpoint_id, task_id, idx
+                )
+            )
+            """
+        )
+
+    @staticmethod
+    def _insert_checkpoint(
+        conn: sqlite3.Connection,
+        *,
+        thread_id: str,
+        checkpoint_id: str,
+        checkpoint_ns: str = "",
+        writes: int = 2,
+    ) -> None:
+        conn.execute(
+            """
+            INSERT INTO checkpoints (
+                thread_id, checkpoint_ns, checkpoint_id,
+                parent_checkpoint_id, type, checkpoint, metadata
+            )
+            VALUES (?, ?, ?, NULL, 'msgpack', ?, ?)
+            """,
+            (thread_id, checkpoint_ns, checkpoint_id, b"x" * 1024, b"{}"),
+        )
+        for idx in range(writes):
+            conn.execute(
+                """
+                INSERT INTO writes (
+                    thread_id, checkpoint_ns, checkpoint_id,
+                    task_id, idx, channel, type, value
+                )
+                VALUES (?, ?, ?, 'task', ?, ?, 'msgpack', ?)
+                """,
+                (
+                    thread_id,
+                    checkpoint_ns,
+                    checkpoint_id,
+                    idx,
+                    f"channel-{idx}",
+                    b"y" * 512,
+                ),
+            )
+
+    def test_prune_keeps_recent_checkpoints_and_matching_writes(self, tmp_path):
+        db_path = tmp_path / "checkpoints.db"
+        conn = sqlite3.connect(db_path)
+        self._make_tables(conn)
+        for idx in range(5):
+            self._insert_checkpoint(
+                conn,
+                thread_id="concordance",
+                checkpoint_id=f"cp-{idx}",
+            )
+        for idx in range(3):
+            self._insert_checkpoint(
+                conn,
+                thread_id="other",
+                checkpoint_id=f"other-{idx}",
+                writes=1,
+            )
+        conn.commit()
+
+        result = prune_checkpoint_history(
+            conn,
+            "concordance",
+            keep_last_n=2,
+        )
+
+        assert result.checkpoints_before == 5
+        assert result.checkpoints_deleted == 3
+        assert result.writes_deleted == 6
+        remaining = [
+            row[0]
+            for row in conn.execute(
+                """
+                SELECT checkpoint_id FROM checkpoints
+                WHERE thread_id = 'concordance'
+                ORDER BY rowid
+                """
+            )
+        ]
+        assert remaining == ["cp-3", "cp-4"]
+        other_count = conn.execute(
+            "SELECT COUNT(*) FROM checkpoints WHERE thread_id = 'other'"
+        ).fetchone()[0]
+        assert other_count == 3
+
+    def test_prune_keeps_recent_per_namespace(self, tmp_path):
+        db_path = tmp_path / "checkpoints.db"
+        conn = sqlite3.connect(db_path)
+        self._make_tables(conn)
+        for ns in ("", "subgraph"):
+            for idx in range(3):
+                self._insert_checkpoint(
+                    conn,
+                    thread_id="concordance",
+                    checkpoint_ns=ns,
+                    checkpoint_id=f"{ns or 'root'}-{idx}",
+                    writes=1,
+                )
+        conn.commit()
+
+        result = prune_checkpoint_history(
+            conn,
+            "concordance",
+            keep_last_n=1,
+        )
+
+        assert result.checkpoints_deleted == 4
+        remaining = {
+            row
+            for row in conn.execute(
+                """
+                SELECT checkpoint_ns, checkpoint_id FROM checkpoints
+                WHERE thread_id = 'concordance'
+                """
+            )
+        }
+        assert remaining == {
+            ("", "root-2"),
+            ("subgraph", "subgraph-2"),
+        }
+
+    def test_configured_retention_defaults_enabled_and_zero_disables(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.delenv("WORKFLOW_CHECKPOINT_RETENTION_KEEP_LAST", raising=False)
+        assert configured_checkpoint_retention_keep_last() == 500
+
+        monkeypatch.setenv("WORKFLOW_CHECKPOINT_RETENTION_KEEP_LAST", "0")
+        assert configured_checkpoint_retention_keep_last() is None
 
 
 # -----------------------------------------------------------------------

--- a/tests/test_storage_utilization_universe.py
+++ b/tests/test_storage_utilization_universe.py
@@ -45,7 +45,13 @@ def test_path_size_bytes_directory_recursive(tmp_path):
 # ── get_status patches per-universe subsystems ────────────────────────────────
 
 
-def _make_universe(tmp_path: Path, *, log_bytes: int, output_bytes: int) -> tuple[Path, str]:
+def _make_universe(
+    tmp_path: Path,
+    *,
+    log_bytes: int,
+    output_bytes: int,
+    checkpoint_bytes: int = 0,
+) -> tuple[Path, str]:
     """Create a minimal universe directory with activity.log and output/."""
     uid = "test-universe"
     udir = tmp_path / uid
@@ -54,6 +60,8 @@ def _make_universe(tmp_path: Path, *, log_bytes: int, output_bytes: int) -> tupl
     out = udir / "output"
     out.mkdir()
     (out / "chapter1.txt").write_bytes(b"O" * output_bytes)
+    if checkpoint_bytes:
+        (udir / "checkpoints.db").write_bytes(b"C" * checkpoint_bytes)
     return udir, uid
 
 
@@ -104,6 +112,39 @@ def test_get_status_universe_outputs_bytes_nonzero(tmp_path, monkeypatch):
     )
 
 
+def test_get_status_checkpoint_db_bytes_nonzero_and_cap_current(
+    tmp_path,
+    monkeypatch,
+):
+    """get_status must report the active universe checkpoint DB, not root."""
+    from workflow.universe_server import get_status
+
+    udir, uid = _make_universe(
+        tmp_path,
+        log_bytes=10,
+        output_bytes=20,
+        checkpoint_bytes=4096,
+    )
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("WORKFLOW_CAP_CHECKPOINTS_BYTES", "10000")
+
+    _cfg = _minimal_cfg()
+    with (
+        patch("workflow.dispatcher.load_dispatcher_config", return_value=_cfg),
+        patch("workflow.dispatcher.paid_market_enabled", return_value=False),
+        patch("workflow.api.helpers._default_universe", return_value=uid),
+        patch("workflow.api.helpers._universe_dir", return_value=udir),
+    ):
+        raw = get_status(universe_id=uid)
+
+    result = json.loads(raw)
+    su = result.get("storage_utilization", {})
+    checkpoint_entry = su["per_subsystem"].get("checkpoint_db", {})
+    assert checkpoint_entry.get("bytes", 0) == 4096
+    assert uid in checkpoint_entry.get("path", "")
+    assert su["subsystem_caps"]["checkpoints"]["current_bytes"] == 4096
+
+
 def test_get_status_activity_log_path_points_into_udir(tmp_path, monkeypatch):
     """The reported path for activity_log must be inside udir, not data_dir root."""
     from workflow.universe_server import get_status
@@ -128,7 +169,9 @@ def test_get_status_activity_log_path_points_into_udir(tmp_path, monkeypatch):
 
 def test_get_status_missing_log_and_output_still_reports_zero_not_error(tmp_path, monkeypatch):
     """Missing activity.log + output/ must yield bytes=0, not crash."""
-    from workflow.universe_server import get_status  # Universe dir exists but no activity.log or output/
+    from workflow.universe_server import get_status
+
+    # Universe dir exists but has no activity.log or output/.
     uid = "empty-universe"
     udir = tmp_path / uid
     udir.mkdir()

--- a/workflow/api/status.py
+++ b/workflow/api/status.py
@@ -675,6 +675,11 @@ def get_status(universe_id: str = "") -> str:
         # directory, not at data_dir() root; patch the per-subsystem byte
         # counts using the already-resolved udir.
         if "per_subsystem" in storage_utilization:
+            checkpoint_bytes = path_size_bytes(udir / "checkpoints.db")
+            storage_utilization["per_subsystem"]["checkpoint_db"] = {
+                "bytes": checkpoint_bytes,
+                "path": str(udir / "checkpoints.db"),
+            }
             storage_utilization["per_subsystem"]["activity_log"] = {
                 "bytes": path_size_bytes(udir / "activity.log"),
                 "path": str(udir / "activity.log"),
@@ -683,6 +688,20 @@ def get_status(universe_id: str = "") -> str:
                 "bytes": path_size_bytes(udir / "output"),
                 "path": str(udir / "output"),
             }
+            try:
+                from workflow.storage.caps import subsystem_cap_snapshot
+
+                storage_utilization["subsystem_caps"] = subsystem_cap_snapshot({
+                    "checkpoints": checkpoint_bytes,
+                    "logs": storage_utilization["per_subsystem"]
+                    .get("activity_log", {})
+                    .get("bytes", 0),
+                    "run_artifacts": storage_utilization["per_subsystem"]
+                    .get("run_transcripts", {})
+                    .get("bytes", 0),
+                })
+            except Exception:  # noqa: BLE001 — keep status best-effort
+                pass
     except Exception as exc:  # noqa: BLE001 — best-effort observability
         storage_utilization = {
             "error": "inspect_failed",

--- a/workflow/checkpointing/__init__.py
+++ b/workflow/checkpointing/__init__.py
@@ -9,18 +9,27 @@ create_checkpointer     -- create a SqliteSaver with WAL mode
 compile_all_graphs      -- compile all 4 graphs with a shared checkpointer
 get_checkpoint_history  -- list checkpoints for a thread
 CheckpointRetentionPolicy -- custom retention policy
+prune_checkpoint_history -- direct SQLite retention for large databases
 """
 
 from workflow.checkpointing.sqlite_saver import (
+    DEFAULT_CHECKPOINT_RETENTION_KEEP_LAST,
     CheckpointRetentionPolicy,
+    apply_configured_checkpoint_retention,
     compile_all_graphs,
+    configured_checkpoint_retention_keep_last,
     create_checkpointer,
     get_checkpoint_history,
+    prune_checkpoint_history,
 )
 
 __all__ = [
+    "DEFAULT_CHECKPOINT_RETENTION_KEEP_LAST",
     "CheckpointRetentionPolicy",
+    "apply_configured_checkpoint_retention",
     "compile_all_graphs",
+    "configured_checkpoint_retention_keep_last",
     "create_checkpointer",
     "get_checkpoint_history",
+    "prune_checkpoint_history",
 ]

--- a/workflow/checkpointing/sqlite_saver.py
+++ b/workflow/checkpointing/sqlite_saver.py
@@ -28,6 +28,7 @@ Typical usage
 
 from __future__ import annotations
 
+import os
 import sqlite3
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -39,6 +40,10 @@ from workflow.exceptions import CheckpointError
 
 if TYPE_CHECKING:
     from langgraph.graph.state import CompiledStateGraph
+
+
+DEFAULT_CHECKPOINT_RETENTION_KEEP_LAST = 500
+CHECKPOINT_RETENTION_KEEP_LAST_ENV = "WORKFLOW_CHECKPOINT_RETENTION_KEEP_LAST"
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +263,175 @@ def make_resume_config(
 # ---------------------------------------------------------------------------
 # Checkpoint retention policy
 # ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CheckpointPruneResult:
+    """Summary of a direct SQLite checkpoint-retention pass."""
+
+    thread_id: str
+    keep_last_n: int
+    checkpoints_before: int
+    checkpoints_deleted: int
+    writes_deleted: int
+    namespaces_seen: tuple[str, ...] = ()
+    skipped_reason: str = ""
+
+
+def configured_checkpoint_retention_keep_last() -> int | None:
+    """Return configured checkpoint retention count.
+
+    ``None`` means retention is disabled. The default is intentionally
+    bounded because unbounded LangGraph checkpoint history can fill the
+    daemon host disk. Set ``WORKFLOW_CHECKPOINT_RETENTION_KEEP_LAST=0`` to
+    disable retention for a local diagnostic run.
+    """
+    raw = os.environ.get(CHECKPOINT_RETENTION_KEEP_LAST_ENV, "").strip()
+    if not raw:
+        return DEFAULT_CHECKPOINT_RETENTION_KEEP_LAST
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_CHECKPOINT_RETENTION_KEEP_LAST
+    if value <= 0:
+        return None
+    return value
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    try:
+        return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
+    except sqlite3.Error:
+        return set()
+
+
+def _sqlite_delete_many(
+    conn: sqlite3.Connection,
+    sql: str,
+    params: list[tuple[object, ...]],
+) -> int:
+    if not params:
+        return 0
+    before = conn.total_changes
+    conn.executemany(sql, params)
+    return conn.total_changes - before
+
+
+def prune_checkpoint_history(
+    conn: sqlite3.Connection,
+    thread_id: str,
+    *,
+    keep_last_n: int,
+    checkpoint_ns: str | None = None,
+) -> CheckpointPruneResult:
+    """Prune old LangGraph SQLite checkpoints without loading checkpoint blobs.
+
+    This is the production retention path. It operates directly on the
+    ``checkpoints`` and ``writes`` tables so a multi-GB checkpoint database can
+    be bounded without deserializing every historical checkpoint into process
+    memory. The newest ``keep_last_n`` checkpoints are preserved per namespace.
+    """
+    if keep_last_n < 1:
+        raise ValueError("keep_last_n must be >= 1")
+
+    checkpoint_cols = _table_columns(conn, "checkpoints")
+    if not {"thread_id", "checkpoint_id"}.issubset(checkpoint_cols):
+        return CheckpointPruneResult(
+            thread_id=thread_id,
+            keep_last_n=keep_last_n,
+            checkpoints_before=0,
+            checkpoints_deleted=0,
+            writes_deleted=0,
+            skipped_reason="missing_checkpoints_table",
+        )
+
+    has_checkpoint_ns = "checkpoint_ns" in checkpoint_cols
+    where = "thread_id = ?"
+    params: list[object] = [thread_id]
+    if checkpoint_ns is not None and has_checkpoint_ns:
+        where += " AND checkpoint_ns = ?"
+        params.append(checkpoint_ns)
+
+    ns_select = ", checkpoint_ns" if has_checkpoint_ns else ""
+    rows = conn.execute(
+        f"SELECT rowid, checkpoint_id{ns_select} "
+        f"FROM checkpoints WHERE {where} ORDER BY rowid DESC",
+        tuple(params),
+    ).fetchall()
+    namespaces_seen = tuple(
+        sorted({str(row[2]) for row in rows})
+    ) if has_checkpoint_ns else ()
+
+    grouped: dict[str, list[tuple[int, str, str]]] = {}
+    for row in rows:
+        ns = str(row[2]) if has_checkpoint_ns else ""
+        grouped.setdefault(ns, []).append((int(row[0]), str(row[1]), ns))
+
+    delete_rows: list[tuple[int, str, str]] = []
+    for group_rows in grouped.values():
+        delete_rows.extend(group_rows[keep_last_n:])
+
+    if not delete_rows:
+        return CheckpointPruneResult(
+            thread_id=thread_id,
+            keep_last_n=keep_last_n,
+            checkpoints_before=len(rows),
+            checkpoints_deleted=0,
+            writes_deleted=0,
+            namespaces_seen=namespaces_seen,
+        )
+
+    checkpoint_delete_params = [(rowid,) for rowid, _cp_id, _ns in delete_rows]
+    checkpoints_deleted = _sqlite_delete_many(
+        conn,
+        "DELETE FROM checkpoints WHERE rowid = ?",
+        checkpoint_delete_params,
+    )
+
+    writes_deleted = 0
+    writes_cols = _table_columns(conn, "writes")
+    if {"thread_id", "checkpoint_id"}.issubset(writes_cols):
+        if "checkpoint_ns" in writes_cols:
+            writes_deleted = _sqlite_delete_many(
+                conn,
+                (
+                    "DELETE FROM writes "
+                    "WHERE thread_id = ? AND checkpoint_ns = ? "
+                    "AND checkpoint_id = ?"
+                ),
+                [(thread_id, ns, cp_id) for _rowid, cp_id, ns in delete_rows],
+            )
+        else:
+            writes_deleted = _sqlite_delete_many(
+                conn,
+                "DELETE FROM writes WHERE thread_id = ? AND checkpoint_id = ?",
+                [(thread_id, cp_id) for _rowid, cp_id, _ns in delete_rows],
+            )
+
+    conn.commit()
+    return CheckpointPruneResult(
+        thread_id=thread_id,
+        keep_last_n=keep_last_n,
+        checkpoints_before=len(rows),
+        checkpoints_deleted=checkpoints_deleted,
+        writes_deleted=writes_deleted,
+        namespaces_seen=namespaces_seen,
+    )
+
+
+def apply_configured_checkpoint_retention(
+    checkpointer: SqliteSaver,
+    thread_id: str,
+) -> CheckpointPruneResult | None:
+    """Apply env-configured direct retention to an active SqliteSaver."""
+    keep_last_n = configured_checkpoint_retention_keep_last()
+    if keep_last_n is None:
+        return None
+    return prune_checkpoint_history(
+        checkpointer.conn,
+        thread_id,
+        keep_last_n=keep_last_n,
+    )
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add direct SQLite checkpoint pruning that keeps the most recent 500 checkpoints per thread/namespace by default without deserializing checkpoint blobs
- run configured retention after each daemon graph stream so per-universe `checkpoints.db` stops growing unbounded
- expose active-universe `checkpoints.db` bytes and cap status in `get_status.storage_utilization`
- add `scripts/checkpoint_retention.py` for one-time prune/VACUUM maintenance after deploy
- sync Claude plugin runtime mirrors for touched workflow files

## Operational note
Pruning stops future growth and creates reusable SQLite free pages. Existing oversized files only shrink after running the maintenance script with `--vacuum` while the daemon using that DB is stopped.

## Verification
- `python -m pytest tests/test_storage_inspect.py tests/test_storage_utilization_universe.py tests/test_checkpointing.py -q`
- `python -m ruff check workflow/checkpointing/sqlite_saver.py workflow/checkpointing/__init__.py workflow/api/status.py fantasy_daemon/__main__.py scripts/checkpoint_retention.py tests/test_checkpointing.py tests/test_storage_utilization_universe.py`
- `git diff --cached --check`
- temp-DB smoke: `python scripts/checkpoint_retention.py --data-dir <tmp> --keep-last 2`