### PR TITLE
BUG-080: patch_branch auto-snapshots post-state as a branch_version_id

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -1939,6 +1939,31 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
     saved = save_branch_definition(_base_path(), branch_def=staging.to_dict())
     persisted = BranchDefinition.from_dict(saved)
 
+    # BUG-080: snapshot the post-patch state as an immutable
+    # branch_version_id so callers can compare before/after, roll back
+    # via fork_from, and reason about which historical version produced
+    # a given run. Previous behavior was in-place mutation with no
+    # version preservation, which broke the "fork → compare → keep
+    # best" promise the autoresearch lab itself is built on. Skip the
+    # snapshot when ops_applied == 0 (no-op patches don't deserve a
+    # new version).
+    new_version_id = None
+    if len(changes) > 0:
+        try:
+            from workflow.branch_versions import publish_branch_version
+            new_version = publish_branch_version(
+                _base_path(),
+                saved,
+                notes="auto-snapshot from patch_branch (BUG-080)",
+            )
+            new_version_id = new_version.branch_version_id
+        except Exception as exc:  # noqa: BLE001 — snapshot is best-effort
+            # If the version store is unavailable for any reason,
+            # patch_branch still succeeds — the mutation is the primary
+            # contract. The snapshot is observability; log the failure
+            # in the response but don't fail the patch.
+            new_version_id = f"snapshot_failed: {exc.__class__.__name__}"
+
     _SKIP_DIFF = {"updated_at", "created_at", "node_defs", "edges",
                   "conditional_edges", "graph_nodes", "state_schema", "stats"}
     patched_fields = [
@@ -1984,6 +2009,7 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
         "name_updated": name_updated,
         "new_name": persisted.name,
         "post_patch": post_patch,
+        "branch_version_id": new_version_id,
     }
     if verbose:
         patch_payload["branch"] = saved

