### PR TITLE
[auto-change] WIKI-DESIGN: User-Buildable Community Change Loop — v0 Substrate Readiness Baseline

### DIFF
--- a/docs/ops/wiki-bug-sync-runbook.md
+++ b/docs/ops/wiki-bug-sync-runbook.md
@@ -19,8 +19,10 @@ of the community change loop.
 3. BUG lane: filters promoted BUG entries with `bug_number > cursor`.
 4. Community lane: filters promoted non-bug request artifacts not in
    `.agents/.wiki_change_sync_seen.json`.
-5. For each new item, calls `wiki action=read` to pull frontmatter, then POSTs
-   a GH Issue via `GITHUB_TOKEN`.
+5. For each new item, calls `wiki action=read` to pull frontmatter. Non-bug
+   community request issues also include a bounded copy of the source wiki body
+   so auto-change writers see the request evidence without a separate lookup.
+   Then the sync POSTs a GH Issue via `GITHUB_TOKEN`.
 6. BUG issue title: `[BUG-NNN] <title>`. Labels: `daemon-request`,
    `auto-change`, `auto-bug`, `request:bug`, `payment:free-ok`,
    `writer-pool:claude-codex`, `checker:cross-family`, `gate-required`, and

--- a/scripts/wiki_bug_sync.py
+++ b/scripts/wiki_bug_sync.py
@@ -49,6 +49,7 @@ DEFAULT_URL = "https://tinyassets.io/mcp"
 DEFAULT_TIMEOUT = 20.0
 GITHUB_API = "https://api.github.com"
 GITHUB_REPO = os.environ.get("GITHUB_REPOSITORY", "Jonnyton/Workflow")
