### PR TITLE
[auto-change] BUG-082: list_branches published_only=true filters on branch-level published flag, NOT on "has a published version_id"

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -381,7 +381,6 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
     # Branches and any private Branches they authored.
     rows = list_branch_definitions(
         _base_path(),
-        published_only=published_only,
         domain_id=kwargs.get("domain_id", ""),
         author=kwargs.get("author", ""),
         goal_id=kwargs.get("goal_id", ""),
@@ -395,8 +394,11 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
 
     summaries = []
     for r in rows:
-        if published_only and not r.get("published", False):
-            continue
+        if published_only:
+            from workflow.branch_versions import list_branch_versions
+
+            if not list_branch_versions(_base_path(), r.get("branch_def_id", ""), limit=1):
+                continue
         node_defs = r.get("node_defs", [])
         has_sandbox_nodes = any(nd.get("requires_sandbox") for nd in node_defs)
         if rs_filter == "none" and has_sandbox_nodes:

--- a/tests/test_branch_authoring_actions.py
+++ b/tests/test_branch_authoring_actions.py
@@ -69,10 +69,10 @@ def test_list_branches_returns_summaries(branch_env):
     assert all("node_count" in b for b in listing["branches"])
 
 
-def test_list_branches_published_only_filter(branch_env):
+def test_list_branches_published_only_filter_uses_published_versions(branch_env):
     us, _ = branch_env
     spec = {
-        "name": "Published",
+        "name": "Versioned",
         "entry_point": "ready",
         "node_defs": [{
             "node_id": "ready",
@@ -85,20 +85,28 @@ def test_list_branches_published_only_filter(branch_env):
         ],
         "state_schema": [{"name": "x", "type": "str"}],
     }
-    published = _call(us, "build_branch", spec_json=json.dumps(spec))
+    versioned = _call(us, "build_branch", spec_json=json.dumps(spec))
     _call(us, "create_branch", name="Probe draft")
+    legacy_spec = {**spec, "name": "Legacy flag only"}
+    legacy_flagged = _call(us, "build_branch", spec_json=json.dumps(legacy_spec))
     patched = _call(
         us,
         "patch_branch",
-        branch_def_id=published["branch_def_id"],
+        branch_def_id=legacy_flagged["branch_def_id"],
         changes_json=json.dumps([{"op": "set_published", "published": True}]),
     )
     assert patched.get("status") != "rejected", patched
+    version = _call(
+        us,
+        "publish_version",
+        branch_def_id=versioned["branch_def_id"],
+    )
+    assert version["branch_version_id"].startswith(f"{versioned['branch_def_id']}@")
 
     listing = _call(us, "list_branches", published_only=True)
     assert listing["count"] == 1
-    assert listing["branches"][0]["name"] == "Published"
-    assert listing["branches"][0]["published"] is True
+    assert listing["branches"][0]["name"] == "Versioned"
+    assert listing["branches"][0]["published"] is False
 
 
 def test_list_branches_node_count_matches_node_defs_length(branch_env):

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -381,7 +381,6 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
     # Branches and any private Branches they authored.
     rows = list_branch_definitions(
         _base_path(),
-        published_only=published_only,
         domain_id=kwargs.get("domain_id", ""),
         author=kwargs.get("author", ""),
         goal_id=kwargs.get("goal_id", ""),
@@ -395,8 +394,11 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
 
     summaries = []
     for r in rows:
-        if published_only and not r.get("published", False):
-            continue
+        if published_only:
+            from workflow.branch_versions import list_branch_versions
+
+            if not list_branch_versions(_base_path(), r.get("branch_def_id", ""), limit=1):
+                continue
         node_defs = r.get("node_defs", [])
         has_sandbox_nodes = any(nd.get("requires_sandbox") for nd in node_defs)
         if rs_filter == "none" and has_sandbox_nodes:


### PR DESCRIPTION
Fixes #853

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-082-list-branches-published-only-true-filters-on-branch-level-pu.md`
- GitHub issue: #853
- Branch task: `auto-change/issue-853`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.