### PR TITLE
[auto-change] WIKI-PATCH: Filing-time effort-class prediction — Circuit-Breaker classifier flags ghost-risk and merge-instant filings at file_bug time so carrier attention can land before stall (MSR '26 prior art with AUC 0.96 on 33K agent PRs)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
@@ -88,6 +88,79 @@ _REQUEST_TYPE_MEANING: dict[str, str] = {
     "revision": "patch",
     "scene_direction": "branch_refinement",
 }
+_GHOST_RISK_SIGNALS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "research_prior_art",
+        (
+            "prior art",
+            "paper",
+            "benchmark",
+            "auc",
+            "msr",
+            "dataset",
+            "classifier",
+            "prediction",
+            "model",
+            "33k",
+        ),
+    ),
+    (
+        "review_gate",
+        (
+            "opposite-family",
+            "opposite family",
+            "checker",
+            "gate requirement",
+            "gate ladder",
+            "review blocker",
+        ),
+    ),
+    (
+        "stall_language",
+        (
+            "ghost-risk",
+            "ghost risk",
+            "stall",
+            "carrier attention",
+            "before stall",
+        ),
+    ),
+)
+_MERGE_INSTANT_SIGNALS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "mechanical_shape",
+        (
+            "mechanical",
+            "typo",
+            "copy edit",
+            "copy-edit",
+            "formatting",
+            "format-only",
+            "rename only",
+            "one-line",
+        ),
+    ),
+    (
+        "low_runtime_risk",
+        (
+            "docs only",
+            "docs-only",
+            "documentation only",
+            "no runtime",
+            "no behavior change",
+            "comment only",
+        ),
+    ),
+    (
+        "merge_instant_language",
+        (
+            "merge-instant",
+            "merge instant",
+            "safe to merge",
+            "trivial patch",
+        ),
+    ),
+)
 
 
 def classify_patch_request(
@@ -123,6 +196,72 @@ def classify_patch_request(
             "scope": authority_scope,
             "boundary": dict(PATCH_REQUEST_AUTHORITY_BOUNDARY),
         },
+    }
+
+
+def classify_filing_effort(
+    *,
+    title: str,
+    component: str = "",
+    severity: str = "",
+    kind: str = "bug",
+    repro: str = "",
+    observed: str = "",
+    expected: str = "",
+    workaround: str = "",
+    tags: str = "",
+) -> dict[str, Any]:
+    """Classify filing attention needs while the wiki entry is created.
+
+    This is a deterministic circuit-breaker, not a merge decision. It gives
+    carriers a pickup signal for filings likely to stall despite looking
+    mechanical, while keeping merge authority with the normal review gates.
+    """
+    haystack = " ".join(
+        str(part or "")
+        for part in (
+            title,
+            component,
+            severity,
+            kind,
+            repro,
+            observed,
+            expected,
+            workaround,
+            tags,
+        )
+    ).lower()
+
+    def _matched_signals(catalog: tuple[tuple[str, tuple[str, ...]], ...]) -> list[str]:
+        return [
+            signal
+            for signal, keywords in catalog
+            if any(keyword in haystack for keyword in keywords)
+        ]
+
+    ghost_signals = _matched_signals(_GHOST_RISK_SIGNALS)
+    merge_instant_signals = _matched_signals(_MERGE_INSTANT_SIGNALS)
+    if ghost_signals:
+        effort_class = "ghost-risk"
+        attention = "carrier-review-before-daemon-pickup"
+        signals = ghost_signals + [
+            signal for signal in merge_instant_signals if signal not in ghost_signals
+        ]
+    elif merge_instant_signals:
+        effort_class = "merge-instant"
+        attention = "normal-review-gates"
+        signals = merge_instant_signals
+    else:
+        effort_class = "standard"
+        attention = "normal-review-gates"
+        signals = []
+
+    return {
+        "effort_class": effort_class,
+        "attention": attention,
+        "signals": signals,
+        "confidence": "heuristic",
+        "authority_boundary": dict(PATCH_REQUEST_AUTHORITY_BOUNDARY),
     }
 
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1589,12 +1589,25 @@ def _render_bug_markdown(
     first_seen_date: str,
     kind: str = "bug",
     extra_tags: list[str] | None = None,
+    effort_classification: dict[str, Any] | None = None,
 ) -> str:
     comp_tag = component.split(".")[0] if component else "unknown"
     base_tags = [kind, comp_tag]
     if extra_tags:
         base_tags.extend(t for t in extra_tags if t not in base_tags)
     tags_str = ", ".join(base_tags)
