### PR TITLE
[auto-change] WIKI-PATCH: fork_from is lineage metadata only — does NOT auto-inherit parent's node_defs, users still walled by PR-037 when forking via build_branch

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -69,6 +69,7 @@ symbols from this module). ``_gates_enabled`` is also lazy-imported, but from
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -1014,6 +1015,50 @@ def _ext_branch_describe(kwargs: dict[str, Any]) -> str:
 _VALID_STATE_TYPES = {"str", "int", "float", "bool", "list", "dict", "any"}
 
 
+def _spec_with_fork_snapshot_defaults(
+    spec: dict[str, Any],
+    fork_snapshot: dict[str, Any],
+) -> dict[str, Any]:
+    """Seed omitted branch content from a published fork source snapshot.
+
+    `fork_from` remains lineage metadata on the saved branch. This helper only
+    uses the immutable version snapshot as a creation-time copy source when the
+    caller follows the fork path without manually re-submitting every node.
+    Explicit caller fields keep precedence.
+    """
+    seeded = dict(spec)
+    graph = spec.get("graph") if isinstance(spec.get("graph"), dict) else None
+
+    if not (spec.get("node_defs") or spec.get("nodes")):
+        source_nodes = fork_snapshot.get("node_defs") or fork_snapshot.get("nodes")
+        if source_nodes:
+            seeded["node_defs"] = copy.deepcopy(source_nodes)
+
+    if graph is None and isinstance(fork_snapshot.get("graph"), dict):
+        seeded["graph"] = copy.deepcopy(fork_snapshot["graph"])
+
+    for key in (
+        "description",
+        "domain_id",
+        "tags",
+        "skills",
+        "state_schema",
+        "edges",
+        "conditional_edges",
+        "entry_point",
+    ):
+        if seeded.get(key) in (None, "", []):
+            value = fork_snapshot.get(key)
+            if value not in (None, "", []):
+                seeded[key] = copy.deepcopy(value)
+
+    if not (seeded.get("name") or "").strip():
+        source_name = (fork_snapshot.get("name") or "forked branch").strip()
+        seeded["name"] = f"{source_name} (fork)"
+
+    return seeded
+
+
 def _suggest_entry_point(branch: Any) -> str:
     if not branch.graph_nodes:
         return ""
@@ -1559,14 +1604,21 @@ def _ext_branch_build(kwargs: dict[str, Any]) -> str:
             }],
         })
 
+    fork_version = None
+    fork_from_raw = (spec.get("fork_from") or "").strip()
+    if fork_from_raw:
+        from workflow.branch_versions import get_branch_version
+        fork_version = get_branch_version(_base_path(), fork_from_raw)
+        if fork_version is not None:
+            spec = _spec_with_fork_snapshot_defaults(spec, fork_version.snapshot)
+
     branch, staging_errors = _staged_branch_from_spec(spec)
     validation_errors = branch.validate()
     errors = staging_errors + validation_errors
 
     # Validate fork_from points to a real branch_version_id.
     if branch.fork_from:
