### PR TITLE
[auto-change] WIKI-PATCH: Loop 2 branches must integrate with the existing gates system — emit rung-claim recommendations matching the bound Goal's ladder + archive_consultation queries gates leaderboard for parent-selection signal (the actual Loop 2 wiring task after PR-125 rescope; corrected M5 work)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
@@ -26,11 +26,11 @@ Public surface (back-compat re-exported via ``workflow.universe_server``):
     Attribution handlers:
         _action_record_remix / _action_get_provenance
 
-    Goal handlers (9):
+    Goal handlers (10):
         _action_goal_propose / _action_goal_update / _action_goal_bind /
         _action_goal_list / _action_goal_get / _action_goal_search /
         _action_goal_leaderboard / _action_goal_common_nodes /
-        _action_goal_set_canonical
+        _action_goal_archive_consultation / _action_goal_set_canonical
 
     Gates handlers (9 + 6 gate_event):
         _action_gates_define_ladder / _action_gates_get_ladder /
@@ -609,7 +609,8 @@ _ATTRIBUTION_ACTIONS: dict[str, Any] = {
 # Phase 5 per docs/specs/community_branches_phase5.md. A Goal is the
 # intent a Branch serves — "produce a research paper", "plan a
 # wedding". Many Branches bind to one Goal. 8 actions: propose,
-# update, bind, list, get, search, leaderboard, common_nodes.
+# update, bind, list, get, search, leaderboard, common_nodes,
+# archive_consultation.
 # Storage in workflow/author_server.py.
 
 
@@ -1349,6 +1350,76 @@ def _action_goal_common_nodes(kwargs: dict[str, Any]) -> str:
     }, default=str)
 
 
