### PR TITLE
[auto-change] BUG-084: child_invocation_receipt_gate's 300s ceiling has no retry, promotion, or reclaim path — long child runs fail unrecoverably and leave parents in receipt-waiting purgatory (the gate has never had its own filing despite being observed for 10+ days)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/runs.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/runs.py
@@ -1572,6 +1572,25 @@ class ChildFailure:
     partial_output: dict[str, Any] | None = None
 
 
+class ChildRunAwaitTimeout(TimeoutError):
+    """Raised when an awaited child run is still non-terminal at the ceiling."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        run_id: str,
+        child_status: str,
+        child_branch_def_id: str,
+        timeout_seconds: float,
+    ) -> None:
+        super().__init__(message)
+        self.run_id = run_id
+        self.child_status = child_status
+        self.child_branch_def_id = child_branch_def_id
+        self.timeout_seconds = timeout_seconds
+
+
 @dataclass
 class RunOutcome:
     run_id: str
@@ -1929,6 +1948,44 @@ def _invoke_graph(
             run_id=run_id, status=RUN_STATUS_FAILED,
             output={}, error=msg,
             child_failures=[failure] if failure is not None else [],
+        )
+    except ChildRunAwaitTimeout as exc:
+        msg = (
+            f"Child invocation receipt gate timed out after "
+            f"{exc.timeout_seconds}s while child run '{exc.run_id}' was "
+            f"still {exc.child_status}; parent is receipt-waiting and can be "
+            "reclaimed with attach_existing_child_run."
+        )
+        output = {
+            "parent_loop_status": "receipt_waiting",
+            "selected_child_status": "child_invocation_receipt_waiting",
+            "selected_branch_state": "child_invocation_receipt_waiting",
+            "automation_claim_status": "child_invocation_receipt_waiting",
+            "child_run_id": exc.run_id,
+            "selected_child_run_id": exc.run_id,
+            "selected_child_branch_def_id": exc.child_branch_def_id,
+            "child_invocation_receipt_gate": {
+                "status": "receipt_waiting",
+                "reason": "child_run_still_running_after_timeout",
+                "child_run_id": exc.run_id,
+                "child_status": exc.child_status,
+                "child_branch_def_id": exc.child_branch_def_id,
+                "timeout_seconds": exc.timeout_seconds,
+                "reclaim_action": "attach_existing_child_run",
+            },
+        }
+        update_run_status(
+            base_path, run_id,
+            status=RUN_STATUS_INTERRUPTED,
+            output=output,
+            error=msg,
+            finished_at=_now(),
+        )
+        return RunOutcome(
+            run_id=run_id,
+            status=RUN_STATUS_INTERRUPTED,
+            output=output,
+            error=msg,
         )
     except Exception as exc:
         # GraphRecursionError: structured error naming the applied limit.
@@ -3087,9 +3144,13 @@ def poll_child_run_status(
             return record
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            raise TimeoutError(
+            raise ChildRunAwaitTimeout(
                 f"await_branch_run: child run '{run_id}' did not complete "
-                f"within {timeout_seconds}s."
+                f"within {timeout_seconds}s.",
+                run_id=run_id,
+                child_status=str(record.get("status") or ""),
+                child_branch_def_id=str(record.get("branch_def_id") or ""),
+                timeout_seconds=timeout_seconds,
             )
         time.sleep(min(poll_interval, remaining))
 
@@ -3294,6 +3355,7 @@ ACTIONABLE_BY: dict[str, str] = {
     "compile_error": "chatbot",
     "snapshot_schema_drift": "chatbot",
     "interrupted": "chatbot",
+    "child_receipt_waiting": "chatbot",
     # user — opaque/internal; chatbot escalates raw error for human judgment
     "unknown": "user",
     "error": "user",
@@ -3316,6 +3378,11 @@ def _classify_failure(run: dict) -> str:
     if status == RUN_STATUS_CANCELLED:
         return "cancelled"
     if status == RUN_STATUS_INTERRUPTED:
+        output = run.get("output") or {}
+        if isinstance(output, dict):
+            gate = output.get("child_invocation_receipt_gate")
+            if isinstance(gate, dict) and gate.get("status") == "receipt_waiting":
+                return "child_receipt_waiting"
         return "interrupted"
     if not error:
         return ""
@@ -3401,6 +3468,11 @@ def list_recent_runs(
             suggested_action = "Run was cancelled by request."
         elif failure_class == "interrupted":
             suggested_action = "Run was interrupted; use resume_run to continue."
+        elif failure_class == "child_receipt_waiting":
+            suggested_action = (
+                "Wait for the child run to complete, then call "
+                "attach_existing_child_run with the recorded child_run_id."
+            )
         elif failure_class == "error":
             suggested_action = "Check error field for details; re-run after fixing root cause."
 
@@ -3446,6 +3518,7 @@ __all__ = [
     "NODE_STATUS_FAILED",
     "ACTIONABLE_BY",
     "ChildRunAttachmentError",
+    "ChildRunAwaitTimeout",
     "RunCancelledError",
     "RunOutcome",
     "RunStepEvent",

--- a/tests/test_attach_existing_child_run.py
+++ b/tests/test_attach_existing_child_run.py
@@ -234,3 +234,28 @@ def test_attach_existing_child_run_rejects_parent_not_receipt_waiting(attach_env
     result = _attach(parent_id, child_id)
 
     assert result["error_code"] == "parent_not_receipt_waiting"
+
+
+def test_attach_existing_child_run_reclaims_child_invocation_receipt_waiting_parent(attach_env):
+    parent_id = _make_run(
+        attach_env,
+        branch_def_id="parent-branch",
+        status="interrupted",
+        output={
+            "parent_loop_status": "receipt_waiting",
+            "selected_child_status": "child_invocation_receipt_waiting",
+            "selected_branch_state": "child_invocation_receipt_waiting",
+            "selected_child_branch_def_id": "child-branch",
+            "child_invocation_receipt_gate": {
+                "status": "receipt_waiting",
+                "reclaim_action": "attach_existing_child_run",
+            },
+        },
+    )
+    child_id = _completed_child(attach_env)
+
+    result = _attach(parent_id, child_id)
+
+    assert result["status"] == "attached"
+    assert result["automation_claim_status"] == "child_attached_with_handle"
+    assert result["stable_evidence_handle"].startswith("run-attachment:")

--- a/tests/test_sub_branch_invocation.py
+++ b/tests/test_sub_branch_invocation.py
@@ -30,7 +30,11 @@ from workflow.graph_compiler import (
     _build_await_branch_run_node,
     _build_invoke_branch_node,
 )
-from workflow.runs import MAX_INVOKE_BRANCH_DEPTH, poll_child_run_status
+from workflow.runs import (
+    MAX_INVOKE_BRANCH_DEPTH,
+    ChildRunAwaitTimeout,
+    poll_child_run_status,
+)
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -393,6 +397,103 @@ class TestPollChildRunStatus:
 
         with pytest.raises(TimeoutError):
             poll_child_run_status(tmp_path, run_id, timeout_seconds=0.05, poll_interval=0.01)
+
+    def test_timeout_carries_reclaim_context_for_still_running_child(self, tmp_path):
+        from workflow.runs import (
+            RUN_STATUS_RUNNING,
+            create_run,
+            initialize_runs_db,
+            update_run_status,
+        )
+
+        initialize_runs_db(tmp_path)
+        run_id = create_run(
+            tmp_path,
+            branch_def_id="child-branch",
+            thread_id="thread-stuck",
+            run_name="stuck",
+            actor="tester",
+            inputs={},
+        )
+        update_run_status(tmp_path, run_id, status=RUN_STATUS_RUNNING)
+
+        with pytest.raises(ChildRunAwaitTimeout) as exc_info:
+            poll_child_run_status(
+                tmp_path, run_id, timeout_seconds=0.05, poll_interval=0.01,
+            )
+
+        exc = exc_info.value
+        assert exc.run_id == run_id
+        assert exc.child_status == RUN_STATUS_RUNNING
+        assert exc.child_branch_def_id == "child-branch"
+        assert exc.timeout_seconds == 0.05
+
+    def test_await_timeout_promotes_parent_to_receipt_waiting(self, tmp_path):
+        from workflow.runs import (
+            RUN_STATUS_INTERRUPTED,
+            RUN_STATUS_RUNNING,
+            create_run,
+            execute_branch,
+            get_run,
+            initialize_runs_db,
+            list_recent_runs,
+            update_run_status,
+        )
+
+        initialize_runs_db(tmp_path)
+        child_run_id = create_run(
+            tmp_path,
+            branch_def_id="child-branch",
+            thread_id="thread-child",
+            run_name="child",
+            actor="tester",
+            inputs={},
+        )
+        update_run_status(tmp_path, child_run_id, status=RUN_STATUS_RUNNING)
+
+        branch = BranchDefinition(name="parent", entry_point="await-child")
+        branch.node_defs = [
+            NodeDefinition(
+                node_id="await-child",
+                display_name="Await Child",
+                await_run_spec={
+                    "run_id_field": "child_run_id",
+                    "output_mapping": {"child_result": "result"},
+                    "timeout_seconds": 0.05,
+                },
+            ),
+        ]
+        branch.graph_nodes = [GraphNodeRef(id="await-child", node_def_id="await-child")]
+        branch.edges = [
+            EdgeDefinition(from_node="START", to_node="await-child"),
+            EdgeDefinition(from_node="await-child", to_node="END"),
+        ]
+        branch.state_schema = [
+            {"name": "child_run_id", "type": "str"},
+            {"name": "child_result", "type": "str"},
+        ]
+
+        outcome = execute_branch(
+            tmp_path,
+            branch=branch,
+            inputs={"child_run_id": child_run_id},
+        )
+
+        assert outcome.status == RUN_STATUS_INTERRUPTED
+        assert outcome.output["selected_child_status"] == "child_invocation_receipt_waiting"
+        assert outcome.output["child_invocation_receipt_gate"]["child_run_id"] == child_run_id
+        assert outcome.output["child_invocation_receipt_gate"]["reclaim_action"] == (
+            "attach_existing_child_run"
+        )
+
+        parent = get_run(tmp_path, outcome.run_id)
+        assert parent is not None
+        assert parent["status"] == RUN_STATUS_INTERRUPTED
+        assert parent["output"]["selected_child_run_id"] == child_run_id
+
+        recent = list_recent_runs(tmp_path, limit=1)
+        assert recent[0]["failure_class"] == "child_receipt_waiting"
+        assert "attach_existing_child_run" in recent[0]["suggested_action"]
 
 
 # ─── Phase A item 5 (Task #76a) — invoke_branch_version_spec validation ──────

--- a/workflow/runs.py
+++ b/workflow/runs.py
@@ -1572,6 +1572,25 @@ class ChildFailure:
     partial_output: dict[str, Any] | None = None
 
 
+class ChildRunAwaitTimeout(TimeoutError):
+    """Raised when an awaited child run is still non-terminal at the ceiling."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        run_id: str,
+        child_status: str,
+        child_branch_def_id: str,
+        timeout_seconds: float,
+    ) -> None:
+        super().__init__(message)
+        self.run_id = run_id
+        self.child_status = child_status
+        self.child_branch_def_id = child_branch_def_id
+        self.timeout_seconds = timeout_seconds
+
+
 @dataclass
 class RunOutcome:
     run_id: str