-        from workflow.branch_versions import get_branch_version
-        if get_branch_version(_base_path(), branch.fork_from) is None:
+        if fork_version is None:
             errors.append(
                 f"fork_from '{branch.fork_from}' is not a known branch_version_id. "
                 "Pass a published branch_version_id, not a branch_def_id."

--- a/tests/test_build_branch_nested_graph_shape.py
+++ b/tests/test_build_branch_nested_graph_shape.py
@@ -183,3 +183,40 @@ def test_round_trip_get_branch_then_build_branch_works(ext_env):
     assert res_b.get("edge_count") == res_a.get("edge_count")
     assert res_b.get("entry_point") == res_a.get("entry_point")
     assert res_b.get("node_count") == res_a.get("node_count")
+
+
+def test_build_branch_fork_from_seeds_from_published_version(ext_env):
+    """`fork_from` alone should create a usable fork from the version snapshot.
+
+    `fork_from` remains immutable lineage metadata after creation; this guards
+    the authoring path where a non-author follows the fork hint and supplies a
+    published branch_version_id instead of manually copying every node.
+    """
+    us = ext_env
+    source = _call(
+        us,
+        action="build_branch",
+        spec_json=json.dumps(_two_node_spec_nested_graph()),
+    )
+    assert source.get("status") == "built", source
+    version = _call(
+        us,
+        action="publish_version",
+        branch_def_id=source["branch_def_id"],
+    )
+    assert version.get("branch_version_id"), version
+
+    fork_spec = {
+        "name": "pr-109-version-seeded-fork",
+        "fork_from": version["branch_version_id"],
+    }
+    forked = _call(us, action="build_branch", spec_json=json.dumps(fork_spec))
+
+    assert forked.get("status") == "built", forked
+    assert forked.get("branch_def_id") != source["branch_def_id"]
+    assert forked.get("node_count") == source["node_count"]
+    assert forked.get("edge_count") == source["edge_count"]
+    assert forked.get("entry_point") == source["entry_point"]
+
+    readback = _call(us, action="get_branch", branch_def_id=forked["branch_def_id"])
+    assert readback.get("fork_from") == version["branch_version_id"]

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -69,6 +69,7 @@ symbols from this module). ``_gates_enabled`` is also lazy-imported, but from
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -1014,6 +1015,50 @@ def _ext_branch_describe(kwargs: dict[str, Any]) -> str:
 _VALID_STATE_TYPES = {"str", "int", "float", "bool", "list", "dict", "any"}
 
 
+def _spec_with_fork_snapshot_defaults(
+    spec: dict[str, Any],
+    fork_snapshot: dict[str, Any],
+) -> dict[str, Any]:
+    """Seed omitted branch content from a published fork source snapshot.
+
+    `fork_from` remains lineage metadata on the saved branch. This helper only
+    uses the immutable version snapshot as a creation-time copy source when the
+    caller follows the fork path without manually re-submitting every node.
+    Explicit caller fields keep precedence.
+    """
+    seeded = dict(spec)
+    graph = spec.get("graph") if isinstance(spec.get("graph"), dict) else None
+
+    if not (spec.get("node_defs") or spec.get("nodes")):
+        source_nodes = fork_snapshot.get("node_defs") or fork_snapshot.get("nodes")
+        if source_nodes:
+            seeded["node_defs"] = copy.deepcopy(source_nodes)
+
+    if graph is None and isinstance(fork_snapshot.get("graph"), dict):
+        seeded["graph"] = copy.deepcopy(fork_snapshot["graph"])
+
+    for key in (
+        "description",
+        "domain_id",
+        "tags",
+        "skills",
+        "state_schema",
+        "edges",
+        "conditional_edges",
+        "entry_point",
+    ):
+        if seeded.get(key) in (None, "", []):
+            value = fork_snapshot.get(key)
+            if value not in (None, "", []):
+                seeded[key] = copy.deepcopy(value)
+
+    if not (seeded.get("name") or "").strip():
+        source_name = (fork_snapshot.get("name") or "forked branch").strip()
+        seeded["name"] = f"{source_name} (fork)"
+
+    return seeded
+
+
 def _suggest_entry_point(branch: Any) -> str:
     if not branch.graph_nodes:
         return ""
@@ -1559,14 +1604,21 @@ def _ext_branch_build(kwargs: dict[str, Any]) -> str:
             }],
         })
 
+    fork_version = None
+    fork_from_raw = (spec.get("fork_from") or "").strip()
+    if fork_from_raw:
+        from workflow.branch_versions import get_branch_version
+        fork_version = get_branch_version(_base_path(), fork_from_raw)
+        if fork_version is not None:
+            spec = _spec_with_fork_snapshot_defaults(spec, fork_version.snapshot)
+
     branch, staging_errors = _staged_branch_from_spec(spec)
     validation_errors = branch.validate()
     errors = staging_errors + validation_errors
 
     # Validate fork_from points to a real branch_version_id.
     if branch.fork_from:
-        from workflow.branch_versions import get_branch_version
-        if get_branch_version(_base_path(), branch.fork_from) is None:
+        if fork_version is None:
             errors.append(
                 f"fork_from '{branch.fork_from}' is not a known branch_version_id. "
                 "Pass a published branch_version_id, not a branch_def_id."


### PR DESCRIPTION
Fixes #854

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-109-fork-from-is-lineage-metadata-only-does-not-auto-inherit-par.md`
- GitHub issue: #854
- Branch task: `auto-change/issue-854`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.