### PR TITLE
chore: set permissions.defaultMode to "auto" as project default

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,7 @@
     "CLAUDE_CODE_TEAMMATE_MODE": "in-process"
   },
   "permissions": {
+    "defaultMode": "auto",
     "allow": [
       "Bash(*)",
       "Read(*)",


### PR DESCRIPTION
## Summary
- Add `"defaultMode": "auto"` to `permissions` in `.claude/settings.json` so every Claude Code session opened in this project defaults to auto-mode without needing `--permission-mode auto` on the CLI.

## Test plan
- [ ] Open a new Claude Code session in this repo and confirm the session starts in auto mode (no `--permission-mode` flag).
- [ ] Confirm existing permission allowlist + hooks are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)