--- a/tests/test_patch_branch_versioning.py
+++ b/tests/test_patch_branch_versioning.py
@@ -1,0 +1,174 @@
+"""BUG-080 regression: patch_branch auto-snapshots post-state as a version.
+
+Before this fix, `extensions action=patch_branch` mutated a branch in
+place. The branch's `version` field stayed at its old value, no
+`branch_version_id` appeared in the response, and there was no
+preserved pre-patch version that callers could read or roll back to.
+
+Fix: after a successful patch with at least one op applied, call
+`publish_branch_version` on the post-state. The response now includes
+`branch_version_id` so callers can fork_from / compare / roll back.
+
+Slice-0 substrate-readiness probe 2026-05-13 motivated this filing —
+the mutation-in-place behavior breaks the "fork → compare → keep best"
+promise the autoresearch lab itself is built on.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def ext_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    base = tmp_path / "output"
+    base.mkdir()
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(base))
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "tester")
+    from workflow import universe_server as us
+
+    importlib.reload(us)
+    yield us, base
+    importlib.reload(us)
+
+
+def _call(us, action, **kwargs):
+    return json.loads(us.extensions(action=action, **kwargs))
+
+
+def _build(us, *, name: str = "b") -> str:
+    spec = {
+        "name": name,
+        "tags": ["initial"],
+        "entry_point": "capture",
+        "node_defs": [{
+            "node_id": "capture",
+            "display_name": "Capture",
+            "prompt_template": "cap: {x}",
+        }],
+        "edges": [
+            {"from": "START", "to": "capture"},
+            {"from": "capture", "to": "END"},
+        ],
+        "state_schema": [{"name": "x", "type": "str"}],
+    }
+    res = _call(us, "build_branch", spec_json=json.dumps(spec))
+    assert res.get("status") == "built", res
+    return res["branch_def_id"]
+
+
+def _patch_tags(us, bid: str, new_tags: list[str]):
+    return _call(
+        us, "patch_branch",
+        branch_def_id=bid,
+        changes_json=json.dumps([{"op": "set_tags", "tags": new_tags}]),
+    )
+
+
+class TestPatchBranchVersioning:
+
+    def test_patch_returns_new_branch_version_id(self, ext_env):
+        """Successful patch must include a branch_version_id in the response."""
+        us, _base = ext_env
+        bid = _build(us)
+        res = _patch_tags(us, bid, ["initial", "amended"])
+        assert res.get("status") == "patched", res
+        version_id = res.get("branch_version_id")
+        assert version_id, f"patched response missing branch_version_id: {res}"
+        assert "@" in version_id, (
+            f"branch_version_id must follow def_id@hash format; got {version_id}"
+        )
+        assert version_id.startswith(bid + "@"), (
+            f"branch_version_id must start with the branch_def_id; got {version_id}"
+        )
+
+    def test_two_topology_patches_produce_two_distinct_versions(self, ext_env):
+        """Two patches that change branch topology must produce distinct
+        version_ids. Content-hash semantics: only topology fields
+        (node_defs, edges, conditional_edges, state_schema, entry_point)
+        feed the hash — tag/description changes deliberately do NOT
+        produce a new version_id because they don't affect runtime
+        behavior.
+        """
+        us, _base = ext_env
+        bid = _build(us)
+
+        # First topology mutation: rename the node's display_name.
+        res1 = _call(
+            us, "patch_branch",
+            branch_def_id=bid,
+            changes_json=json.dumps([
+                {"op": "set_name", "name": "first-amend"},
+                {"op": "add_state_field", "name": "y", "type": "str"},
+            ]),
+        )
+        assert res1.get("status") == "patched", res1
+        v1 = res1["branch_version_id"]
+
+        # Second topology mutation: add another state field.
+        res2 = _call(
+            us, "patch_branch",
+            branch_def_id=bid,
+            changes_json=json.dumps([
+                {"op": "add_state_field", "name": "z", "type": "str"},
+            ]),
+        )
+        assert res2.get("status") == "patched", res2
+        v2 = res2["branch_version_id"]
+
+        assert v1 != v2, "two topology-changing patches must produce distinct versions"
+
+    def test_noop_patch_does_not_create_a_version(self, ext_env):
+        """An empty patch (zero ops) is not a real mutation — no version snapshot."""
+        us, _base = ext_env
+        bid = _build(us)
+        res = _call(
+            us, "patch_branch",
+            branch_def_id=bid,
+            changes_json=json.dumps([]),
+        )
+        assert res.get("status") == "patched"
+        assert res.get("ops_applied") == 0
+        assert res.get("branch_version_id") is None, (
+            "no-op patch must not create a version snapshot"
+        )
+
+    def test_version_round_trip_via_list_branch_versions(self, ext_env):
+        """The created version_id must be discoverable via list_branch_versions."""
+        from workflow.branch_versions import list_branch_versions
+
+        us, base = ext_env
+        bid = _build(us)
+        res = _patch_tags(us, bid, ["initial", "amended"])
+        v_id = res["branch_version_id"]
+
+        versions = list_branch_versions(base, bid)
+        assert any(v.branch_version_id == v_id for v in versions), (
+            f"patch-created version_id {v_id} not found in "
+            f"list_branch_versions; got {[v.branch_version_id for v in versions]}"
+        )
+
+    def test_rejected_patch_does_not_create_a_version(self, ext_env):
+        """A patch that fails validation must not leave behind a version."""
+        from workflow.branch_versions import list_branch_versions
+
+        us, base = ext_env
+        bid = _build(us)
+        before = list_branch_versions(base, bid)
+
+        # Submit an unknown op — patch_branch will reject before save.
+        res = _call(
+            us, "patch_branch",
+            branch_def_id=bid,
+            changes_json=json.dumps([{"op": "unknown_op_for_test"}]),
+        )
+        assert res.get("status") == "rejected"
+
+        after = list_branch_versions(base, bid)
+        assert len(after) == len(before), (
+            "rejected patch must not create a version snapshot"
+        )

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -1939,6 +1939,31 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
     saved = save_branch_definition(_base_path(), branch_def=staging.to_dict())
     persisted = BranchDefinition.from_dict(saved)
 
+    # BUG-080: snapshot the post-patch state as an immutable
+    # branch_version_id so callers can compare before/after, roll back
+    # via fork_from, and reason about which historical version produced
+    # a given run. Previous behavior was in-place mutation with no
+    # version preservation, which broke the "fork → compare → keep
+    # best" promise the autoresearch lab itself is built on. Skip the
+    # snapshot when ops_applied == 0 (no-op patches don't deserve a
+    # new version).
+    new_version_id = None
+    if len(changes) > 0:
+        try:
+            from workflow.branch_versions import publish_branch_version
+            new_version = publish_branch_version(
+                _base_path(),
+                saved,
+                notes="auto-snapshot from patch_branch (BUG-080)",
+            )
+            new_version_id = new_version.branch_version_id
+        except Exception as exc:  # noqa: BLE001 — snapshot is best-effort
+            # If the version store is unavailable for any reason,
+            # patch_branch still succeeds — the mutation is the primary
+            # contract. The snapshot is observability; log the failure
+            # in the response but don't fail the patch.
+            new_version_id = f"snapshot_failed: {exc.__class__.__name__}"
+
     _SKIP_DIFF = {"updated_at", "created_at", "node_defs", "edges",
                   "conditional_edges", "graph_nodes", "state_schema", "stats"}
     patched_fields = [
@@ -1984,6 +2009,7 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
         "name_updated": name_updated,
         "new_name": persisted.name,
         "post_patch": post_patch,
+        "branch_version_id": new_version_id,
     }
     if verbose:
         patch_payload["branch"] = saved


### PR DESCRIPTION
Closes #840.

## Summary

`extensions action=patch_branch` used to mutate a branch in place: `version` stayed at its old value, no `branch_version_id` appeared in the response, no pre-patch version preserved. Slice-0 substrate-readiness probe 2026-05-13 demonstrated this breaks the "fork → compare → keep best" promise the autoresearch lab itself is built on.

## Fix

After a successful patch with at least one op applied, `_ext_branch_patch` calls `workflow.branch_versions.publish_branch_version` on the post-state and includes the resulting `branch_version_id` in the response. Callers can now fork_from the snapshot, list it via `list_branch_versions`, or compare two patches' content hashes.

## Semantics

- **No-op patches** (`ops_applied == 0`) do NOT create a version — preserves existing idempotency.
- **Rejected patches** (op validation failures) do NOT create a version — publish only on successful save.
- **Snapshot is best-effort**: if the version store is unavailable, the patch still succeeds; response records `branch_version_id: "snapshot_failed: <ExceptionClass>"`.
- **Content-hash is topology-only** (`node_defs`, `edges`, `conditional_edges`, `state_schema`, `entry_point`). Tag / description / skills changes do NOT bump the version_id — they don't affect runtime behavior.

## Tests

5 new in `tests/test_patch_branch_versioning.py`:
- patch returns new `branch_version_id` in `def_id@hash` format
- two topology-changing patches produce distinct version_ids
- no-op patch does NOT create a version
- version_id is discoverable via `list_branch_versions`
- rejected patch does NOT create a version

## Verification

- `pytest tests/test_patch_branch_versioning.py tests/test_patch_branch_metadata.py tests/test_patch_branch_readback.py` → 30 passed
- `ruff check` → clean
- Plugin mirror synced

## Cross-references

- Brain page: `pages/bugs/bug-080-patch-branch-is-in-place-destructive-no-versioning-no-branch.md`
- Slice-0 finding: `pages/notes/slice-0-substrate-readiness-finding-2026-05-13.md` (gap #3)
- Companion: BUG-081 / PR #846 (patch_branch author gate) — together complete Move B's safety pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)