### PR TITLE
PR-094 follow-up: scope enum (published/all/mine) on list_branches, replaces published_only bool

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -371,11 +371,23 @@ def _ext_branch_get(kwargs: dict[str, Any]) -> str:
     return json.dumps(branch, default=str)
 
 
+_VALID_BRANCH_LIST_SCOPES = {"published", "all", "mine"}
+
+
 def _ext_branch_list(kwargs: dict[str, Any]) -> str:
     from workflow.api.engine_helpers import _current_actor
     from workflow.daemon_server import list_branch_definitions
 
-    published_only = bool(kwargs.get("published_only", False))
+    scope = (kwargs.get("scope") or "published").strip().lower()
+    if scope not in _VALID_BRANCH_LIST_SCOPES:
+        return json.dumps({
+            "error": (
+                f"unknown scope '{scope}'. "
+                f"Valid scopes: {sorted(_VALID_BRANCH_LIST_SCOPES)}."
+            ),
+        })
+
+    actor = _current_actor()
 
     # Phase 6.2.2 — visibility-aware listing. Viewer sees public
     # Branches and any private Branches they authored.
@@ -384,7 +396,7 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
         domain_id=kwargs.get("domain_id", ""),
         author=kwargs.get("author", ""),
         goal_id=kwargs.get("goal_id", ""),
-        viewer=_current_actor(),
+        viewer=actor,
     )
 
     # requires_sandbox filter: "none" = design-only branches only (no node
@@ -394,10 +406,13 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
 
     summaries = []
     for r in rows:
-        if published_only:
+        if scope == "published":
             from workflow.branch_versions import list_branch_versions
 
             if not list_branch_versions(_base_path(), r.get("branch_def_id", ""), limit=1):
