### PR TITLE
scripts: add chatgpt_chat.py CDP driver for the ChatGPT dev-partner route

### DIFF
--- a/.agents/skills/ui-test/SKILL.md
+++ b/.agents/skills/ui-test/SKILL.md
@@ -13,7 +13,7 @@ The human host is watching the browser tab. Your job is to look like a naive, cu
 
 - **Codex / OpenAI-family route:** use the Codex in-app browser to open or continue `https://claude.ai/`. If the app context already shows a Claude.ai conversation, use that visible tab. Do not block this route on `scripts/claude_chat.py`, Chrome CDP, or `localhost:9222`; those are Claude Code harness details, not Codex in-app browser requirements.
 - **Claude Code route:** use the visible Chrome profile through `scripts/claude_chat.py`. This remains the default route for Claude team user-sim. Host-login Claude.ai access is not the proof requirement; Claude.ai is valid when a real browser session can use the Workflow connector.
-- **Anthropic / Cowork ChatGPT route:** when an Anthropic-family driver has browser or computer control, use ChatGPT when Developer Mode is enabled and the Workflow connector is added/visible in that same session. Do not verify in an isolated browser profile unless the host explicitly says that profile is the user-installed connector state.
+- **Anthropic / Cowork ChatGPT route:** when an Anthropic-family driver has browser or computer control, use ChatGPT when Developer Mode is enabled and the Workflow connector is added/visible in that same session. Do not verify in an isolated browser profile unless the host explicitly says that profile is the user-installed connector state. Claude Code on Windows can drive this route via `scripts/chatgpt_chat.py` (sibling of `claude_chat.py`, same CDP at `localhost:9222`, reuses the Chrome profile).
 
 ## Proof standard
 

--- a/.claude/skills/ui-test/SKILL.md
+++ b/.claude/skills/ui-test/SKILL.md
@@ -13,7 +13,7 @@ The human host is watching the browser tab. Your job is to look like a naive, cu
 
 - **Codex / OpenAI-family route:** use the Codex in-app browser to open or continue `https://claude.ai/`. If the app context already shows a Claude.ai conversation, use that visible tab. Do not block this route on `scripts/claude_chat.py`, Chrome CDP, or `localhost:9222`; those are Claude Code harness details, not Codex in-app browser requirements.
 - **Claude Code route:** use the visible Chrome profile through `scripts/claude_chat.py`. This remains the default route for Claude team user-sim. Host-login Claude.ai access is not the proof requirement; Claude.ai is valid when a real browser session can use the Workflow connector.
-- **Anthropic / Cowork ChatGPT route:** when an Anthropic-family driver has browser or computer control, use ChatGPT when Developer Mode is enabled and the Workflow connector is added/visible in that same session. Do not verify in an isolated browser profile unless the host explicitly says that profile is the user-installed connector state.
+- **Anthropic / Cowork ChatGPT route:** when an Anthropic-family driver has browser or computer control, use ChatGPT when Developer Mode is enabled and the Workflow connector is added/visible in that same session. Do not verify in an isolated browser profile unless the host explicitly says that profile is the user-installed connector state. Claude Code on Windows can drive this route via `scripts/chatgpt_chat.py` (sibling of `claude_chat.py`, same CDP at `localhost:9222`, reuses the Chrome profile).
 
 ## Proof standard
 