@@ -1929,6 +1948,44 @@ def _invoke_graph(
             run_id=run_id, status=RUN_STATUS_FAILED,
             output={}, error=msg,
             child_failures=[failure] if failure is not None else [],
+        )
+    except ChildRunAwaitTimeout as exc:
+        msg = (
+            f"Child invocation receipt gate timed out after "
+            f"{exc.timeout_seconds}s while child run '{exc.run_id}' was "
+            f"still {exc.child_status}; parent is receipt-waiting and can be "
+            "reclaimed with attach_existing_child_run."
+        )
+        output = {
+            "parent_loop_status": "receipt_waiting",
+            "selected_child_status": "child_invocation_receipt_waiting",
+            "selected_branch_state": "child_invocation_receipt_waiting",
+            "automation_claim_status": "child_invocation_receipt_waiting",
+            "child_run_id": exc.run_id,
+            "selected_child_run_id": exc.run_id,
+            "selected_child_branch_def_id": exc.child_branch_def_id,
+            "child_invocation_receipt_gate": {
+                "status": "receipt_waiting",
+                "reason": "child_run_still_running_after_timeout",
+                "child_run_id": exc.run_id,
+                "child_status": exc.child_status,
+                "child_branch_def_id": exc.child_branch_def_id,
+                "timeout_seconds": exc.timeout_seconds,
+                "reclaim_action": "attach_existing_child_run",
+            },
+        }
+        update_run_status(
+            base_path, run_id,
+            status=RUN_STATUS_INTERRUPTED,
+            output=output,
+            error=msg,
+            finished_at=_now(),
+        )
+        return RunOutcome(
+            run_id=run_id,
+            status=RUN_STATUS_INTERRUPTED,
+            output=output,
+            error=msg,
         )
     except Exception as exc:
         # GraphRecursionError: structured error naming the applied limit.
