### PR TITLE
[auto-change] WIKI-PATCH: Goal archive with parent-selection — turn the existing set of bound branches into a navigable search space with quality+diversity parent ranking (DGM-style; structural upgrade that makes Loop 2 evolvable)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
@@ -26,11 +26,11 @@ Public surface (back-compat re-exported via ``workflow.universe_server``):
     Attribution handlers:
         _action_record_remix / _action_get_provenance
 
-    Goal handlers (9):
+    Goal handlers (10):
         _action_goal_propose / _action_goal_update / _action_goal_bind /
         _action_goal_list / _action_goal_get / _action_goal_search /
         _action_goal_leaderboard / _action_goal_common_nodes /
-        _action_goal_set_canonical
+        _action_goal_parent_candidates / _action_goal_set_canonical
 
     Gates handlers (9 + 6 gate_event):
         _action_gates_define_ladder / _action_gates_get_ladder /
@@ -609,7 +609,8 @@ _ATTRIBUTION_ACTIONS: dict[str, Any] = {
 # Phase 5 per docs/specs/community_branches_phase5.md. A Goal is the
 # intent a Branch serves — "produce a research paper", "plan a
 # wedding". Many Branches bind to one Goal. 8 actions: propose,
-# update, bind, list, get, search, leaderboard, common_nodes.
+# update, bind, list, get, search, leaderboard, common_nodes,
+# parent_candidates, set_canonical.
 # Storage in workflow/author_server.py.
 
 
@@ -1349,6 +1350,69 @@ def _action_goal_common_nodes(kwargs: dict[str, Any]) -> str:
     }, default=str)
 
 