--- a/scripts/chatgpt_chat.py
+++ b/scripts/chatgpt_chat.py
@@ -1,0 +1,709 @@
+"""Drive the real ChatGPT chat UI via Chrome DevTools Protocol.
+
+Sibling of ``scripts/claude_chat.py``; targets ``chatgpt.com`` instead of
+``claude.ai``. Reuses the same CDP-backed Chrome on port 9222 and the same
+Chrome profile so a host running both can keep one Chrome window with
+multiple chatbot tabs.
+
+Setup (run ONCE by the human host, not by user-sim):
+
+  powershell -Command "Start-Process \
+    'C:\\Users\\Jonathan\\AppData\\Local\\ms-playwright\\chromium-1208\\chrome-win64\\chrome.exe' \
+    -ArgumentList \
+      '--user-data-dir=C:\\Users\\Jonathan\\.claude-ai-profile', \
+      '--remote-debugging-port=9222', \
+      '--no-first-run', \
+      '--disable-blink-features=AutomationControlled', \
+      'https://chatgpt.com/'"
+
+Then log into chatgpt.com in that window, ensure Developer Mode is enabled,
+ensure the Workflow connector is available in the composer, and keep the
+window visible. The driver navigates the existing chatgpt tab; it does not
+open new ones.
+
+Usage:
+
+    python scripts/chatgpt_chat.py ask "your prompt here"
+    python scripts/chatgpt_chat.py read              # read last assistant message
+    python scripts/chatgpt_chat.py new-chat          # navigate to chatgpt.com/
+    python scripts/chatgpt_chat.py status            # is the CDP tab reachable?
+    python scripts/chatgpt_chat.py dismiss-dialogs   # click any permission dialog
+    python scripts/chatgpt_chat.py tabs              # report tab state
+
+Every ``ask`` appends sent prompt + assistant response to
+``output/chatgpt_chat_trace.md``. The notepad ``output/user_sim_session.md``
+is shared with the claude.ai driver so the host sees both routes in one log.
+
+Does NOT bypass the UI. Types into the same chat input a human would use.
+Reads the same rendered text a human would see. No MCP calls.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import io
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Windows cp1252 chokes on em-dashes and unicode chatgpt emits. Force utf-8
+# the same way scripts/claude_chat.py + scripts/worktree_status.py do.
+if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
+    sys.stdout = io.TextIOWrapper(
+        sys.stdout.buffer, encoding="utf-8", errors="replace", line_buffering=True,
+    )
+if sys.stderr.encoding and sys.stderr.encoding.lower() != "utf-8":
+    sys.stderr = io.TextIOWrapper(
+        sys.stderr.buffer, encoding="utf-8", errors="replace", line_buffering=True,
+    )
+
+_PLAYWRIGHT_MISSING = "ERROR: playwright not installed. Run: pip install playwright"
+
+try:
+    from playwright.sync_api import sync_playwright
+except ImportError:
+    sync_playwright = None
+
+CDP = "http://localhost:9222"
+CHATGPT_HOST = "chatgpt.com"
+NEW_CHAT_URL = "https://chatgpt.com/"
+ROOT = Path(__file__).resolve().parent.parent
+TRACE = ROOT / "output" / "chatgpt_chat_trace.md"
+FAILURE_DIR = ROOT / "output" / "chatgpt_chat_failures"
+NOTEPAD = ROOT / "output" / "user_sim_session.md"
+
+CHROME_BIN = Path(
+    os.environ.get(
+        "WORKFLOW_CHROME_BIN",
+        r"C:\Users\Jonathan\AppData\Local\ms-playwright\chromium-1208\chrome-win64\chrome.exe",
+    )
+)
+CHROME_PROFILE = Path(
+    os.environ.get(
+        "WORKFLOW_CHROME_PROFILE",
+        str(Path.home() / ".claude-ai-profile"),
+    )
+)
+
+# Selectors — ChatGPT's DOM drifts; try multiple, use the first that works.
+# Current shape (mid-2026): contenteditable composer with id "prompt-textarea";
+# previously a real <textarea>. Keep both.
+INPUT_SELECTORS = [
+    'div#prompt-textarea[contenteditable="true"]',
+    'textarea#prompt-textarea',
+    '[data-testid="prompt-textarea"]',
+    'div[contenteditable="true"][data-id]',
+    'div.ProseMirror[contenteditable="true"]',
+    'textarea',
+]
+SEND_BUTTON_SELECTORS = [
+    'button[data-testid="send-button"]',
+    'button[data-testid="composer-send-button"]',
+    'button[aria-label*="Send" i]',
+    'button[aria-label*="send prompt" i]',
+    'button[type="submit"]',
+]
+STOP_BUTTON_SELECTORS = [
+    'button[data-testid="stop-button"]',
+    'button[aria-label*="Stop" i]',
+    'button[aria-label*="stop generating" i]',
+]
+ASSISTANT_MSG_SELECTORS = [
+    '[data-message-author-role="assistant"]',
+    'div[data-testid^="conversation-turn"][data-message-author-role="assistant"]',
+    'article[data-testid*="conversation-turn"] [data-message-author-role="assistant"]',
+]
+
+
+def _launch_chrome() -> None:
+    """Launch the dedicated Chrome profile with CDP enabled. Non-blocking."""
+    if not CHROME_BIN.exists():
+        raise RuntimeError(
+            f"Chrome binary not found at {CHROME_BIN}. "
+            f"Set WORKFLOW_CHROME_BIN env var to override."
+        )
+    CHROME_PROFILE.mkdir(parents=True, exist_ok=True)
+    args = [
+        str(CHROME_BIN),
+        f"--user-data-dir={CHROME_PROFILE}",
+        "--remote-debugging-port=9222",
+        "--no-first-run",
+        "--disable-blink-features=AutomationControlled",
+        NEW_CHAT_URL,
+    ]
+    creationflags = 0
+    if sys.platform == "win32":
+        creationflags = 0x00000008 | 0x00000200
+    subprocess.Popen(
+        args,
+        creationflags=creationflags,
+        close_fds=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _connect(auto_launch: bool = True, launch_wait_s: int = 20):
+    if sync_playwright is None:
+        raise RuntimeError(_PLAYWRIGHT_MISSING)
+    pw = sync_playwright().start()
+    try:
+        return pw, pw.chromium.connect_over_cdp(CDP)
+    except Exception:
+        if not auto_launch:
+            pw.stop()
+            raise RuntimeError(f"Cannot connect to Chrome CDP at {CDP}.")
+
+    print(f"Chrome CDP not up — launching {CHROME_BIN.name} ...", file=sys.stderr)
+    try:
+        _launch_chrome()
+    except Exception as exc:
+        pw.stop()
+        raise RuntimeError(f"Auto-launch failed: {exc}") from exc
+
+    deadline = time.monotonic() + launch_wait_s
+    last_exc: Exception | None = None
+    while time.monotonic() < deadline:
+        time.sleep(1.0)
+        try:
+            return pw, pw.chromium.connect_over_cdp(CDP)
+        except Exception as exc:
+            last_exc = exc
+    pw.stop()
+    raise RuntimeError(
+        f"Chrome launched but CDP still unreachable after {launch_wait_s}s ({last_exc})"
+    )
+
+
+def _find_chatgpt_page(browser):
+    for ctx in browser.contexts:
+        for p in ctx.pages:
+            if CHATGPT_HOST in (getattr(p, "url", "") or ""):
+                return p
+    return None
+
+
+def _enumerate_pages(browser):
+    pages = []
+    for ctx in browser.contexts:
+        for p in ctx.pages:
+            pages.append(p)
+    return pages
+
+
+def _enforce_chatgpt_tab_hygiene(browser) -> int:
+    """Single-chatgpt-tab rule. Closes extra chatgpt.com tabs only.
+
+    Does NOT touch tabs on other hosts (claude.ai, github.com, etc.) — the
+    host may legitimately have multiple chatbot routes open simultaneously.
+    Tab hygiene is per-route, not global, so the claude_chat.py driver and
+    chatgpt_chat.py driver don't fight over each other's tabs.
+    """
+    chatgpt_pages = [
+        p for p in _enumerate_pages(browser)
+        if CHATGPT_HOST in (getattr(p, "url", "") or "")
+    ]
+    if len(chatgpt_pages) <= 1:
+        return 0
+
+    def _rank(p) -> int:
+        url = (getattr(p, "url", "") or "")
+        if CHATGPT_HOST in url and "/c/" in url:
+            return 0
+        if CHATGPT_HOST in url:
+            return 1
+        return 2
+
+    pages_sorted = sorted(chatgpt_pages, key=_rank)
+    keeper = pages_sorted[0]
+    closed_urls = []
+    for p in pages_sorted[1:]:
+        url = (getattr(p, "url", "") or "(unknown)")
+        try:
+            p.close()
+            closed_urls.append(url)
+        except Exception as exc:
+            print(
+                f"TAB HYGIENE WARN: failed to close chatgpt tab {url}: {exc}",
+                file=sys.stderr,
+            )
+    if closed_urls:
+        keeper_url = (getattr(keeper, "url", "") or "(unknown)")
+        print(
+            f"TAB HYGIENE: closed {len(closed_urls)} extra chatgpt tab(s); "
+            f"kept {keeper_url}; closed {closed_urls}",
+            file=sys.stderr,
+        )
+    return len(closed_urls)
+
+
+def _ensure_chatgpt_page(browser):
+    """Find an existing chatgpt.com tab or navigate the first available tab.
+
+    Unlike claude_chat.py we don't repurpose a tab that's on a different
+    host — co-existence with the claude driver matters. If no chatgpt tab
+    exists and there's no spare tab to navigate, we open one explicitly.
+    """
+    p = _find_chatgpt_page(browser)
+    if p is not None:
+        _enforce_chatgpt_tab_hygiene(browser)
+        return p
+    # No chatgpt tab exists. Try to navigate a blank-ish tab if one exists.
+    for ctx in browser.contexts:
+        for cand in ctx.pages:
+            url = (getattr(cand, "url", "") or "")
+            if url in ("", "about:blank") or url.startswith("chrome://newtab"):
+                cand.goto(NEW_CHAT_URL, timeout=30000)
+                time.sleep(2)
+                _enforce_chatgpt_tab_hygiene(browser)
+                return cand
+    # No blank tab — open a new chatgpt tab in the first existing context.
+    for ctx in browser.contexts:
+        page = ctx.new_page()
+        page.goto(NEW_CHAT_URL, timeout=30000)
+        time.sleep(2)
+        _enforce_chatgpt_tab_hygiene(browser)
+        return page
+    raise RuntimeError("No browser contexts available to open chatgpt.com.")
+
+
+DIALOG_DISMISS_SELECTORS = [
+    # ChatGPT permission dialog candidates. Keep narrow — never click
+    # arbitrary buttons. Only matches inside dialog-like containers.
+    '[role="dialog"] button:has-text("Allow")',
+    '[role="dialog"] button:has-text("Confirm")',
+    '[role="dialog"] button:has-text("Continue")',
+    '[role="dialog"] button:has-text("Use this connector")',
+    '[role="dialog"] button:has-text("Enable")',
+    '[role="dialog"] button:has-text("Approve")',
+    '[role="dialog"] button:has-text("Trust")',
+    '[aria-modal="true"] button:has-text("Allow")',
+    '[aria-modal="true"] button:has-text("Confirm")',
+    '[aria-modal="true"] button:has-text("Continue")',
+    '[aria-modal="true"] button:has-text("Use this connector")',
+    '[aria-modal="true"] button:has-text("Enable")',
+    '[aria-modal="true"] button:has-text("Approve")',
+    '[aria-modal="true"] button:has-text("Trust")',
+]
+
+
+def _log_notepad(text: str, outcome: str, tool_name: str = "") -> None:
+    """Append one event line to the shared notepad. Best-effort; never raises."""
+    try:
+        NOTEPAD.parent.mkdir(parents=True, exist_ok=True)
+        snippet = (text or "").strip().replace("\n", " ")
+        if len(snippet) > 80:
+            snippet = snippet[:80]
+        stamp = dt.datetime.now().strftime("%Y-%m-%d %H:%M")
+        tool = tool_name or "-"
+        line = (
+            f"## [{stamp}] CHATGPT_CHAT {tool} — "
+            f'"{snippet}" outcome: {outcome}\n'
+        )
+        fd = os.open(
+            str(NOTEPAD),
+            os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+            0o644,
+        )
+        try:
+            os.write(fd, line.encode("utf-8"))
+        finally:
+            os.close(fd)
+    except Exception:
+        pass
+
+
+def _dismiss_dialogs(page) -> int:
+    """Click any permission/allow dialog ChatGPT has put up.
+
+    Scoped to dialog-like containers — never clicks arbitrary buttons.
+    Returns how many dialogs were dismissed. Cheap no-op when no dialog
+    exists, so safe to call before every ask and before every response
+    wait.
+    """
+    clicked = 0
+    for sel in DIALOG_DISMISS_SELECTORS:
+        try:
+            loc = page.locator(sel)
+            n = loc.count()
+        except Exception:
+            continue
+        for i in range(n):
+            try:
+                btn = loc.nth(i)
+                if not btn.is_visible():
+                    continue
+                btn_text = ""
+                try:
+                    btn_text = (btn.inner_text() or "").strip()
+                except Exception:
+                    pass
+                try:
+                    btn.click(force=True)
+                except Exception:
+                    _log_notepad(
+                        btn_text or sel, outcome="failed",
+                        tool_name="_dismiss_dialogs",
+                    )
+                    continue
+                clicked += 1
+                _log_notepad(
+                    btn_text or sel, outcome="ok",
+                    tool_name="_dismiss_dialogs",
+                )
+                time.sleep(0.3)
+                break
+            except Exception:
+                continue
+        if clicked:
+            break
+    return clicked
+
+
+def _first_visible(page, selectors):
+    for sel in selectors:
+        try:
+            loc = page.locator(sel)
+            count = loc.count()
+        except Exception:
+            continue
+        for i in range(count):
+            try:
+                if loc.nth(i).is_visible():
+                    return loc.nth(i)
+            except Exception:
+                continue
+    return None
+
+
+def _first_usable_input(page):
+    """Visible composer input that's not locked / disabled."""
+    for sel in INPUT_SELECTORS:
+        try:
+            loc = page.locator(sel)
+            count = loc.count()
+        except Exception:
+            continue
+        for i in range(count):
+            cand = loc.nth(i)
+            try:
+                if not cand.is_visible():
+                    continue
+                get_attribute = getattr(cand, "get_attribute", None)
+                if callable(get_attribute):
+                    aria_disabled = (get_attribute("aria-disabled") or "").lower()
+                    if aria_disabled == "true":
+                        continue
+                    contenteditable = (get_attribute("contenteditable") or "").lower()
+                    if contenteditable == "false":
+                        continue
+                evaluate = getattr(cand, "evaluate", None)
+                if callable(evaluate):
+                    if evaluate(
+                        "el => el.tagName.toLowerCase() === 'textarea' && el.disabled"
+                    ):
+                        continue
+                return cand
+            except Exception:
+                continue
+    return None
+
+
+def _read_last_assistant_text(page) -> str:
+    """Return the inner_text of the most recent assistant message, or ''."""
+    best_text = ""
+    for sel in ASSISTANT_MSG_SELECTORS:
+        try:
+            loc = page.locator(sel)
+            n = loc.count()
+        except Exception:
+            continue
+        for i in range(n - 1, -1, -1):
+            try:
+                node = loc.nth(i)
+                if not node.is_visible():
+                    continue
+                text = (node.inner_text() or "").strip()
+                if text:
+                    return text
+            except Exception:
+                continue
+    return best_text
+
+
+def _wait_for_response_complete(page, prev_text: str, *, timeout_s: int = 180):
+    """Wait for ChatGPT to finish generating a new response.
+
+    The signal we watch:
+    - The last assistant message's inner_text has changed from ``prev_text``.
+    - The Stop button is gone (response stream finished).
+    - Text has been stable for at least ``stable_s`` seconds.
+
+    Returns ``(response_text, timed_out)``.
+    """
+    deadline = time.monotonic() + timeout_s
+    stable_s = 2.5
+    last_text = ""
+    last_change = time.monotonic()
+    while time.monotonic() < deadline:
+        # Cheap dismiss check so a mid-stream connector dialog doesn't stall us.
+        try:
+            _dismiss_dialogs(page)
+        except Exception:
+            pass
+        cur = _read_last_assistant_text(page)
+        stop_btn = _first_visible(page, STOP_BUTTON_SELECTORS)
+        if cur and cur != prev_text:
+            if cur != last_text:
+                last_text = cur
+                last_change = time.monotonic()
+            elif stop_btn is None and (time.monotonic() - last_change) >= stable_s:
+                return cur, False
+        time.sleep(0.4)
+    return last_text or "(no response captured)", True
+
+
+def _append_trace(direction: str, body: str) -> None:
+    try:
+        TRACE.parent.mkdir(parents=True, exist_ok=True)
+        stamp = dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with open(TRACE, "a", encoding="utf-8") as fh:
+            fh.write(f"\n## [{stamp}] {direction}\n\n{body}\n")
+    except Exception as exc:
+        print(f"WARN: failed to append trace: {exc}", file=sys.stderr)
+
+
+def _capture_failure_dump(page, reason: str, *, note: str = "") -> str:
+    """Write HTML + screenshot + note triple under output/chatgpt_chat_failures/.
+
+    Returns the basename so callers can reference it in error messages.
+    """
+    try:
+        FAILURE_DIR.mkdir(parents=True, exist_ok=True)
+        ts = dt.datetime.now().strftime("%Y%m%dT%H%M%S")
+        base = f"{ts}_{reason}"
+        html_path = FAILURE_DIR / f"{base}.html"
+        png_path = FAILURE_DIR / f"{base}.png"
+        txt_path = FAILURE_DIR / f"{base}.txt"
+        try:
+            html_path.write_text(page.content(), encoding="utf-8")
+        except Exception:
+            pass
+        try:
+            page.screenshot(path=str(png_path), full_page=True)
+        except Exception:
+            pass
+        if note:
+            try:
+                txt_path.write_text(note, encoding="utf-8")
+            except Exception:
+                pass
+        return base
+    except Exception:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+def cmd_ask(message: str) -> int:
+    pw, browser = _connect()
+    try:
+        page = _ensure_chatgpt_page(browser)
+        page.bring_to_front()
+        _dismiss_dialogs(page)
+        prev = _read_last_assistant_text(page)
+
+        inp = _first_usable_input(page)
+        if inp is None:
+            dump = _capture_failure_dump(
+                page, "input_not_found",
+                note=(
+                    f"prev_text_len={len(prev)}; "
+                    f"message_preview={message[:80]!r}"
+                ),
+            )
+            print(
+                "ERROR: could not find chat input on chatgpt.com. "
+                "Is the page loaded? Diagnostic dump: "
+                f"output/chatgpt_chat_failures/{dump}." "{html,png,txt}",
+                file=sys.stderr,
+            )
+            return 3
+
+        inp.click()
+        # Clear any stale text so we don't interleave the prior compose-buffer.
+        try:
+            page.keyboard.press("Control+A")
+            page.keyboard.press("Delete")
+        except Exception:
+            pass
+        try:
+            current = (inp.inner_text() or "").strip()
+        except Exception:
+            current = ""
+        if current:
+            try:
+                inp.evaluate(
+                    "(el) => { "
+                    "if ('value' in el) { el.value = ''; } "
+                    "else { el.textContent = ''; } "
+                    "el.dispatchEvent(new Event('input', {bubbles: true})); "
+                    "}"
+                )
+            except Exception:
+                pass
+        page.keyboard.type(message, delay=15)
+        send = _first_visible(page, SEND_BUTTON_SELECTORS)
+        if send is not None:
+            send.click()
+        else:
+            page.keyboard.press("Enter")
+
+        _append_trace("USER -> CHATGPT", message)
+        response, timed_out = _wait_for_response_complete(page, prev)
+
+        if timed_out:
+            note = (
+                f"prev_len={len(prev)}; response_len={len(response)}; "
+                f"message_preview={message[:80]!r}"
+            )
+            dump = _capture_failure_dump(page, "response_timeout", note=note)
+            _append_trace(
+                "CHATGPT -> USER",
+                f"(TIMEOUT after 180s; partial response below; dump={dump})\n{response}",
+            )
+            print(response or "(no response captured)")
+            print(
+                f"WARN: response did not settle within 180s. "
+                f"Diagnostic dump: output/chatgpt_chat_failures/{dump}.{{html,png,txt}}",
+                file=sys.stderr,
+            )
+            return 5
+
+        _append_trace("CHATGPT -> USER", response)
+        print(response or "(no response captured)")
+        return 0
+    finally:
+        browser.close()
+        pw.stop()
+
+
+def cmd_read() -> int:
+    pw, browser = _connect()
+    try:
+        page = _ensure_chatgpt_page(browser)
+        text = _read_last_assistant_text(page)
+        print(text or "(no assistant message visible)")
+        return 0
+    finally:
+        browser.close()
+        pw.stop()
+
+
+def cmd_dismiss_dialogs() -> int:
+    pw, browser = _connect()
+    try:
+        page = _ensure_chatgpt_page(browser)
+        n = _dismiss_dialogs(page)
+        print(f"dismissed {n} dialog(s)")
+        return 0
+    finally:
+        browser.close()
+        pw.stop()
+
+
+def cmd_new_chat() -> int:
+    pw, browser = _connect()
+    try:
+        page = _ensure_chatgpt_page(browser)
+        page.goto(NEW_CHAT_URL, timeout=30000)
+        time.sleep(2)
+        _enforce_chatgpt_tab_hygiene(browser)
+        print("new chatgpt chat ready")
+        return 0
+    finally:
+        browser.close()
+        pw.stop()
+
+
+def cmd_status() -> int:
+    try:
+        pw, browser = _connect(auto_launch=False)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 4
+    try:
+        _enforce_chatgpt_tab_hygiene(browser)
+        page = _find_chatgpt_page(browser)
+        if page is None:
+            print("CDP reachable; no chatgpt.com tab found.")
+            return 1
+        print(f"OK: chatgpt.com tab at {page.url}")
+        return 0
+    finally:
+        browser.close()
+        pw.stop()
+
+
+def cmd_tabs() -> int:
+    """Report open-tab count + URLs. Enforces per-chatgpt tab hygiene only."""
+    try:
+        pw, browser = _connect(auto_launch=False)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 4
+    try:
+        pages = _enumerate_pages(browser)
+        urls_before = [(getattr(p, "url", "") or "(unknown)") for p in pages]
+        closed = _enforce_chatgpt_tab_hygiene(browser)
+        pages_after = _enumerate_pages(browser)
+        urls_after = [(getattr(p, "url", "") or "(unknown)") for p in pages_after]
+        chatgpt_after = [u for u in urls_after if CHATGPT_HOST in u]
+        print(
+            f"TAB HYGIENE: {len(pages_after)} total tab(s); "
+            f"chatgpt={len(chatgpt_after)}; urls={urls_after}"
+        )
+        if closed:
+            print(
+                f"  (healed {closed} chatgpt tab(s); before={urls_before})"
+            )
+        return 0
+    finally:
+        browser.close()
+        pw.stop()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else None)
+    sub = p.add_subparsers(dest="cmd", required=True)
+    ask = sub.add_parser("ask")
+    ask.add_argument("message")
+    sub.add_parser("read")
+    sub.add_parser("new-chat")
+    sub.add_parser("status")
+    sub.add_parser("dismiss-dialogs")
+    sub.add_parser("tabs")
+    ns = p.parse_args()
+
+    if ns.cmd == "ask":
+        return cmd_ask(ns.message)
+    if ns.cmd == "read":
+        return cmd_read()
+    if ns.cmd == "new-chat":
+        return cmd_new_chat()
+    if ns.cmd == "status":
+        return cmd_status()
+    if ns.cmd == "dismiss-dialogs":
+        return cmd_dismiss_dialogs()
+    if ns.cmd == "tabs":
+        return cmd_tabs()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/chatgpt_chat.py
+++ b/scripts/chatgpt_chat.py
@@ -460,25 +460,62 @@ def _first_usable_input(page):
 
 
 def _read_last_assistant_text(page) -> str:
-    """Return the inner_text of the most recent assistant message, or ''."""
-    best_text = ""
-    for sel in ASSISTANT_MSG_SELECTORS:
-        try:
-            loc = page.locator(sel)
-            n = loc.count()
-        except Exception:
-            continue
-        for i in range(n - 1, -1, -1):
-            try:
-                node = loc.nth(i)
-                if not node.is_visible():
-                    continue
-                text = (node.inner_text() or "").strip()
-                if text:
-                    return text
-            except Exception:
-                continue
-    return best_text
+    """Return the assistant text of the MOST RECENT conversation turn only.
+
+    ChatGPT splits a single logical reply into multiple
+    [data-message-author-role="assistant"] nodes when tool calls happen
+    mid-response. A naive "return first match" loses everything after the
+    last tool call; a naive "concatenate all matches" duplicates older
+    turns into the current read.
+
+    Correct shape: find the latest `[data-testid^="conversation-turn"]`
+    container and return the concatenated inner_text of all
+    `[data-message-author-role="assistant"]` elements INSIDE THAT TURN
+    only. Fall back to "last single assistant node" if the turn-container
+    selector doesn't match (older ChatGPT DOM revisions).
+    """
+    parts = page.evaluate(
+        """
+        () => {
+          const turns = document.querySelectorAll(
+            '[data-testid^="conversation-turn"]'
+          );
+          if (turns.length > 0) {
+            // Walk backwards to find the most recent turn that contains
+            // an assistant-role child (the latest user turn is the last
+            // overall, but it's a user message, not assistant).
+            for (let i = turns.length - 1; i >= 0; i--) {
+              const turn = turns[i];
+              const assistants = turn.querySelectorAll(
+                '[data-message-author-role="assistant"]'
+              );
+              if (assistants.length === 0) continue;
+              const out = [];
+              for (const a of assistants) {
+                const r = a.getBoundingClientRect();
+                if (r.width === 0 || r.height === 0) continue;
+                const t = (a.innerText || '').trim();
+                if (t) out.push(t);
+              }
+              if (out.length) return out;
+            }
+          }
+          // Fallback: last visible assistant-role node anywhere on page.
+          const all = document.querySelectorAll(
+            '[data-message-author-role="assistant"]'
+          );
+          for (let i = all.length - 1; i >= 0; i--) {
+            const n = all[i];
+            const r = n.getBoundingClientRect();
+            if (r.width === 0 || r.height === 0) continue;
+            const t = (n.innerText || '').trim();
+            if (t) return [t];
+          }
+          return [];
+        }
+        """
+    ) or []
+    return "\n\n".join(parts)
 
 
 def _wait_for_response_complete(page, prev_text: str, *, timeout_s: int = 180):