@@ -3087,9 +3144,13 @@ def poll_child_run_status(
             return record
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            raise TimeoutError(
+            raise ChildRunAwaitTimeout(
                 f"await_branch_run: child run '{run_id}' did not complete "
-                f"within {timeout_seconds}s."
+                f"within {timeout_seconds}s.",
+                run_id=run_id,
+                child_status=str(record.get("status") or ""),
+                child_branch_def_id=str(record.get("branch_def_id") or ""),
+                timeout_seconds=timeout_seconds,
             )
         time.sleep(min(poll_interval, remaining))
 
@@ -3294,6 +3355,7 @@ ACTIONABLE_BY: dict[str, str] = {
     "compile_error": "chatbot",
     "snapshot_schema_drift": "chatbot",
     "interrupted": "chatbot",
+    "child_receipt_waiting": "chatbot",
     # user — opaque/internal; chatbot escalates raw error for human judgment
     "unknown": "user",
     "error": "user",
@@ -3316,6 +3378,11 @@ def _classify_failure(run: dict) -> str:
     if status == RUN_STATUS_CANCELLED:
         return "cancelled"
     if status == RUN_STATUS_INTERRUPTED:
+        output = run.get("output") or {}
+        if isinstance(output, dict):
+            gate = output.get("child_invocation_receipt_gate")
+            if isinstance(gate, dict) and gate.get("status") == "receipt_waiting":
+                return "child_receipt_waiting"
         return "interrupted"
     if not error:
         return ""
@@ -3401,6 +3468,11 @@ def list_recent_runs(
             suggested_action = "Run was cancelled by request."
         elif failure_class == "interrupted":
             suggested_action = "Run was interrupted; use resume_run to continue."
+        elif failure_class == "child_receipt_waiting":
+            suggested_action = (
+                "Wait for the child run to complete, then call "
+                "attach_existing_child_run with the recorded child_run_id."
+            )
         elif failure_class == "error":
             suggested_action = "Check error field for details; re-run after fixing root cause."
 
@@ -3446,6 +3518,7 @@ __all__ = [
     "NODE_STATUS_FAILED",
     "ACTIONABLE_BY",
     "ChildRunAttachmentError",
+    "ChildRunAwaitTimeout",
     "RunCancelledError",
     "RunOutcome",
     "RunStepEvent",


### PR DESCRIPTION
Fixes #874

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-084-child-invocation-receipt-gate-s-300s-ceiling-has-no-retry-pr.md`
- GitHub issue: #874
- Branch task: `auto-change/issue-874`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.