### PR TITLE
[auto-change] BUG-080: patch_branch is in-place destructive — no versioning, no branch_version_id returned, mutation visible immediately

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -1956,7 +1956,6 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
     # the gap by mutating a chatgpt-community-builder-authored branch
     # from a non-author session. See pages/bugs/bug-081-... for the
     # filing.
-    from workflow.api.engine_helpers import _current_actor
     branch_author = (source.get("author") or "").strip()
     caller = (_current_actor() or "").strip()
     force_mutate = bool(kwargs.get("force", False))
@@ -2042,7 +2041,11 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
             "error": f"Could not snapshot pre-patch branch: {exc}",
         })
 
-    saved = save_branch_definition(_base_path(), branch_def=staging.to_dict())
+    old_version = int(source.get("version") or 1)
+    new_version = old_version + 1
+    staging_dict = staging.to_dict()
+    staging_dict["version"] = new_version
+    saved = save_branch_definition(_base_path(), branch_def=staging_dict)
     persisted = BranchDefinition.from_dict(saved)
     try:
         branch_version = publish_branch_version(
@@ -2103,6 +2106,8 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
         "published_at": branch_version.published_at,
         "parent_version_id": branch_version.parent_version_id,
         "ops_applied": len(changes),
+        "version_before": old_version,
+        "version_after": new_version,
         "node_count": len(persisted.node_defs),
         "edge_count": len(persisted.edges),
         "skill_count": len(persisted.skills),

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_versions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_versions.py
@@ -3,9 +3,10 @@
 Spec: docs/vetted-specs.md §publish_version.
 Rollback design: docs/design-notes/2026-04-25-surgical-rollback-proposal.md.
 
-A published version is a write-once snapshot of a BranchDefinition's full
-topology (node_defs, edges, conditional_edges, state_schema, entry_point)
-at the moment of publish. It is immutable after creation.
+A published version is a write-once snapshot of a BranchDefinition's stable
+branch metadata and full topology (node_defs, edges, conditional_edges,
+state_schema, entry_point) at the moment of publish. It is immutable after
+creation.
 
 ``publish_version`` mints a new ``branch_version_id`` of the form
 ``<branch_def_id>@<sha256_prefix8>`` and stores the canonical JSON in
@@ -207,19 +208,31 @@ def initialize_branch_versions_db(base_path: str | Path) -> None:
 
 
 def _canonical_snapshot(branch_dict: dict[str, Any]) -> dict[str, Any]:
-    """Extract fields that define published branch behavior."""
+    """Extract stable fields that define a comparable branch version."""
     from workflow.branches import BranchDefinition
 
     normalized = BranchDefinition.from_dict(branch_dict).to_dict()
     return {
         "branch_def_id": normalized.get("branch_def_id", ""),
+        "name": normalized.get("name", ""),
+        "description": normalized.get("description", ""),
+        "domain_id": normalized.get("domain_id", ""),
+        "goal_id": normalized.get("goal_id", ""),
+        "tags": normalized.get("tags", []),
+        "version": normalized.get("version", 1),
         "skills": normalized.get("skills", []),
+        "parent_def_id": normalized.get("parent_def_id"),
+        "fork_from": normalized.get("fork_from"),
         "entry_point": normalized.get("entry_point", ""),
+        "published": normalized.get("published", False),
+        "visibility": normalized.get("visibility", "public"),
         "graph_nodes": normalized.get("graph_nodes", []),
         "edges": normalized.get("edges", []),
         "conditional_edges": normalized.get("conditional_edges", []),
         "node_defs": normalized.get("node_defs", []),
         "state_schema": normalized.get("state_schema", []),
+        "default_llm_policy": normalized.get("default_llm_policy"),
+        "concurrency_budget": normalized.get("concurrency_budget"),
     }
 
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
@@ -1635,8 +1635,8 @@ def _build_invoke_branch_version_node(
         def _resolve_branch_def_id_for_author() -> str:
             """Map child_branch_version_id → branch_def_id for author lookup.
 
-            ``branch_versions.snapshot`` is topology-only; author lives on the
-            live BranchDefinition. ``get_branch_version`` returns None on
+            Author attribution lives on the live BranchDefinition, not the
+            branch_versions snapshot. ``get_branch_version`` returns None on
             missing — return "" so emit silently skips (orphan-row prevention).
             """
             from workflow.branch_versions import get_branch_version

--- a/tests/test_composite_branch_actions.py
+++ b/tests/test_composite_branch_actions.py
@@ -301,6 +301,47 @@ def test_patch_branch_publishes_versioned_snapshot(comp_env):
     assert any(f["name"] == "review_output" for f in version.snapshot["state_schema"])
 
 
+def test_patch_branch_metadata_patch_bumps_version_and_snapshots_tags(comp_env):
+    us, base = comp_env
+    built = _call(us, "build_branch", spec_json=json.dumps(RECIPE_SPEC))
+    bid = built["branch_def_id"]
+
+    before = _call(us, "get_branch", branch_def_id=bid)
+    assert before["version"] == 1
+    assert "probe-touch" not in before["tags"]
+
+    result = _call(
+        us,
+        "patch_branch",
+        branch_def_id=bid,
+        changes_json=json.dumps([
+            {"op": "set_tags", "tags": ["recipes", "probe-touch"]},
+        ]),
+    )
+
+    assert result["status"] == "patched", result
+    assert result["branch_version_id"]
+    assert result["parent_version_id"]
+    assert result["branch_version_id"] != result["parent_version_id"]
+    assert result["version_before"] == 1
+    assert result["version_after"] == 2
+
+    after = _call(us, "get_branch", branch_def_id=bid)
+    assert after["version"] == 2
+    assert after["tags"] == ["recipes", "probe-touch"]
+
+    from workflow.branch_versions import get_branch_version
+
+    parent = get_branch_version(base, result["parent_version_id"])
+    version = get_branch_version(base, result["branch_version_id"])
+    assert parent is not None
+    assert version is not None
+    assert parent.snapshot["version"] == 1
+    assert version.snapshot["version"] == 2
+    assert parent.snapshot["tags"] == []
+    assert version.snapshot["tags"] == ["recipes", "probe-touch"]
+
+
 def test_patch_branch_rollback_on_any_op_failure(comp_env):
     """AC #3 — if op 3 is invalid, zero rows mutated. All errors reported."""
     us, _ = comp_env

--- a/tests/test_publish_version.py
+++ b/tests/test_publish_version.py
@@ -59,14 +59,14 @@ class TestComputeContentHash:
         h2 = compute_content_hash(_canonical_snapshot(d2))
         assert h1 != h2
 
-    def test_metadata_change_does_not_affect_hash(self):
-        """Only topology fields contribute to the hash, not name/author."""
+    def test_stable_metadata_change_affects_hash(self):
+        """Branch metadata participates in version identity."""
         d1 = _make_branch_dict(name="Version Alpha")
         d2 = _make_branch_dict(name="Version Beta")
         from workflow.branch_versions import _canonical_snapshot
         h1 = compute_content_hash(_canonical_snapshot(d1))
         h2 = compute_content_hash(_canonical_snapshot(d2))
-        assert h1 == h2
+        assert h1 != h2
 
     def test_hash_is_64_hex_chars(self):
         d = _make_branch_dict()
@@ -132,9 +132,12 @@ class TestPublishBranchVersion:
         child = publish_branch_version(tmp_path, d2, parent_version_id=parent.branch_version_id)
         assert child.parent_version_id == parent.branch_version_id
 
-    def test_snapshot_contains_topology_fields(self, tmp_path):
+    def test_snapshot_contains_stable_metadata_and_topology_fields(self, tmp_path):
         d = _make_branch_dict()
         v = publish_branch_version(tmp_path, d)
+        assert v.snapshot["name"] == d["name"]
+        assert v.snapshot["tags"] == d["tags"]
+        assert v.snapshot["version"] == d["version"]
         assert "node_defs" in v.snapshot
         assert "edges" in v.snapshot
         assert "entry_point" in v.snapshot
@@ -175,12 +178,13 @@ class TestPublishBranchVersion:
         assert row_version.snapshot["graph_nodes"] == d["graph_nodes"]
         assert row_version.snapshot["edges"] == d["edges"]
 
-    def test_snapshot_excludes_metadata_fields(self, tmp_path):
+    def test_snapshot_excludes_unstable_and_attribution_fields(self, tmp_path):
         d = _make_branch_dict()
         v = publish_branch_version(tmp_path, d)
-        assert "name" not in v.snapshot
         assert "author" not in v.snapshot
         assert "stats" not in v.snapshot
+        assert "created_at" not in v.snapshot
+        assert "updated_at" not in v.snapshot
 
 
 # ─── get_branch_version ───────────────────────────────────────────────────────

--- a/tests/test_run_branch_version.py
+++ b/tests/test_run_branch_version.py
@@ -189,12 +189,10 @@ class TestExecuteBranchVersionAsync:
             tmp_path, branch_version_id=bvid, inputs={},
         )
         assert outcome.run_id
-        # Note: snapshot's NAME is not retained in branch_versions.snapshot
-        # (only topology fields per _canonical_snapshot). But the bvid the
-        # run was tagged with is stable, so the immutability invariant we
-        # actually test is that the run record carries the published bvid
-        # — not whatever bvid a fresh publish_version on the edited def
-        # would mint.
+        # The bvid the run was tagged with is stable, so the immutability
+        # invariant we test is that the run record carries the published bvid
+        # — not whatever bvid a fresh publish_version on the edited def would
+        # mint.
         wait_for(outcome.run_id, timeout=10.0)
         record = get_run(tmp_path, outcome.run_id)
         assert record is not None

--- a/tests/test_sub_branch_invocation.py
+++ b/tests/test_sub_branch_invocation.py
@@ -1422,7 +1422,7 @@ class TestInvokeBranchDesignUsedEmit:
 
 class TestInvokeBranchVersionDesignUsedEmit:
     """invoke_branch_version_spec emits design_used keyed by the resolved
-    branch_def_id (since branch_version snapshot is topology-only)."""
+    branch_def_id (author attribution stays on the live BranchDefinition)."""
 
     def test_emits_design_used_for_version_blocking_success(self, tmp_path):
         from workflow.branch_versions import (

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -1956,7 +1956,6 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
     # the gap by mutating a chatgpt-community-builder-authored branch
     # from a non-author session. See pages/bugs/bug-081-... for the
     # filing.
-    from workflow.api.engine_helpers import _current_actor
     branch_author = (source.get("author") or "").strip()
     caller = (_current_actor() or "").strip()
     force_mutate = bool(kwargs.get("force", False))
@@ -2042,7 +2041,11 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
             "error": f"Could not snapshot pre-patch branch: {exc}",
         })
 
-    saved = save_branch_definition(_base_path(), branch_def=staging.to_dict())
+    old_version = int(source.get("version") or 1)
+    new_version = old_version + 1
+    staging_dict = staging.to_dict()
+    staging_dict["version"] = new_version
+    saved = save_branch_definition(_base_path(), branch_def=staging_dict)
     persisted = BranchDefinition.from_dict(saved)
     try:
         branch_version = publish_branch_version(
@@ -2103,6 +2106,8 @@ def _ext_branch_patch(kwargs: dict[str, Any]) -> str:
         "published_at": branch_version.published_at,
         "parent_version_id": branch_version.parent_version_id,
         "ops_applied": len(changes),
+        "version_before": old_version,
+        "version_after": new_version,
         "node_count": len(persisted.node_defs),
         "edge_count": len(persisted.edges),
         "skill_count": len(persisted.skills),

--- a/workflow/branch_versions.py
+++ b/workflow/branch_versions.py
@@ -3,9 +3,10 @@
 Spec: docs/vetted-specs.md §publish_version.
 Rollback design: docs/design-notes/2026-04-25-surgical-rollback-proposal.md.
 
-A published version is a write-once snapshot of a BranchDefinition's full
-topology (node_defs, edges, conditional_edges, state_schema, entry_point)
-at the moment of publish. It is immutable after creation.
+A published version is a write-once snapshot of a BranchDefinition's stable
+branch metadata and full topology (node_defs, edges, conditional_edges,
+state_schema, entry_point) at the moment of publish. It is immutable after
+creation.
 
 ``publish_version`` mints a new ``branch_version_id`` of the form
 ``<branch_def_id>@<sha256_prefix8>`` and stores the canonical JSON in
@@ -207,19 +208,31 @@ def initialize_branch_versions_db(base_path: str | Path) -> None:
 
 
 def _canonical_snapshot(branch_dict: dict[str, Any]) -> dict[str, Any]:
-    """Extract fields that define published branch behavior."""
+    """Extract stable fields that define a comparable branch version."""
     from workflow.branches import BranchDefinition
 
     normalized = BranchDefinition.from_dict(branch_dict).to_dict()
     return {
         "branch_def_id": normalized.get("branch_def_id", ""),
+        "name": normalized.get("name", ""),
+        "description": normalized.get("description", ""),
+        "domain_id": normalized.get("domain_id", ""),
+        "goal_id": normalized.get("goal_id", ""),
+        "tags": normalized.get("tags", []),
+        "version": normalized.get("version", 1),
         "skills": normalized.get("skills", []),
+        "parent_def_id": normalized.get("parent_def_id"),
+        "fork_from": normalized.get("fork_from"),
         "entry_point": normalized.get("entry_point", ""),
+        "published": normalized.get("published", False),
+        "visibility": normalized.get("visibility", "public"),
         "graph_nodes": normalized.get("graph_nodes", []),
         "edges": normalized.get("edges", []),
         "conditional_edges": normalized.get("conditional_edges", []),
         "node_defs": normalized.get("node_defs", []),
         "state_schema": normalized.get("state_schema", []),
+        "default_llm_policy": normalized.get("default_llm_policy"),
+        "concurrency_budget": normalized.get("concurrency_budget"),
     }
 
 

--- a/workflow/graph_compiler.py
+++ b/workflow/graph_compiler.py
@@ -1635,8 +1635,8 @@ def _build_invoke_branch_version_node(
         def _resolve_branch_def_id_for_author() -> str:
             """Map child_branch_version_id → branch_def_id for author lookup.
 
-            ``branch_versions.snapshot`` is topology-only; author lives on the
-            live BranchDefinition. ``get_branch_version`` returns None on
+            Author attribution lives on the live BranchDefinition, not the
+            branch_versions snapshot. ``get_branch_version`` returns None on
             missing — return "" so emit silently skips (orphan-row prevention).
             """
             from workflow.branch_versions import get_branch_version


### PR DESCRIPTION
Fixes #840

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-080-patch-branch-is-in-place-destructive-no-versioning-no-branch.md`
- GitHub issue: #840
- Branch task: `auto-change/issue-840`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.