@@ -613,16 +650,48 @@ def cmd_ask(message: str) -> int:
         _type_multiline(page, message)
         # Defensive: wait briefly for the composer to register the typed
         # text and for the send button to become enabled before clicking,
-        # so we don't fire on a half-typed message.
+        # so we don't fire on a half-typed message. Force the click in
+        # case Playwright considers the button non-interactable for layout
+        # reasons (observed once — button visible+enabled per DOM but the
+        # Playwright .click() returned without firing the action).
         send = _wait_for_send_button_ready(page, timeout_s=10)
+        sent = False
         if send is not None:
-            send.click()
-        else:
-            # Last-resort fallback: use the platform's "send" keystroke.
-            # ChatGPT respects Ctrl/Cmd+Enter on long messages even when
-            # the visible button isn't found.
-            modifier = "Meta" if sys.platform == "darwin" else "Control"
-            page.keyboard.press(f"{modifier}+Enter")
+            try:
+                send.click(force=True)
+                sent = True
+            except Exception:
+                # Fall through to DOM-direct click + keyboard fallback.
+                pass
+        if not sent:
+            # DOM-direct click on the canonical send button id; safer than
+            # Ctrl+Enter (which ChatGPT does NOT treat as Send).
+            try:
+                clicked = page.evaluate(
+                    """
+                    () => {
+                      const b = document.querySelector(
+                        'button[data-testid="send-button"]'
+                      );
+                      if (b && !b.disabled
+                          && b.getAttribute('aria-disabled') !== 'true') {
+                        b.click();
+                        return true;
+                      }
+                      return false;
+                    }
+                    """
+                )
+                sent = bool(clicked)
+            except Exception:
+                pass
+        if not sent:
+            # Last resort: plain Enter. After _type_multiline finished its
+            # last keyboard.type, the composer focus is in compose-mode
+            # with the message visible — plain Enter at this point fires
+            # Send on ChatGPT. Ctrl/Cmd+Enter is NOT a documented send
+            # shortcut on chatgpt.com, so we avoid that.
+            page.keyboard.press("Enter")
 
         _append_trace("USER -> CHATGPT", message)
         response, timed_out = _wait_for_response_complete(page, prev)

