### PR TITLE
[auto-change] WIKI-PATCH: supervisor stuck_pending alarm misfires on tier_enabled=false rows; should distinguish policy-parked tasks from wedged dispatcher

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
@@ -304,7 +304,9 @@ def _compute_supervisor_liveness(
             "succeeded": 0,
             "failed": 0,
             "cancelled": 0,
+            "policy_parked_pending": 0,
             "stuck_pending_max_age_s": 0,
+            "policy_parked_pending_max_age_s": 0,
             "stuck_running_max_age_s": 0,
         },
         "running_tasks_lease": [],
@@ -324,8 +326,16 @@ def _compute_supervisor_liveness(
     if not queue:
         return out
 
+    try:
+        from workflow.dispatcher import load_dispatcher_config
+        dispatcher_config = load_dispatcher_config(Path(udir))
+    except Exception as exc:  # noqa: BLE001 — status must remain best-effort
+        dispatcher_config = None
+        out["warnings"].append(f"dispatcher_config_read_failed: {exc}")
+
     any_lease_field_seen = False
     pending_ages: list[float] = []
+    policy_parked_pending_ages: list[float] = []
     running_ages: list[float] = []
 
     for task in queue:
@@ -339,7 +349,15 @@ def _compute_supervisor_liveness(
         queued_ts = _parse_iso_to_epoch(queued_at) if queued_at else None
         if status == "pending" and queued_ts is not None:
             age = max(0.0, now_ts - queued_ts)
-            pending_ages.append(age)
+            trigger_source = getattr(task, "trigger_source", "") or ""
+            if (
+                dispatcher_config is not None
+                and not dispatcher_config.tier_enabled(trigger_source)
+            ):
+                out["queue_state"]["policy_parked_pending"] += 1
+                policy_parked_pending_ages.append(age)
+            else:
+                pending_ages.append(age)
 
         if status != "running":
             continue
@@ -418,6 +436,10 @@ def _compute_supervisor_liveness(
 
     if pending_ages:
         out["queue_state"]["stuck_pending_max_age_s"] = int(max(pending_ages))
+    if policy_parked_pending_ages:
+        out["queue_state"]["policy_parked_pending_max_age_s"] = int(
+            max(policy_parked_pending_ages)
+        )
     if running_ages:
         out["queue_state"]["stuck_running_max_age_s"] = int(max(running_ages))
 

--- a/tests/test_supervisor_liveness.py
+++ b/tests/test_supervisor_liveness.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-import pytest
-
 from workflow.api.status import (
     _HEARTBEAT_STALE_THRESHOLD_S,
     _STUCK_PENDING_THRESHOLD_S,
@@ -20,7 +18,6 @@ from workflow.api.status import (
     _parse_iso_to_epoch,
 )
 from workflow.branch_tasks import BranchTask, append_task
-
 
 # ── _parse_iso_to_epoch unit ───────────────────────────────────────────────
 
@@ -108,6 +105,53 @@ def test_stuck_pending_above_threshold_emits_warning(tmp_path):
     append_task(tmp_path, t)
     out = _compute_supervisor_liveness(tmp_path)
     assert out["queue_state"]["stuck_pending_max_age_s"] >= 600
+    assert any("stuck_pending" in w for w in out["warnings"])
+
+
+def test_policy_parked_pending_does_not_emit_stuck_pending_warning(tmp_path):
+    old = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+    t = BranchTask(
+        branch_task_id="bt-policy-parked",
+        branch_def_id="branch-1",
+        universe_id="u",
+        trigger_source="goal_pool",
+        status="pending",
+        queued_at=old,
+    )
+    append_task(tmp_path, t)
+
+    out = _compute_supervisor_liveness(tmp_path)
+
+    assert out["queue_state"]["pending"] == 1
+    assert out["queue_state"]["policy_parked_pending"] == 1
+    assert out["queue_state"]["policy_parked_pending_max_age_s"] >= 600
+    assert out["queue_state"]["stuck_pending_max_age_s"] == 0
+    assert not any("stuck_pending" in w for w in out["warnings"])
+
+
+def test_enabled_pending_still_warns_when_policy_parked_pending_exists(tmp_path):
+    now = datetime.now(timezone.utc)
+    append_task(tmp_path, BranchTask(
+        branch_task_id="bt-policy-parked",
+        branch_def_id="branch-1",
+        universe_id="u",
+        trigger_source="goal_pool",
+        status="pending",
+        queued_at=(now - timedelta(minutes=10)).isoformat(),
+    ))
+    append_task(tmp_path, BranchTask(
+        branch_task_id="bt-stuck-enabled",
+        branch_def_id="branch-1",
+        universe_id="u",
+        trigger_source="user_request",
+        status="pending",
+        queued_at=(now - timedelta(minutes=5)).isoformat(),
+    ))
+
+    out = _compute_supervisor_liveness(tmp_path)
+
+    assert out["queue_state"]["policy_parked_pending"] == 1
+    assert 300 <= out["queue_state"]["stuck_pending_max_age_s"] < 600
     assert any("stuck_pending" in w for w in out["warnings"])
 
 
@@ -262,6 +306,7 @@ def test_running_task_without_lease_fields_emits_lease_unavailable_warning(tmp_p
 
 def test_get_status_response_includes_supervisor_liveness(tmp_path, monkeypatch):
     import json
+
     from workflow.api.status import get_status
 
     monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
@@ -278,6 +323,7 @@ def test_get_status_response_includes_supervisor_liveness(tmp_path, monkeypatch)
 
 def test_get_status_supervisor_liveness_reflects_stuck_pending(tmp_path, monkeypatch):
     import json
+
     from workflow.api.status import get_status
 
     monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))

--- a/workflow/api/status.py
+++ b/workflow/api/status.py
@@ -304,7 +304,9 @@ def _compute_supervisor_liveness(
             "succeeded": 0,
             "failed": 0,
             "cancelled": 0,
+            "policy_parked_pending": 0,
             "stuck_pending_max_age_s": 0,
+            "policy_parked_pending_max_age_s": 0,
             "stuck_running_max_age_s": 0,
         },
         "running_tasks_lease": [],
@@ -324,8 +326,16 @@ def _compute_supervisor_liveness(
     if not queue:
         return out
 
+    try:
+        from workflow.dispatcher import load_dispatcher_config
+        dispatcher_config = load_dispatcher_config(Path(udir))
+    except Exception as exc:  # noqa: BLE001 — status must remain best-effort
+        dispatcher_config = None
+        out["warnings"].append(f"dispatcher_config_read_failed: {exc}")
+
     any_lease_field_seen = False
     pending_ages: list[float] = []
+    policy_parked_pending_ages: list[float] = []
     running_ages: list[float] = []
 
     for task in queue:
@@ -339,7 +349,15 @@ def _compute_supervisor_liveness(
         queued_ts = _parse_iso_to_epoch(queued_at) if queued_at else None
         if status == "pending" and queued_ts is not None:
             age = max(0.0, now_ts - queued_ts)
-            pending_ages.append(age)
+            trigger_source = getattr(task, "trigger_source", "") or ""
+            if (
+                dispatcher_config is not None
+                and not dispatcher_config.tier_enabled(trigger_source)
+            ):
+                out["queue_state"]["policy_parked_pending"] += 1
+                policy_parked_pending_ages.append(age)
+            else:
+                pending_ages.append(age)
 
         if status != "running":
             continue
@@ -418,6 +436,10 @@ def _compute_supervisor_liveness(
 
     if pending_ages:
         out["queue_state"]["stuck_pending_max_age_s"] = int(max(pending_ages))
+    if policy_parked_pending_ages:
+        out["queue_state"]["policy_parked_pending_max_age_s"] = int(
+            max(policy_parked_pending_ages)
+        )
     if running_ages:
         out["queue_state"]["stuck_running_max_age_s"] = int(max(running_ages))
 


### PR DESCRIPTION
Fixes #875

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-111-supervisor-stuck-pending-alarm-misfires-on-tier-enabled-fals.md`
- GitHub issue: #875
- Branch task: `auto-change/issue-875`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.