### PR TITLE
PR-094: list_branches default flips to published_only=True (fresh-user UX)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -520,7 +520,12 @@ def extensions(
     node_ref_json: str = "",
     intent: str = "",
     node_query: str = "",
-    published_only: bool = False,
+    # PR-094: default flipped to True so fresh-user chatbots calling
+    # list_branches without args see only forkable production-ready
+    # branches, not the 35+ smoke/probe/test artifacts that accumulate
+    # during substrate development. Callers wanting all branches must
+    # pass published_only=False explicitly.
+    published_only: bool = True,
     force: bool = False,
     project_id: str = "",
     key: str = "",

--- a/tests/test_branch_authoring_actions.py
+++ b/tests/test_branch_authoring_actions.py
@@ -58,15 +58,45 @@ def test_create_branch_requires_name(branch_env):
 
 
 def test_list_branches_returns_summaries(branch_env):
+    """All-branches listing for callers that explicitly opt in.
+
+    PR-094 flipped the MCP-tool default of ``published_only`` from False
+    to True so fresh-user chatbots see only forkable production-ready
+    branches by default. Callers wanting all branches (drafts, probes,
+    smoke tests) must explicitly pass ``published_only=False``.
+    """
     us, _ = branch_env
     _call(us, "create_branch", name="A")
     _call(us, "create_branch", name="B")
 
-    listing = _call(us, "list_branches")
+    listing = _call(us, "list_branches", published_only=False)
     assert listing["count"] == 2
     names = sorted(b["name"] for b in listing["branches"])
     assert names == ["A", "B"]
     assert all("node_count" in b for b in listing["branches"])
+
+
+def test_list_branches_default_filters_to_published(branch_env):
+    """PR-094: the MCP-tool default for list_branches is now
+    ``published_only=True``. Fresh-user chatbots calling without args
+    see only forkable production-ready branches — not the 35 smoke /
+    probe / test artifacts that accumulate during substrate development.
+
+    Repro: create 2 unpublished draft branches; default list_branches
+    must return 0. Explicitly request all-branches with
+    ``published_only=False`` to retrieve them.
+    """
+    us, _ = branch_env
+    _call(us, "create_branch", name="DraftOne")
+    _call(us, "create_branch", name="DraftTwo")
+
+    # Default — chatbot caller sees only published.
+    default_listing = _call(us, "list_branches")
+    assert default_listing["count"] == 0
+
+    # Explicit opt-in — gets the drafts back.
+    all_listing = _call(us, "list_branches", published_only=False)
+    assert all_listing["count"] == 2
 
 
 def test_list_branches_published_only_filter(branch_env):
@@ -129,7 +159,9 @@ def test_list_branches_node_count_matches_node_defs_length(branch_env):
     )
 
     # list_branches.node_count must match.
-    listing = _call(us, "list_branches")
+    # PR-094: default flipped to published_only=True; this draft branch
+    # is unpublished so we must explicitly opt into all-branches.
+    listing = _call(us, "list_branches", published_only=False)
     entry = next(b for b in listing["branches"] if b["branch_def_id"] == bid)
     assert entry["node_count"] == expected, (
         f"list_branches.node_count ({entry['node_count']}) "

--- a/tests/test_goals_surface.py
+++ b/tests/test_goals_surface.py
@@ -259,7 +259,13 @@ def test_list_branches_goal_id_filter(p5_env):
     _call(us, "goals", "bind", branch_def_id=b2, goal_id=gid1)
     _call(us, "goals", "bind", branch_def_id=b3, goal_id=gid2)
 
-    result = _call(us, "extensions", "list_branches", goal_id=gid1)
+    # PR-094: list_branches MCP-tool default is published_only=True;
+    # these test branches are drafts so we must explicitly opt into
+    # all-branches via published_only=False.
+    result = _call(
+        us, "extensions", "list_branches",
+        goal_id=gid1, published_only=False,
+    )
     assert result["count"] == 2
     ids = {b["branch_def_id"] for b in result["branches"]}
     assert ids == {b1, b2}

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -520,7 +520,12 @@ def extensions(
     node_ref_json: str = "",
     intent: str = "",
     node_query: str = "",
-    published_only: bool = False,
+    # PR-094: default flipped to True so fresh-user chatbots calling
+    # list_branches without args see only forkable production-ready
+    # branches, not the 35+ smoke/probe/test artifacts that accumulate
+    # during substrate development. Callers wanting all branches must
+    # pass published_only=False explicitly.
+    published_only: bool = True,
     force: bool = False,
     project_id: str = "",
     key: str = "",


### PR DESCRIPTION
Closes #844.

## Summary

Cowork's user-onboarding friction scout (2026-05-10) found `extensions action=list_branches` returns 35 unpublished smoke/probe/test artifacts alongside 4 published branches. Fresh-user chatbots trying to find "branches I can fork toward goal X" see mostly noise (`probe_typed_output_2026_04_22`, `BUG-045 live invoke authoring proof 1777698663`, etc.).

The `published_only` flag already existed but defaulted to `False`.

## Fix

Flip the MCP-tool default for `extensions.list_branches` from `published_only=False` to `published_only=True`. Fresh-user chatbots calling without args now see only forkable production-ready branches. Callers wanting all branches (drafts, probes, smoke) must pass `published_only=False` explicitly.

## Breaking change

This flips the default. Three existing tests updated to opt into all-branches behaviour explicitly:
- `test_list_branches_returns_summaries`
- `test_list_branches_node_count_matches_node_defs_length`
- `test_list_branches_goal_id_filter`

New test `test_list_branches_default_filters_to_published` documents the new default.

## Verification

- `pytest tests/test_branch_authoring_actions.py tests/test_goals_surface.py tests/test_universe_server_framing.py tests/test_text_channel_id_redaction.py` → 89 passed
- `ruff check workflow/universe_server.py + updated tests` → clean
- Plugin mirror synced

## Sibling concern not addressed

PR-094's brain page proposes "server-side cleanup of stale smoke/probe artifacts" (delete or archive branches matching `probe_*`, `BUG-* proof *`, `* smoke *` patterns >30 days old). That's orthogonal cleanup; this PR scopes only to the default-flip.

## Pre-existing failure note

`tests/test_inspect_cross_surface_hint.py::TestPromptCrossDomainRule::test_prompt_cross_domain_pivot_rule_present` fails on `origin/main` (asserts `"fantasy-only" in _CONTROL_STATION_PROMPT` but the string isn't in main's `prompts.py`). Verified failure pre-exists this change; not caused by PR-094.

## Cross-references

- Brain page: `pages/patch-requests/pr-094-extensions-action-list-branches-surfaces-35-unpublished-smok.md`
- Companion: BUG-082 / PR #845 (filter handles versioned branches). With both fixes, `list_branches published_only=True` correctly includes branches with published version_ids whose top-level published flag is unset.
- Slice-0 finding: `pages/notes/slice-0-substrate-readiness-finding-2026-05-13.md` (companion to gap #6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)