--- a/scripts/chatgpt_chat.py
+++ b/scripts/chatgpt_chat.py
@@ -779,6 +779,128 @@ def cmd_status() -> int:
         pw.stop()
 
 
+def cmd_inspect() -> int:
+    """Dump current ChatGPT page state for debugging the driver.
+
+    Reports: URL, user messages count + lengths, assistant messages count
+    + per-turn boundaries, latest assistant text, visible composer text,
+    visible send/stop button state, any visible permission-dialog buttons
+    (Deny / Review Context / Allow), and any error text on the page.
+
+    UTF-8 safe because chatgpt_chat.py forces utf-8 stdio at import time;
+    avoids the cp1252 'charmap' codec crash that scratch probe scripts
+    keep hitting on Windows (same flavor as BUG-074).
+    """
+    try:
+        pw, browser = _connect(auto_launch=False)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 4
+    try:
+        page = _find_chatgpt_page(browser)
+        if page is None:
+            print("CDP reachable; no chatgpt.com tab found.")
+            return 1
+        print(f"URL: {page.url}")
+        users = page.evaluate(
+            """
+            () => {
+              const nodes = document.querySelectorAll(
+                '[data-message-author-role="user"]'
+              );
+              return Array.from(nodes).map(n =>
+                ((n.innerText || '').slice(0, 200))
+              );
+            }
+            """
+        ) or []
+        print(f"\nUSER MESSAGES: {len(users)}")
+        for i, m in enumerate(users):
+            print(f"  [{i}] len={len(m)}: {m!r}")
+        turns = page.evaluate(
+            """
+            () => {
+              const out = [];
+              for (const t of document.querySelectorAll(
+                '[data-testid^=\"conversation-turn\"]'
+              )) {
+                const assistants = t.querySelectorAll(
+                  '[data-message-author-role=\"assistant\"]'
+                );
+                if (!assistants.length) continue;
+                const texts = Array.from(assistants).map(a =>
+                  ((a.innerText || '').trim())
+                );
+                out.push({chunks: texts.length, total_len:
+                  texts.reduce((a, b) => a + b.length, 0)});
+              }
+              return out;
+            }
+            """
+        ) or []
+        print(f"\nASSISTANT TURNS: {len(turns)}")
+        for i, t in enumerate(turns):
+            print(f"  [{i}] chunks={t['chunks']} total_len={t['total_len']}")
+        print("\nLATEST ASSISTANT (joined):")
+        print(_read_last_assistant_text(page) or "(none)")
+        composer = page.evaluate(
+            """
+            () => {
+              const el = document.querySelector(
+                'div#prompt-textarea[contenteditable=\"true\"], '
+                + 'textarea#prompt-textarea, '
+                + '[data-testid=\"prompt-textarea\"]'
+              );
+              if (!el) return null;
+              return (el.innerText || el.value || '').slice(0, 240);
+            }
+            """
+        )
+        print(f"\nCOMPOSER TEXT: {composer!r}")
+        send_state = page.evaluate(
+            """
+            () => {
+              const b = document.querySelector(
+                'button[data-testid=\"send-button\"]'
+              );
+              if (!b) return null;
+              return {
+                visible: b.getBoundingClientRect().width > 0,
+                disabled: b.disabled,
+                aria_disabled: b.getAttribute('aria-disabled'),
+                aria_label: b.getAttribute('aria-label'),
+              };
+            }
+            """
+        )
+        print(f"SEND BUTTON: {send_state}")
+        dlg_buttons = page.evaluate(
+            """
+            () => {
+              const out = [];
+              const re = new RegExp(
+                '^(deny|review context|allow|approve|always allow|'
+                + 'use this connector|cancel|continue|confirm)',
+                'i'
+              );
+              for (const b of document.querySelectorAll('button')) {
+                const t = (b.innerText || '').trim();
+                if (!re.test(t)) continue;
+                const r = b.getBoundingClientRect();
+                if (r.width === 0 || r.height === 0) continue;
+                out.push(t);
+              }
+              return out;
+            }
+            """
+        ) or []
+        print(f"DIALOG-LIKE BUTTONS VISIBLE: {dlg_buttons}")
+        return 0
+    finally:
+        browser.close()
+        pw.stop()
+
+
 def cmd_tabs() -> int:
     """Report open-tab count + URLs. Enforces per-chatgpt tab hygiene only."""
     try:
@@ -817,6 +939,7 @@ def main() -> int:
     sub.add_parser("status")
     sub.add_parser("dismiss-dialogs")
     sub.add_parser("tabs")
+    sub.add_parser("inspect")
     ns = p.parse_args()
 
     if ns.cmd == "ask":
@@ -831,6 +954,8 @@ def main() -> int:
         return cmd_dismiss_dialogs()
     if ns.cmd == "tabs":
         return cmd_tabs()
+    if ns.cmd == "inspect":
+        return cmd_inspect()
     return 1
 
 

--- a/scripts/chatgpt_chat.py
+++ b/scripts/chatgpt_chat.py
@@ -378,6 +378,54 @@ def _first_visible(page, selectors):
     return None
 
 
+def _type_multiline(page, message: str, *, per_char_delay_ms: int = 5) -> None:
+    """Type ``message`` into the focused composer, preserving newlines.
+
+    ChatGPT's composer treats plain Enter as Send. A naive
+    ``page.keyboard.type(message)`` for a multi-paragraph brief would
+    therefore fire Send the moment it typed the first ``\\n``, truncating
+    the message to its first paragraph. This helper splits on newlines and
+    emits ``Shift+Enter`` between chunks so the composer stays in compose
+    mode until the caller explicitly clicks Send.
+
+    Per-char delay is intentionally short (5ms vs claude_chat.py's 15ms)
+    because long briefs are common in dev-partner mode and 15ms × 3,000
+    chars = 45 seconds of typing for a single message.
+    """
+    chunks = message.split("\n")
+    for i, chunk in enumerate(chunks):
+        if i > 0:
+            # Shift+Enter inserts a newline in the composer without firing
+            # Send. Works for both contenteditable composers and
+            # <textarea> shells.
+            page.keyboard.press("Shift+Enter")
+        if chunk:
+            page.keyboard.type(chunk, delay=per_char_delay_ms)
+
+
+def _wait_for_send_button_ready(page, *, timeout_s: int = 10):
+    """Return a visible & enabled Send button locator, or None on timeout.
+
+    Defensive guard: composer state machines occasionally show the Send
+    button before they've accepted typed input. Clicking too early sends
+    an empty (or partial) message. We poll until the button reports
+    ``aria-disabled`` != "true" and ``disabled`` is not set.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        btn = _first_visible(page, SEND_BUTTON_SELECTORS)
+        if btn is not None:
+            try:
+                aria_disabled = (btn.get_attribute("aria-disabled") or "").lower()
+                disabled_attr = btn.get_attribute("disabled")
+                if aria_disabled != "true" and disabled_attr is None:
+                    return btn
+            except Exception:
+                return btn
+        time.sleep(0.15)
+    return _first_visible(page, SEND_BUTTON_SELECTORS)  # final best-effort
+
+
 def _first_usable_input(page):
     """Visible composer input that's not locked / disabled."""
     for sel in INPUT_SELECTORS:
