### PR TITLE
PR-037: build_branch accepts the nested 'graph' shape returned by get_branch

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -1445,17 +1445,36 @@ def _staged_branch_from_spec(
     except ValueError as exc:
         errors.append(str(exc))
 
+    # PR-037: accept the nested `graph` shape that `get_branch` RETURNS.
+    # Without this, a user trying to fork by mirroring a live branch's
+    # response shape (`{"graph": {"edges": [...], "conditional_edges":
+    # [...], "entry_point": "..."}}`) has their edges silently dropped
+    # during staging. The validator then reports "node not reachable
+    # from entry point" — diagnostics that contradict what the submitted
+    # spec literally contains. This mirrors what
+    # `BranchDefinition.from_dict` already does for the DB-row path.
+    graph_blob = spec.get("graph") if isinstance(spec.get("graph"), dict) else None
+
+    def _spec_get(key: str, default=None):
+        """Top-level key wins; otherwise fall back to graph_blob[key]."""
+        top = spec.get(key)
+        if top is not None:
+            return top
+        if graph_blob is not None and graph_blob.get(key) is not None:
+            return graph_blob.get(key)
+        return default
+
     for idx, raw in enumerate(spec.get("node_defs") or spec.get("nodes") or []):
         err = _apply_node_spec(branch, raw)
         if err:
             errors.append(f"node[{idx}]: {err}")
 
-    for idx, raw in enumerate(spec.get("edges") or []):
+    for idx, raw in enumerate(_spec_get("edges") or []):
         err = _apply_edge_spec(branch, raw)
         if err:
             errors.append(f"edge[{idx}]: {err}")
 
-    for idx, raw in enumerate(spec.get("conditional_edges") or []):
+    for idx, raw in enumerate(_spec_get("conditional_edges") or []):
         err = _apply_conditional_edge_spec(branch, raw)
         if err:
             errors.append(f"conditional_edge[{idx}]: {err}")
@@ -1466,6 +1485,8 @@ def _staged_branch_from_spec(
             errors.append(f"state_schema[{idx}]: {err}")
 
     entry = (spec.get("entry_point") or "").strip()
+    if not entry and graph_blob is not None:
+        entry = (graph_blob.get("entry_point") or "").strip()
     if entry:
         branch.entry_point = entry
 

--- a/tests/test_build_branch_nested_graph_shape.py
+++ b/tests/test_build_branch_nested_graph_shape.py
@@ -1,0 +1,185 @@
+"""PR-037 regression: build_branch accepts the nested ``graph`` shape.
+
+Before this fix, ``_staged_branch_from_spec`` read only top-level
+``spec["edges"]`` / ``spec["conditional_edges"]`` / ``spec["entry_point"]``.
+But the shape ``extensions action=get_branch`` RETURNS nests these inside
+a top-level ``graph`` dict — exactly the shape a user trying to fork by
+mirroring the live branch would re-submit. The result: edges silently
+dropped during staging, validator reports "node not reachable from entry
+point" with diagnostics that contradict what the submitted spec literally
+contains. See PR-037 brain page + slice-0 substrate-readiness finding
+2026-05-13.
+
+These tests submit specs with the nested ``graph`` shape and assert that
+the resulting staged branch has the expected edges, conditional edges,
+and entry_point copied through.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def ext_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    base = tmp_path / "output"
+    base.mkdir()
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(base))
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "tester")
+    from workflow import universe_server as us
+
+    importlib.reload(us)
+    yield us
+    importlib.reload(us)
+
+
+def _call(us, **kwargs):
+    return json.loads(us.extensions(**kwargs))
+
+
+def _two_node_spec_nested_graph() -> dict:
+    """Spec mirroring what ``get_branch`` would return for a 2-node branch.
+
+    Note the nested ``graph`` with ``edges`` + ``entry_point`` inside — the
+    shape PR-037 documented as failing pre-fix.
+    """
+    return {
+        "name": "pr-037-regression-nested",
+        "tags": ["test"],
+        "state_schema": [{"name": "x", "type": "str"}],
+        "graph": {
+            "entry_point": "classify",
+            "nodes": [
+                {"id": "classify", "node_def_id": "classify", "position": 0},
+                {"id": "end_marker", "node_def_id": "end_marker", "position": 1},
+            ],
+            "edges": [
+                {"from": "classify", "to": "end_marker"},
+                {"from": "end_marker", "to": "END"},
+            ],
+            "conditional_edges": [],
+        },
+        "node_defs": [
+            {
+                "node_id": "classify",
+                "display_name": "Classify",
+                "input_keys": ["x"],
+                "output_keys": ["y"],
+                "prompt_template": "classify {x}",
+                "phase": "custom",
+                "enabled": True,
+            },
+            {
+                "node_id": "end_marker",
+                "display_name": "End Marker",
+                "input_keys": ["y"],
+                "output_keys": [],
+                "prompt_template": "done",
+                "phase": "custom",
+                "enabled": True,
+            },
+        ],
+    }
+
+
+def test_nested_graph_shape_accepted_by_build_branch(ext_env):
+    """The canonical PR-037 failure shape now builds cleanly."""
+    us = ext_env
+    spec = _two_node_spec_nested_graph()
+    res = _call(us, action="build_branch", spec_json=json.dumps(spec))
+    assert res.get("status") == "built", res
+    # Edge count + entry_point came through from the nested graph blob.
+    assert res.get("edge_count") == 2  # classify->end_marker + end_marker->END
+    assert res.get("entry_point") == "classify"
+    assert res.get("node_count") == 2
+
+
+def test_top_level_keys_still_win_when_both_present(ext_env):
+    """If a spec has BOTH top-level edges AND graph.edges, top-level wins.
+
+    This mirrors `BranchDefinition.from_dict`'s precedence and keeps the
+    legacy / canonical write path stable.
+    """
+    us = ext_env
+    spec = _two_node_spec_nested_graph()
+    # Override at top level. The graph.edges values should be ignored
+    # because top-level takes precedence.
+    spec["edges"] = [
+        {"from": "classify", "to": "end_marker"},
+        {"from": "end_marker", "to": "END"},
+    ]
+    spec["entry_point"] = "classify"
+    res = _call(us, action="build_branch", spec_json=json.dumps(spec))
+    assert res.get("status") == "built", res
+    assert res.get("edge_count") == 2
+
+
+def test_nested_graph_entry_point_used_when_top_level_missing(ext_env):
+    """`graph.entry_point` should be used when no top-level entry_point."""
+    us = ext_env
+    spec = _two_node_spec_nested_graph()
+    # The fixture spec has no top-level entry_point — only graph.entry_point.
+    assert "entry_point" not in {k for k in spec if k != "graph"}
+    res = _call(us, action="build_branch", spec_json=json.dumps(spec))
+    assert res.get("status") == "built", res
+    assert res.get("entry_point") == "classify"
+
+
+def test_nested_graph_conditional_edges_read(ext_env):
+    """conditional_edges inside `graph` should also flow through."""
+    us = ext_env
+    spec = _two_node_spec_nested_graph()
+    spec["graph"]["edges"] = [{"from": "end_marker", "to": "END"}]
+    spec["graph"]["conditional_edges"] = [
+        {
+            "from": "classify",
+            "conditions": {"done": "end_marker"},
+        },
+    ]
+    res = _call(us, action="build_branch", spec_json=json.dumps(spec))
+    assert res.get("status") == "built", res
+    # Conditional edges count toward graph reachability — branch built ok.
+    assert res.get("node_count") == 2
+
+
+def test_round_trip_get_branch_then_build_branch_works(ext_env):
+    """A user can fork a built branch by re-submitting its `get_branch` shape.
+
+    End-to-end:
+    1. Build a branch
+    2. Call get_branch on it -> read the response (nested graph shape)
+    3. Submit that response as a new build_branch spec (with renamed `name`)
+    4. The new branch builds cleanly and matches the source structurally
+    """
+    us = ext_env
+    spec_a = _two_node_spec_nested_graph()
+    res_a = _call(us, action="build_branch", spec_json=json.dumps(spec_a))
+    assert res_a.get("status") == "built", res_a
+    bid_a = res_a["branch_def_id"]
+
+    # Read the live shape back
+    src = _call(us, action="get_branch", branch_def_id=bid_a)
+    assert src.get("name") == spec_a["name"]
+    # Forge a fork spec from the live shape (just rename).
+    fork_spec = dict(src)
+    fork_spec["name"] = "pr-037-regression-fork"
+    fork_spec.pop("branch_def_id", None)
+    fork_spec.pop("created_at", None)
+    fork_spec.pop("updated_at", None)
+    fork_spec.pop("stats", None)
+    fork_spec.pop("published", None)
+    fork_spec.pop("version", None)
+    fork_spec.pop("parent_def_id", None)
+    fork_spec.pop("fork_from", None)
+    fork_spec.pop("visibility", None)
+    fork_spec.pop("gate_claims", None)
+
+    res_b = _call(us, action="build_branch", spec_json=json.dumps(fork_spec))
+    assert res_b.get("status") == "built", res_b
+    assert res_b.get("edge_count") == res_a.get("edge_count")
+    assert res_b.get("entry_point") == res_a.get("entry_point")
+    assert res_b.get("node_count") == res_a.get("node_count")

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -1445,17 +1445,36 @@ def _staged_branch_from_spec(
     except ValueError as exc:
         errors.append(str(exc))
 
+    # PR-037: accept the nested `graph` shape that `get_branch` RETURNS.
+    # Without this, a user trying to fork by mirroring a live branch's
+    # response shape (`{"graph": {"edges": [...], "conditional_edges":
+    # [...], "entry_point": "..."}}`) has their edges silently dropped
+    # during staging. The validator then reports "node not reachable
+    # from entry point" — diagnostics that contradict what the submitted
+    # spec literally contains. This mirrors what
+    # `BranchDefinition.from_dict` already does for the DB-row path.
+    graph_blob = spec.get("graph") if isinstance(spec.get("graph"), dict) else None
+
+    def _spec_get(key: str, default=None):
+        """Top-level key wins; otherwise fall back to graph_blob[key]."""
+        top = spec.get(key)
+        if top is not None:
+            return top
+        if graph_blob is not None and graph_blob.get(key) is not None:
+            return graph_blob.get(key)
+        return default
+
     for idx, raw in enumerate(spec.get("node_defs") or spec.get("nodes") or []):
         err = _apply_node_spec(branch, raw)
         if err:
             errors.append(f"node[{idx}]: {err}")
 
-    for idx, raw in enumerate(spec.get("edges") or []):
+    for idx, raw in enumerate(_spec_get("edges") or []):
         err = _apply_edge_spec(branch, raw)
         if err:
             errors.append(f"edge[{idx}]: {err}")
 
-    for idx, raw in enumerate(spec.get("conditional_edges") or []):
+    for idx, raw in enumerate(_spec_get("conditional_edges") or []):
         err = _apply_conditional_edge_spec(branch, raw)
         if err:
             errors.append(f"conditional_edge[{idx}]: {err}")
@@ -1466,6 +1485,8 @@ def _staged_branch_from_spec(
             errors.append(f"state_schema[{idx}]: {err}")
 
     entry = (spec.get("entry_point") or "").strip()
+    if not entry and graph_blob is not None:
+        entry = (graph_blob.get("entry_point") or "").strip()
     if entry:
         branch.entry_point = entry
 


### PR DESCRIPTION
Closes #843.

## Summary

`_staged_branch_from_spec` previously read only top-level `spec["edges"]` / `spec["conditional_edges"]` / `spec["entry_point"]`. But the shape `extensions action=get_branch` RETURNS nests these inside a top-level `graph` dict — exactly the shape a user trying to fork by mirroring a live branch would re-submit.

**Result before this fix:** edges and conditional_edges silently dropped during staging → validator reports "Graph node X is not reachable from entry point Y" → diagnostics that contradict what the submitted spec literally contains.

This is the wall slice-0 hit today (see `pages/notes/slice-0-substrate-readiness-finding-2026-05-13.md`) and the wall PR-037 originally documented.

## Fix

In `workflow/api/branches.py::_staged_branch_from_spec`:

- If `spec["graph"]` is a dict, treat it as a fallback source for `edges`, `conditional_edges`, and `entry_point`.
- Top-level keys win when both are present (legacy precedence preserved).
- `entry_point` falls back to `graph.entry_point` when there's no top-level entry_point.

This mirrors what `BranchDefinition.from_dict` already does for the DB-row path. The two write paths now agree on the read shape.

## Tests (5 new)

- `test_nested_graph_shape_accepted_by_build_branch` — canonical PR-037 failure shape now builds.
- `test_top_level_keys_still_win_when_both_present` — precedence preserved.
- `test_nested_graph_entry_point_used_when_top_level_missing` — entry_point fallback.
- `test_nested_graph_conditional_edges_read` — conditional_edges in graph flow through.
- `test_round_trip_get_branch_then_build_branch_works` — end-to-end: build, get_branch, submit response back as fork spec. This is the user-buildable "grab similar shape and modify" workflow.

## Verification

- `pytest tests/test_build_branch_nested_graph_shape.py tests/test_build_branch_summary_response.py tests/test_fork_from.py` → 51 passed
- `ruff check workflow/api/branches.py tests/test_build_branch_nested_graph_shape.py` → clean
- Plugin mirror synced via `python packaging/claude-plugin/build_plugin.py`

## Note on PR-037's other concern

PR-037 also reported diagnostic-message clarity (the "Nodes in cycle without exit condition" wording for a node that simply lacks an edge to END). That's a separate concern and not addressed here; this fix is scoped to making the validator actually SEE the edges when the caller submits them under `graph.edges`. With this fix, the staging output matches the submitted spec.

## Cross-references

- Brain page: `pages/patch-requests/pr-037-build-branch-diagnostics-contradict-submitted-spec-chat-auth.md`
- Slice-0 finding: `pages/notes/slice-0-substrate-readiness-finding-2026-05-13.md` (gap #1)
- This fix is a precondition for Move A (clone-with-inherit, PR-110) — once submitted specs are read faithfully, fork-from-published becomes the next substrate move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)