### PR TITLE
wiki-bug-sync: GitHub-side dedup safety net (prevents the 3rd recurrence today of dup auto-change PRs)

### DIFF
--- a/scripts/wiki_bug_sync.py
+++ b/scripts/wiki_bug_sync.py
@@ -40,6 +40,7 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -505,6 +506,61 @@ def _gh_ensure_label(
         pass  # best-effort
 
 
+def find_existing_gh_issue(
+    token: str,
+    repo: str,
+    title_prefix: str,
+    gh_api: str = GITHUB_API,
+    timeout: float = 20.0,
+    opener=None,
+) -> str | None:
+    """Return URL of an existing issue whose title starts with ``title_prefix``.
+
+    Checks both open and closed issues — even a closed/landed prior filing
+    for the same wiki bug means we should not re-file. Returns None on no
+    match, malformed response, or network/HTTP error; the caller falls
+    through to its create-path so a transient API blip never silently
+    drops a needed filing. Pass ``opener`` for testability — it must
+    behave like ``urllib.request.urlopen``.
+
+    Today's recurrence pattern (2026-05-14) is multiple GitHub issues
+    referencing the same wiki BUG/PR-NNN: the cursor + change-seen state
+    is a write-side advance marker and cannot detect issues filed by a
+    different mechanism (host manual filing, earlier ad-hoc runs). This
+    check is a final safety net independent of the state files.
+    """
+    if not token:
+        return None
+    # The GitHub search API's `in:title` matches any token in the title,
+    # so we still need a post-filter for exact-prefix.
+    query = f'repo:{repo} is:issue in:title "{title_prefix}"'
+    search_url = (
+        f"{gh_api}/search/issues?q={urllib.parse.quote(query)}&per_page=10"
+    )
+    req = urllib.request.Request(
+        search_url,
+        method="GET",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "workflow-wiki-bug-sync/1.0",
+        },
+    )
+    _open = opener or urllib.request.urlopen
+    try:
+        with _open(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError,
+            json.JSONDecodeError):
+        return None
+    for item in data.get("items", []):
+        title = item.get("title", "")
+        if title.startswith(title_prefix):
+            return item.get("html_url")
+    return None
+
+
 def _label_color(label: str) -> str:
     if label == _AUTO_LABEL:
         return "0075ca"
