### PR TITLE
[auto-change] BUG-080: patch_branch is in-place destructive — no versioning, no branch_version_id returned, mutation visible to live consumers immediately

### DIFF
--- a/docs/mcp-actions/2026-04-25-session-additions.md
+++ b/docs/mcp-actions/2026-04-25-session-additions.md
@@ -108,6 +108,10 @@ Two new fields in the patch_branch response for post-op verification:
 - `post_patch` (dict) — re-read of the patched branch fields after write, so caller can
   confirm the update landed.
 - `patched_fields` (list[str]) — names of the fields that were actually changed.
+- `branch_version_id` (str) — immutable post-patch branch snapshot ID.
+- `parent_version_id` (str | null) — pre-patch snapshot linked as the parent when the
+  post-patch topology creates a new version.
+- `content_hash` (str) / `published_at` (str) — metadata for the post-patch snapshot.
 
 ---
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -1839,6 +1839,10 @@ def _apply_patch_op(branch: Any, op: dict[str, Any]) -> str:
 
 
 def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
+    import copy
+
+    from workflow.api.engine_helpers import _current_actor
+    from workflow.branch_versions import publish_branch_version
     from workflow.branches import BranchDefinition
     from workflow.daemon_server import (
         get_branch_definition,
@@ -1883,7 +1887,7 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
         })
 
     old_name = source.get("name", "")
-    staging = BranchDefinition.from_dict(source)
+    staging = BranchDefinition.from_dict(copy.deepcopy(source))
 
     per_op_errors: list[dict[str, Any]] = []
     for idx, op in enumerate(changes):
@@ -1936,8 +1940,37 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
             "suggestions": suggestions,
         })
 
+    actor = _current_actor()
+    try:
+        parent_version = publish_branch_version(
+            _base_path(),
+            source,
+            publisher=actor,
+            notes="patch_branch pre-patch snapshot",
+        )
+    except (KeyError, ValueError) as exc:
+        return json.dumps({
+            "status": "rejected",
+            "error": f"Could not snapshot pre-patch branch: {exc}",
+        })
+
     saved = save_branch_definition(_base_path(), branch_def=staging.to_dict())
     persisted = BranchDefinition.from_dict(saved)
+    try:
+        branch_version = publish_branch_version(
+            _base_path(),
+            saved,
+            publisher=actor,
+            notes="patch_branch post-patch snapshot",
+            parent_version_id=parent_version.branch_version_id,
+        )
+    except (KeyError, ValueError) as exc:
+        return json.dumps({
+            "status": "rejected",
+            "error": f"Patch saved but post-patch version snapshot failed: {exc}",
+            "branch_def_id": persisted.branch_def_id,
+            "parent_version_id": parent_version.branch_version_id,
+        })
 
     _SKIP_DIFF = {"updated_at", "created_at", "node_defs", "edges",
                   "conditional_edges", "graph_nodes", "state_schema", "stats"}
@@ -1961,6 +1994,7 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
         f"**Patched branch '{persisted.name}'**: applied {len(changes)} op(s). "
         f"{len(persisted.node_defs)} nodes, {len(persisted.edges)} edges, "
         f"{len(persisted.skills)} skills, entry=`{persisted.entry_point}`.",
+        f"Published version `{branch_version.branch_version_id}`.",
     ]
     if patched_fields:
         text_lines += ["", f"Changed fields: {', '.join(patched_fields)}."]
@@ -1976,6 +2010,10 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
         "text": "\n".join(text_lines),
         "status": "patched",
         "branch_def_id": persisted.branch_def_id,
+        "branch_version_id": branch_version.branch_version_id,
+        "content_hash": branch_version.content_hash,
+        "published_at": branch_version.published_at,
+        "parent_version_id": branch_version.parent_version_id,
         "ops_applied": len(changes),
         "node_count": len(persisted.node_defs),
         "edge_count": len(persisted.edges),

--- a/tests/test_composite_branch_actions.py
+++ b/tests/test_composite_branch_actions.py
@@ -221,6 +221,42 @@ def test_patch_branch_batch_succeeds(comp_env):
     assert any(n["node_id"] == "novelty_check" for n in got["node_defs"])
 
 