+def _action_goal_archive_consultation(kwargs: dict[str, Any]) -> str:
+    from workflow.api.branches import _ensure_workflow_db
+    from workflow.api.engine_helpers import _current_actor
+    from workflow.daemon_server import get_goal, goal_archive_consultation
+
+    gid = (kwargs.get("goal_id") or "").strip()
+    if not gid:
+        return json.dumps({
+            "status": "rejected",
+            "error": "goal_id is required.",
+        })
+    _ensure_workflow_db()
+    try:
+        goal = get_goal(_base_path(), goal_id=gid)
+    except KeyError:
+        return json.dumps({
+            "status": "rejected",
+            "error": f"Goal '{gid}' not found.",
+        })
+
+    query = (kwargs.get("query") or "").strip()
+    consultation = goal_archive_consultation(
+        _base_path(),
+        goal_id=gid,
+        query=query,
+        limit=int(kwargs.get("limit", 20) or 20),
+        viewer=_current_actor(),
+    )
+    candidates = consultation["candidates"]
+    lines = [
+        f"**Archive consultation for Goal '{goal['name']}'**",
+        (
+            "Parent candidates are ranked with quality, diversity, "
+            "and the gate leaderboard outcome signal."
+        ),
+        "",
+    ]
+    if candidates:
+        for candidate in candidates[:12]:
+            outcome = candidate.get("outcome_signal") or {}
+            lines.append(
+                f"{candidate['rank']}. **{candidate['name']}** · "
+                f"score={candidate['parent_rank_score']} · "
+                f"quality={candidate['quality_score']} · "
+                f"outcome={candidate['outcome_score']} "
+                f"(`{outcome.get('highest_rung_key', '')}`) · "
+                f"diversity={candidate['diversity_score']} · "
+                f"`{candidate['branch_def_id']}`"
+            )
+    else:
+        if query:
+            lines.append("_No bound Branches match that archive query._")
+        else:
+            lines.append(
+                "_No Branches are bound to this Goal yet. Bind existing "
+                "Branches before selecting fork parents._"
+            )
+
+    return json.dumps({
+        "status": "ok",
+        "text": "\n".join(lines),
+        "goal_id": gid,
+        "query": query,
+        "candidates": candidates,
+        "outcome_leaderboard": consultation["outcome_leaderboard"],
+        "selection_basis": consultation["selection_basis"],
+        "count": len(candidates),
+    }, default=str)
+
+
 def _action_goal_set_canonical(kwargs: dict[str, Any]) -> str:
     from workflow.api.branches import _ensure_workflow_db
     from workflow.api.engine_helpers import (
@@ -1416,6 +1487,7 @@ _GOAL_ACTIONS: dict[str, Any] = {
     "search": _action_goal_search,
     "leaderboard": _action_goal_leaderboard,
     "common_nodes": _action_goal_common_nodes,
+    "archive_consultation": _action_goal_archive_consultation,
     "set_canonical": _action_goal_set_canonical,
 }
 
@@ -1549,6 +1621,9 @@ def goals(
                    this when helping a user decide "is there already
                    a node that does X somewhere on this server?" even
                    if they haven't committed to a Goal yet.
+      archive_consultation Rank bound Branches as fork parents using
+                   quality, diversity, and gates leaderboard outcome
+                   signal. Optional query filters the candidate space.
 
     Args:
       action: see above.

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
@@ -97,6 +97,7 @@ class BranchTask:
     lease_expires_at: str = ""
     heartbeat_at: str = ""
     last_progress_at: str = ""
+    rung_claim_recommendations: list[dict] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
@@ -2763,6 +2763,172 @@ def branches_for_goal(
     )[:max(1, int(limit))]
 
 
+def _branch_feature_tokens(branch: dict[str, Any]) -> set[str]:
+    """Return coarse feature tokens for parent diversity ranking."""
+    fields: list[str] = [
+        branch.get("name") or "",
+        branch.get("description") or "",
+        branch.get("author") or "",
+        " ".join(branch.get("tags") or []),
+    ]
+    for node in branch.get("node_defs") or []:
+        if not isinstance(node, dict):
+            continue
+        fields.extend([
+            node.get("node_id") or "",
+            node.get("display_name") or "",
+        ])
+    return set(_goal_search_tokens(" ".join(fields)))
+
+
+def _branch_quality_score(branch: dict[str, Any]) -> float:
+    stats = branch.get("stats") or {}
+    try:
+        score = float(stats.get("avg_quality_score", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        score = 0.0
+    return max(0.0, min(1.0, score))
+
+
+def _feature_distance(tokens: set[str], selected: list[set[str]]) -> float:
+    if not selected:
+        return 1.0
+    if not tokens:
+        return 0.0
+    max_similarity = 0.0
+    for other in selected:
+        if not other:
+            continue
+        union = tokens | other
+        if not union:
+            continue
+        max_similarity = max(max_similarity, len(tokens & other) / len(union))
+    return max(0.0, min(1.0, 1.0 - max_similarity))
+
+
+def goal_archive_consultation(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    query: str = "",
+    limit: int = 20,
+    viewer: str = "",
+) -> dict[str, Any]:
+    """Rank Goal-bound Branches as fork parents with gate outcome signal."""
+    branches = branches_for_goal(
+        base_path,
+        goal_id=goal_id,
+        limit=500,
+        viewer=viewer,
+    )
+    query_tokens = set(_goal_search_tokens(query or ""))
+    outcome_entries = gates_leaderboard(
+        base_path,
+        goal_id=goal_id,
+        limit=500,
+    )
+    outcome_by_branch = {
+        entry["branch_def_id"]: entry
+        for entry in outcome_entries
+        if entry.get("branch_def_id")
+    }
+    ladder_len = len(get_goal_ladder(base_path, goal_id=goal_id))
+    max_rung_index = max(0, ladder_len - 1)
+
+    pool: list[dict[str, Any]] = []
+    for branch in branches:
+        feature_tokens = _branch_feature_tokens(branch)
+        if query_tokens and not (query_tokens & feature_tokens):
+            continue
+        outcome = outcome_by_branch.get(branch["branch_def_id"], {})
+        try:
+            rung_index = int(outcome.get("highest_rung_index", -1))
+        except (TypeError, ValueError):
+            rung_index = -1
+        outcome_score = (
+            max(0.0, min(1.0, rung_index / max_rung_index))
+            if max_rung_index > 0 else 0.0
+        )
+        pool.append({
+            "branch": branch,
+            "feature_tokens": feature_tokens,
+            "quality_score": _branch_quality_score(branch),
+            "outcome_score": outcome_score,
+            "outcome_signal": {
+                "highest_rung_key": outcome.get("highest_rung_key", ""),
+                "highest_rung_index": rung_index,
+                "claimed_at": outcome.get("claimed_at", ""),
+                "evidence_url": outcome.get("evidence_url", ""),
+            },
+        })
+
+    selected_tokens: list[set[str]] = []
+    ranked: list[dict[str, Any]] = []
+    remaining = pool[:]
+    while remaining and len(ranked) < max(1, int(limit)):
+        best_index = 0
+        best_payload: dict[str, Any] | None = None
+        for index, item in enumerate(remaining):
+            diversity = _feature_distance(item["feature_tokens"], selected_tokens)
+            score = (
+                0.4 * item["quality_score"]
+                + 0.4 * item["outcome_score"]
+                + 0.2 * diversity
+            )
+            payload = {
+                **item["branch"],
+                "quality_score": round(item["quality_score"], 3),
+                "outcome_score": round(item["outcome_score"], 3),
+                "diversity_score": round(diversity, 3),
+                "parent_rank_score": round(score, 3),
+                "outcome_signal": item["outcome_signal"],
+                "selection_basis": (
+                    "0.4 quality + 0.4 gate leaderboard outcome + "
+                    "0.2 diversity"
+                ),
+            }
+            if best_payload is None:
+                best_index = index
+                best_payload = payload
+                continue
+            current_key = (
+                payload["parent_rank_score"],
+                payload["outcome_score"],
+                payload["quality_score"],
+                payload.get("updated_at") or "",
+                payload.get("branch_def_id") or "",
+            )
+            best_key = (
+                best_payload["parent_rank_score"],
+                best_payload["outcome_score"],
+                best_payload["quality_score"],
+                best_payload.get("updated_at") or "",
+                best_payload.get("branch_def_id") or "",
+            )
+            if current_key > best_key:
+                best_index = index
+                best_payload = payload
+        chosen = remaining.pop(best_index)
+        selected_tokens.append(chosen["feature_tokens"])
+        if best_payload is not None:
+            best_payload["rank"] = len(ranked) + 1
+            ranked.append(best_payload)
+
+    visible_ids = {entry["branch_def_id"] for entry in ranked}
+    visible_outcomes = [
+        entry for entry in outcome_entries
+        if entry.get("branch_def_id") in visible_ids
+    ]
+    return {
+        "candidates": ranked,
+        "outcome_leaderboard": visible_outcomes,
+        "selection_basis": (
+            "parent candidates ranked by quality, gates leaderboard "
+            "outcome, and diversity"
+        ),
+    }
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Phase 6: Outcome gates — ladder on goals, claims per branch
 # ═══════════════════════════════════════════════════════════════════════════

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/producers/goal_pool.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/producers/goal_pool.py
@@ -58,6 +58,54 @@ _REJECTED_INPUT_KEYS = frozenset({
 })
 
 
+def _rung_claim_recommendations(
+    universe_path: Path,
+    goal_id: str,
+    branch_def_id: str = "",
+) -> list[dict]:
+    """Return claim recommendations copied from the bound Goal ladder."""
+    if not goal_id:
+        return []
+    try:
+        from workflow.daemon_server import get_goal_ladder
+        from workflow.storage import base_path_from_universe
+
+        ladder = get_goal_ladder(
+            base_path_from_universe(universe_path),
+            goal_id=goal_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "goal_pool: no gate ladder recommendations for %s: %s",
+            goal_id,
+            exc,
+        )
+        return []
+
+    recommendations: list[dict] = []
+    for rung in ladder:
+        if not isinstance(rung, dict):
+            continue
+        rung_key = str(rung.get("rung_key") or "").strip()
+        if not rung_key:
+            continue
+        label = rung.get("label") or rung.get("name") or rung_key
+        recommendations.append({
+            "goal_id": goal_id,
+            "rung_key": rung_key,
+            "label": label,
+            "description": rung.get("description", ""),
+            "branch_requirements": dict(rung.get("branch_requirements") or {}),
+            "bounty_requirements": dict(rung.get("bounty_requirements") or {}),
+            "claim_action": (
+                "gates action=claim "
+                f"branch_def_id={branch_def_id or '<branch_def_id>'} "
+                f"rung_key={rung_key} evidence_url=<evidence_url>"
+            ),
+        })
+    return recommendations
+
+
 def repo_root_path(universe_path: Path) -> Path:
     """Resolve the shared pool location. Preflight §4.1 #7 order:
 
@@ -209,7 +257,13 @@ class GoalPoolProducer:
             if not goal_dir.is_dir():
                 continue
             out.extend(
-                self._scan_goal_dir(goal_dir, goal, accessible, max_per_cycle - len(out))
+                self._scan_goal_dir(
+                    goal_dir,
+                    goal,
+                    accessible,
+                    max_per_cycle - len(out),
+                    universe_path=Path(universe_path),
+                )
             )
             if len(out) >= max_per_cycle:
                 break
@@ -221,6 +275,8 @@ class GoalPoolProducer:
         goal_id: str,
         accessible_slugs: set[str],
         budget: int,
+        *,
+        universe_path: Path,
     ) -> list[BranchTask]:
         if budget <= 0:
             return []
@@ -231,7 +287,12 @@ class GoalPoolProducer:
             return []
         cached_mtime = self._mtime_cache.get(goal_dir)
         if cached_mtime is not None and cached_mtime == current_mtime:
-            return list(self._result_cache.get(goal_dir, [])[:budget])
+            cached = list(self._result_cache.get(goal_dir, [])[:budget])
+            for task in cached:
+                task.rung_claim_recommendations = _rung_claim_recommendations(
+                    universe_path, goal_id, task.branch_def_id,
+                )
+            return cached
 
         import yaml
 
@@ -253,6 +314,9 @@ class GoalPoolProducer:
                 continue
             task = self._parse_pool_yaml(data, yaml_path, goal_id, accessible_slugs)
             if task is not None:
+                task.rung_claim_recommendations = _rung_claim_recommendations(
+                    universe_path, goal_id, task.branch_def_id,
+                )
                 tasks.append(task)
             if len(tasks) >= budget:
                 break

--- a/tests/test_branch_tasks.py
+++ b/tests/test_branch_tasks.py
@@ -39,6 +39,7 @@ def test_branch_task_lease_fields_default_and_roundtrip() -> None:
     assert task.lease_expires_at == ""
     assert task.heartbeat_at == ""
     assert task.last_progress_at == ""
+    assert task.rung_claim_recommendations == []
     assert BranchTask.from_dict(task.to_dict()) == task
 
 

--- a/tests/test_goal_pool.py
+++ b/tests/test_goal_pool.py
@@ -273,6 +273,62 @@ def test_goal_pool_valid_task_emits_branch_task(repo_root, universe_dir):
     assert out[0].status == "pending"
 
 
+def test_goal_pool_emits_goal_ladder_rung_claim_recommendations(
+    repo_root, universe_dir,
+):
+    from workflow.daemon_server import save_goal
+
+    save_goal(
+        universe_dir.parent,
+        goal={
+            "goal_id": "maintenance",
+            "name": "Maintenance",
+            "author": "host",
+            "gate_ladder": [
+                {
+                    "rung_key": "pr_ready",
+                    "label": "PR ready",
+                    "description": "Patch and tests are ready.",
+                    "branch_requirements": {
+                        "allowed_writer_families": ["claude", "codex"],
+                        "forbid_same_family_checker": True,
+                    },
+                    "bounty_requirements": {
+                        "settlement_gate": "pr_ready",
+                    },
+                },
+            ],
+        },
+    )
+    _write_pool_yaml(repo_root, "maintenance", "loop_2_task")
+
+    out = GoalPoolProducer().produce(
+        universe_dir, subscribed_goals=["maintenance"],
+    )
+
+    assert len(out) == 1
+    assert out[0].rung_claim_recommendations == [
+        {
+            "goal_id": "maintenance",
+            "rung_key": "pr_ready",
+            "label": "PR ready",
+            "description": "Patch and tests are ready.",
+            "branch_requirements": {
+                "allowed_writer_families": ["claude", "codex"],
+                "forbid_same_family_checker": True,
+            },
+            "bounty_requirements": {
+                "settlement_gate": "pr_ready",
+            },
+            "claim_action": (
+                "gates action=claim "
+                "branch_def_id=fantasy_author:universe_cycle_wrapper "
+                "rung_key=pr_ready evidence_url=<evidence_url>"
+            ),
+        },
+    ]
+
+
 def test_goal_pool_rescan_idempotency(repo_root, universe_dir):
     """Invariant 4: re-running produces same tasks, not duplicates."""
     for i in range(3):

--- a/tests/test_goals_surface.py
+++ b/tests/test_goals_surface.py
@@ -406,6 +406,67 @@ def test_leaderboard_forks_counts_parent_chain(p5_env):
     assert ranked.get(parent_bid) == 2
 
 
+def test_archive_consultation_uses_gate_leaderboard_parent_signal(p5_env):
+    us, base = p5_env
+    gid = _call(us, "goals", "propose", name="G")["goal"]["goal_id"]
+
+    from workflow.daemon_server import (
+        claim_gate,
+        set_goal_ladder,
+        update_branch_definition,
+    )
+
+    set_goal_ladder(
+        _helpers_base_path(),
+        goal_id=gid,
+        ladder=[
+            {"rung_key": "draft", "label": "Draft"},
+            {"rung_key": "reviewed", "label": "Reviewed"},
+        ],
+    )
+
+    stronger_outcome = _build_branch(us, name="Stronger Outcome")
+    higher_quality = _build_branch(us, name="Higher Quality")
+    for branch_id, quality in (
+        (stronger_outcome, 0.75),
+        (higher_quality, 0.95),
+    ):
+        _call(us, "goals", "bind", branch_def_id=branch_id, goal_id=gid)
+        update_branch_definition(
+            base,
+            branch_def_id=branch_id,
+            updates={"stats": {"avg_quality_score": quality}},
+        )
+
+    claim_gate(
+        base,
+        branch_def_id=stronger_outcome,
+        goal_id=gid,
+        rung_key="reviewed",
+        evidence_url="https://example.com/reviewed",
+        claimed_by="tester",
+    )
+    claim_gate(
+        base,
+        branch_def_id=higher_quality,
+        goal_id=gid,
+        rung_key="draft",
+        evidence_url="https://example.com/draft",
+        claimed_by="tester",
+    )
+
+    result = _call(us, "goals", "archive_consultation", goal_id=gid, limit=2)
+
+    assert result["status"] == "ok"
+    assert [entry["branch_def_id"] for entry in result["candidates"]] == [
+        stronger_outcome,
+        higher_quality,
+    ]
+    assert result["candidates"][0]["outcome_signal"]["highest_rung_key"] == "reviewed"
+    assert result["outcome_leaderboard"][0]["branch_def_id"] == stronger_outcome
+    assert "gate leaderboard" in result["text"].lower()
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # common_nodes
 # ─────────────────────────────────────────────────────────────────────────────
@@ -597,9 +658,11 @@ def test_reads_do_not_ledger(p5_env):
     _call(us, "goals", "search", query="G")
     _call(us, "goals", "leaderboard", goal_id=gid, metric="run_count")
     _call(us, "goals", "common_nodes", goal_id=gid)
+    _call(us, "goals", "archive_consultation", goal_id=gid)
     ledger = json.loads((Path(base) / "ledger.json").read_text("utf-8"))
     read_actions = {"goals.list", "goals.get", "goals.search",
-                    "goals.leaderboard", "goals.common_nodes"}
+                    "goals.leaderboard", "goals.common_nodes",
+                    "goals.archive_consultation"}
     for e in ledger:
         assert e["action"] not in read_actions
 
@@ -615,7 +678,8 @@ def test_unknown_action_lists_available(p5_env):
     assert "error" in result
     avail = result.get("available_actions", [])
     for a in ("propose", "update", "bind", "list", "get",
-              "search", "leaderboard", "common_nodes"):
+              "search", "leaderboard", "common_nodes",
+              "archive_consultation"):
         assert a in avail
 
 

--- a/workflow/api/market.py
+++ b/workflow/api/market.py
@@ -26,11 +26,11 @@ Public surface (back-compat re-exported via ``workflow.universe_server``):
     Attribution handlers:
         _action_record_remix / _action_get_provenance
 
-    Goal handlers (9):
+    Goal handlers (10):
         _action_goal_propose / _action_goal_update / _action_goal_bind /
         _action_goal_list / _action_goal_get / _action_goal_search /
         _action_goal_leaderboard / _action_goal_common_nodes /
-        _action_goal_set_canonical
+        _action_goal_archive_consultation / _action_goal_set_canonical
 
     Gates handlers (9 + 6 gate_event):
         _action_gates_define_ladder / _action_gates_get_ladder /
@@ -609,7 +609,8 @@ _ATTRIBUTION_ACTIONS: dict[str, Any] = {
 # Phase 5 per docs/specs/community_branches_phase5.md. A Goal is the
 # intent a Branch serves — "produce a research paper", "plan a
 # wedding". Many Branches bind to one Goal. 8 actions: propose,
-# update, bind, list, get, search, leaderboard, common_nodes.
+# update, bind, list, get, search, leaderboard, common_nodes,
+# archive_consultation.
 # Storage in workflow/author_server.py.
 
 
@@ -1349,6 +1350,76 @@ def _action_goal_common_nodes(kwargs: dict[str, Any]) -> str:
     }, default=str)
 
 
+def _action_goal_archive_consultation(kwargs: dict[str, Any]) -> str:
+    from workflow.api.branches import _ensure_workflow_db
+    from workflow.api.engine_helpers import _current_actor
+    from workflow.daemon_server import get_goal, goal_archive_consultation
+
+    gid = (kwargs.get("goal_id") or "").strip()
+    if not gid:
+        return json.dumps({
+            "status": "rejected",
+            "error": "goal_id is required.",
+        })
+    _ensure_workflow_db()
+    try:
+        goal = get_goal(_base_path(), goal_id=gid)
+    except KeyError:
+        return json.dumps({
+            "status": "rejected",
+            "error": f"Goal '{gid}' not found.",
+        })
+
+    query = (kwargs.get("query") or "").strip()
+    consultation = goal_archive_consultation(
+        _base_path(),
+        goal_id=gid,
+        query=query,
+        limit=int(kwargs.get("limit", 20) or 20),
+        viewer=_current_actor(),
+    )
+    candidates = consultation["candidates"]
+    lines = [
+        f"**Archive consultation for Goal '{goal['name']}'**",
+        (
+            "Parent candidates are ranked with quality, diversity, "
+            "and the gate leaderboard outcome signal."
+        ),
+        "",
+    ]
+    if candidates:
+        for candidate in candidates[:12]:
+            outcome = candidate.get("outcome_signal") or {}
+            lines.append(
+                f"{candidate['rank']}. **{candidate['name']}** · "
+                f"score={candidate['parent_rank_score']} · "
+                f"quality={candidate['quality_score']} · "
+                f"outcome={candidate['outcome_score']} "
+                f"(`{outcome.get('highest_rung_key', '')}`) · "
+                f"diversity={candidate['diversity_score']} · "
+                f"`{candidate['branch_def_id']}`"
+            )
+    else:
+        if query:
+            lines.append("_No bound Branches match that archive query._")
+        else:
+            lines.append(
+                "_No Branches are bound to this Goal yet. Bind existing "
+                "Branches before selecting fork parents._"
+            )
+
+    return json.dumps({
+        "status": "ok",
+        "text": "\n".join(lines),
+        "goal_id": gid,
+        "query": query,
+        "candidates": candidates,
+        "outcome_leaderboard": consultation["outcome_leaderboard"],
+        "selection_basis": consultation["selection_basis"],
+        "count": len(candidates),
+    }, default=str)
+
+
 def _action_goal_set_canonical(kwargs: dict[str, Any]) -> str:
     from workflow.api.branches import _ensure_workflow_db
     from workflow.api.engine_helpers import (
@@ -1416,6 +1487,7 @@ _GOAL_ACTIONS: dict[str, Any] = {
     "search": _action_goal_search,
     "leaderboard": _action_goal_leaderboard,
     "common_nodes": _action_goal_common_nodes,
+    "archive_consultation": _action_goal_archive_consultation,
     "set_canonical": _action_goal_set_canonical,
 }
 
@@ -1549,6 +1621,9 @@ def goals(
                    this when helping a user decide "is there already
                    a node that does X somewhere on this server?" even
                    if they haven't committed to a Goal yet.
+      archive_consultation Rank bound Branches as fork parents using
+                   quality, diversity, and gates leaderboard outcome
+                   signal. Optional query filters the candidate space.
 
     Args:
       action: see above.

--- a/workflow/branch_tasks.py
+++ b/workflow/branch_tasks.py
@@ -97,6 +97,7 @@ class BranchTask:
     lease_expires_at: str = ""
     heartbeat_at: str = ""
     last_progress_at: str = ""
+    rung_claim_recommendations: list[dict] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/workflow/daemon_server.py
+++ b/workflow/daemon_server.py
@@ -2763,6 +2763,172 @@ def branches_for_goal(
     )[:max(1, int(limit))]
 
 
+def _branch_feature_tokens(branch: dict[str, Any]) -> set[str]:
+    """Return coarse feature tokens for parent diversity ranking."""
+    fields: list[str] = [
+        branch.get("name") or "",
+        branch.get("description") or "",
+        branch.get("author") or "",
+        " ".join(branch.get("tags") or []),
+    ]
+    for node in branch.get("node_defs") or []:
+        if not isinstance(node, dict):
+            continue
+        fields.extend([
+            node.get("node_id") or "",
+            node.get("display_name") or "",
+        ])
+    return set(_goal_search_tokens(" ".join(fields)))
+
+
+def _branch_quality_score(branch: dict[str, Any]) -> float:
+    stats = branch.get("stats") or {}
+    try:
+        score = float(stats.get("avg_quality_score", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        score = 0.0
+    return max(0.0, min(1.0, score))
+
+
+def _feature_distance(tokens: set[str], selected: list[set[str]]) -> float:
+    if not selected:
+        return 1.0
+    if not tokens:
+        return 0.0
+    max_similarity = 0.0
+    for other in selected:
+        if not other:
+            continue
+        union = tokens | other
+        if not union:
+            continue
+        max_similarity = max(max_similarity, len(tokens & other) / len(union))
+    return max(0.0, min(1.0, 1.0 - max_similarity))
+
+
+def goal_archive_consultation(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    query: str = "",
+    limit: int = 20,
+    viewer: str = "",
+) -> dict[str, Any]:
+    """Rank Goal-bound Branches as fork parents with gate outcome signal."""
+    branches = branches_for_goal(
+        base_path,
+        goal_id=goal_id,
+        limit=500,
+        viewer=viewer,
+    )
+    query_tokens = set(_goal_search_tokens(query or ""))
+    outcome_entries = gates_leaderboard(
+        base_path,
+        goal_id=goal_id,
+        limit=500,
+    )
+    outcome_by_branch = {
+        entry["branch_def_id"]: entry
+        for entry in outcome_entries
+        if entry.get("branch_def_id")
+    }
+    ladder_len = len(get_goal_ladder(base_path, goal_id=goal_id))
+    max_rung_index = max(0, ladder_len - 1)
+
+    pool: list[dict[str, Any]] = []
+    for branch in branches:
+        feature_tokens = _branch_feature_tokens(branch)
+        if query_tokens and not (query_tokens & feature_tokens):
+            continue
+        outcome = outcome_by_branch.get(branch["branch_def_id"], {})
+        try:
+            rung_index = int(outcome.get("highest_rung_index", -1))
+        except (TypeError, ValueError):
+            rung_index = -1
+        outcome_score = (
+            max(0.0, min(1.0, rung_index / max_rung_index))
+            if max_rung_index > 0 else 0.0
+        )
+        pool.append({
+            "branch": branch,
+            "feature_tokens": feature_tokens,
+            "quality_score": _branch_quality_score(branch),
+            "outcome_score": outcome_score,
+            "outcome_signal": {
+                "highest_rung_key": outcome.get("highest_rung_key", ""),
+                "highest_rung_index": rung_index,
+                "claimed_at": outcome.get("claimed_at", ""),
+                "evidence_url": outcome.get("evidence_url", ""),
+            },
+        })
+
+    selected_tokens: list[set[str]] = []
+    ranked: list[dict[str, Any]] = []
+    remaining = pool[:]
+    while remaining and len(ranked) < max(1, int(limit)):
+        best_index = 0
+        best_payload: dict[str, Any] | None = None
+        for index, item in enumerate(remaining):
+            diversity = _feature_distance(item["feature_tokens"], selected_tokens)
+            score = (
+                0.4 * item["quality_score"]
+                + 0.4 * item["outcome_score"]
+                + 0.2 * diversity
+            )
+            payload = {
+                **item["branch"],
+                "quality_score": round(item["quality_score"], 3),
+                "outcome_score": round(item["outcome_score"], 3),
+                "diversity_score": round(diversity, 3),
+                "parent_rank_score": round(score, 3),
+                "outcome_signal": item["outcome_signal"],
+                "selection_basis": (
+                    "0.4 quality + 0.4 gate leaderboard outcome + "
+                    "0.2 diversity"
+                ),
+            }
+            if best_payload is None:
+                best_index = index
+                best_payload = payload
+                continue
+            current_key = (
+                payload["parent_rank_score"],
+                payload["outcome_score"],
+                payload["quality_score"],
+                payload.get("updated_at") or "",
+                payload.get("branch_def_id") or "",
+            )
+            best_key = (
+                best_payload["parent_rank_score"],
+                best_payload["outcome_score"],
+                best_payload["quality_score"],
+                best_payload.get("updated_at") or "",
+                best_payload.get("branch_def_id") or "",
+            )
+            if current_key > best_key:
+                best_index = index
+                best_payload = payload
+        chosen = remaining.pop(best_index)
+        selected_tokens.append(chosen["feature_tokens"])
+        if best_payload is not None:
+            best_payload["rank"] = len(ranked) + 1
+            ranked.append(best_payload)
+
+    visible_ids = {entry["branch_def_id"] for entry in ranked}
+    visible_outcomes = [
+        entry for entry in outcome_entries
+        if entry.get("branch_def_id") in visible_ids
+    ]
+    return {
+        "candidates": ranked,
+        "outcome_leaderboard": visible_outcomes,
+        "selection_basis": (
+            "parent candidates ranked by quality, gates leaderboard "
+            "outcome, and diversity"
+        ),
+    }
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Phase 6: Outcome gates — ladder on goals, claims per branch
 # ═══════════════════════════════════════════════════════════════════════════

--- a/workflow/producers/goal_pool.py
+++ b/workflow/producers/goal_pool.py
@@ -58,6 +58,54 @@ _REJECTED_INPUT_KEYS = frozenset({
 })
 
 
+def _rung_claim_recommendations(
+    universe_path: Path,
+    goal_id: str,
+    branch_def_id: str = "",
+) -> list[dict]:
+    """Return claim recommendations copied from the bound Goal ladder."""
+    if not goal_id:
+        return []
+    try:
+        from workflow.daemon_server import get_goal_ladder
+        from workflow.storage import base_path_from_universe
+
+        ladder = get_goal_ladder(
+            base_path_from_universe(universe_path),
+            goal_id=goal_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "goal_pool: no gate ladder recommendations for %s: %s",
+            goal_id,
+            exc,
+        )
+        return []
+
+    recommendations: list[dict] = []
+    for rung in ladder:
+        if not isinstance(rung, dict):
+            continue
+        rung_key = str(rung.get("rung_key") or "").strip()
+        if not rung_key:
+            continue
+        label = rung.get("label") or rung.get("name") or rung_key
+        recommendations.append({
+            "goal_id": goal_id,
+            "rung_key": rung_key,
+            "label": label,
+            "description": rung.get("description", ""),
+            "branch_requirements": dict(rung.get("branch_requirements") or {}),
+            "bounty_requirements": dict(rung.get("bounty_requirements") or {}),
+            "claim_action": (
+                "gates action=claim "
+                f"branch_def_id={branch_def_id or '<branch_def_id>'} "
+                f"rung_key={rung_key} evidence_url=<evidence_url>"
+            ),
+        })
+    return recommendations
+
+
 def repo_root_path(universe_path: Path) -> Path:
     """Resolve the shared pool location. Preflight §4.1 #7 order:
 
@@ -209,7 +257,13 @@ class GoalPoolProducer:
             if not goal_dir.is_dir():
                 continue
             out.extend(
-                self._scan_goal_dir(goal_dir, goal, accessible, max_per_cycle - len(out))
+                self._scan_goal_dir(
+                    goal_dir,
+                    goal,
+                    accessible,
+                    max_per_cycle - len(out),
+                    universe_path=Path(universe_path),
+                )
             )
             if len(out) >= max_per_cycle:
                 break
@@ -221,6 +275,8 @@ class GoalPoolProducer:
         goal_id: str,
         accessible_slugs: set[str],
         budget: int,
+        *,
+        universe_path: Path,
     ) -> list[BranchTask]:
         if budget <= 0:
             return []
@@ -231,7 +287,12 @@ class GoalPoolProducer:
             return []
         cached_mtime = self._mtime_cache.get(goal_dir)
         if cached_mtime is not None and cached_mtime == current_mtime:
-            return list(self._result_cache.get(goal_dir, [])[:budget])
+            cached = list(self._result_cache.get(goal_dir, [])[:budget])
+            for task in cached:
+                task.rung_claim_recommendations = _rung_claim_recommendations(
+                    universe_path, goal_id, task.branch_def_id,
+                )
+            return cached
 
         import yaml
 
@@ -253,6 +314,9 @@ class GoalPoolProducer:
                 continue
             task = self._parse_pool_yaml(data, yaml_path, goal_id, accessible_slugs)
             if task is not None:
+                task.rung_claim_recommendations = _rung_claim_recommendations(
+                    universe_path, goal_id, task.branch_def_id,
+                )
                 tasks.append(task)
             if len(tasks) >= budget:
                 break


### PR DESCRIPTION
Fixes #897

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-126-loop-2-branches-must-integrate-with-the-existing-gates-syste.md`
- GitHub issue: #897
- Branch task: `auto-change/issue-897`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.