### PR TITLE
BUG-081: patch_branch author-gates non-author callers (force=true bypass)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -1882,6 +1882,32 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
             "error": f"Branch '{bid}' not found.",
         })
 
+    # BUG-081: author-gate. Reject patch_branch on a non-author branch
+    # unless the caller explicitly passes force=true. The previous shape
+    # accepted any caller against any public branch, conflating
+    # `visibility=public` (discoverable + readable) with mutation
+    # authority. Slice-0 substrate-readiness probe 2026-05-13 demonstrated
+    # the gap by mutating a chatgpt-community-builder-authored branch
+    # from a non-author session. See pages/bugs/bug-081-... for the
+    # filing.
+    from workflow.api.engine_helpers import _current_actor
+    branch_author = (source.get("author") or "").strip()
+    caller = (_current_actor() or "").strip()
+    force_mutate = bool(kwargs.get("force", False))
+    if branch_author and caller and branch_author != caller and not force_mutate:
+        return json.dumps({
+            "status": "rejected",
+            "error": (
+                f"patch_branch denied: branch '{bid}' is authored by "
+                f"'{branch_author}'; caller is '{caller}'. Pass "
+                "force=true to mutate another author's branch, or fork "
+                "it (publish_version + build_branch with fork_from) and "
+                "amend your own copy. See BUG-081."
+            ),
+            "branch_author": branch_author,
+            "caller": caller,
+        })
+
     old_name = source.get("name", "")
     staging = BranchDefinition.from_dict(source)
 

--- a/tests/test_build_branch_summary_response.py
+++ b/tests/test_build_branch_summary_response.py
@@ -98,11 +98,22 @@ def _call_patch(branch_before, branch_after, changes_json, verbose=None):
     if verbose is not None:
         kwargs["verbose"] = str(verbose).lower()
 
+    # BUG-081: patch_branch author-gates non-author callers. These tests
+    # don't set UNIVERSE_SERVER_USER, so _current_actor() returns
+    # "anonymous" and the gate would reject mutations against a branch
+    # authored by "tester". Mock _current_actor to match the branch's
+    # author so the response-shape assertions aren't contaminated by the
+    # auth check. Auth-gate semantics are covered in
+    # test_patch_branch_auth_gate.py.
     with (
         patch("workflow.daemon_server.get_branch_definition", return_value=branch_before),
         patch("workflow.daemon_server.save_branch_definition", save_mock),
         patch("workflow.api.helpers._base_path", return_value="/fake"),
         patch("workflow.branches.BranchDefinition.validate", return_value=[]),
+        patch(
+            "workflow.api.engine_helpers._current_actor",
+            return_value=branch_before.get("author", "tester"),
+        ),
     ):
         result = _ext_branch_patch(kwargs)
     return json.loads(result)