+def test_patch_branch_publishes_versioned_snapshot(comp_env):
+    us, base = comp_env
+    built = _call(us, "build_branch", spec_json=json.dumps(RECIPE_SPEC))
+    bid = built["branch_def_id"]
+
+    result = _call(
+        us,
+        "patch_branch",
+        branch_def_id=bid,
+        changes_json=json.dumps([
+            {
+                "op": "add_state_field",
+                "name": "review_output",
+                "type": "str",
+            },
+        ]),
+    )
+
+    assert result["status"] == "patched", result
+    assert result["branch_version_id"]
+    assert result["parent_version_id"]
+
+    from workflow.branch_versions import get_branch_version
+
+    parent = get_branch_version(base, result["parent_version_id"])
+    version = get_branch_version(base, result["branch_version_id"])
+    assert parent is not None
+    assert version is not None
+    assert parent.branch_version_id != version.branch_version_id
+    assert version.parent_version_id == parent.branch_version_id
+    assert parent.snapshot["branch_def_id"] == bid
+    assert version.snapshot["branch_def_id"] == bid
+    assert all(f["name"] != "review_output" for f in parent.snapshot["state_schema"])
+    assert any(f["name"] == "review_output" for f in version.snapshot["state_schema"])
+
+
 def test_patch_branch_rollback_on_any_op_failure(comp_env):
     """AC #3 — if op 3 is invalid, zero rows mutated. All errors reported."""
     us, _ = comp_env

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -1839,6 +1839,10 @@ def _apply_patch_op(branch: Any, op: dict[str, Any]) -> str:
 
 
 def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
+    import copy
+
+    from workflow.api.engine_helpers import _current_actor
+    from workflow.branch_versions import publish_branch_version
     from workflow.branches import BranchDefinition
     from workflow.daemon_server import (
         get_branch_definition,
@@ -1883,7 +1887,7 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
         })
 
     old_name = source.get("name", "")
-    staging = BranchDefinition.from_dict(source)
+    staging = BranchDefinition.from_dict(copy.deepcopy(source))
 
     per_op_errors: list[dict[str, Any]] = []
     for idx, op in enumerate(changes):
@@ -1936,8 +1940,37 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
             "suggestions": suggestions,
         })
 
+    actor = _current_actor()
+    try:
+        parent_version = publish_branch_version(
+            _base_path(),
+            source,
+            publisher=actor,
+            notes="patch_branch pre-patch snapshot",
+        )
+    except (KeyError, ValueError) as exc:
+        return json.dumps({
+            "status": "rejected",
+            "error": f"Could not snapshot pre-patch branch: {exc}",
+        })
+
     saved = save_branch_definition(_base_path(), branch_def=staging.to_dict())
     persisted = BranchDefinition.from_dict(saved)
+    try:
+        branch_version = publish_branch_version(
+            _base_path(),
+            saved,
+            publisher=actor,
+            notes="patch_branch post-patch snapshot",
+            parent_version_id=parent_version.branch_version_id,
+        )
+    except (KeyError, ValueError) as exc:
+        return json.dumps({
+            "status": "rejected",
+            "error": f"Patch saved but post-patch version snapshot failed: {exc}",
+            "branch_def_id": persisted.branch_def_id,
+            "parent_version_id": parent_version.branch_version_id,
+        })
 
     _SKIP_DIFF = {"updated_at", "created_at", "node_defs", "edges",
                   "conditional_edges", "graph_nodes", "state_schema", "stats"}
@@ -1961,6 +1994,7 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
         f"**Patched branch '{persisted.name}'**: applied {len(changes)} op(s). "
         f"{len(persisted.node_defs)} nodes, {len(persisted.edges)} edges, "
         f"{len(persisted.skills)} skills, entry=`{persisted.entry_point}`.",
+        f"Published version `{branch_version.branch_version_id}`.",
     ]
     if patched_fields:
         text_lines += ["", f"Changed fields: {', '.join(patched_fields)}."]
@@ -1976,6 +2010,10 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
         "text": "\n".join(text_lines),
         "status": "patched",
         "branch_def_id": persisted.branch_def_id,
+        "branch_version_id": branch_version.branch_version_id,
+        "content_hash": branch_version.content_hash,
+        "published_at": branch_version.published_at,
+        "parent_version_id": branch_version.parent_version_id,
         "ops_applied": len(changes),
         "node_count": len(persisted.node_defs),
         "edge_count": len(persisted.edges),


### PR DESCRIPTION
Fixes #851

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-080-patch-branch-is-in-place-destructive-no-versioning-no-branch.md`
- GitHub issue: #851
- Branch task: `auto-change/issue-851`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.