### PR TITLE
BUG-082: list_branch_definitions(published_only) honors versioned branches

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_versions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_versions.py
@@ -379,6 +379,24 @@ def get_branch_version(
     return _row_to_version(row)
 
 
+def list_versioned_branch_def_ids(base_path: str | Path) -> set[str]:
+    """Return the set of branch_def_ids that have at least one published version.
+
+    Used by ``list_branch_definitions(published_only=True)`` to include
+    branches whose first version was published but whose top-level
+    ``published`` column was never auto-flipped — see BUG-082. The version
+    store and the branch-definitions store are separate SQLite databases,
+    so this helper does the lookup as a distinct query and the caller
+    composes the result back into its main predicate.
+    """
+    initialize_branch_versions_db(base_path)
+    with _connect(base_path) as conn:
+        rows = conn.execute(
+            "SELECT DISTINCT branch_def_id FROM branch_versions"
+        ).fetchall()
+    return {row["branch_def_id"] for row in rows}
+
+
 def list_branch_versions(
     base_path: str | Path,
     branch_def_id: str,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
@@ -2158,7 +2158,21 @@ def list_branch_definitions(
     params: list[Any] = []
 
     if published_only:
-        clauses.append("published = 1")
+        # BUG-082: "published_only" must match branches that EITHER have
+        # the branch-level published flag set OR have at least one
+        # published version snapshot in the branch_versions table. The
+        # branch-level flag is not auto-flipped by publish_branch_version
+        # (separate write path), so a flag-only filter silently misses
+        # version-stamped branches like the autoresearch lab after its
+        # first publish_version call.
+        from workflow.branch_versions import list_versioned_branch_def_ids
+        versioned_ids = list_versioned_branch_def_ids(base_path)
+        if versioned_ids:
+            placeholders = ",".join("?" * len(versioned_ids))
+            clauses.append(f"(published = 1 OR branch_def_id IN ({placeholders}))")
+            params.extend(sorted(versioned_ids))
+        else:
+            clauses.append("published = 1")
     if author:
         clauses.append("author = ?")
         params.append(author)

--- a/tests/test_branch_definitions_db.py
+++ b/tests/test_branch_definitions_db.py
@@ -195,6 +195,37 @@ class TestListAndFilter:
         assert len(results) == 1
         assert results[0]["name"] == "alpha-branch"
 
+    def test_filter_published_includes_versioned_without_branch_flag(
+        self, db_path: Path
+    ):
+        """BUG-082 regression: branches with a published version_id but no
+        branch-level published flag must still appear in
+        ``published_only=True`` listings.
+
+        Repro shape from the slice-0 substrate-readiness probe (2026-05-13):
+        ``publish_branch_version`` mints a permanent ``branch_version_id``
+        in the branch_versions table but does not flip the branch-level
+        ``published`` flag, so the discovery filter missed branches the
+        substrate had genuinely version-stamped.
+        """
+        from workflow.branch_versions import publish_branch_version
+
+        # Reuse the insert-two helper: alpha-branch has published=1 (the
+        # already-covered legacy path); beta-branch has published=0.
+        self._insert_two(db_path)
+
+        # Mint a real published version for beta-branch — the version
+        # store records it, the branch-level flag stays False.
+        beta_def = get_branch_definition(db_path, branch_def_id="second-id")
+        publish_branch_version(db_path, beta_def)
+
+        results = list_branch_definitions(db_path, published_only=True)
+        names = sorted(item["name"] for item in results)
+        assert names == ["alpha-branch", "beta-branch"], (
+            "published_only must include a branch with a published "
+            "version_id even when its branch-level published flag is False"
+        )
+
     def test_filter_author(self, db_path: Path):
         self._insert_two(db_path)
         results = list_branch_definitions(db_path, author="bob")

--- a/workflow/branch_versions.py
+++ b/workflow/branch_versions.py
@@ -379,6 +379,24 @@ def get_branch_version(
     return _row_to_version(row)
 
 
+def list_versioned_branch_def_ids(base_path: str | Path) -> set[str]:
+    """Return the set of branch_def_ids that have at least one published version.
+
+    Used by ``list_branch_definitions(published_only=True)`` to include
+    branches whose first version was published but whose top-level
+    ``published`` column was never auto-flipped — see BUG-082. The version
+    store and the branch-definitions store are separate SQLite databases,
+    so this helper does the lookup as a distinct query and the caller
+    composes the result back into its main predicate.
+    """
+    initialize_branch_versions_db(base_path)
+    with _connect(base_path) as conn:
+        rows = conn.execute(
+            "SELECT DISTINCT branch_def_id FROM branch_versions"
+        ).fetchall()
+    return {row["branch_def_id"] for row in rows}
+
+
 def list_branch_versions(
     base_path: str | Path,
     branch_def_id: str,

--- a/workflow/daemon_server.py
+++ b/workflow/daemon_server.py
@@ -2158,7 +2158,21 @@ def list_branch_definitions(
     params: list[Any] = []
 
     if published_only:
-        clauses.append("published = 1")
+        # BUG-082: "published_only" must match branches that EITHER have
+        # the branch-level published flag set OR have at least one
+        # published version snapshot in the branch_versions table. The
+        # branch-level flag is not auto-flipped by publish_branch_version
+        # (separate write path), so a flag-only filter silently misses
+        # version-stamped branches like the autoresearch lab after its
+        # first publish_version call.
+        from workflow.branch_versions import list_versioned_branch_def_ids
+        versioned_ids = list_versioned_branch_def_ids(base_path)
+        if versioned_ids:
+            placeholders = ",".join("?" * len(versioned_ids))
+            clauses.append(f"(published = 1 OR branch_def_id IN ({placeholders}))")
+            params.extend(sorted(versioned_ids))
+        else:
+            clauses.append("published = 1")
     if author:
         clauses.append("author = ?")
         params.append(author)


### PR DESCRIPTION
Closes #842.

## Summary

`extensions action=list_branches published_only=true` used to filter only on the branch_definitions `published` column. The `publish_branch_version` write path writes to a separate `branch_versions` table without flipping the branch-level `published` flag, so a branch could have a real published `branch_version_id` and still be invisible to the production-ready discovery filter.

Surfaced today during the slice-0 substrate-readiness probe — after publishing v1 of `community_change_loop_autoresearch_lab_v1` (`e019229850f9@634815eb`), `list_branches published_only=true` still returned only the 4 historically-published branches.

## Fix

- New helper `workflow.branch_versions.list_versioned_branch_def_ids(base_path) -> set[str]` returns the set of branch_def_ids that have at least one row in `branch_versions`.
- `list_branch_definitions` in `workflow/daemon_server.py`: when `published_only=True`, OR the flag-based clause with `branch_def_id IN (versioned_ids)`. The two stores are separate SQLite databases so this is composed at the Python layer.

## Tests

- New regression test `test_filter_published_includes_versioned_without_branch_flag` — inserts two branches (one `published=True`, one `published=False`), mints a real version for the `published=False` branch via `publish_branch_version`, asserts both appear in `published_only=True` listing.
- Existing `test_filter_published` still passes (legacy flag-only path still works).

## Verification

- `pytest tests/test_branch_definitions_db.py tests/test_branch_versions.py` → 40+8 passed
- `ruff check workflow/branch_versions.py workflow/daemon_server.py tests/test_branch_definitions_db.py` → clean
- Plugin mirror synced via `python packaging/claude-plugin/build_plugin.py`

## Cross-references

- Brain page: `pages/bugs/bug-082-list-branches-published-only-true-filters-on-branch-level-pu.md`
- Slice-0 finding: `pages/notes/slice-0-substrate-readiness-finding-2026-05-13.md` (gap #6, Move C)
- Companion patch_request: PR-094 (broader discovery filter friction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)