@@ -591,6 +647,15 @@ def create_gh_issue(
     if not token:
         raise SyncError(3, "GITHUB_TOKEN is not set — cannot create GH Issues")
 
+    existing = find_existing_gh_issue(
+        token, repo, f"[{bug_id}]", gh_api=gh_api, timeout=timeout,
+    )
+    if existing:
+        print(
+            f"[wiki-bug-sync] {bug_id} skipped — existing issue at {existing}"
+        )
+        return existing
+
     # Ensure labels exist
     for label in labels:
         _gh_ensure_label(
@@ -659,6 +724,15 @@ def create_gh_change_issue(
 
     if not token:
         raise SyncError(3, "GITHUB_TOKEN is not set — cannot create GH Issues")
+
+    existing = find_existing_gh_issue(
+        token, repo, title_str, gh_api=gh_api, timeout=timeout,
+    )
+    if existing:
+        print(
+            f"[wiki-bug-sync] {prefix}:{path} skipped — existing issue at {existing}"
+        )
+        return existing
 
     for label in labels:
         _gh_ensure_label(

--- a/tests/test_wiki_bug_sync.py
+++ b/tests/test_wiki_bug_sync.py
@@ -16,6 +16,7 @@ from wiki_bug_sync import (  # noqa: E402
     create_gh_change_issue,
     create_gh_issue,
     fetch_bug_detail,
+    find_existing_gh_issue,
     list_new_bugs,
     list_new_change_requests,
     priority_labels_for_request,
@@ -414,6 +415,171 @@ def test_create_gh_issue_no_token_raises():
             body_md="desc", dry_run=False,
         )
     assert exc_info.value.code == 3
+
+
+# ---------------------------------------------------------------------------
+# find_existing_gh_issue — GitHub-side dedup safety net
+# ---------------------------------------------------------------------------
+
+
+class _MockHTTPResponse:
+    """Context-manager-friendly stand-in for urllib.request.urlopen result."""
+
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode()
+
+
+def _make_opener(payload: dict | None = None, raise_exc: Exception | None = None):
+    calls = []
+
+    def _opener(req, timeout=None):
+        calls.append({"url": req.full_url, "headers": dict(req.headers)})
+        if raise_exc is not None:
+            raise raise_exc
+        return _MockHTTPResponse(payload or {"items": []})
+
+    _opener.calls = calls
+    return _opener
+
+
+def test_find_existing_gh_issue_returns_url_on_prefix_match():
+    opener = _make_opener({
+        "items": [
+            {"title": "[BUG-080] some title", "html_url": "https://example/issues/851"},
+        ],
+    })
+    url = find_existing_gh_issue(
+        token="tok", repo="owner/repo", title_prefix="[BUG-080]",
+        opener=opener,
+    )
+    assert url == "https://example/issues/851"
+    assert len(opener.calls) == 1
+    assert "search/issues" in opener.calls[0]["url"]
+    assert "%5BBUG-080%5D" in opener.calls[0]["url"]  # url-encoded "[BUG-080]"
+
+
+def test_find_existing_gh_issue_returns_none_on_no_match():
+    opener = _make_opener({"items": []})
+    assert find_existing_gh_issue(
+        token="tok", repo="owner/repo", title_prefix="[BUG-999]",
+        opener=opener,
+    ) is None
+
+
+def test_find_existing_gh_issue_filters_post_hoc_for_exact_prefix():
+    """GitHub's `in:title` matches any token, so the helper must post-filter
+    on exact prefix match — otherwise a `BUG-080` search would falsely
+    return a `BUG-8000` issue whose title also contains the token."""
+    opener = _make_opener({
+        "items": [
+            {"title": "[BUG-8000] unrelated bug", "html_url": "https://example/issues/9000"},
+            {"title": "[BUG-080] real match", "html_url": "https://example/issues/851"},
+        ],
+    })
+    url = find_existing_gh_issue(
+        token="tok", repo="owner/repo", title_prefix="[BUG-080]",
+        opener=opener,
+    )
+    assert url == "https://example/issues/851"
+
+
+def test_find_existing_gh_issue_returns_none_on_network_error():
+    import urllib.error
+
+    opener = _make_opener(raise_exc=urllib.error.URLError("dns fail"))
+    # Best-effort: must not raise; falling through to create-path is the
+    # correct safety posture so a transient API blip never silently drops
+    # a needed filing.
+    assert find_existing_gh_issue(
+        token="tok", repo="owner/repo", title_prefix="[BUG-080]",
+        opener=opener,
+    ) is None
+
+
+def test_find_existing_gh_issue_returns_none_without_token():
+    """No GITHUB_TOKEN → can't search, so return None and fall through."""
+    opener = _make_opener({"items": []})
+    assert find_existing_gh_issue(
+        token="", repo="owner/repo", title_prefix="[BUG-080]",
+        opener=opener,
+    ) is None
+    # MUST NOT have called the opener — no token means no GH API hit at all.
+    assert opener.calls == []
+
+
+def test_create_gh_issue_skips_when_existing_issue_found(monkeypatch, capsys):
+    """The recurrence pattern from 2026-05-14 (#840+#851 etc.): wiki-bug-sync
+    must not re-file an issue when one with the same `[BUG-NNN]` prefix
+    already exists, even when the cursor would otherwise advance past it."""
+    import wiki_bug_sync as wbs
+
+    captured = {}
+
+    def fake_find(token, repo, title_prefix, **kwargs):
+        captured["title_prefix"] = title_prefix
+        return "https://example/issues/851"
+
+    monkeypatch.setattr(wbs, "find_existing_gh_issue", fake_find)
+
+    # If we *did* fall through to creation it would raise on the urlopen
+    # POST; the dedup short-circuit prevents that. Wrap urlopen so a
+    # missed short-circuit produces a clear failure.
+    def boom(*_a, **_kw):
+        raise AssertionError("create_gh_issue should not POST when dedup hits")
+
+    monkeypatch.setattr(wbs.urllib.request, "urlopen", boom)
+
+    url = create_gh_issue(
+        token="tok", repo="owner/repo",
+        bug_id="BUG-080", title="Test", severity="major", component="x",
+        body_md="desc", dry_run=False,
+    )
+    assert url == "https://example/issues/851"
+    assert captured["title_prefix"] == "[BUG-080]"
+    out = capsys.readouterr().out
+    assert "BUG-080 skipped" in out
+    assert "https://example/issues/851" in out
+
+
+def test_create_gh_change_issue_skips_when_existing_issue_found(monkeypatch, capsys):
+    """Same dedup safety net for non-bug change requests. The full
+    `[WIKI-PATCH] <title>` is used (not just `[WIKI-PATCH]`) so distinct
+    patches with the same prefix don't false-positive each other."""
+    import wiki_bug_sync as wbs
+
+    captured = {}
+
+    def fake_find(token, repo, title_prefix, **kwargs):
+        captured["title_prefix"] = title_prefix
+        return "https://example/issues/855"
+
+    monkeypatch.setattr(wbs, "find_existing_gh_issue", fake_find)
+
+    def boom(*_a, **_kw):
+        raise AssertionError("create_gh_change_issue should not POST when dedup hits")
+
+    monkeypatch.setattr(wbs.urllib.request, "urlopen", boom)
+
+    url = create_gh_change_issue(
+        token="tok", repo="owner/repo",
+        request_kind="patch",
+        title="Move A — clone-with-inherit",
+        path="pages/patch-requests/pr-110-move-a.md",
+        body_md="desc", dry_run=False,
+    )
+    assert url == "https://example/issues/855"
+    # Must search on the full title prefix, not just `[WIKI-PATCH]`, to
+    # avoid matching unrelated WIKI-PATCH issues.
+    assert captured["title_prefix"].startswith("[WIKI-PATCH] Move A")
 
 
 def test_fetch_bug_detail_reads_with_page_not_path():


### PR DESCRIPTION
## Summary

Three duplicate auto-change PR pairs today (#862/#863/#864 each filed against an already-merged sibling fix) showed the existing dedup mechanism has a real-world gap:

| Wiki BUG/PR | Manual-issue (host-authored) | Auto-sync issue | Result |
|---|---|---|---|
| BUG-080 | #840 (2026-05-13T05:46Z) | #851 (07:31Z) | dup PRs #857 merged, #863 closed |
| BUG-082 | #842 | #853 | dup PRs #859 merged, #862 closed |
| PR-110 | #844 | #855 | dup PRs #861 merged, #864 closed |

The cursor + change-seen state files are write-side advance markers and can't detect issues filed by a different mechanism (host manual filing, ad-hoc runs, daemon-driven paths).

## What this PR does

Adds a GitHub-side existence check inside `create_gh_issue` and `create_gh_change_issue` as a final safety net independent of the state files. Searches the GitHub Issues API for exact title-prefix matches before POSTing a new issue. If found, logs + returns the existing URL instead of duplicating.

## Root-cause framing

The `project_file_bug_dedup_at_filing` memory pointed at `_wiki_file_bug` as the dedup site, but `_wiki_file_bug` already dedups correctly — each wiki BUG/PR-NNN page exists exactly once on disk. The actual gap is at the wiki-page → GitHub-issue sync layer where two filing mechanisms ran without seeing each other.

## Key design choices

- **Post-filter on exact prefix** to avoid false positives from GitHub's `in:title` token search (e.g. `[BUG-080]` query returning `[BUG-8000]` issues).
- **Full-title prefix for change-requests** (`[WIKI-PATCH] Move A...` not just `[WIKI-PATCH]`) so distinct patches don't false-positive each other.
- **Best-effort on network errors** — network/HTTP errors return None and fall through to create-path; a transient API blip must never silently drop a needed filing.
- **No-token short-circuit** — returns None without an API call so dry-run + no-credentials paths stay clean.
- **Additive** — doesn't change cursor / seen-changes state mechanics; acts as a redundant final check on top of them.

## Tests

Six new tests in `tests/test_wiki_bug_sync.py`:
- `test_find_existing_gh_issue_returns_url_on_prefix_match` — happy path
- `test_find_existing_gh_issue_returns_none_on_no_match` — empty items
- `test_find_existing_gh_issue_filters_post_hoc_for_exact_prefix` — BUG-080 vs BUG-8000
- `test_find_existing_gh_issue_returns_none_on_network_error` — fall-through safety
- `test_find_existing_gh_issue_returns_none_without_token` — no API call without token
- `test_create_gh_issue_skips_when_existing_issue_found` — wiring + log + asserts no POST
- `test_create_gh_change_issue_skips_when_existing_issue_found` — same wiring for non-bug kinds + full-title-prefix check

41/41 tests in the file pass locally. `python -m ruff check scripts/wiki_bug_sync.py tests/test_wiki_bug_sync.py` clean.

## Related

- [[project_file_bug_dedup_at_filing]] memory — root-cause framing (slightly different target than initially hypothesized)
- Closed duplicate PRs: #862 / #863 / #864 — would not have been filed if this safety net was live
- Substrate-readiness landing receipts: pages/notes/substrate-readiness-pr857-pr858-pr859-pr861-merged-2026-05-14, pages/notes/scope-enum-list-branches-pr865-merged-2026-05-15

## Test plan
- [ ] `python -m pytest tests/test_wiki_bug_sync.py -p no:cacheprovider` passes 41/41 (local).
- [ ] `python -m ruff check scripts/wiki_bug_sync.py tests/test_wiki_bug_sync.py` clean.
- [ ] Cross-family checker review (writer:claude, checker:codex).
- [ ] After merge: next wiki-bug-sync schedule run on a wiki BUG that already has a manual issue should log "skipped — existing issue at https://..." instead of creating a duplicate.