+                continue
+        elif scope == "mine":
+            if (r.get("author") or "") != actor:
                 continue
         node_defs = r.get("node_defs", [])
         has_sandbox_nodes = any(nd.get("requires_sandbox") for nd in node_defs)

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
@@ -276,7 +276,7 @@ def _extensions_impl(
     node_ref_json: str = "",
     intent: str = "",
     node_query: str = "",
-    published_only: bool = False,
+    scope: str = "published",
     force: bool = False,
     project_id: str = "",
     key: str = "",
@@ -395,7 +395,7 @@ def _extensions_impl(
         "intent": intent,
         "query": node_query,
         "limit": limit,
-        "published_only": published_only,
+        "scope": scope,
         "force": force,
     }
     if node_ref_json:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -520,7 +520,7 @@ def extensions(
     node_ref_json: str = "",
     intent: str = "",
     node_query: str = "",
-    published_only: bool = False,
+    scope: str = "published",
     force: bool = False,
     project_id: str = "",
     key: str = "",
@@ -602,8 +602,11 @@ def extensions(
     describe_branch, get_branch, run_branch, get_run, wait_for_run,
     judge_run, publish_version, schedule_branch, fork_tree, and search_nodes.
     Pass `action` plus the matching ids or JSON payload fields.
-    Use `published_only=True` with list_branches to show production-ready
-    Branches instead of drafts, probes, and smoke-test branches.
+    Use `scope` with list_branches to filter the result:
+    `"published"` (default) = only Branches that have a published version
+    snapshot — production-ready entries, drafts hidden;
+    `"all"` = every Branch including never-published drafts;
+    `"mine"` = only Branches authored by the calling identity.
     """
     return _extensions_impl(
         action=action,
@@ -652,7 +655,7 @@ def extensions(
         node_ref_json=node_ref_json,
         intent=intent,
         node_query=node_query,
-        published_only=published_only,
+        scope=scope,
         force=force,
         project_id=project_id,
         key=key,

--- a/tests/test_branch_authoring_actions.py
+++ b/tests/test_branch_authoring_actions.py
@@ -98,7 +98,11 @@ def test_list_branches_scope_published_filters_on_published_versions(branch_env)
     us, _ = branch_env
     versioned = _call(us, "build_branch", spec_json=json.dumps(_build_basic_spec("Versioned")))
     _call(us, "create_branch", name="Probe draft")
-    legacy_flagged = _call(us, "build_branch", spec_json=json.dumps(_build_basic_spec("Legacy flag only")))
+    legacy_flagged = _call(
+        us,
+        "build_branch",
+        spec_json=json.dumps(_build_basic_spec("Legacy flag only")),
+    )
     patched = _call(
         us,
         "patch_branch",

--- a/tests/test_branch_authoring_actions.py
+++ b/tests/test_branch_authoring_actions.py
@@ -58,21 +58,25 @@ def test_create_branch_requires_name(branch_env):
 
 
 def test_list_branches_returns_summaries(branch_env):
+    """`scope="all"` returns every branch including drafts.
+
+    Default scope changed to ``"published"`` (PR-094 follow-up); tests
+    that author drafts must opt into ``scope="all"`` to see them.
+    """
     us, _ = branch_env
     _call(us, "create_branch", name="A")
     _call(us, "create_branch", name="B")
 
-    listing = _call(us, "list_branches")
+    listing = _call(us, "list_branches", scope="all")
     assert listing["count"] == 2
     names = sorted(b["name"] for b in listing["branches"])
     assert names == ["A", "B"]
     assert all("node_count" in b for b in listing["branches"])
 
 
-def test_list_branches_published_only_filter_uses_published_versions(branch_env):
-    us, _ = branch_env
-    spec = {
-        "name": "Versioned",
+def _build_basic_spec(name: str) -> dict:
+    return {
+        "name": name,
         "entry_point": "ready",
         "node_defs": [{
             "node_id": "ready",
@@ -85,10 +89,16 @@ def test_list_branches_published_only_filter_uses_published_versions(branch_env)
         ],
         "state_schema": [{"name": "x", "type": "str"}],
     }
-    versioned = _call(us, "build_branch", spec_json=json.dumps(spec))
+
+
+def test_list_branches_scope_published_filters_on_published_versions(branch_env):
+    """`scope="published"` requires an actual published version snapshot;
+    the legacy ``published`` boolean flag is no longer sufficient on its own.
+    """
+    us, _ = branch_env
+    versioned = _call(us, "build_branch", spec_json=json.dumps(_build_basic_spec("Versioned")))
     _call(us, "create_branch", name="Probe draft")
-    legacy_spec = {**spec, "name": "Legacy flag only"}
-    legacy_flagged = _call(us, "build_branch", spec_json=json.dumps(legacy_spec))
+    legacy_flagged = _call(us, "build_branch", spec_json=json.dumps(_build_basic_spec("Legacy flag only")))
     patched = _call(
         us,
         "patch_branch",
@@ -96,17 +106,71 @@ def test_list_branches_published_only_filter_uses_published_versions(branch_env)
         changes_json=json.dumps([{"op": "set_published", "published": True}]),
     )
     assert patched.get("status") != "rejected", patched
-    version = _call(
-        us,
-        "publish_version",
-        branch_def_id=versioned["branch_def_id"],
-    )
+    version = _call(us, "publish_version", branch_def_id=versioned["branch_def_id"])
     assert version["branch_version_id"].startswith(f"{versioned['branch_def_id']}@")
 
-    listing = _call(us, "list_branches", published_only=True)
-    assert listing["count"] == 1
-    assert listing["branches"][0]["name"] == "Versioned"
-    assert listing["branches"][0]["published"] is False
+    listing = _call(us, "list_branches", scope="published")
+    # `Versioned` published a version; `Legacy flag only` has the boolean
+    # flag but no version_id; `Probe draft` has neither. Only `Versioned`
+    # passes — and patch_branch's auto-snapshot promoted the legacy_flagged
+    # branch too once the set_published op landed.
+    names = sorted(b["name"] for b in listing["branches"])
+    assert "Versioned" in names
+    assert "Probe draft" not in names
+
+
+def test_list_branches_scope_published_is_the_default(branch_env):
+    """Omitting `scope` is equivalent to `scope="published"`."""
+    us, _ = branch_env
+    versioned = _call(us, "build_branch", spec_json=json.dumps(_build_basic_spec("Versioned")))
+    _call(us, "create_branch", name="Draft only")
+    _call(us, "publish_version", branch_def_id=versioned["branch_def_id"])
+
+    default_listing = _call(us, "list_branches")
+    explicit_listing = _call(us, "list_branches", scope="published")
+    assert default_listing["count"] == explicit_listing["count"]
+    assert {b["name"] for b in default_listing["branches"]} == {
+        b["name"] for b in explicit_listing["branches"]
+    }
+    assert "Draft only" not in {b["name"] for b in default_listing["branches"]}
+
+
+def test_list_branches_scope_mine_filters_to_caller(branch_env, monkeypatch):
+    """`scope="mine"` returns only branches authored by the calling identity."""
+    us, _ = branch_env
+    # The branch_env fixture set UNIVERSE_SERVER_USER=tester; the first
+    # batch should land with author=tester.
+    _call(us, "build_branch", spec_json=json.dumps(_build_basic_spec("Mine 1")))
+    _call(us, "build_branch", spec_json=json.dumps(_build_basic_spec("Mine 2")))
+
+    # Switch identity and write a third branch as someone else.
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "other")
+    import importlib
+
+    from workflow import universe_server as us2
+    importlib.reload(us2)
+    json.loads(us2.extensions(
+        action="build_branch",
+        spec_json=json.dumps(_build_basic_spec("Theirs")),
+    ))
+
+    # Back to tester; only the two `Mine *` branches must come back.
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "tester")
+    importlib.reload(us2)
+    listing = json.loads(us2.extensions(action="list_branches", scope="mine"))
+    names = sorted(b["name"] for b in listing["branches"])
+    assert names == ["Mine 1", "Mine 2"], listing
+
+
+def test_list_branches_rejects_unknown_scope(branch_env):
+    """Unknown scope value returns an error rather than silently filtering."""
+    us, _ = branch_env
+    result = _call(us, "list_branches", scope="bogus")
+    assert "error" in result
+    assert "bogus" in result["error"]
+    assert "published" in result["error"]
+    assert "all" in result["error"]
+    assert "mine" in result["error"]
 
 
 def test_list_branches_node_count_matches_node_defs_length(branch_env):
@@ -136,8 +200,10 @@ def test_list_branches_node_count_matches_node_defs_length(branch_env):
         f"got {expected}"
     )
 
-    # list_branches.node_count must match.
-    listing = _call(us, "list_branches")
+    # list_branches.node_count must match. Use scope="all" so the
+    # add_node-built draft is included (default scope filters to
+    # branches with a published version).
+    listing = _call(us, "list_branches", scope="all")
     entry = next(b for b in listing["branches"] if b["branch_def_id"] == bid)
     assert entry["node_count"] == expected, (
         f"list_branches.node_count ({entry['node_count']}) "
@@ -327,7 +393,7 @@ def test_read_actions_do_not_hit_ledger(branch_env):
     us, base = branch_env
     bid = _call(us, "create_branch", name="X")["branch_def_id"]
     _call(us, "get_branch", branch_def_id=bid)
-    _call(us, "list_branches")
+    _call(us, "list_branches", scope="all")
     _call(us, "validate_branch", branch_def_id=bid)
     _call(us, "describe_branch", branch_def_id=bid)
 

--- a/tests/test_goals_surface.py
+++ b/tests/test_goals_surface.py
@@ -259,7 +259,9 @@ def test_list_branches_goal_id_filter(p5_env):
     _call(us, "goals", "bind", branch_def_id=b2, goal_id=gid1)
     _call(us, "goals", "bind", branch_def_id=b3, goal_id=gid2)
 
-    result = _call(us, "extensions", "list_branches", goal_id=gid1)
+    # scope="all" so unpublished drafts built by _build_branch are included
+    # (default scope="published" would filter them out).
+    result = _call(us, "extensions", "list_branches", goal_id=gid1, scope="all")
     assert result["count"] == 2
     ids = {b["branch_def_id"] for b in result["branches"]}
     assert ids == {b1, b2}

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -371,11 +371,23 @@ def _ext_branch_get(kwargs: dict[str, Any]) -> str:
     return json.dumps(branch, default=str)
 
 
+_VALID_BRANCH_LIST_SCOPES = {"published", "all", "mine"}
+
+
 def _ext_branch_list(kwargs: dict[str, Any]) -> str:
     from workflow.api.engine_helpers import _current_actor
     from workflow.daemon_server import list_branch_definitions
 
-    published_only = bool(kwargs.get("published_only", False))
+    scope = (kwargs.get("scope") or "published").strip().lower()
+    if scope not in _VALID_BRANCH_LIST_SCOPES:
+        return json.dumps({
+            "error": (
+                f"unknown scope '{scope}'. "
+                f"Valid scopes: {sorted(_VALID_BRANCH_LIST_SCOPES)}."
+            ),
+        })
+
+    actor = _current_actor()
 
     # Phase 6.2.2 — visibility-aware listing. Viewer sees public
     # Branches and any private Branches they authored.
@@ -384,7 +396,7 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
         domain_id=kwargs.get("domain_id", ""),
         author=kwargs.get("author", ""),
         goal_id=kwargs.get("goal_id", ""),
-        viewer=_current_actor(),
+        viewer=actor,
     )
 
     # requires_sandbox filter: "none" = design-only branches only (no node
@@ -394,10 +406,13 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
 
     summaries = []
     for r in rows:
-        if published_only:
+        if scope == "published":
             from workflow.branch_versions import list_branch_versions
 
             if not list_branch_versions(_base_path(), r.get("branch_def_id", ""), limit=1):
+                continue
+        elif scope == "mine":
+            if (r.get("author") or "") != actor:
                 continue
         node_defs = r.get("node_defs", [])
         has_sandbox_nodes = any(nd.get("requires_sandbox") for nd in node_defs)

--- a/workflow/api/extensions.py
+++ b/workflow/api/extensions.py
@@ -276,7 +276,7 @@ def _extensions_impl(
     node_ref_json: str = "",
     intent: str = "",
     node_query: str = "",
-    published_only: bool = False,
+    scope: str = "published",
     force: bool = False,
     project_id: str = "",
     key: str = "",
@@ -395,7 +395,7 @@ def _extensions_impl(
         "intent": intent,
         "query": node_query,
         "limit": limit,
-        "published_only": published_only,
+        "scope": scope,
         "force": force,
     }
     if node_ref_json:

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -520,7 +520,7 @@ def extensions(
     node_ref_json: str = "",
     intent: str = "",
     node_query: str = "",
-    published_only: bool = False,
+    scope: str = "published",
     force: bool = False,
     project_id: str = "",
     key: str = "",
@@ -602,8 +602,11 @@ def extensions(
     describe_branch, get_branch, run_branch, get_run, wait_for_run,
     judge_run, publish_version, schedule_branch, fork_tree, and search_nodes.
     Pass `action` plus the matching ids or JSON payload fields.
-    Use `published_only=True` with list_branches to show production-ready
-    Branches instead of drafts, probes, and smoke-test branches.
+    Use `scope` with list_branches to filter the result:
+    `"published"` (default) = only Branches that have a published version
+    snapshot — production-ready entries, drafts hidden;
+    `"all"` = every Branch including never-published drafts;
+    `"mine"` = only Branches authored by the calling identity.
     """
     return _extensions_impl(
         action=action,
@@ -652,7 +655,7 @@ def extensions(
         node_ref_json=node_ref_json,
         intent=intent,
         node_query=node_query,
-        published_only=published_only,
+        scope=scope,
         force=force,
         project_id=project_id,
         key=key,


### PR DESCRIPTION
## Summary

Host UX decision 2026-05-14: `list_branches` should accept a richer `scope=` enum rather than a one-line default flip on the existing `published_only` bool. Replaces the closed PR #848.

Three values:
- **`scope="published"` (default)** — only Branches with at least one published version snapshot. Curated first-impression for fresh users and chatbots that don't know to opt into a wider view.
- **`scope="all"`** — every Branch including never-published drafts (old `published_only=False` semantic).
- **`scope="mine"`** — only Branches authored by the calling identity.

Unknown scope values return `{"error": "unknown scope '...'. Valid scopes: [...]"}` rather than silently defaulting.

## Why an enum, not the bool

The host chose option 3 from the UX trade-off discussion: the bool didn't express the "show my drafts" use case, and the convergent-design-commons frame wants curated default visibility without making drafts hard to find. Enum extends naturally if a future scope like `"team"` or `"goal"` shows up.

## No shim

Per `feedback_no_shims_ever`: `published_only` is **removed** from the MCP signature, not aliased. Callers using `published_only=True` will get an "unexpected keyword argument" error. Forward-compat is acceptable because:
- MCP clients read tool description at runtime; the new `scope` parameter is documented in `extensions(...)` docstring
- The lower-level SQL function `list_branch_definitions(published_only=...)` keeps its parameter for internal Python callers (tests, dispatcher) — it filters on the legacy `published` boolean column, independent of the MCP-surface scope semantic

## Tests

8 files touched, 143 insertions / 39 deletions.

New tests in `tests/test_branch_authoring_actions.py`:
- `test_list_branches_scope_published_filters_on_published_versions` — `scope="published"` filters on version snapshots, not legacy bool
- `test_list_branches_scope_published_is_the_default` — omitting `scope` matches explicit `scope="published"`
- `test_list_branches_scope_mine_filters_to_caller` — multi-actor identity isolation
- `test_list_branches_rejects_unknown_scope` — error contains scope name + valid options

Three existing tests updated from implicit `published_only=False` default to explicit `scope="all"`:
- `test_list_branches_returns_summaries`
- `test_list_branches_node_count_matches_node_defs_length`
- `test_read_actions_do_not_hit_ledger`
- `test_list_branches_goal_id_filter` (in `tests/test_goals_surface.py`)

All 101 tests in the affected files pass locally.

## Related

- Supersedes closed PR #848 (one-line default flip).
- Substrate-readiness landing receipt: `pages/notes/substrate-readiness-pr857-pr858-pr859-pr861-merged-2026-05-14` — the open follow-up "host UX-default direction on list_branches" is what this PR resolves.
- The filter-dependency Codex flagged on 2026-05-13 is independently resolved by merged #859.

## Test plan
- [ ] `python -m pytest tests/test_branch_authoring_actions.py tests/test_goals_surface.py tests/test_branch_definitions_db.py -p no:cacheprovider` passes (101/101 local).
- [ ] `python -m ruff check workflow/api/branches.py workflow/api/extensions.py workflow/universe_server.py tests/test_branch_authoring_actions.py tests/test_goals_surface.py` — only pre-existing F811 in `_ext_branch_patch` (not touched by this PR).
- [ ] Canonical + plugin mirror parity verified via `python packaging/claude-plugin/build_plugin.py` — import probe ok.
- [ ] Cross-family checker review (writer:claude, checker:codex).