--- a/tests/test_patch_branch_auth_gate.py
+++ b/tests/test_patch_branch_auth_gate.py
@@ -1,0 +1,153 @@
+"""BUG-081 regression: patch_branch author authority gate.
+
+Before this fix, `extensions action=patch_branch` accepted mutations
+against any branch with ``visibility:public`` regardless of who the
+branch's ``author`` field named. `visibility=public` was being treated as
+"anyone can mutate," not "anyone can fork or read." Slice-0 substrate
+probe 2026-05-13 demonstrated the gap by mutating a
+chatgpt-community-builder-authored branch from a non-author session.
+
+Fix: when the caller (``UNIVERSE_SERVER_USER``) differs from the branch's
+``author``, patch_branch rejects with an auth error unless ``force=true``
+is explicitly passed.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def ext_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    base = tmp_path / "output"
+    base.mkdir()
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(base))
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "alice")
+    from workflow import universe_server as us
+
+    importlib.reload(us)
+    yield us, base, monkeypatch
+    importlib.reload(us)
+
+
+def _call(us, tool: str, action: str, **kwargs):
+    fn = getattr(us, tool)
+    return json.loads(fn(action=action, **kwargs))
+
+
+def _build_as_alice(us) -> str:
+    """Build a minimal branch authored by 'alice' (set by ext_env)."""
+    spec = {
+        "name": "alice-branch",
+        "tags": ["initial"],
+        "entry_point": "capture",
+        "node_defs": [{
+            "node_id": "capture",
+            "display_name": "Capture",
+            "prompt_template": "cap: {x}",
+        }],
+        "edges": [
+            {"from": "START", "to": "capture"},
+            {"from": "capture", "to": "END"},
+        ],
+        "state_schema": [{"name": "x", "type": "str"}],
+    }
+    res = _call(us, "extensions", "build_branch", spec_json=json.dumps(spec))
+    assert res["status"] == "built", res
+    return res["branch_def_id"]
+
+
+def _patch_tags(us, bid: str, *, force: bool = False):
+    return _call(
+        us, "extensions", "patch_branch",
+        branch_def_id=bid,
+        changes_json=json.dumps([{"op": "set_tags", "tags": ["amended"]}]),
+        force=force,
+    )
+
+
+class TestPatchBranchAuthGate:
+
+    def test_author_can_patch_own_branch(self, ext_env):
+        """The branch author can always patch their own branch."""
+        us, _base, _monkeypatch = ext_env
+        bid = _build_as_alice(us)  # caller = alice = author
+        res = _patch_tags(us, bid)
+        assert res["status"] == "patched", res
+        assert res["patched_fields"] == ["tags"]
+
+    def test_non_author_is_rejected(self, ext_env):
+        """A different caller is rejected without force=true."""
+        us, _base, monkeypatch = ext_env
+        bid = _build_as_alice(us)  # author = alice
+
+        # Switch to bob and try to mutate alice's branch.
+        monkeypatch.setenv("UNIVERSE_SERVER_USER", "bob")
+        importlib.reload(__import__("workflow.universe_server", fromlist=["x"]))
+        from workflow import universe_server as us_bob
+
+        res = _patch_tags(us_bob, bid)
+        assert res["status"] == "rejected", res
+        assert "denied" in res["error"].lower()
+        assert res.get("branch_author") == "alice"
+        assert res.get("caller") == "bob"
+
+    def test_non_author_can_force_through(self, ext_env):
+        """force=true bypasses the auth gate (escape hatch for ops)."""
+        us, _base, monkeypatch = ext_env
+        bid = _build_as_alice(us)  # author = alice
+
+        monkeypatch.setenv("UNIVERSE_SERVER_USER", "bob")
+        importlib.reload(__import__("workflow.universe_server", fromlist=["x"]))
+        from workflow import universe_server as us_bob
+
+        res = _patch_tags(us_bob, bid, force=True)
+        assert res["status"] == "patched", res
+        assert res["patched_fields"] == ["tags"]
+
+    def test_anonymous_branch_still_gated(self, ext_env):
+        """Even branches authored by 'anonymous' require force from non-anon
+        callers — anonymous authorship is not a free-mutation pass.
+
+        Otherwise the substrate would treat the default un-attributed
+        identity as a "anyone can mutate this" marker, which inverts the
+        intended safety property.
+        """
+        us, _base, monkeypatch = ext_env
+
+        # Build the branch as anonymous.
+        monkeypatch.setenv("UNIVERSE_SERVER_USER", "anonymous")
+        importlib.reload(__import__("workflow.universe_server", fromlist=["x"]))
+        from workflow import universe_server as us_anon
+        bid = _build_as_alice(us_anon)  # author = anonymous
+
+        # alice tries to mutate the anonymous-authored branch.
+        monkeypatch.setenv("UNIVERSE_SERVER_USER", "alice")
+        importlib.reload(__import__("workflow.universe_server", fromlist=["x"]))
+        from workflow import universe_server as us_alice
+
+        res = _patch_tags(us_alice, bid)
+        assert res["status"] == "rejected", res
+        assert res.get("branch_author") == "anonymous"
+        assert res.get("caller") == "alice"
+
+    def test_anonymous_caller_against_authored_branch_is_rejected(self, ext_env):
+        """An anonymous caller is also rejected when trying to mutate an
+        authored branch. Anonymous is the most-restrictive identity, not
+        the least.
+        """
+        us, _base, monkeypatch = ext_env
+        bid = _build_as_alice(us)  # author = alice
+
+        monkeypatch.setenv("UNIVERSE_SERVER_USER", "anonymous")
+        importlib.reload(__import__("workflow.universe_server", fromlist=["x"]))
+        from workflow import universe_server as us_anon
+
+        res = _patch_tags(us_anon, bid)
+        assert res["status"] == "rejected", res
+        assert res.get("branch_author") == "alice"
+        assert res.get("caller") == "anonymous"

--- a/tests/test_patch_branch_readback.py
+++ b/tests/test_patch_branch_readback.py
@@ -37,11 +37,22 @@ def _call_patch(branch_before, branch_after, changes_json):
 
     save_mock = MagicMock(return_value=branch_after)
 
+    # BUG-081: patch_branch now author-gates non-author callers. These
+    # tests build a branch with author="tester" but don't set
+    # UNIVERSE_SERVER_USER — so _current_actor() returns "anonymous"
+    # by default and the gate would reject. Mock _current_actor to
+    # return the branch's author so the readback-shape assertions are
+    # not contaminated by the auth check. Tests covering the auth
+    # behavior itself live in test_patch_branch_auth_gate.py.
     with (
         patch("workflow.daemon_server.get_branch_definition", return_value=branch_before),
         patch("workflow.daemon_server.save_branch_definition", save_mock),
         patch("workflow.api.helpers._base_path", return_value="/fake"),
         patch("workflow.branches.BranchDefinition.validate", return_value=[]),
+        patch(
+            "workflow.api.engine_helpers._current_actor",
+            return_value=branch_before.get("author", "tester"),
+        ),
     ):
         result = _ext_branch_patch({
             "branch_def_id": branch_before["branch_def_id"],

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -1882,6 +1882,32 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
             "error": f"Branch '{bid}' not found.",
         })
 
+    # BUG-081: author-gate. Reject patch_branch on a non-author branch
+    # unless the caller explicitly passes force=true. The previous shape
+    # accepted any caller against any public branch, conflating
+    # `visibility=public` (discoverable + readable) with mutation
+    # authority. Slice-0 substrate-readiness probe 2026-05-13 demonstrated
+    # the gap by mutating a chatgpt-community-builder-authored branch
+    # from a non-author session. See pages/bugs/bug-081-... for the
+    # filing.
+    from workflow.api.engine_helpers import _current_actor
+    branch_author = (source.get("author") or "").strip()
+    caller = (_current_actor() or "").strip()
+    force_mutate = bool(kwargs.get("force", False))
+    if branch_author and caller and branch_author != caller and not force_mutate:
+        return json.dumps({
+            "status": "rejected",
+            "error": (
+                f"patch_branch denied: branch '{bid}' is authored by "
+                f"'{branch_author}'; caller is '{caller}'. Pass "
+                "force=true to mutate another author's branch, or fork "
+                "it (publish_version + build_branch with fork_from) and "
+                "amend your own copy. See BUG-081."
+            ),
+            "branch_author": branch_author,
+            "caller": caller,
+        })
+
     old_name = source.get("name", "")
     staging = BranchDefinition.from_dict(source)
 


### PR DESCRIPTION
Closes #841.

## Summary

`extensions action=patch_branch` used to accept mutations against any branch with `visibility:public` regardless of who the branch's `author` field named. `visibility:public` was being treated as "anyone can mutate," not "anyone can fork or read."

Slice-0 substrate-readiness probe 2026-05-13 demonstrated the gap: caller `claude-code-slice-0-probe` successfully mutated `community_change_loop_autoresearch_lab_v1` (authored by `chatgpt-community-builder`) with no permission warning.

## Fix

In `workflow/api/branches.py::_ext_branch_patch`, after fetching the source branch:

- Compare `_current_actor()` (from `UNIVERSE_SERVER_USER`) against `source.author`.
- When they differ AND both non-empty AND caller didn't pass `force=true`, reject with an auth-error response.
- Rejection includes `branch_author` and `caller` fields so the caller can decide between (a) fork via `publish_version` + `build_branch` with `fork_from`, (b) re-call with `force=true`, or (c) give up.

**Anonymous handling:** branches authored by `"anonymous"` are NOT special-cased — a non-anonymous caller still requires `force=true`. Anonymous authorship is the most-restrictive identity, not a free-mutation pass. Anonymous callers against authored branches are also rejected (defense-in-depth).

## Tests

- New: `tests/test_patch_branch_auth_gate.py` — 5 tests covering author-patches-own / non-author-rejected / force-bypass / anonymous-branch-still-gated / anonymous-caller-rejected.
- Updated: 2 existing test files (`test_patch_branch_readback.py`, `test_build_branch_summary_response.py`) that used `_ext_branch_patch` with mock branches authored by `"tester"` but didn't set `UNIVERSE_SERVER_USER`. Their `_call_patch` helpers now mock `_current_actor` to match the branch's author field — these tests verify response-shape, not auth.

## Verification

- `pytest tests/test_patch_branch_metadata.py tests/test_patch_branch_readback.py tests/test_patch_branch_auth_gate.py tests/test_build_branch_summary_response.py tests/test_fork_from.py` → 76 passed
- `ruff check workflow/api/branches.py tests/test_patch_branch_auth_gate.py tests/test_patch_branch_readback.py tests/test_build_branch_summary_response.py` → clean
- Plugin mirror synced

## Cross-references

- Brain page: `pages/bugs/bug-081-patch-branch-has-no-authority-gate-any-caller-can-mutate-any.md`
- Slice-0 finding: `pages/notes/slice-0-substrate-readiness-finding-2026-05-13.md` (gap #4, Move B half)
- Companion: BUG-080 (in-place destructive, no versioning) — together they're Move B in the slice-0 finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)