+def _action_goal_parent_candidates(kwargs: dict[str, Any]) -> str:
+    from workflow.api.branches import _ensure_workflow_db
+    from workflow.api.engine_helpers import _current_actor
+    from workflow.daemon_server import (
+        get_goal,
+        goal_parent_candidates,
+    )
+
+    gid = (kwargs.get("goal_id") or "").strip()
+    if not gid:
+        return json.dumps({
+            "status": "rejected",
+            "error": "goal_id is required.",
+        })
+    _ensure_workflow_db()
+    try:
+        goal = get_goal(_base_path(), goal_id=gid)
+    except KeyError:
+        return json.dumps({
+            "status": "rejected",
+            "error": f"Goal '{gid}' not found.",
+        })
+
+    query = (kwargs.get("query") or "").strip()
+    candidates = goal_parent_candidates(
+        _base_path(),
+        goal_id=gid,
+        query=query,
+        limit=int(kwargs.get("limit", 20) or 20),
+        viewer=_current_actor(),
+    )
+    lines = [
+        f"**Parent candidates for Goal '{goal['name']}'**",
+        "Ranked by quality plus diversity across branch tags and node IDs.",
+        "",
+    ]
+    if candidates:
+        for candidate in candidates[:12]:
+            lines.append(
+                f"{candidate['rank']}. **{candidate['name']}** · "
+                f"quality={candidate['quality_score']} · "
+                f"diversity={candidate['diversity_score']} · "
+                f"score={candidate['parent_rank_score']} · "
+                f"`{candidate['branch_def_id']}`"
+            )
+    else:
+        if query:
+            lines.append("_No bound Branches match that parent-candidate query._")
+        else:
+            lines.append(
+                "_No Branches are bound to this Goal yet. Bind existing "
+                "Branches before selecting fork parents._"
+            )
+
+    return json.dumps({
+        "text": "\n".join(lines),
+        "goal_id": gid,
+        "query": query,
+        "candidates": candidates,
+        "count": len(candidates),
+    }, default=str)
+
+
 def _action_goal_set_canonical(kwargs: dict[str, Any]) -> str:
     from workflow.api.branches import _ensure_workflow_db
     from workflow.api.engine_helpers import (
@@ -1416,6 +1480,7 @@ _GOAL_ACTIONS: dict[str, Any] = {
     "search": _action_goal_search,
     "leaderboard": _action_goal_leaderboard,
     "common_nodes": _action_goal_common_nodes,
+    "parent_candidates": _action_goal_parent_candidates,
     "set_canonical": _action_goal_set_canonical,
 }
 
@@ -1549,6 +1614,9 @@ def goals(
                    this when helping a user decide "is there already
                    a node that does X somewhere on this server?" even
                    if they haven't committed to a Goal yet.
+      parent_candidates Rank bound Branches as fork parents using
+                   quality + diversity. Optional query filters the
+                   candidate space before ranking.
 
     Args:
       action: see above.

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
@@ -221,6 +221,8 @@ enumerate ALL FIVE. Don't list extensions actions and forget the rest.
    |                                | bound workflows + daemon + run counts)  |
    | Compare workflows on a Goal    | `goals action=leaderboard goal_id=...   |
    |                                | metric=run_count`                       |
+   | Pick a fork parent             | `goals action=parent_candidates         |
+   |                                | goal_id=...`                            |
    | Find reusable nodes            | `goals action=common_nodes scope=all`   |
    |                                | (across all Goals) or                   |
    |                                | `extensions action=search_nodes`        |
@@ -292,6 +294,8 @@ enumerate ALL FIVE. Don't list extensions actions and forget the rest.
   existing one anchors the work and lets future users find prior art.
 - "Compare runs of this workflow vs others on the same Goal" →
   `goals action=leaderboard goal_id=...`.
+- "Which existing workflow should I fork or improve next?" →
+  `goals action=parent_candidates goal_id=...`.
 - Cross-domain pivot: the active workspace may be themed (e.g. named
   "concordance" with a novel-writing premise, or "team-standup-action-
   tracker" with a meeting premise). That does NOT mean this connector is

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
@@ -2763,6 +2763,124 @@ def branches_for_goal(
     )[:max(1, int(limit))]
 
 
+def _branch_feature_tokens(branch: dict[str, Any]) -> set[str]:
+    """Return coarse feature tokens for parent diversity ranking."""
+    fields: list[str] = [
+        branch.get("name") or "",
+        branch.get("description") or "",
+        branch.get("author") or "",
+        " ".join(branch.get("tags") or []),
+    ]
+    for node in branch.get("node_defs") or []:
+        if not isinstance(node, dict):
+            continue
+        fields.extend([
+            node.get("node_id") or "",
+            node.get("display_name") or "",
+        ])
+    return set(_goal_search_tokens(" ".join(fields)))
+
+
+def _branch_quality_score(branch: dict[str, Any]) -> float:
+    stats = branch.get("stats") or {}
+    try:
+        score = float(stats.get("avg_quality_score", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        score = 0.0
+    return max(0.0, min(1.0, score))
+
+
+def _feature_distance(tokens: set[str], selected: list[set[str]]) -> float:
+    if not selected:
+        return 1.0
+    if not tokens:
+        return 0.0
+    max_similarity = 0.0
+    for other in selected:
+        if not other:
+            continue
+        union = tokens | other
+        if not union:
+            continue
+        max_similarity = max(max_similarity, len(tokens & other) / len(union))
+    return max(0.0, min(1.0, 1.0 - max_similarity))
+
+
+def goal_parent_candidates(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    query: str = "",
+    limit: int = 20,
+    viewer: str = "",
+) -> list[dict[str, Any]]:
+    """Rank bound Branches as fork parents using quality + diversity.
+
+    This is a bounded read-side archive view over existing Goal-bound
+    Branches. It does not create a separate archive table; it turns the
+    current bound set into a navigable parent-selection space.
+    """
+    branches = branches_for_goal(
+        base_path,
+        goal_id=goal_id,
+        limit=500,
+        viewer=viewer,
+    )
+    query_tokens = set(_goal_search_tokens(query or ""))
+    pool: list[dict[str, Any]] = []
+    for branch in branches:
+        feature_tokens = _branch_feature_tokens(branch)
+        if query_tokens and not (query_tokens & feature_tokens):
+            continue
+        pool.append({
+            "branch": branch,
+            "feature_tokens": feature_tokens,
+            "quality_score": _branch_quality_score(branch),
+        })
+
+    selected_tokens: list[set[str]] = []
+    ranked: list[dict[str, Any]] = []
+    remaining = pool[:]
+    while remaining and len(ranked) < max(1, int(limit)):
+        best_index = 0
+        best_payload: dict[str, Any] | None = None
+        for index, item in enumerate(remaining):
+            diversity = _feature_distance(item["feature_tokens"], selected_tokens)
+            score = (0.7 * item["quality_score"]) + (0.3 * diversity)
+            payload = {
+                **item["branch"],
+                "quality_score": round(item["quality_score"], 3),
+                "diversity_score": round(diversity, 3),
+                "parent_rank_score": round(score, 3),
+                "selection_basis": "0.7 quality + 0.3 diversity",
+            }
+            if best_payload is None:
+                best_index = index
+                best_payload = payload
+                continue
+            current_key = (
+                payload["parent_rank_score"],
+                payload["quality_score"],
+                payload.get("updated_at") or "",
+                payload.get("branch_def_id") or "",
+            )
+            best_key = (
+                best_payload["parent_rank_score"],
+                best_payload["quality_score"],
+                best_payload.get("updated_at") or "",
+                best_payload.get("branch_def_id") or "",
+            )
+            if current_key > best_key:
+                best_index = index
+                best_payload = payload
+        chosen = remaining.pop(best_index)
+        selected_tokens.append(chosen["feature_tokens"])
+        if best_payload is not None:
+            best_payload["rank"] = len(ranked) + 1
+            ranked.append(best_payload)
+    return ranked
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Phase 6: Outcome gates — ladder on goals, claims per branch
 # ═══════════════════════════════════════════════════════════════════════════

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -788,6 +788,8 @@ def goals(
                    tags. Needs query.
       leaderboard  Rank bound Branches by metric (run_count/forks/outcome).
       common_nodes Nodes appearing in >=`min_branches` Branches.
+      parent_candidates Rank bound Branches as fork parents using
+                   quality + diversity. Optional query filters first.
 
     """
     return _goals_impl(

--- a/tests/test_api_market.py
+++ b/tests/test_api_market.py
@@ -50,11 +50,11 @@ def test_module_exposes_expected_public_names():
         "_action_get_outcome",
         # Attribution handlers
         "_action_record_remix", "_action_get_provenance",
-        # Goal handlers (9)
+        # Goal handlers (10)
         "_action_goal_propose", "_action_goal_update", "_action_goal_bind",
         "_action_goal_list", "_action_goal_get", "_action_goal_search",
         "_action_goal_leaderboard", "_action_goal_common_nodes",
-        "_action_goal_set_canonical",
+        "_action_goal_parent_candidates", "_action_goal_set_canonical",
         # Gates main handlers (9)
         "_action_gates_define_ladder", "_action_gates_get_ladder",
         "_action_gates_claim", "_action_gates_retract",
@@ -109,14 +109,14 @@ def test_attribution_actions_keys():
 # ── _GOAL_ACTIONS dispatch table ────────────────────────────────────────────
 
 
-def test_goal_actions_table_has_9_handlers():
-    assert len(_GOAL_ACTIONS) == 9
+def test_goal_actions_table_has_10_handlers():
+    assert len(_GOAL_ACTIONS) == 10
 
 
 def test_goal_actions_keys():
     expected = {
         "propose", "update", "bind", "list", "get", "search",
-        "leaderboard", "common_nodes", "set_canonical",
+        "leaderboard", "common_nodes", "parent_candidates", "set_canonical",
     }
     assert set(_GOAL_ACTIONS.keys()) == expected
 
@@ -132,7 +132,10 @@ def test_goal_write_actions_includes_state_mutators():
 
 
 def test_goal_read_actions_excluded_from_write_set():
-    for r in ("list", "get", "search", "leaderboard", "common_nodes"):
+    for r in (
+        "list", "get", "search", "leaderboard", "common_nodes",
+        "parent_candidates",
+    ):
         assert r not in _GOAL_WRITE_ACTIONS
 
 

--- a/tests/test_goals_surface.py
+++ b/tests/test_goals_surface.py
@@ -406,6 +406,77 @@ def test_leaderboard_forks_counts_parent_chain(p5_env):
     assert ranked.get(parent_bid) == 2
 
 
+def test_parent_candidates_balances_quality_and_diversity(p5_env):
+    us, _ = p5_env
+    gid = _call(us, "goals", "propose", name="G")["goal"]["goal_id"]
+
+    from workflow.daemon_server import update_branch_definition
+
+    def candidate(name, tags, node_ids, avg_quality_score):
+        spec = {
+            "name": name,
+            "entry_point": node_ids[0],
+            "tags": tags,
+            "goal_id": gid,
+            "node_defs": [
+                {"node_id": node_id, "display_name": node_id.title(),
+                 "prompt_template": "{x}"}
+                for node_id in node_ids
+            ],
+            "edges": (
+                [{"from": "START", "to": node_ids[0]}]
+                + [
+                    {"from": left, "to": right}
+                    for left, right in zip(node_ids, node_ids[1:])
+                ]
+                + [{"from": node_ids[-1], "to": "END"}]
+            ),
+            "state_schema": [{"name": "x", "type": "str"}],
+        }
+        built = _call(us, "extensions", "build_branch", spec_json=json.dumps(spec))
+        update_branch_definition(
+            _helpers_base_path(),
+            branch_def_id=built["branch_def_id"],
+            updates={"stats": {
+                "fork_count": 0,
+                "run_count": 1,
+                "avg_quality_score": avg_quality_score,
+            }},
+        )
+        return built["branch_def_id"]
+
+    alpha = candidate("Alpha", ["research", "search"], ["search", "summarize"], 0.9)
+    beta = candidate("Beta", ["research", "search"], ["search", "summarize"], 0.85)
+    gamma = candidate("Gamma", ["simulation", "solver"], ["simulate", "score"], 0.7)
+
+    result = _call(us, "goals", "parent_candidates", goal_id=gid, limit=3)
+
+    ids = [entry["branch_def_id"] for entry in result["candidates"]]
+    assert ids[0] == alpha
+    assert ids[1] == gamma
+    assert ids[2] == beta
+    assert result["candidates"][1]["diversity_score"] > result["candidates"][2]["diversity_score"]
+    assert result["candidates"][0]["quality_score"] == 0.9
+    assert "quality" in result["text"].lower()
+    assert "diversity" in result["text"].lower()
+
+
+def test_parent_candidates_query_filters_bound_branches(p5_env):
+    us, _ = p5_env
+    gid = _call(us, "goals", "propose", name="G")["goal"]["goal_id"]
+    _build_branch(us, name="Literature Review")
+    target = _build_branch(us, name="Simulation Solver")
+    for branch in _call(us, "extensions", "list_branches", scope="all")["branches"]:
+        _call(us, "goals", "bind", branch_def_id=branch["branch_def_id"], goal_id=gid)
+
+    result = _call(
+        us, "goals", "parent_candidates", goal_id=gid, query="simulation",
+    )
+
+    assert result["count"] == 1
+    assert result["candidates"][0]["branch_def_id"] == target
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # common_nodes
 # ─────────────────────────────────────────────────────────────────────────────
@@ -597,9 +668,11 @@ def test_reads_do_not_ledger(p5_env):
     _call(us, "goals", "search", query="G")
     _call(us, "goals", "leaderboard", goal_id=gid, metric="run_count")
     _call(us, "goals", "common_nodes", goal_id=gid)
+    _call(us, "goals", "parent_candidates", goal_id=gid)
     ledger = json.loads((Path(base) / "ledger.json").read_text("utf-8"))
     read_actions = {"goals.list", "goals.get", "goals.search",
-                    "goals.leaderboard", "goals.common_nodes"}
+                    "goals.leaderboard", "goals.common_nodes",
+                    "goals.parent_candidates"}
     for e in ledger:
         assert e["action"] not in read_actions
 
@@ -615,7 +688,8 @@ def test_unknown_action_lists_available(p5_env):
     assert "error" in result
     avail = result.get("available_actions", [])
     for a in ("propose", "update", "bind", "list", "get",
-              "search", "leaderboard", "common_nodes"):
+              "search", "leaderboard", "common_nodes",
+              "parent_candidates"):
         assert a in avail
 
 

--- a/workflow/api/market.py
+++ b/workflow/api/market.py
@@ -26,11 +26,11 @@ Public surface (back-compat re-exported via ``workflow.universe_server``):
     Attribution handlers:
         _action_record_remix / _action_get_provenance
 
-    Goal handlers (9):
+    Goal handlers (10):
         _action_goal_propose / _action_goal_update / _action_goal_bind /
         _action_goal_list / _action_goal_get / _action_goal_search /
         _action_goal_leaderboard / _action_goal_common_nodes /
-        _action_goal_set_canonical
+        _action_goal_parent_candidates / _action_goal_set_canonical
 
     Gates handlers (9 + 6 gate_event):
         _action_gates_define_ladder / _action_gates_get_ladder /
@@ -609,7 +609,8 @@ _ATTRIBUTION_ACTIONS: dict[str, Any] = {
 # Phase 5 per docs/specs/community_branches_phase5.md. A Goal is the
 # intent a Branch serves — "produce a research paper", "plan a
 # wedding". Many Branches bind to one Goal. 8 actions: propose,
-# update, bind, list, get, search, leaderboard, common_nodes.
+# update, bind, list, get, search, leaderboard, common_nodes,
+# parent_candidates, set_canonical.
 # Storage in workflow/author_server.py.
 
 
@@ -1349,6 +1350,69 @@ def _action_goal_common_nodes(kwargs: dict[str, Any]) -> str:
     }, default=str)
 
 
+def _action_goal_parent_candidates(kwargs: dict[str, Any]) -> str:
+    from workflow.api.branches import _ensure_workflow_db
+    from workflow.api.engine_helpers import _current_actor
+    from workflow.daemon_server import (
+        get_goal,
+        goal_parent_candidates,
+    )
+
+    gid = (kwargs.get("goal_id") or "").strip()
+    if not gid:
+        return json.dumps({
+            "status": "rejected",
+            "error": "goal_id is required.",
+        })
+    _ensure_workflow_db()
+    try:
+        goal = get_goal(_base_path(), goal_id=gid)
+    except KeyError:
+        return json.dumps({
+            "status": "rejected",
+            "error": f"Goal '{gid}' not found.",
+        })
+
+    query = (kwargs.get("query") or "").strip()
+    candidates = goal_parent_candidates(
+        _base_path(),
+        goal_id=gid,
+        query=query,
+        limit=int(kwargs.get("limit", 20) or 20),
+        viewer=_current_actor(),
+    )
+    lines = [
+        f"**Parent candidates for Goal '{goal['name']}'**",
+        "Ranked by quality plus diversity across branch tags and node IDs.",
+        "",
+    ]
+    if candidates:
+        for candidate in candidates[:12]:
+            lines.append(
+                f"{candidate['rank']}. **{candidate['name']}** · "
+                f"quality={candidate['quality_score']} · "
+                f"diversity={candidate['diversity_score']} · "
+                f"score={candidate['parent_rank_score']} · "
+                f"`{candidate['branch_def_id']}`"
+            )
+    else:
+        if query:
+            lines.append("_No bound Branches match that parent-candidate query._")
+        else:
+            lines.append(
+                "_No Branches are bound to this Goal yet. Bind existing "
+                "Branches before selecting fork parents._"
+            )
+
+    return json.dumps({
+        "text": "\n".join(lines),
+        "goal_id": gid,
+        "query": query,
+        "candidates": candidates,
+        "count": len(candidates),
+    }, default=str)
+
+
 def _action_goal_set_canonical(kwargs: dict[str, Any]) -> str:
     from workflow.api.branches import _ensure_workflow_db
     from workflow.api.engine_helpers import (
@@ -1416,6 +1480,7 @@ _GOAL_ACTIONS: dict[str, Any] = {
     "search": _action_goal_search,
     "leaderboard": _action_goal_leaderboard,
     "common_nodes": _action_goal_common_nodes,
+    "parent_candidates": _action_goal_parent_candidates,
     "set_canonical": _action_goal_set_canonical,
 }
 
@@ -1549,6 +1614,9 @@ def goals(
                    this when helping a user decide "is there already
                    a node that does X somewhere on this server?" even
                    if they haven't committed to a Goal yet.
+      parent_candidates Rank bound Branches as fork parents using
+                   quality + diversity. Optional query filters the
+                   candidate space before ranking.
 
     Args:
       action: see above.

--- a/workflow/api/prompts.py
+++ b/workflow/api/prompts.py
@@ -221,6 +221,8 @@ enumerate ALL FIVE. Don't list extensions actions and forget the rest.
    |                                | bound workflows + daemon + run counts)  |
    | Compare workflows on a Goal    | `goals action=leaderboard goal_id=...   |
    |                                | metric=run_count`                       |
+   | Pick a fork parent             | `goals action=parent_candidates         |
+   |                                | goal_id=...`                            |
    | Find reusable nodes            | `goals action=common_nodes scope=all`   |
    |                                | (across all Goals) or                   |
    |                                | `extensions action=search_nodes`        |
@@ -292,6 +294,8 @@ enumerate ALL FIVE. Don't list extensions actions and forget the rest.
   existing one anchors the work and lets future users find prior art.
 - "Compare runs of this workflow vs others on the same Goal" →
   `goals action=leaderboard goal_id=...`.
+- "Which existing workflow should I fork or improve next?" →
+  `goals action=parent_candidates goal_id=...`.
 - Cross-domain pivot: the active workspace may be themed (e.g. named
   "concordance" with a novel-writing premise, or "team-standup-action-
   tracker" with a meeting premise). That does NOT mean this connector is

--- a/workflow/daemon_server.py
+++ b/workflow/daemon_server.py
@@ -2763,6 +2763,124 @@ def branches_for_goal(
     )[:max(1, int(limit))]
 
 
+def _branch_feature_tokens(branch: dict[str, Any]) -> set[str]:
+    """Return coarse feature tokens for parent diversity ranking."""
+    fields: list[str] = [
+        branch.get("name") or "",
+        branch.get("description") or "",
+        branch.get("author") or "",
+        " ".join(branch.get("tags") or []),
+    ]
+    for node in branch.get("node_defs") or []:
+        if not isinstance(node, dict):
+            continue
+        fields.extend([
+            node.get("node_id") or "",
+            node.get("display_name") or "",
+        ])
+    return set(_goal_search_tokens(" ".join(fields)))
+
+
+def _branch_quality_score(branch: dict[str, Any]) -> float:
+    stats = branch.get("stats") or {}
+    try:
+        score = float(stats.get("avg_quality_score", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        score = 0.0
+    return max(0.0, min(1.0, score))
+
+
+def _feature_distance(tokens: set[str], selected: list[set[str]]) -> float:
+    if not selected:
+        return 1.0
+    if not tokens:
+        return 0.0
+    max_similarity = 0.0
+    for other in selected:
+        if not other:
+            continue
+        union = tokens | other
+        if not union:
+            continue
+        max_similarity = max(max_similarity, len(tokens & other) / len(union))
+    return max(0.0, min(1.0, 1.0 - max_similarity))
+
+
+def goal_parent_candidates(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    query: str = "",
+    limit: int = 20,
+    viewer: str = "",
+) -> list[dict[str, Any]]:
+    """Rank bound Branches as fork parents using quality + diversity.
+
+    This is a bounded read-side archive view over existing Goal-bound
+    Branches. It does not create a separate archive table; it turns the
+    current bound set into a navigable parent-selection space.
+    """
+    branches = branches_for_goal(
+        base_path,
+        goal_id=goal_id,
+        limit=500,
+        viewer=viewer,
+    )
+    query_tokens = set(_goal_search_tokens(query or ""))
+    pool: list[dict[str, Any]] = []
+    for branch in branches:
+        feature_tokens = _branch_feature_tokens(branch)
+        if query_tokens and not (query_tokens & feature_tokens):
+            continue
+        pool.append({
+            "branch": branch,
+            "feature_tokens": feature_tokens,
+            "quality_score": _branch_quality_score(branch),
+        })
+
+    selected_tokens: list[set[str]] = []
+    ranked: list[dict[str, Any]] = []
+    remaining = pool[:]
+    while remaining and len(ranked) < max(1, int(limit)):
+        best_index = 0
+        best_payload: dict[str, Any] | None = None
+        for index, item in enumerate(remaining):
+            diversity = _feature_distance(item["feature_tokens"], selected_tokens)
+            score = (0.7 * item["quality_score"]) + (0.3 * diversity)
+            payload = {
+                **item["branch"],
+                "quality_score": round(item["quality_score"], 3),
+                "diversity_score": round(diversity, 3),
+                "parent_rank_score": round(score, 3),
+                "selection_basis": "0.7 quality + 0.3 diversity",
+            }
+            if best_payload is None:
+                best_index = index
+                best_payload = payload
+                continue
+            current_key = (
+                payload["parent_rank_score"],
+                payload["quality_score"],
+                payload.get("updated_at") or "",
+                payload.get("branch_def_id") or "",
+            )
+            best_key = (
+                best_payload["parent_rank_score"],
+                best_payload["quality_score"],
+                best_payload.get("updated_at") or "",
+                best_payload.get("branch_def_id") or "",
+            )
+            if current_key > best_key:
+                best_index = index
+                best_payload = payload
+        chosen = remaining.pop(best_index)
+        selected_tokens.append(chosen["feature_tokens"])
+        if best_payload is not None:
+            best_payload["rank"] = len(ranked) + 1
+            ranked.append(best_payload)
+    return ranked
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Phase 6: Outcome gates — ladder on goals, claims per branch
 # ═══════════════════════════════════════════════════════════════════════════

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -788,6 +788,8 @@ def goals(
                    tags. Needs query.
       leaderboard  Rank bound Branches by metric (run_count/forks/outcome).
       common_nodes Nodes appearing in >=`min_branches` Branches.
+      parent_candidates Rank bound Branches as fork parents using
+                   quality + diversity. Optional query filters first.
 
     """
     return _goals_impl(


### PR DESCRIPTION
Fixes #890

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-123-goal-archive-with-parent-selection-turn-the-existing-set-of-.md`
- GitHub issue: #890
- Branch task: `auto-change/issue-890`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.