+    effort_frontmatter = ""
+    if effort_classification:
+        effort_class = str(effort_classification.get("effort_class") or "standard")
+        attention = str(effort_classification.get("attention") or "normal-review-gates")
+        raw_signals = effort_classification.get("signals") or []
+        signals = [str(signal) for signal in raw_signals if str(signal)]
+        signals_str = ", ".join(signals)
+        effort_frontmatter = (
+            f"effort_class: {effort_class}\n"
+            f"effort_attention: {attention}\n"
+            f"effort_signals: [{signals_str}]\n"
+        )
     return (
         f"---\n"
         f"id: {bug_id}\n"
@@ -1607,6 +1620,7 @@ def _render_bug_markdown(
         f"severity: {severity}\n"
         f"status: open\n"
         f"reported_by: chatbot\n"
+        f"{effort_frontmatter}"
         f"tags: [{tags_str}]\n"
         f"---\n\n"
         f"# {bug_id}: {title}\n\n"
@@ -1834,6 +1848,19 @@ def _wiki_file_bug(
 
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     slug = _slugify_title(title)
+    from workflow.api.market import classify_filing_effort
+
+    effort_classification = classify_filing_effort(
+        title=title,
+        component=component,
+        severity=severity,
+        kind=effective_kind,
+        repro=repro,
+        observed=observed,
+        expected=expected,
+        workaround=workaround,
+        tags=tags,
+    )
 
     # Dedup check: scan existing filings of THIS kind for Jaccard similarity
     # ≥ threshold. Per-kind only — a feature-request shouldn't dedup against
@@ -1862,6 +1889,7 @@ def _wiki_file_bug(
                 "status": "similar_found",
                 "bug_id": None,
                 "similar": top3,
+                "effort_classification": effort_classification,
                 "hint": (
                     "Similar filings exist. Use cosign_bug to add your context "
                     "to the top match, or set force_new=true if the symptom is "
@@ -1885,6 +1913,7 @@ def _wiki_file_bug(
             first_seen_date=today,
             kind=effective_kind,
             extra_tags=[t.strip() for t in tags.split(",") if t.strip()],
+            effort_classification=effort_classification,
         )
         try:
             with open(target, "x", encoding="utf-8") as fh:
@@ -2040,6 +2069,7 @@ def _wiki_file_bug(
         "kind": effective_kind,
         "severity": severity,
         "component": component,
+        "effort_classification": effort_classification,
         "investigation": investigation,
         "note": "Filing sent to navigator triage pipeline. "
                 f"Use `wiki action=list category={category_dir}` to view.",

--- a/tests/test_patch_request_incentives.py
+++ b/tests/test_patch_request_incentives.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from workflow.api.market import classify_filing_effort
 from workflow.branch_tasks import BranchTask, read_queue
 from workflow.dispatcher import DispatcherConfig, score_task
 from workflow.work_targets import (
@@ -194,6 +195,40 @@ def test_submit_request_classifies_access_meaning_and_authority(
         queue[0].inputs["request_classification"]
         == response["request_classification"]
     )
+
+
+def test_filing_effort_classifier_flags_research_ghost_risk():
+    result = classify_filing_effort(
+        title=(
+            "Filing-time effort-class prediction circuit-breaker classifier "
+            "for MSR prior art"
+        ),
+        kind="patch_request",
+        observed=(
+            "Mechanical filing cites AUC 0.96 on 33K agent PRs and requires "
+            "opposite-family checker attention before stall."
+        ),
+        tags="mechanical",
+    )
+
+    assert result["effort_class"] == "ghost-risk"
+    assert result["attention"] == "carrier-review-before-daemon-pickup"
+    assert "research_prior_art" in result["signals"]
+    assert "review_gate" in result["signals"]
+    assert result["authority_boundary"]["affects_merge"] is False
+
+
+def test_filing_effort_classifier_flags_merge_instant_without_ghost_signals():
+    result = classify_filing_effort(
+        title="Fix typo in connector docs",
+        kind="patch_request",
+        observed="Mechanical docs-only copy edit with no runtime behavior change.",
+    )
+
+    assert result["effort_class"] == "merge-instant"
+    assert result["attention"] == "normal-review-gates"
+    assert "mechanical_shape" in result["signals"]
+    assert "low_runtime_risk" in result["signals"]
 
 
 def test_requester_directed_daemon_requires_ownership(

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -741,6 +741,58 @@ class TestWikiFileBugDispatch:
         assert out["bug_id"].startswith("BUG-")
         assert "path" in out
 
+    def test_file_bug_flags_patch_request_ghost_risk_attention(self, wiki_dir):
+        (wiki_dir / "pages" / "patch-requests").mkdir(parents=True, exist_ok=True)
+        (wiki_dir / "drafts" / "patch-requests").mkdir(parents=True, exist_ok=True)
+
+        out = json.loads(
+            wiki(
+                "file_bug",
+                component="community_loop.classifier",
+                severity="minor",
+                title="Filing-time effort-class prediction circuit-breaker classifier",
+                observed=(
+                    "Mechanical filing cites MSR prior art with AUC 0.96 on "
+                    "33K agent PRs and needs opposite-family checker attention."
+                ),
+                expected="Carrier attention lands before stall.",
+                kind="patch_request",
+                tags="mechanical",
+            )
+        )
+
+        assert out["status"] == "filed"
+        effort = out["effort_classification"]
+        assert effort["effort_class"] == "ghost-risk"
+        assert effort["attention"] == "carrier-review-before-daemon-pickup"
+        assert "research_prior_art" in effort["signals"]
+        body = (wiki_dir / out["path"]).read_text(encoding="utf-8")
+        assert "effort_class: ghost-risk" in body
+        assert "effort_attention: carrier-review-before-daemon-pickup" in body
+
+    def test_file_bug_flags_patch_request_merge_instant(self, wiki_dir):
+        (wiki_dir / "pages" / "patch-requests").mkdir(parents=True, exist_ok=True)
+        (wiki_dir / "drafts" / "patch-requests").mkdir(parents=True, exist_ok=True)
+
+        out = json.loads(
+            wiki(
+                "file_bug",
+                component="docs",
+                severity="cosmetic",
+                title="Fix typo in connector docs",
+                observed="Mechanical docs-only copy edit with no runtime behavior change.",
+                kind="patch_request",
+            )
+        )
+
+        assert out["status"] == "filed"
+        effort = out["effort_classification"]
+        assert effort["effort_class"] == "merge-instant"
+        assert effort["attention"] == "normal-review-gates"
+        assert "mechanical_shape" in effort["signals"]
+        body = (wiki_dir / out["path"]).read_text(encoding="utf-8")
+        assert "effort_class: merge-instant" in body
+
     def test_file_bug_accepts_tags_via_public_wrapper(self, wiki_dir):
         """BUG-040: public wiki wrapper must pass tags through to file_bug."""
         (wiki_dir / "pages" / "bugs").mkdir(parents=True, exist_ok=True)

--- a/workflow/api/market.py
+++ b/workflow/api/market.py
@@ -88,6 +88,79 @@ _REQUEST_TYPE_MEANING: dict[str, str] = {
     "revision": "patch",
     "scene_direction": "branch_refinement",
 }
+_GHOST_RISK_SIGNALS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "research_prior_art",
+        (
+            "prior art",
+            "paper",
+            "benchmark",
+            "auc",
+            "msr",
+            "dataset",
+            "classifier",
+            "prediction",
+            "model",
+            "33k",
+        ),
+    ),
+    (
+        "review_gate",
+        (
+            "opposite-family",
+            "opposite family",
+            "checker",
+            "gate requirement",
+            "gate ladder",
+            "review blocker",
+        ),
+    ),
+    (
+        "stall_language",
+        (
+            "ghost-risk",
+            "ghost risk",
+            "stall",
+            "carrier attention",
+            "before stall",
+        ),
+    ),
+)
+_MERGE_INSTANT_SIGNALS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "mechanical_shape",
+        (
+            "mechanical",
+            "typo",
+            "copy edit",
+            "copy-edit",
+            "formatting",
+            "format-only",
+            "rename only",
+            "one-line",
+        ),
+    ),
+    (
+        "low_runtime_risk",
+        (
+            "docs only",
+            "docs-only",
+            "documentation only",
+            "no runtime",
+            "no behavior change",
+            "comment only",
+        ),
+    ),
+    (
+        "merge_instant_language",
+        (
+            "merge-instant",
+            "merge instant",
+            "safe to merge",
+            "trivial patch",
+        ),
+    ),
+)
 
 
 def classify_patch_request(
@@ -123,6 +196,72 @@ def classify_patch_request(
             "scope": authority_scope,
             "boundary": dict(PATCH_REQUEST_AUTHORITY_BOUNDARY),
         },
+    }
+
+
+def classify_filing_effort(
+    *,
+    title: str,
+    component: str = "",
+    severity: str = "",
+    kind: str = "bug",
+    repro: str = "",
+    observed: str = "",
+    expected: str = "",
+    workaround: str = "",
+    tags: str = "",
+) -> dict[str, Any]:
+    """Classify filing attention needs while the wiki entry is created.
+
+    This is a deterministic circuit-breaker, not a merge decision. It gives
+    carriers a pickup signal for filings likely to stall despite looking
+    mechanical, while keeping merge authority with the normal review gates.
+    """
+    haystack = " ".join(
+        str(part or "")
+        for part in (
+            title,
+            component,
+            severity,
+            kind,
+            repro,
+            observed,
+            expected,
+            workaround,
+            tags,
+        )
+    ).lower()
+
+    def _matched_signals(catalog: tuple[tuple[str, tuple[str, ...]], ...]) -> list[str]:
+        return [
+            signal
+            for signal, keywords in catalog
+            if any(keyword in haystack for keyword in keywords)
+        ]
+
+    ghost_signals = _matched_signals(_GHOST_RISK_SIGNALS)
+    merge_instant_signals = _matched_signals(_MERGE_INSTANT_SIGNALS)
+    if ghost_signals:
+        effort_class = "ghost-risk"
+        attention = "carrier-review-before-daemon-pickup"
+        signals = ghost_signals + [
+            signal for signal in merge_instant_signals if signal not in ghost_signals
+        ]
+    elif merge_instant_signals:
+        effort_class = "merge-instant"
+        attention = "normal-review-gates"
+        signals = merge_instant_signals
+    else:
+        effort_class = "standard"
+        attention = "normal-review-gates"
+        signals = []
+
+    return {
+        "effort_class": effort_class,
+        "attention": attention,
+        "signals": signals,
+        "confidence": "heuristic",
+        "authority_boundary": dict(PATCH_REQUEST_AUTHORITY_BOUNDARY),
     }
 
 

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1589,12 +1589,25 @@ def _render_bug_markdown(
     first_seen_date: str,
     kind: str = "bug",
     extra_tags: list[str] | None = None,
+    effort_classification: dict[str, Any] | None = None,
 ) -> str:
     comp_tag = component.split(".")[0] if component else "unknown"
     base_tags = [kind, comp_tag]
     if extra_tags:
         base_tags.extend(t for t in extra_tags if t not in base_tags)
     tags_str = ", ".join(base_tags)
+    effort_frontmatter = ""
+    if effort_classification:
+        effort_class = str(effort_classification.get("effort_class") or "standard")
+        attention = str(effort_classification.get("attention") or "normal-review-gates")
+        raw_signals = effort_classification.get("signals") or []
+        signals = [str(signal) for signal in raw_signals if str(signal)]
+        signals_str = ", ".join(signals)
+        effort_frontmatter = (
+            f"effort_class: {effort_class}\n"
+            f"effort_attention: {attention}\n"
+            f"effort_signals: [{signals_str}]\n"
+        )
     return (
         f"---\n"
         f"id: {bug_id}\n"
@@ -1607,6 +1620,7 @@ def _render_bug_markdown(
         f"severity: {severity}\n"
         f"status: open\n"
         f"reported_by: chatbot\n"
+        f"{effort_frontmatter}"
         f"tags: [{tags_str}]\n"
         f"---\n\n"
         f"# {bug_id}: {title}\n\n"
@@ -1834,6 +1848,19 @@ def _wiki_file_bug(
 
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     slug = _slugify_title(title)
+    from workflow.api.market import classify_filing_effort
+
+    effort_classification = classify_filing_effort(
+        title=title,
+        component=component,
+        severity=severity,
+        kind=effective_kind,
+        repro=repro,
+        observed=observed,
+        expected=expected,
+        workaround=workaround,
+        tags=tags,
+    )
 
     # Dedup check: scan existing filings of THIS kind for Jaccard similarity
     # ≥ threshold. Per-kind only — a feature-request shouldn't dedup against
@@ -1862,6 +1889,7 @@ def _wiki_file_bug(
                 "status": "similar_found",
                 "bug_id": None,
                 "similar": top3,
+                "effort_classification": effort_classification,
                 "hint": (
                     "Similar filings exist. Use cosign_bug to add your context "
                     "to the top match, or set force_new=true if the symptom is "
@@ -1885,6 +1913,7 @@ def _wiki_file_bug(
             first_seen_date=today,
             kind=effective_kind,
             extra_tags=[t.strip() for t in tags.split(",") if t.strip()],
+            effort_classification=effort_classification,
         )
         try:
             with open(target, "x", encoding="utf-8") as fh:
@@ -2040,6 +2069,7 @@ def _wiki_file_bug(
         "kind": effective_kind,
         "severity": severity,
         "component": component,
+        "effort_classification": effort_classification,
         "investigation": investigation,
         "note": "Filing sent to navigator triage pipeline. "
                 f"Use `wiki action=list category={category_dir}` to view.",


### PR DESCRIPTION
Fixes #891

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-124-filing-time-effort-class-prediction-circuit-breaker-classifi.md`
- GitHub issue: #891
- Branch task: `auto-change/issue-891`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.