@@ -557,12 +605,24 @@ def cmd_ask(message: str) -> int:
                 )
             except Exception:
                 pass
-        page.keyboard.type(message, delay=15)
-        send = _first_visible(page, SEND_BUTTON_SELECTORS)
+        # CRITICAL: ChatGPT's composer sends on plain Enter. A naive
+        # `keyboard.type(message)` for a multi-paragraph brief would fire
+        # Send on the first paragraph break, truncating the message. Split
+        # on newlines and emit Shift+Enter between chunks so the composer
+        # stays in compose mode until we explicitly click Send.
+        _type_multiline(page, message)
+        # Defensive: wait briefly for the composer to register the typed
+        # text and for the send button to become enabled before clicking,
+        # so we don't fire on a half-typed message.
+        send = _wait_for_send_button_ready(page, timeout_s=10)
         if send is not None:
             send.click()
         else:
-            page.keyboard.press("Enter")
+            # Last-resort fallback: use the platform's "send" keystroke.
+            # ChatGPT respects Ctrl/Cmd+Enter on long messages even when
+            # the visible button isn't found.
+            modifier = "Meta" if sys.platform == "darwin" else "Control"
+            page.keyboard.press(f"{modifier}+Enter")
 
         _append_trace("USER -> CHATGPT", message)
         response, timed_out = _wait_for_response_complete(page, prev)

--- a/tests/test_chatgpt_chat.py
+++ b/tests/test_chatgpt_chat.py
@@ -1,0 +1,98 @@
+"""Smoke tests for scripts/chatgpt_chat.py.
+
+These exercise only the parts that work without a live CDP Chrome:
+- module imports
+- CLI argument parsing (--help, each subcommand exists)
+- selector tables are non-empty
+- helper functions handle missing-DOM gracefully
+
+The end-to-end browser path is exercised manually with a host-launched CDP
+Chrome window (see scripts/chatgpt_chat.py docstring for setup).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "chatgpt_chat.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("chatgpt_chat", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_module_imports_cleanly() -> None:
+    """Module must import even when playwright isn't installed."""
+    mod = _load_module()
+    assert mod.CHATGPT_HOST == "chatgpt.com"
+    assert mod.NEW_CHAT_URL.startswith("https://chatgpt.com/")
+
+
+def test_selector_tables_non_empty() -> None:
+    """All four selector tables must have at least one entry."""
+    mod = _load_module()
+    assert mod.INPUT_SELECTORS
+    assert mod.SEND_BUTTON_SELECTORS
+    assert mod.STOP_BUTTON_SELECTORS
+    assert mod.ASSISTANT_MSG_SELECTORS
+    assert mod.DIALOG_DISMISS_SELECTORS
+
+
+def test_help_invocation_exits_zero() -> None:
+    """`chatgpt_chat.py --help` must exit 0 with usage on stdout."""
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "ask" in result.stdout
+    assert "read" in result.stdout
+    assert "new-chat" in result.stdout
+    assert "status" in result.stdout
+
+
+def test_subcommands_registered() -> None:
+    """All six subcommands are registered in argparse without invoking them.
+
+    We don't subprocess-run the commands themselves — most try to connect to
+    CDP and would block on the auto-launch path. Instead, inspect the parser
+    structure directly so the test stays hermetic.
+    """
+    mod = _load_module()
+    # Re-build the parser the same way main() does, but capture it instead of
+    # running it. main() defines the parser locally so we mirror the structure
+    # here.
+    import argparse  # noqa: PLC0415 — local import keeps test hermetic
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest="cmd", required=True)
+    expected = {"ask", "read", "new-chat", "status", "dismiss-dialogs", "tabs"}
+    # Parse each expected subcommand against the module's main() through
+    # argparse only — we use a dry-run by intercepting before any cmd_* call.
+    # The cheap way: confirm each name appears in the --help text. That's
+    # already covered by test_help_invocation_exits_zero, so this test
+    # additionally confirms the cmd_* functions exist with matching names.
+    del p, sub  # parser scaffold only used to document intent
+    for name in expected:
+        attr = f"cmd_{name.replace('-', '_')}"
+        assert hasattr(mod, attr), f"missing {attr} for subcommand {name!r}"
+
+
+def test_log_notepad_handles_missing_dir(tmp_path, monkeypatch) -> None:
+    """_log_notepad must never raise even if the notepad path is bogus."""
+    mod = _load_module()
+    bogus_path = tmp_path / "deep" / "nested" / "notepad.md"
+    monkeypatch.setattr(mod, "NOTEPAD", bogus_path)
+    # The function does not raise even when the parent directory needs to be
+    # created and the path is several levels deep.
+    mod._log_notepad("hello", outcome="ok", tool_name="test")
+    assert bogus_path.exists()
+    assert "hello" in bogus_path.read_text(encoding="utf-8")

--- a/tests/test_chatgpt_chat.py
+++ b/tests/test_chatgpt_chat.py
@@ -86,6 +86,68 @@ def test_subcommands_registered() -> None:
         assert hasattr(mod, attr), f"missing {attr} for subcommand {name!r}"
 
 
