### PR TITLE
Move A (PR-110): build_branch fork_from now clones parent topology (clone-with-inherit)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -1445,7 +1445,97 @@ def _staged_branch_from_spec(
     except ValueError as exc:
         errors.append(str(exc))
 
+    # Move A — clone-with-inherit (PR-110). When `fork_from` points at a
+    # published `branch_version_id`, seed the staging branch from the
+    # parent version's snapshot first. The user then applies overrides
+    # via `node_overrides` (dict[node_id, partial_node_def]) and/or
+    # top-level keys that REPLACE inherited fields. This is the "users
+    # have primitives to build from scratch when needed but rarely do
+    # so because they can always grab something similar-shaped to start
+    # with" promise that slice-0 found unreachable without this fix.
+    parent_snapshot: dict[str, Any] | None = None
+    if branch.fork_from:
+        from workflow.branch_versions import get_branch_version
+
+        # If parent_version is None, the caller's downstream fork_from
+        # validator (in _ext_branch_build) will surface the error —
+        # we don't double-flag here. Only seed staging when we have a
+        # real parent to inherit from.
+        parent_version = get_branch_version(_base_path(), branch.fork_from)
+        if parent_version is not None:
+            parent_snapshot = parent_version.snapshot or {}
+
+    if parent_snapshot:
+        # Seed staging with parent's topology. Each helper handles
+        # its own dedup, so re-applying later from spec.node_defs is
+        # blocked (the caller must use node_overrides for changes
+        # to existing nodes).
+        for raw in parent_snapshot.get("node_defs") or []:
+            err = _apply_node_spec(branch, raw)
+            if err:
+                errors.append(f"parent_node_def[{raw.get('node_id', '?')}]: {err}")
+        for raw in parent_snapshot.get("edges") or []:
+            err = _apply_edge_spec(branch, raw)
+            if err:
+                errors.append(f"parent_edge[{raw.get('from', '?')}->{raw.get('to', '?')}]: {err}")
+        for raw in parent_snapshot.get("conditional_edges") or []:
+            err = _apply_conditional_edge_spec(branch, raw)
+            if err:
+                errors.append(f"parent_conditional_edge[{raw.get('from', '?')}]: {err}")
+        for raw in parent_snapshot.get("state_schema") or []:
+            err = _apply_state_field_spec(branch, raw)
+            if err:
+                errors.append(f"parent_state_field[{raw.get('name', '?')}]: {err}")
+        parent_entry = (parent_snapshot.get("entry_point") or "").strip()
+        if parent_entry:
+            branch.entry_point = parent_entry
+
+    # node_overrides: dict[node_id, partial_node_def]. For each entry,
+    # find the matching parent-inherited node_def and apply the
+    # override fields on top. Only valid when fork_from inherited a
+    # parent — overriding a node that wasn't inherited is a spec error.
+    overrides = spec.get("node_overrides") or {}
+    if overrides and not isinstance(overrides, dict):
+        errors.append(
+            "node_overrides must be a JSON object "
+            "{node_id: {field: value, ...}}"
+        )
+        overrides = {}
+    for node_id, override_fields in overrides.items():
+        if not isinstance(override_fields, dict):
+            errors.append(
+                f"node_overrides[{node_id!r}]: value must be an object"
+            )
+            continue
+        target = next(
+            (n for n in branch.node_defs if n.node_id == node_id), None
+        )
+        if target is None:
+            errors.append(
+                f"node_overrides[{node_id!r}]: no inherited node with "
+                f"that id; add a new node via node_defs instead"
+            )
+            continue
+        for field_name, value in override_fields.items():
+            # Skip fields that would invalidate identity.
+            if field_name == "node_id":
+                continue
+            if hasattr(target, field_name):
+                setattr(target, field_name, value)
+
     for idx, raw in enumerate(spec.get("node_defs") or spec.get("nodes") or []):
+        # If we've inherited from parent, new node_defs are ADDITIVE —
+        # they cannot collide with parent nodes (use node_overrides for
+        # changes to inherited nodes).
+        nid = (raw.get("node_id") or raw.get("id") or "").strip()
+        if parent_snapshot and nid and any(
+            n.node_id == nid for n in branch.node_defs
+        ):
+            errors.append(
+                f"node[{idx}] ({nid!r}): already inherited from parent; "
+                f"use node_overrides to amend an inherited node"
+            )
+            continue
         err = _apply_node_spec(branch, raw)
         if err:
             errors.append(f"node[{idx}]: {err}")
@@ -1461,6 +1551,9 @@ def _staged_branch_from_spec(
             errors.append(f"conditional_edge[{idx}]: {err}")
 
     for idx, raw in enumerate(spec.get("state_schema") or []):
+        # When inheriting from parent, parent's state_schema already
+        # populated branch.state_schema; new state fields are additive
+        # and dedup is enforced inside _apply_state_field_spec.
         err = _apply_state_field_spec(branch, raw)
         if err:
             errors.append(f"state_schema[{idx}]: {err}")

--- a/tests/test_fork_from.py
+++ b/tests/test_fork_from.py
@@ -74,22 +74,32 @@ class TestForkFromField:
             update_branch_definition(tmp_path, branch_def_id="b3", updates={"fork_from": bvid2})
 
     def test_build_branch_with_fork_from_roundtrips(self, tmp_path, monkeypatch):
+        """fork_from is preserved in the built branch's record.
+
+        Move A (PR-110, 2026-05-13) changed fork_from semantics: it
+        now ALSO inherits the parent's topology (node_defs / edges /
+        state_schema / entry_point) — fork_from is no longer metadata-
+        only. This test asserts both the lineage record AND the
+        inheritance: an empty fork yields a branch with parent's nodes.
+        """
         from workflow.api.branches import _ext_branch_build
 
         monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
         _seed_branch(tmp_path, "b1")
         bvid = _publish(tmp_path, "b1")
 
+        # Empty fork — Move A inherits parent's topology from the
+        # published version; the caller doesn't have to re-author n1.
         spec = json.dumps({
             "name": "Forked Branch",
             "fork_from": bvid,
-            "node_defs": [{"node_id": "n1", "display_name": "N1", "prompt_template": "hi"}],
-            "edges": [{"from_node": "n1", "to_node": "END"}],
-            "entry_point": "n1",
         })
         result = json.loads(_ext_branch_build({"spec_json": spec, "verbose": "true"}))
-        assert result["status"] == "built"
+        assert result["status"] == "built", result
         assert result["branch"]["fork_from"] == bvid
+        # Inherited the parent's n1 node + n1->END edge.
+        assert len(result["branch"]["node_defs"]) == 1
+        assert result["branch"]["node_defs"][0]["node_id"] == "n1"
 
     def test_build_branch_invalid_fork_from_rejected(self, tmp_path, monkeypatch):
         from workflow.api.branches import _ext_branch_build

--- a/tests/test_move_a_clone_with_inherit.py
+++ b/tests/test_move_a_clone_with_inherit.py
@@ -1,0 +1,331 @@
+"""Move A regression: build_branch with fork_from clones parent topology.
+
+Before this fix, ``fork_from`` was lineage metadata only — the caller
+still had to author the full spec from scratch, and the validator would
+reject any non-trivial multi-node graph. Slice-0 substrate-readiness
+finding 2026-05-13 named this the single highest-leverage substrate-
+finishing move ("Move A").
+
+Fix: when ``fork_from`` points at a published ``branch_version_id``,
+``_staged_branch_from_spec`` seeds the staging branch from the parent
+version's snapshot (node_defs, edges, conditional_edges, state_schema,
+entry_point). The caller's spec then applies overrides on top via
+``node_overrides`` (dict[node_id, partial_node_def]) or new top-level
+``node_defs`` / ``edges`` / ``state_schema`` entries.
+
+Slice-1 acceptance criteria (per the slice-1 spec):
+1. A published version can be cloned via ``build_branch fork_from=<vid>``.
+2. The clone inherits the parent's graph, nodes, state schema, lineage.
+3. A user can amend exactly one node via ``node_overrides``.
+4. The parent branch is unchanged.
+5. The clone validates past the inherited graph shape without
+   re-triggering PR-037's multi-node build wall.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def ext_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    base = tmp_path / "output"
+    base.mkdir()
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(base))
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "tester")
+    from workflow import universe_server as us
+
+    importlib.reload(us)
+    yield us, base
+    importlib.reload(us)
+
+
+def _call(us, action, **kwargs):
+    return json.loads(us.extensions(action=action, **kwargs))
+
+
+def _build_parent(us, *, name: str = "parent") -> tuple[str, str]:
+    """Build + publish a 2-node parent branch. Returns (branch_def_id, version_id)."""
+    spec = {
+        "name": name,
+        "tags": ["parent-tag"],
+        "entry_point": "classify",
+        "node_defs": [
+            {
+                "node_id": "classify",
+                "display_name": "Classify",
+                "prompt_template": "classify {x}",
+                "input_keys": ["x"],
+                "output_keys": ["y"],
+            },
+            {
+                "node_id": "end_marker",
+                "display_name": "End",
+                "prompt_template": "done",
+                "input_keys": ["y"],
+                "output_keys": [],
+            },
+        ],
+        "edges": [
+            {"from": "START", "to": "classify"},
+            {"from": "classify", "to": "end_marker"},
+            {"from": "end_marker", "to": "END"},
+        ],
+        "state_schema": [{"name": "x", "type": "str"}, {"name": "y", "type": "str"}],
+    }
+    built = _call(us, "build_branch", spec_json=json.dumps(spec))
+    assert built.get("status") == "built", built
+    bid = built["branch_def_id"]
+
+    published = _call(us, "publish_version", branch_def_id=bid)
+    vid = published.get("branch_version_id")
+    assert vid, f"publish_version did not return branch_version_id: {published}"
+    return bid, vid
+
+
+class TestMoveAcceptance:
+    """Tests #1-#5 from the slice-1 acceptance criteria."""
+
+    def test_published_version_can_be_cloned(self, ext_env):
+        """(1) Empty fork inherits parent topology byte-identically."""
+        us, _base = ext_env
+        parent_bid, parent_vid = _build_parent(us)
+
+        fork = _call(
+            us, "build_branch",
+            spec_json=json.dumps({
+                "name": "empty-fork",
+                "fork_from": parent_vid,
+            }),
+        )
+        assert fork.get("status") == "built", fork
+        # Inherited the 3 edges (incl. START + END markers) and 2 nodes.
+        assert fork.get("node_count") == 2
+        assert fork.get("edge_count") == 3
+        assert fork.get("entry_point") == "classify"
+
+    def test_clone_inherits_node_defs_state_lineage(self, ext_env):
+        """(2) Clone has the parent's node_defs, state_schema, and fork_from lineage."""
+        us, _base = ext_env
+        parent_bid, parent_vid = _build_parent(us)
+
+        fork = _call(
+            us, "build_branch",
+            spec_json=json.dumps({
+                "name": "lineage-fork",
+                "fork_from": parent_vid,
+            }),
+        )
+        assert fork.get("status") == "built", fork
+        fork_bid = fork["branch_def_id"]
+
+        described = _call(us, "get_branch", branch_def_id=fork_bid)
+        # Lineage preserved
+        assert described.get("fork_from") == parent_vid
+        # Inherited node_def_ids match parent's
+        node_ids = sorted(n["node_id"] for n in described["node_defs"])
+        assert node_ids == ["classify", "end_marker"]
+        # state_schema inherited
+        field_names = sorted(f["name"] for f in described["state_schema"])
+        assert field_names == ["x", "y"]
+        # Inherited prompt templates are present
+        classify = next(n for n in described["node_defs"] if n["node_id"] == "classify")
+        assert classify["prompt_template"] == "classify {x}"
+
+    def test_node_overrides_amend_one_node(self, ext_env):
+        """(3) node_overrides applies field-level merges to inherited nodes."""
+        us, _base = ext_env
+        parent_bid, parent_vid = _build_parent(us)
+
+        fork = _call(
+            us, "build_branch",
+            spec_json=json.dumps({
+                "name": "overrides-fork",
+                "fork_from": parent_vid,
+                "node_overrides": {
+                    "classify": {
+                        "prompt_template": "AMENDED: classify {x} differently",
+                    },
+                },
+            }),
+        )
+        assert fork.get("status") == "built", fork
+
+        described = _call(us, "get_branch", branch_def_id=fork["branch_def_id"])
+        classify = next(n for n in described["node_defs"] if n["node_id"] == "classify")
+        end_marker = next(n for n in described["node_defs"] if n["node_id"] == "end_marker")
+        assert classify["prompt_template"] == "AMENDED: classify {x} differently"
+        # Sibling node inherited verbatim
+        assert end_marker["prompt_template"] == "done"
+
+    def test_parent_branch_unchanged_after_fork(self, ext_env):
+        """(4) The parent branch is byte-identical before/after the fork."""
+        us, _base = ext_env
+        parent_bid, parent_vid = _build_parent(us)
+
+        before = _call(us, "get_branch", branch_def_id=parent_bid)
+
+        _ = _call(
+            us, "build_branch",
+            spec_json=json.dumps({
+                "name": "unchanged-test-fork",
+                "fork_from": parent_vid,
+                "node_overrides": {
+                    "classify": {"prompt_template": "amended"},
+                },
+            }),
+        )
+
+        after = _call(us, "get_branch", branch_def_id=parent_bid)
+        # Topology unchanged
+        for field in ("name", "entry_point", "graph", "node_defs", "state_schema"):
+            assert before.get(field) == after.get(field), (
+                f"parent {field!r} was mutated by the fork"
+            )
+
+    def test_clone_validates_past_pr037_wall(self, ext_env):
+        """(5) The clone path bypasses PR-037's multi-node spec re-validation.
+
+        Pre-fix, a user submitting a multi-node spec (with edges) via
+        build_branch hit PR-037's validator wall. With Move A, the
+        clone inherits the parent's already-validated topology and
+        only the overrides are validated, so multi-node forks succeed.
+        """
+        us, _base = ext_env
+        parent_bid, parent_vid = _build_parent(us)
+
+        # Submit a fork spec that, pre-Move-A, would have required
+        # passing the validator with the full multi-node graph.
+        fork = _call(
+            us, "build_branch",
+            spec_json=json.dumps({
+                "name": "pr-037-bypass-fork",
+                "fork_from": parent_vid,
+                "node_overrides": {"classify": {"prompt_template": "v2"}},
+            }),
+        )
+        # Move A goal: this succeeds without the caller having to
+        # author the full graph from scratch.
+        assert fork.get("status") == "built", fork
+        assert fork.get("node_count") == 2
+
+
+class TestMoveAEdgeCases:
+
+    def test_unknown_fork_from_version_id_still_rejected(self, ext_env):
+        """An invalid version_id surfaces the existing rejection — no
+        silent fallback to empty staging.
+        """
+        us, _base = ext_env
+        res = _call(
+            us, "build_branch",
+            spec_json=json.dumps({
+                "name": "bad-fork",
+                "fork_from": "nonexistent@deadbeef",
+                "node_overrides": {"x": {"prompt_template": "y"}},
+            }),
+        )
+        assert res.get("status") == "rejected"
+        # The fork_from validator's specific error must fire.
+        assert any(
+            "fork_from" in err and "not a known" in err
+            for err in res.get("errors", [])
+        ), res
+
+    def test_node_overrides_for_nonexistent_node_is_error(self, ext_env):
+        """Overriding a node not in the parent is a spec error, not a silent no-op."""
+        us, _base = ext_env
+        _, parent_vid = _build_parent(us)
+        res = _call(
+            us, "build_branch",
+            spec_json=json.dumps({
+                "name": "bad-override",
+                "fork_from": parent_vid,
+                "node_overrides": {
+                    "nonexistent_node": {"prompt_template": "x"},
+                },
+            }),
+        )
+        assert res.get("status") == "rejected"
+        assert any(
+            "nonexistent_node" in err and "no inherited node" in err
+            for err in res.get("errors", [])
+        ), res
+
+    def test_node_overrides_must_be_dict(self, ext_env):
+        """A malformed node_overrides shape is a spec error with a clear message."""
+        us, _base = ext_env
+        _, parent_vid = _build_parent(us)
+        res = _call(
+            us, "build_branch",
+            spec_json=json.dumps({
+                "name": "bad-shape",
+                "fork_from": parent_vid,
+                "node_overrides": ["this", "should", "be", "a", "dict"],
+            }),
+        )
+        assert res.get("status") == "rejected"
+        assert any(
+            "node_overrides" in err and "JSON object" in err
+            for err in res.get("errors", [])
+        ), res
+
+    def test_top_level_node_defs_additive_no_collision_with_parent(self, ext_env):
+        """New node_defs that don't collide with parent are additive.
+
+        The new node must connect to the inherited graph via edges or
+        the validator's reachability check will reject it. This test
+        demonstrates the user re-wires the graph: classify -> new node
+        -> end_marker -> END.
+        """
+        us, _base = ext_env
+        _, parent_vid = _build_parent(us)
+        res = _call(
+            us, "build_branch",
+            spec_json=json.dumps({
+                "name": "additive-fork",
+                "fork_from": parent_vid,
+                "node_defs": [{
+                    "node_id": "post_classify",
+                    "display_name": "Post Classify",
+                    "prompt_template": "post {y}",
+                    "input_keys": ["y"],
+                    "output_keys": [],
+                }],
+                "edges": [
+                    {"from": "classify", "to": "post_classify"},
+                    {"from": "post_classify", "to": "end_marker"},
+                ],
+            }),
+        )
+        assert res.get("status") == "built", res
+        # 2 inherited + 1 new
+        assert res.get("node_count") == 3
+
+    def test_top_level_node_def_collision_rejected(self, ext_env):
+        """A top-level node_def whose id collides with an inherited node is rejected;
+        caller must use node_overrides to amend.
+        """
+        us, _base = ext_env
+        _, parent_vid = _build_parent(us)
+        res = _call(
+            us, "build_branch",
+            spec_json=json.dumps({
+                "name": "collision-fork",
+                "fork_from": parent_vid,
+                "node_defs": [{
+                    "node_id": "classify",  # already inherited from parent
+                    "display_name": "Re-Classify",
+                    "prompt_template": "different",
+                }],
+            }),
+        )
+        assert res.get("status") == "rejected"
+        assert any(
+            "classify" in err and "node_overrides" in err
+            for err in res.get("errors", [])
+        ), res

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -1445,7 +1445,97 @@ def _staged_branch_from_spec(
     except ValueError as exc:
         errors.append(str(exc))
 
+    # Move A — clone-with-inherit (PR-110). When `fork_from` points at a
+    # published `branch_version_id`, seed the staging branch from the
+    # parent version's snapshot first. The user then applies overrides
+    # via `node_overrides` (dict[node_id, partial_node_def]) and/or
+    # top-level keys that REPLACE inherited fields. This is the "users
+    # have primitives to build from scratch when needed but rarely do
+    # so because they can always grab something similar-shaped to start
+    # with" promise that slice-0 found unreachable without this fix.
+    parent_snapshot: dict[str, Any] | None = None
+    if branch.fork_from:
+        from workflow.branch_versions import get_branch_version
+
+        # If parent_version is None, the caller's downstream fork_from
+        # validator (in _ext_branch_build) will surface the error —
+        # we don't double-flag here. Only seed staging when we have a
+        # real parent to inherit from.
+        parent_version = get_branch_version(_base_path(), branch.fork_from)
+        if parent_version is not None:
+            parent_snapshot = parent_version.snapshot or {}
+
+    if parent_snapshot:
+        # Seed staging with parent's topology. Each helper handles
+        # its own dedup, so re-applying later from spec.node_defs is
+        # blocked (the caller must use node_overrides for changes
+        # to existing nodes).
+        for raw in parent_snapshot.get("node_defs") or []:
+            err = _apply_node_spec(branch, raw)
+            if err:
+                errors.append(f"parent_node_def[{raw.get('node_id', '?')}]: {err}")
+        for raw in parent_snapshot.get("edges") or []:
+            err = _apply_edge_spec(branch, raw)
+            if err:
+                errors.append(f"parent_edge[{raw.get('from', '?')}->{raw.get('to', '?')}]: {err}")
+        for raw in parent_snapshot.get("conditional_edges") or []:
+            err = _apply_conditional_edge_spec(branch, raw)
+            if err:
+                errors.append(f"parent_conditional_edge[{raw.get('from', '?')}]: {err}")
+        for raw in parent_snapshot.get("state_schema") or []:
+            err = _apply_state_field_spec(branch, raw)
+            if err:
+                errors.append(f"parent_state_field[{raw.get('name', '?')}]: {err}")
+        parent_entry = (parent_snapshot.get("entry_point") or "").strip()
+        if parent_entry:
+            branch.entry_point = parent_entry
+
+    # node_overrides: dict[node_id, partial_node_def]. For each entry,
+    # find the matching parent-inherited node_def and apply the
+    # override fields on top. Only valid when fork_from inherited a
+    # parent — overriding a node that wasn't inherited is a spec error.
+    overrides = spec.get("node_overrides") or {}
+    if overrides and not isinstance(overrides, dict):
+        errors.append(
+            "node_overrides must be a JSON object "
+            "{node_id: {field: value, ...}}"
+        )
+        overrides = {}
+    for node_id, override_fields in overrides.items():
+        if not isinstance(override_fields, dict):
+            errors.append(
+                f"node_overrides[{node_id!r}]: value must be an object"
+            )
+            continue
+        target = next(
+            (n for n in branch.node_defs if n.node_id == node_id), None
+        )
+        if target is None:
+            errors.append(
+                f"node_overrides[{node_id!r}]: no inherited node with "
+                f"that id; add a new node via node_defs instead"
+            )
+            continue
+        for field_name, value in override_fields.items():
+            # Skip fields that would invalidate identity.
+            if field_name == "node_id":
+                continue
+            if hasattr(target, field_name):
+                setattr(target, field_name, value)
+
     for idx, raw in enumerate(spec.get("node_defs") or spec.get("nodes") or []):
+        # If we've inherited from parent, new node_defs are ADDITIVE —
+        # they cannot collide with parent nodes (use node_overrides for
+        # changes to inherited nodes).
+        nid = (raw.get("node_id") or raw.get("id") or "").strip()
+        if parent_snapshot and nid and any(
+            n.node_id == nid for n in branch.node_defs
+        ):
+            errors.append(
+                f"node[{idx}] ({nid!r}): already inherited from parent; "
+                f"use node_overrides to amend an inherited node"
+            )
+            continue
         err = _apply_node_spec(branch, raw)
         if err:
             errors.append(f"node[{idx}]: {err}")
@@ -1461,6 +1551,9 @@ def _staged_branch_from_spec(
             errors.append(f"conditional_edge[{idx}]: {err}")
 
     for idx, raw in enumerate(spec.get("state_schema") or []):
+        # When inheriting from parent, parent's state_schema already
+        # populated branch.state_schema; new state fields are additive
+        # and dedup is enforced inside _apply_state_field_spec.
         err = _apply_state_field_spec(branch, raw)
         if err:
             errors.append(f"state_schema[{idx}]: {err}")


### PR DESCRIPTION
Closes #843 (PR-109) and #844 (PR-110 / Move A canonical).

## Why this is "the actual unlock"

ChatGPT dev-partner 2026-05-13 (slice-0 substrate-readiness review):

> "Move A is the actual unlock. Either fork_from must clone inherited node_defs, edges, state schema, tags, and parent metadata into a new draft branch, or there needs to be an explicit clone_branch action. Without that, 'fork this live loop and amend one node' remains impossible."

Before this change, `fork_from` was lineage metadata only. The caller still had to author the full spec from scratch — which hit PR-037's multi-node validator wall (separately fixed in PR #847). The user-buildable promise — *"users have primitives to build from scratch when needed but rarely do so because they can always grab something similar-shaped to start with"* — couldn't be exercised on the change-loop domain.

## Fix

`_staged_branch_from_spec` now seeds the staging branch from the parent version's snapshot when `fork_from` points at a published `branch_version_id`. Inherited: `node_defs`, `edges`, `conditional_edges`, `state_schema`, `entry_point`.

Two override paths:

- **`node_overrides`** (new field): `dict[node_id, partial_node_def]`. Field-level merge onto an inherited node. Use this to amend one prompt_template without re-authoring the whole node.
- **Top-level `node_defs` / `edges`**: additive on top of parent's inherited topology. Collisions with inherited node_ids are rejected with a "use node_overrides" hint.

Top-level `entry_point` still wins over parent's.

## Slice-1 acceptance — all 5 covered by tests

1. A published version can be cloned via `build_branch fork_from=<vid>`.
2. The clone inherits parent's graph, nodes, state schema, lineage.
3. A user can amend exactly one node via `node_overrides`.
4. The parent branch is byte-identical before/after.
5. The clone validates past the inherited graph shape without re-triggering PR-037's multi-node build wall.

## Tests

10 new in `tests/test_move_a_clone_with_inherit.py` — 5 acceptance + 5 edge cases (unknown version_id rejection, override-of-nonexistent-node rejection, malformed override shape, additive new node, collision with parent's node). Plus 1 existing test updated (`test_build_branch_with_fork_from_roundtrips`).

## Verification

- `pytest tests/test_move_a_clone_with_inherit.py tests/test_fork_from.py tests/test_build_branch_summary_response.py tests/test_branch_authoring_actions.py` → 76 passed
- `ruff check` → clean
- Plugin mirror synced

## Breaking change

Callers who previously used `fork_from` as metadata-only and provided colliding `node_defs` now hit the new "inherited from parent; use node_overrides" error. One existing test updated. Callers wanting old metadata-only behavior can omit `fork_from`.

## Cross-references

- Brain pages: `pages/patch-requests/pr-109-...`, `pages/patch-requests/pr-110-...`
- Slice-0 finding: `pages/notes/slice-0-substrate-readiness-finding-2026-05-13.md`
- Slice-1 spec: `pages/plans/community-change-loop-routing-fork-slice-1-clone-with-inherit-acceptance.md` — this PR closes the substrate precondition for slice-1
- Companion fixes shipped today: BUG-080 (#849), BUG-081 (#846), BUG-082 (#845), PR-037 (#847), PR-094 (#848)

🤖 Generated with [Claude Code](https://claude.com/claude-code)