+MAX_CHANGE_BODY_CHARS = 12000
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 CURSOR_PATH = _REPO_ROOT / ".agents" / ".wiki_bug_sync_cursor"
@@ -437,14 +438,28 @@ def list_new_change_requests(
 # ---------------------------------------------------------------------------
 
 
-def fetch_bug_detail(
+def _split_frontmatter(content: str) -> tuple[dict[str, str], str]:
+    meta: dict[str, str] = {}
+    body = content
+    if content.startswith("---"):
+        parts = content.split("---", 2)
+        if len(parts) >= 3:
+            for line in parts[1].splitlines():
+                if ":" in line:
+                    k, _, v = line.partition(":")
+                    meta[k.strip()] = v.strip()
+            body = parts[2].lstrip()
+    return meta, body
+
+
+def fetch_wiki_page_detail(
     url: str,
     sid: str | None,
     path: str,
     timeout: float,
     post_fn=None,
 ) -> dict[str, Any]:
-    """Call wiki action=read and parse the frontmatter fields we need."""
+    """Call wiki action=read and return parsed frontmatter plus page body."""
     page = Path(path).stem or path
     result = _mcp_call_tool(
         url, sid, "wiki", {"action": "read", "page": page}, timeout, post_fn
@@ -456,16 +471,35 @@ def fetch_bug_detail(
     except (json.JSONDecodeError, AttributeError):
         content = text
 
-    # Parse frontmatter from the markdown content
-    meta: dict[str, str] = {}
-    if content.startswith("---"):
-        parts = content.split("---", 2)
-        if len(parts) >= 3:
-            for line in parts[1].splitlines():
-                if ":" in line:
-                    k, _, v = line.partition(":")
-                    meta[k.strip()] = v.strip()
-    return meta
+    meta, body = _split_frontmatter(content)
+    return {"meta": meta, "body": body, "content": content}
+
+
+def fetch_bug_detail(
+    url: str,
+    sid: str | None,
+    path: str,
+    timeout: float,
+    post_fn=None,
+) -> dict[str, Any]:
+    """Call wiki action=read and parse the frontmatter fields we need."""
+    return fetch_wiki_page_detail(url, sid, path, timeout, post_fn).get("meta", {})
+
+
+def format_change_issue_body(entry: dict[str, Any], page_detail: dict[str, Any]) -> str:
+    """Build bounded issue context for non-bug community request artifacts."""
+    body = f"**Wiki type:** `{entry.get('type', 'unknown')}`"
+    source_body = str(page_detail.get("body") or "").strip()
+    if not source_body:
+        return body
+
+    truncated = source_body[:MAX_CHANGE_BODY_CHARS]
+    if len(source_body) > MAX_CHANGE_BODY_CHARS:
+        truncated = (
+            f"{truncated}\n\n"
+            f"_Source wiki body truncated at {MAX_CHANGE_BODY_CHARS} characters._"
+        )
+    return f"{body}\n\n## Source wiki body\n\n{truncated}"
 
 
 # ---------------------------------------------------------------------------
@@ -843,12 +877,14 @@ def sync(
             request_kind = entry["request_kind"]
 
             try:
-                meta = fetch_bug_detail(url, sid, path, timeout, post_fn)
+                page_detail = fetch_wiki_page_detail(url, sid, path, timeout, post_fn)
+                meta = page_detail.get("meta", {})
             except SyncError:
+                page_detail = {}
                 meta = {}
 
             title = meta.get("title") or entry.get("title") or Path(path).stem
-            body_md = f"**Wiki type:** `{entry.get('type', 'unknown')}`"
+            body_md = format_change_issue_body(entry, page_detail)
             issue_url = create_gh_change_issue(
                 _token,
                 repo,

--- a/tests/test_wiki_bug_sync.py
+++ b/tests/test_wiki_bug_sync.py
@@ -16,7 +16,9 @@ from wiki_bug_sync import (  # noqa: E402
     create_gh_change_issue,
     create_gh_issue,
     fetch_bug_detail,
+    fetch_wiki_page_detail,
     find_existing_gh_issue,
+    format_change_issue_body,
     list_new_bugs,
     list_new_change_requests,
     priority_labels_for_request,
@@ -50,16 +52,28 @@ def _wiki_list_resp(bugs: list[dict]) -> dict:
     }
 
 
-def _wiki_read_resp(meta: dict) -> dict:
+def _wiki_read_resp(meta: dict, body: str = "# Body") -> dict:
     """Build a mock MCP tools/call result for wiki action=read."""
     fm_lines = "\n".join(f"{k}: {v}" for k, v in meta.items())
-    content = f"---\n{fm_lines}\n---\n\n# Body"
+    content = f"---\n{fm_lines}\n---\n\n{body}"
     return {
         "jsonrpc": "2.0",
         "id": 10,
         "result": {
             "content": [
                 {"type": "text", "text": json.dumps({"content": content})}
+            ]
+        },
+    }
+
+
+def _wiki_list_promoted_resp(promoted: list[dict]) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": 10,
+        "result": {
+            "content": [
+                {"type": "text", "text": json.dumps({"promoted": promoted, "drafts": []})}
             ]
         },
     }
@@ -599,6 +613,36 @@ def test_fetch_bug_detail_reads_with_page_not_path():
     assert detail["title"] == "Bug"
 
 
+def test_fetch_wiki_page_detail_returns_body_without_frontmatter():
+    detail = fetch_wiki_page_detail(
+        "http://fake/mcp",
+        "sid1",
+        "pages/plans/user-buildable-community-change-loop-v0-substrate-readiness-baseline.md",
+        5.0,
+        post_fn=CapturingPost([
+            (_wiki_read_resp(
+                {"title": "User-Buildable Community Change Loop"},
+                "## Main finding\n\nInput-aware loops are gated on BUG-083.",
+            ), "sid1"),
+        ]),
+    )
+
+    assert detail["meta"]["title"] == "User-Buildable Community Change Loop"
+    assert "Input-aware loops are gated on BUG-083." in detail["body"]
+    assert "title:" not in detail["body"]
+
+
+def test_format_change_issue_body_includes_bounded_source_context():
+    body = format_change_issue_body(
+        {"type": "plan"},
+        {"body": "## Pickup hints\n\nRetest immediately after BUG-083 changes."},
+    )
+
+    assert "**Wiki type:** `plan`" in body
+    assert "## Source wiki body" in body
+    assert "Retest immediately after BUG-083 changes." in body
+
+
 # ---------------------------------------------------------------------------
 # sync() — happy path: no new bugs
 # ---------------------------------------------------------------------------
@@ -689,6 +733,67 @@ def test_sync_one_new_bug_updates_cursor(tmp_path):
     assert rc == 0
     assert created_issues == ["BUG-003"]
     assert read_cursor(cursor_path) == 3
+
+
+def test_sync_change_request_includes_source_wiki_body(tmp_path):
+    cursor_path = tmp_path / "cursor"
+    change_seen_path = tmp_path / "seen.json"
+    write_cursor(0, cursor_path)
+
+    path = "pages/plans/user-buildable-community-change-loop-v0-substrate-readiness-baseline.md"
+    captured = {}
+
+    post_fn = _make_post_fn(
+        (_INIT_OK, "sid1"),
+        (_NOTIF_NONE, "sid1"),
+        (_wiki_list_promoted_resp([
+            {
+                "path": path,
+                "title": "User-Buildable Community Change Loop",
+                "type": "plan",
+            }
+        ]), "sid1"),
+        (_wiki_read_resp(
+            {"title": "User-Buildable Community Change Loop"},
+            (
+                "## Main finding\n\n"
+                "Input-aware community loops are gated on BUG-083.\n\n"
+                "## Pickup hints\n\n"
+                "Retest immediately after BUG-083 changes."
+            ),
+        ), "sid1"),
+    )
+
+    def _fake_create_change_issue(
+        token, repo, request_kind, title, path, body_md,
+        dry_run=False, gh_api=None, timeout=20.0,
+    ):
+        captured.update(
+            request_kind=request_kind,
+            title=title,
+            path=path,
+            body_md=body_md,
+        )
+        return "https://github.com/owner/repo/issues/869"
+
+    with patch("wiki_bug_sync.create_gh_change_issue", side_effect=_fake_create_change_issue):
+        rc = sync(
+            "http://fake/mcp",
+            5.0,
+            dry_run=False,
+            include_community_requests=True,
+            token="fake-token",
+            cursor_path=cursor_path,
+            change_seen_path=change_seen_path,
+            post_fn=post_fn,
+        )
+
+    assert rc == 0
+    assert captured["request_kind"] == "project-design"
+    assert captured["path"] == path
+    assert "Input-aware community loops are gated on BUG-083." in captured["body_md"]
+    assert "Retest immediately after BUG-083 changes." in captured["body_md"]
+    assert path in change_seen_path.read_text(encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #869

## Request artifact reconciliation

- Wiki page: `pages/plans/user-buildable-community-change-loop-v0-substrate-readiness-baseline.md`
- GitHub issue: #869
- Branch task: `auto-change/issue-869`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.