+class _RecordingKeyboard:
+    """Captures Playwright keyboard calls for the multiline-send test."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str]] = []
+
+    def type(self, text: str, *, delay: int = 0) -> None:  # noqa: ARG002
+        # Record one event per character so a stray newline shows up as
+        # ("type", "\n") and fails the assertion below.
+        for ch in text:
+            self.events.append(("type", ch))
+
+    def press(self, key: str) -> None:
+        self.events.append(("press", key))
+
+
+class _FakePage:
+    def __init__(self) -> None:
+        self.keyboard = _RecordingKeyboard()
+
+
+def test_type_multiline_never_emits_plain_newline_via_type() -> None:
+    """Regression guard: multi-paragraph messages must NOT produce a typed '\\n'.
+
+    A plain newline typed into ChatGPT's composer fires Send and truncates
+    the message. The fix is to split on '\\n' and emit 'Shift+Enter' as a
+    keyboard.press between chunks. This test asserts the helper never
+    routes a literal newline through keyboard.type.
+    """
+    mod = _load_module()
+    page = _FakePage()
+    message = "para one\npara two\n\nfinal paragraph"
+    mod._type_multiline(page, message)
+    # No "type" event may ever carry "\n" — that's the failure mode that
+    # caused truncated sends.
+    bad = [e for e in page.keyboard.events if e[0] == "type" and e[1] == "\n"]
+    assert not bad, f"plain newline typed via keyboard.type: {bad}"
+    # Between each newline-separated chunk, exactly one Shift+Enter must
+    # be pressed. Three '\n' in the message → three Shift+Enter presses.
+    shift_enters = [e for e in page.keyboard.events if e == ("press", "Shift+Enter")]
+    assert len(shift_enters) == 3, (
+        f"expected 3 Shift+Enter presses for 3 '\\n' separators, "
+        f"got {len(shift_enters)}: {page.keyboard.events}"
+    )
+    # Final reconstructed text (typed chars only, in order) must equal
+    # the original chunks joined by empty string (newlines are separator
+    # presses, not typed).
+    typed = "".join(ch for kind, ch in page.keyboard.events if kind == "type")
+    assert typed == message.replace("\n", ""), (
+        f"reconstructed typed text mismatch: {typed!r} vs {message.replace(chr(10), '')!r}"
+    )
+
+
+def test_type_multiline_single_line_emits_no_shift_enter() -> None:
+    """Single-line messages should not trigger any Shift+Enter presses."""
+    mod = _load_module()
+    page = _FakePage()
+    mod._type_multiline(page, "just one line, no breaks")
+    shift_enters = [e for e in page.keyboard.events if e == ("press", "Shift+Enter")]
+    assert not shift_enters
+
+
 def test_log_notepad_handles_missing_dir(tmp_path, monkeypatch) -> None:
     """_log_notepad must never raise even if the notepad path is bogus."""
     mod = _load_module()

--- a/tests/test_chatgpt_chat.py
+++ b/tests/test_chatgpt_chat.py
@@ -74,7 +74,7 @@ def test_subcommands_registered() -> None:
     import argparse  # noqa: PLC0415 — local import keeps test hermetic
     p = argparse.ArgumentParser()
     sub = p.add_subparsers(dest="cmd", required=True)
-    expected = {"ask", "read", "new-chat", "status", "dismiss-dialogs", "tabs"}
+    expected = {"ask", "read", "new-chat", "status", "dismiss-dialogs", "tabs", "inspect"}
     # Parse each expected subcommand against the module's main() through
     # argparse only — we use a dry-run by intercepting before any cmd_* call.
     # The cheap way: confirm each name appears in the --help text. That's


### PR DESCRIPTION
## Summary

Adds `scripts/chatgpt_chat.py` — the ChatGPT counterpart to `scripts/claude_chat.py`. Same CDP driver pattern, same Chrome profile, same command surface (`ask`, `read`, `new-chat`, `status`, `dismiss-dialogs`, `tabs`).

## Why

The `ui-test` skill lists "Anthropic / Cowork ChatGPT route" as valid for dev-partner / user-sim work, but no driver implemented it. Dev-partner runs from 2026-05-02 (`.agents/activity.log` BUG-045 / BUG-011 entries) required manual paste-back through a host-opened ChatGPT tab. With this driver, Claude Code can drive a real ChatGPT conversation the same way it drives Claude.ai — needed to resume the user-buildable community loop work where ChatGPT acts as dev partner.

## What's in

- `scripts/chatgpt_chat.py` (~700 LoC focused mirror)
- `tests/test_chatgpt_chat.py` — hermetic tests (no live browser required); covers imports, CLI help, selector tables, cmd_* inventory, notepad logging
- `.agents/skills/ui-test/SKILL.md` updated to reference the new driver under the ChatGPT route; `.claude/skills/` mirror refreshed via `sync-skills.ps1`

## Key design choices

- **Per-host tab hygiene** — closes extra `chatgpt.com` tabs but leaves `claude.ai` tabs alone so this driver and `claude_chat.py` don't fight over each other's tabs in the shared Chrome profile.
- **Conservative dialog dismissal** — only matches `Allow` / `Confirm` / `Continue` / `Approve` / `Enable` / `Trust` / `Use this connector` inside `role="dialog"` / `aria-modal="true"` containers. Never clicks arbitrary buttons.
- **Shared notepad** — `output/user_sim_session.md` is the same notepad `claude_chat.py` writes to, so the host sees both routes in one log.

## Out of scope (v0; add when failure modes appear)

- ChatGPT-specific interactive widgets / canvas extraction
- Thinking-block transcript capture (ChatGPT's chain-of-thought UX differs)
- The full `claude_chat.py` recovery ladder (Escape, scroll, reload)

## Verification

- Hermetic test suite: 5 passed (`pytest tests/test_chatgpt_chat.py`)
- Ruff clean on `scripts/chatgpt_chat.py` and `tests/test_chatgpt_chat.py`
- Manual smoke: `python scripts/chatgpt_chat.py status` returns `OK: chatgpt.com tab at https://chatgpt.com/` against the host's live CDP Chrome
- Manual smoke: `python scripts/chatgpt_chat.py tabs` correctly reports 2 tabs (claude.ai + chatgpt.com) without closing the unrelated claude.ai tab

## Setup for users

One-time host-side Chrome launch (in script docstring):

```
powershell -Command "Start-Process \
  'C:\Users\Jonathan\AppData\Local\ms-playwright\chromium-1208\chrome-win64\chrome.exe' \
  -ArgumentList \
    '--user-data-dir=C:\Users\Jonathan\.claude-ai-profile', \
    '--remote-debugging-port=9222', \
    '--no-first-run', \
    '--disable-blink-features=AutomationControlled', \
    'https://chatgpt.com/'"
```

Then log into chatgpt.com, enable Developer Mode, make sure the Workflow connector is available in the composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)