### PR TITLE
[auto-change] WIKI-PATCH: Open-brain v2 slice C — read-only cost ledger + treasury status surface (no autonomous spend)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
@@ -282,6 +282,10 @@ enumerate ALL FIVE. Don't list extensions actions and forget the rest.
   `daemon_memory_review` for accept/reject/supersede, and
   `daemon_memory_promote` only when the user wants a curated daemon-wiki
   review note.
+- "Show costs / ledger / treasury / bounty pool / settlement totals" ->
+  use `universe action="treasury_status"`. This is a read-only status
+  surface with no autonomous spend: it may summarize existing ledger rows
+  but must not lock, release, refund, batch, settle, or spend funds.
 - `wiki` is strictly for knowledge and reference content. It is NOT the
   save-anything surface for workflow structure, workflow state, task
   lists, or artifacts that need to be queried as structured data.

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -1869,6 +1869,22 @@ def _action_daemon_memory_status(
     return json.dumps(result, default=str)
 
 
+def _action_treasury_status(
+    universe_id: str = "",
+    limit: Any = 10,
+    **_kwargs: Any,
+) -> str:
+    from workflow.treasury import treasury_status
+
+    uid = universe_id or _default_universe()
+    try:
+        result = treasury_status(_base_path(), limit=int(limit))
+    except (ValueError, TypeError) as exc:
+        return json.dumps({"universe_id": uid, "error": str(exc)})
+    result["universe_id"] = uid
+    return json.dumps(result, default=str)
+
+
 # ---------------------------------------------------------------------------
 # Phase H — daemon_overview + set_tier_config (aggregated MCP surface)
 # ---------------------------------------------------------------------------
@@ -4304,6 +4320,7 @@ def _universe_impl(
         "daemon_memory_review": _action_daemon_memory_review,
         "daemon_memory_promote": _action_daemon_memory_promote,
         "daemon_memory_status": _action_daemon_memory_status,
+        "treasury_status": _action_treasury_status,
         "set_tier_config": _action_set_tier_config,
     }
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/treasury/__init__.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/treasury/__init__.py
@@ -2,7 +2,7 @@
 
 Schema (schema.py): treasury_balance / bounty_pool_balance / royalty_payout DDL.
 Distribution math (distribution.py): pure functions, no I/O.
-Persistence wiring + MCP surface come in follow-ups post-sweep.
+Status (status.py): read-only cost-ledger + treasury summaries.
 """
 
 from __future__ import annotations
@@ -25,6 +25,7 @@ from workflow.treasury.schema import (
     TreasuryEntry,
     migrate_treasury_schema,
 )
+from workflow.treasury.status import treasury_status
 
 __all__ = [
     # distribution.py
@@ -43,4 +44,6 @@ __all__ = [
     "RoyaltyPayment",
     "TreasuryEntry",
     "migrate_treasury_schema",
+    # status.py
+    "treasury_status",
 ]

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/treasury/status.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/treasury/status.py
@@ -1,0 +1,235 @@
+"""Read-only cost-ledger and treasury status summaries."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from workflow.storage import DB_FILENAME
+
+
+def _workflow_db_path(base_path: str | Path) -> Path:
+    return Path(base_path) / DB_FILENAME
+
+
+def _connect_readonly(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=30.0)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _tables(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    return {str(row["name"]) for row in rows}
+
+
+def _scalar(conn: sqlite3.Connection, sql: str, params: tuple[Any, ...] = ()) -> int:
+    value = conn.execute(sql, params).fetchone()[0]
+    return int(value or 0)
+
+
+def _status_counts(conn: sqlite3.Connection, table: str) -> dict[str, int]:
+    rows = conn.execute(
+        f"SELECT status, COUNT(*) AS count FROM {table} GROUP BY status"
+    ).fetchall()
+    return {str(row["status"]): int(row["count"]) for row in rows}
+
+
+def _recent_rows(conn: sqlite3.Connection, sql: str, limit: int) -> list[dict[str, Any]]:
+    return [dict(row) for row in conn.execute(sql, (limit,)).fetchall()]
+
+
+def _empty_status(db_path: Path, status: str) -> dict[str, Any]:
+    return {
+        "status": status,
+        "database_path": str(db_path),
+        "read_only": True,
+        "autonomous_spend_allowed": False,
+        "cost_ledger": {
+            "escrow": {
+                "count_total": 0,
+                "locked_remaining_total": 0,
+                "by_status": {},
+            },
+            "settlements": {
+                "count_total": 0,
+                "amount_total": 0,
+                "treasury_fee_total": 0,
+                "net_amount_total": 0,
+                "by_status": {},
+            },
+            "batches": {
+                "count_total": 0,
+                "amount_total": 0,
+                "fee_total": 0,
+                "by_status": {},
+            },
+            "transactions": {
+                "count_total": 0,
+                "amount_total": 0,
+            },
+        },
+        "treasury": {
+            "entry_count": 0,
+            "gross_amount_total": 0,
+            "fee_collected_total": 0,
+            "bounty_share_total": 0,
+            "treasury_retained_total": 0,
+            "bounty_pool_allocated_total": 0,
+            "bounty_pool_disbursed_total": 0,
+            "bounty_pool_remaining_total": 0,
+            "royalty_payout_total": 0,
+            "royalty_pending_total": 0,
+        },
+        "recent_settlements": [],
+        "recent_treasury_entries": [],
+        "recent_transactions": [],
+        "caveats": [
+            "Status surface is read-only and never locks, releases, refunds, "
+            "batches, or spends funds.",
+        ],
+    }
+
+
+def treasury_status(base_path: str | Path, *, limit: int = 10) -> dict[str, Any]:
+    """Return a read-only cost-ledger and treasury summary.
+
+    This function intentionally does not run migrations or create the workflow
+    database. Missing tables are reported as zeroed sections so a status check
+    cannot become an implicit payment-system write.
+    """
+    db_path = _workflow_db_path(base_path)
+    safe_limit = max(0, min(int(limit), 100))
+    if not db_path.exists():
+        return _empty_status(db_path, "empty")
+
+    with _connect_readonly(db_path) as conn:
+        tables = _tables(conn)
+        result = _empty_status(db_path, "ok")
+
+        if "escrow_balance" in tables:
+            result["cost_ledger"]["escrow"] = {
+                "count_total": _scalar(conn, "SELECT COUNT(*) FROM escrow_balance"),
+                "locked_remaining_total": _scalar(
+                    conn,
+                    """
+                    SELECT COALESCE(SUM(total_amount - released_amount), 0)
+                    FROM escrow_balance
+                    WHERE status IN ('locked', 'partial')
+                    """,
+                ),
+                "by_status": _status_counts(conn, "escrow_balance"),
+            }
+
+        if "pending_settlement" in tables:
+            result["cost_ledger"]["settlements"] = {
+                "count_total": _scalar(conn, "SELECT COUNT(*) FROM pending_settlement"),
+                "amount_total": _scalar(
+                    conn, "SELECT COALESCE(SUM(amount), 0) FROM pending_settlement"
+                ),
+                "treasury_fee_total": _scalar(
+                    conn,
+                    "SELECT COALESCE(SUM(treasury_fee), 0) FROM pending_settlement",
+                ),
+                "net_amount_total": _scalar(
+                    conn, "SELECT COALESCE(SUM(net_amount), 0) FROM pending_settlement"
+                ),
+                "by_status": _status_counts(conn, "pending_settlement"),
+            }
+            result["recent_settlements"] = _recent_rows(
+                conn,
+                """
+                SELECT settlement_id, escrow_id, recipient_id, amount, treasury_fee,
+                       net_amount, status, event_type, created_at, settled_at, batch_id
+                FROM pending_settlement
+                ORDER BY created_at DESC, settlement_id DESC
+                LIMIT ?
+                """,
+                safe_limit,
+            )
+
+        if "settlement_batch" in tables:
+            result["cost_ledger"]["batches"] = {
+                "count_total": _scalar(conn, "SELECT COUNT(*) FROM settlement_batch"),
+                "amount_total": _scalar(
+                    conn, "SELECT COALESCE(SUM(total_amount), 0) FROM settlement_batch"
+                ),
+                "fee_total": _scalar(
+                    conn, "SELECT COALESCE(SUM(total_fee), 0) FROM settlement_batch"
+                ),
+                "by_status": _status_counts(conn, "settlement_batch"),
+            }
+
+        if "transaction_log" in tables:
+            result["cost_ledger"]["transactions"] = {
+                "count_total": _scalar(conn, "SELECT COUNT(*) FROM transaction_log"),
+                "amount_total": _scalar(
+                    conn, "SELECT COALESCE(SUM(amount), 0) FROM transaction_log"
+                ),
+            }
+            result["recent_transactions"] = _recent_rows(
+                conn,
+                """
+                SELECT tx_id, kind, escrow_id, settlement_id, batch_id, actor_id,
+                       amount, recorded_at, note
+                FROM transaction_log
+                ORDER BY recorded_at DESC, tx_id DESC
+                LIMIT ?
+                """,
+                safe_limit,
+            )
+
+        treasury = result["treasury"]
+        if "treasury_balance" in tables:
+            treasury["entry_count"] = _scalar(conn, "SELECT COUNT(*) FROM treasury_balance")
+            treasury["gross_amount_total"] = _scalar(
+                conn, "SELECT COALESCE(SUM(amount), 0) FROM treasury_balance"
+            )
+            treasury["fee_collected_total"] = _scalar(
+                conn, "SELECT COALESCE(SUM(fee_collected), 0) FROM treasury_balance"
+            )
+            treasury["bounty_share_total"] = _scalar(
+                conn, "SELECT COALESCE(SUM(bounty_share), 0) FROM treasury_balance"
+            )
+            treasury["treasury_retained_total"] = (
+                treasury["fee_collected_total"] - treasury["bounty_share_total"]
+            )
+            result["recent_treasury_entries"] = _recent_rows(
+                conn,
+                """
+                SELECT entry_id, source_tx_id, amount, take_rate_bp, fee_collected,
+                       bounty_share, recorded_at, note
+                FROM treasury_balance
+                ORDER BY recorded_at DESC, entry_id DESC
+                LIMIT ?
+                """,
+                safe_limit,
+            )
+
+        if "bounty_pool_balance" in tables:
+            treasury["bounty_pool_allocated_total"] = _scalar(
+                conn, "SELECT COALESCE(SUM(allocated), 0) FROM bounty_pool_balance"
+            )
+            treasury["bounty_pool_disbursed_total"] = _scalar(
+                conn, "SELECT COALESCE(SUM(disbursed), 0) FROM bounty_pool_balance"
+            )
+            treasury["bounty_pool_remaining_total"] = (
+                treasury["bounty_pool_allocated_total"]
+                - treasury["bounty_pool_disbursed_total"]
+            )
+
+        if "royalty_payout" in tables:
+            treasury["royalty_payout_total"] = _scalar(
+                conn, "SELECT COALESCE(SUM(royalty_amount), 0) FROM royalty_payout"
+            )
+            treasury["royalty_pending_total"] = _scalar(
+                conn,
+                """
+                SELECT COALESCE(SUM(royalty_amount), 0)
+                FROM royalty_payout
+                WHERE status = 'pending'
+                """,
+            )
+
+        return result

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -362,7 +362,8 @@ def universe(
             daemon_update_behavior, daemon_control_status,
             control_daemon; daemon memory: daemon_memory_capture,
             daemon_memory_search, daemon_memory_list, daemon_memory_review,
-            daemon_memory_promote, daemon_memory_status; config: set_tier_config;
+            daemon_memory_promote, daemon_memory_status; economy reads:
+            treasury_status; config: set_tier_config;
         universe_id: Target universe. Defaults to the active universe.
         text/path/filter_text: Action-specific content, file path, or filter.
         branch_id/request_type: Request routing fields.

--- a/tests/test_api_universe.py
+++ b/tests/test_api_universe.py
@@ -67,6 +67,7 @@ def test_module_exposes_expected_public_names() -> None:
         "_action_daemon_memory_capture", "_action_daemon_memory_search",
         "_action_daemon_memory_list", "_action_daemon_memory_review",
         "_action_daemon_memory_promote", "_action_daemon_memory_status",
+        "_action_treasury_status",
         "_action_set_tier_config", "_action_queue_cancel",
         "_action_subscribe_goal", "_action_unsubscribe_goal",
         "_action_list_subscriptions", "_action_post_to_goal_pool",

--- a/tests/test_treasury_schema.py
+++ b/tests/test_treasury_schema.py
@@ -256,7 +256,7 @@ class TestDDLIntegration:
             """INSERT INTO treasury_balance
                (entry_id, source_tx_id, amount, take_rate_bp, fee_collected,
                 bounty_share, recorded_at)
-               VALUES ('t1','tx-1',1_000_000,100,10_000,5_000,'2026-04-24T00:00:00Z')"""
+               VALUES ('t1','tx-1',1000000,100,10000,5000,'2026-04-24T00:00:00Z')"""
         )
         db.execute(
             """INSERT INTO bounty_pool_balance
@@ -290,7 +290,7 @@ class TestDDLIntegration:
                 """INSERT INTO treasury_balance
                    (entry_id, source_tx_id, amount, take_rate_bp, fee_collected,
                     bounty_share, recorded_at)
-                   VALUES ('t1','tx-1',-1,100,10_000,5_000,'2026-04-24T00:00:00Z')"""
+                   VALUES ('t1','tx-1',-1,100,10000,5000,'2026-04-24T00:00:00Z')"""
             )
 
     def test_invalid_status_rejected(self, db):
@@ -319,7 +319,7 @@ class TestDDLIntegration:
             """INSERT INTO treasury_balance
                (entry_id, source_tx_id, amount, take_rate_bp, fee_collected,
                 bounty_share, recorded_at, note)
-               VALUES ('t1','tx-1',2_000_000,100,20_000,10_000,'2026-04-24T00:00:00Z','test')"""
+               VALUES ('t1','tx-1',2000000,100,20000,10000,'2026-04-24T00:00:00Z','test')"""
         )
         db.commit()
         row = dict(db.execute("SELECT * FROM treasury_balance WHERE entry_id='t1'").fetchone())

--- a/tests/test_treasury_status.py
+++ b/tests/test_treasury_status.py
@@ -1,0 +1,100 @@
+"""Read-only treasury/cost-ledger status coverage."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from workflow.payments import migrate_settlement_schema
+from workflow.storage import DB_FILENAME
+from workflow.treasury import migrate_treasury_schema, treasury_status
+
+
+def _connect_db(base_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(base_path / DB_FILENAME))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_treasury_status_reads_cost_ledger_without_writing(tmp_path: Path) -> None:
+    with _connect_db(tmp_path) as conn:
+        migrate_settlement_schema(conn)
+        migrate_treasury_schema(conn)
+        conn.execute(
+            """
+            INSERT INTO escrow_balance
+                (escrow_id, node_id, run_id, staker_id, total_amount,
+                 released_amount, status, locked_at)
+            VALUES ('e1', 'node-1', 'run-1', 'alice', 1000000, 250000,
+                    'partial', '2026-05-17T00:00:00Z')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO pending_settlement
+                (settlement_id, escrow_id, recipient_id, amount, treasury_fee,
+                 net_amount, status, settlement_key, created_at)
+            VALUES ('s1', 'e1', 'daemon-a', 1000000, 10000, 990000,
+                    'pending', 'run-1:node-1:daemon-a:completion',
+                    '2026-05-17T00:01:00Z')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO transaction_log
+                (kind, escrow_id, settlement_id, actor_id, amount, recorded_at,
+                 note)
+            VALUES ('fee', 'e1', 's1', 'system', 10000,
+                    '2026-05-17T00:02:00Z', 'treasury fee')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO treasury_balance
+                (entry_id, source_tx_id, amount, take_rate_bp, fee_collected,
+                 bounty_share, recorded_at, note)
+            VALUES ('t1', 's1', 1000000, 100, 10000, 5000,
+                    '2026-05-17T00:03:00Z', 'first fee')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO bounty_pool_balance
+                (pool_entry_id, treasury_entry_id, allocated, disbursed,
+                 status, recorded_at)
+            VALUES ('bp1', 't1', 5000, 1000, 'pending',
+                    '2026-05-17T00:04:00Z')
+            """
+        )
+        conn.commit()
+
+    before = (tmp_path / DB_FILENAME).stat().st_mtime_ns
+    result = treasury_status(tmp_path, limit=5)
+    after = (tmp_path / DB_FILENAME).stat().st_mtime_ns
+
+    assert after == before
+    assert result["read_only"] is True
+    assert result["autonomous_spend_allowed"] is False
+    assert result["cost_ledger"]["settlements"]["count_total"] == 1
+    assert result["cost_ledger"]["settlements"]["amount_total"] == 1_000_000
+    assert result["cost_ledger"]["settlements"]["treasury_fee_total"] == 10_000
+    assert result["cost_ledger"]["escrow"]["locked_remaining_total"] == 750_000
+    assert result["treasury"]["fee_collected_total"] == 10_000
+    assert result["treasury"]["treasury_retained_total"] == 5_000
+    assert result["treasury"]["bounty_pool_remaining_total"] == 4_000
+    assert result["recent_settlements"][0]["settlement_id"] == "s1"
+    assert result["recent_treasury_entries"][0]["entry_id"] == "t1"
+    assert result["recent_transactions"][0]["kind"] == "fee"
+
+
+def test_treasury_status_missing_database_is_empty_and_does_not_create(
+    tmp_path: Path,
+) -> None:
+    result = treasury_status(tmp_path)
+
+    assert result["status"] == "empty"
+    assert result["read_only"] is True
+    assert result["autonomous_spend_allowed"] is False
+    assert result["cost_ledger"]["settlements"]["count_total"] == 0
+    assert result["treasury"]["fee_collected_total"] == 0
+    assert not (tmp_path / DB_FILENAME).exists()

--- a/tests/test_universe_server_framing.py
+++ b/tests/test_universe_server_framing.py
@@ -189,6 +189,16 @@ def test_control_station_routes_daemon_memory_actions() -> None:
     assert "daemon_id" in text
 
 
+def test_control_station_routes_treasury_status_as_read_only() -> None:
+    """Treasury/cost-ledger status must be discoverable as a read-only route."""
+    from workflow.api.prompts import _CONTROL_STATION_PROMPT
+
+    text = _CONTROL_STATION_PROMPT
+    assert "treasury_status" in text
+    assert "read-only" in text.lower()
+    assert "no autonomous spend" in text.lower()
+
+
 def test_extension_guide_prompt_points_to_control_station() -> None:
     """#15 (post-c97feac): _EXTENSION_GUIDE_PROMPT no longer dup'd the
     NO SIMULATION block. It now points to control_station as the

--- a/tests/test_universe_treasury_status.py
+++ b/tests/test_universe_treasury_status.py
@@ -1,0 +1,43 @@
+"""Universe read-only surface for treasury/cost-ledger status."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from workflow.api import universe as universe_api
+from workflow.payments import migrate_settlement_schema
+from workflow.storage import DB_FILENAME
+from workflow.treasury import migrate_treasury_schema
+
+
+def test_universe_treasury_status_is_read_only(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(universe_api, "_base_path", lambda: tmp_path)
+    with sqlite3.connect(str(tmp_path / DB_FILENAME)) as conn:
+        migrate_settlement_schema(conn)
+        migrate_treasury_schema(conn)
+        conn.execute(
+            """
+            INSERT INTO treasury_balance
+                (entry_id, source_tx_id, amount, take_rate_bp, fee_collected,
+                 bounty_share, recorded_at)
+            VALUES ('t1', 's1', 500000, 100, 5000, 2500,
+                    '2026-05-17T00:00:00Z')
+            """
+        )
+        conn.commit()
+
+    before = (tmp_path / DB_FILENAME).stat().st_mtime_ns
+    result = json.loads(universe_api._universe_impl(
+        action="treasury_status",
+        limit=3,
+    ))
+    after = (tmp_path / DB_FILENAME).stat().st_mtime_ns
+
+    assert after == before
+    assert result["universe_id"] == universe_api._default_universe()
+    assert result["read_only"] is True
+    assert result["autonomous_spend_allowed"] is False
+    assert result["treasury"]["fee_collected_total"] == 5000
+    assert "treasury_status" not in universe_api.WRITE_ACTIONS

--- a/workflow/api/prompts.py
+++ b/workflow/api/prompts.py
@@ -282,6 +282,10 @@ enumerate ALL FIVE. Don't list extensions actions and forget the rest.
   `daemon_memory_review` for accept/reject/supersede, and
   `daemon_memory_promote` only when the user wants a curated daemon-wiki
   review note.
+- "Show costs / ledger / treasury / bounty pool / settlement totals" ->
+  use `universe action="treasury_status"`. This is a read-only status
+  surface with no autonomous spend: it may summarize existing ledger rows
+  but must not lock, release, refund, batch, settle, or spend funds.
 - `wiki` is strictly for knowledge and reference content. It is NOT the
   save-anything surface for workflow structure, workflow state, task
   lists, or artifacts that need to be queried as structured data.

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -1869,6 +1869,22 @@ def _action_daemon_memory_status(
     return json.dumps(result, default=str)
 
 
+def _action_treasury_status(
+    universe_id: str = "",
+    limit: Any = 10,
+    **_kwargs: Any,
+) -> str:
+    from workflow.treasury import treasury_status
+
+    uid = universe_id or _default_universe()
+    try:
+        result = treasury_status(_base_path(), limit=int(limit))
+    except (ValueError, TypeError) as exc:
+        return json.dumps({"universe_id": uid, "error": str(exc)})
+    result["universe_id"] = uid
+    return json.dumps(result, default=str)
+
+
 # ---------------------------------------------------------------------------
 # Phase H — daemon_overview + set_tier_config (aggregated MCP surface)
 # ---------------------------------------------------------------------------
@@ -4304,6 +4320,7 @@ def _universe_impl(
         "daemon_memory_review": _action_daemon_memory_review,
         "daemon_memory_promote": _action_daemon_memory_promote,
         "daemon_memory_status": _action_daemon_memory_status,
+        "treasury_status": _action_treasury_status,
         "set_tier_config": _action_set_tier_config,
     }
 

--- a/workflow/treasury/__init__.py
+++ b/workflow/treasury/__init__.py
@@ -2,7 +2,7 @@
 
 Schema (schema.py): treasury_balance / bounty_pool_balance / royalty_payout DDL.
 Distribution math (distribution.py): pure functions, no I/O.
-Persistence wiring + MCP surface come in follow-ups post-sweep.
+Status (status.py): read-only cost-ledger + treasury summaries.
 """
 
 from __future__ import annotations
@@ -25,6 +25,7 @@ from workflow.treasury.schema import (
     TreasuryEntry,
     migrate_treasury_schema,
 )
+from workflow.treasury.status import treasury_status
 
 __all__ = [
     # distribution.py
@@ -43,4 +44,6 @@ __all__ = [
     "RoyaltyPayment",
     "TreasuryEntry",
     "migrate_treasury_schema",
+    # status.py
+    "treasury_status",
 ]

--- a/workflow/treasury/status.py
+++ b/workflow/treasury/status.py
@@ -1,0 +1,235 @@
+"""Read-only cost-ledger and treasury status summaries."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from workflow.storage import DB_FILENAME
+
+
+def _workflow_db_path(base_path: str | Path) -> Path:
+    return Path(base_path) / DB_FILENAME
+
+
+def _connect_readonly(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=30.0)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _tables(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    return {str(row["name"]) for row in rows}
+
+
+def _scalar(conn: sqlite3.Connection, sql: str, params: tuple[Any, ...] = ()) -> int:
+    value = conn.execute(sql, params).fetchone()[0]
+    return int(value or 0)
+
+
+def _status_counts(conn: sqlite3.Connection, table: str) -> dict[str, int]:
+    rows = conn.execute(
+        f"SELECT status, COUNT(*) AS count FROM {table} GROUP BY status"
+    ).fetchall()
+    return {str(row["status"]): int(row["count"]) for row in rows}
+
+
+def _recent_rows(conn: sqlite3.Connection, sql: str, limit: int) -> list[dict[str, Any]]:
+    return [dict(row) for row in conn.execute(sql, (limit,)).fetchall()]
+
+
+def _empty_status(db_path: Path, status: str) -> dict[str, Any]:
+    return {
+        "status": status,
+        "database_path": str(db_path),
+        "read_only": True,
+        "autonomous_spend_allowed": False,
+        "cost_ledger": {
+            "escrow": {
+                "count_total": 0,
+                "locked_remaining_total": 0,
+                "by_status": {},
+            },
+            "settlements": {
+                "count_total": 0,
+                "amount_total": 0,
+                "treasury_fee_total": 0,
+                "net_amount_total": 0,
+                "by_status": {},
+            },
+            "batches": {
+                "count_total": 0,
+                "amount_total": 0,
+                "fee_total": 0,
+                "by_status": {},
+            },
+            "transactions": {
+                "count_total": 0,
+                "amount_total": 0,
+            },
+        },
+        "treasury": {
+            "entry_count": 0,
+            "gross_amount_total": 0,
+            "fee_collected_total": 0,
+            "bounty_share_total": 0,
+            "treasury_retained_total": 0,
+            "bounty_pool_allocated_total": 0,
+            "bounty_pool_disbursed_total": 0,
+            "bounty_pool_remaining_total": 0,
+            "royalty_payout_total": 0,
+            "royalty_pending_total": 0,
+        },
+        "recent_settlements": [],
+        "recent_treasury_entries": [],
+        "recent_transactions": [],
+        "caveats": [
+            "Status surface is read-only and never locks, releases, refunds, "
+            "batches, or spends funds.",
+        ],
+    }
+
+
+def treasury_status(base_path: str | Path, *, limit: int = 10) -> dict[str, Any]:
+    """Return a read-only cost-ledger and treasury summary.
+
+    This function intentionally does not run migrations or create the workflow
+    database. Missing tables are reported as zeroed sections so a status check
+    cannot become an implicit payment-system write.
+    """
+    db_path = _workflow_db_path(base_path)
+    safe_limit = max(0, min(int(limit), 100))
+    if not db_path.exists():
+        return _empty_status(db_path, "empty")
+
+    with _connect_readonly(db_path) as conn:
+        tables = _tables(conn)
+        result = _empty_status(db_path, "ok")
+
+        if "escrow_balance" in tables:
+            result["cost_ledger"]["escrow"] = {
+                "count_total": _scalar(conn, "SELECT COUNT(*) FROM escrow_balance"),
+                "locked_remaining_total": _scalar(
+                    conn,
+                    """
+                    SELECT COALESCE(SUM(total_amount - released_amount), 0)
+                    FROM escrow_balance
+                    WHERE status IN ('locked', 'partial')
+                    """,
+                ),
+                "by_status": _status_counts(conn, "escrow_balance"),
+            }
+
+        if "pending_settlement" in tables:
+            result["cost_ledger"]["settlements"] = {
+                "count_total": _scalar(conn, "SELECT COUNT(*) FROM pending_settlement"),
+                "amount_total": _scalar(
+                    conn, "SELECT COALESCE(SUM(amount), 0) FROM pending_settlement"
+                ),
+                "treasury_fee_total": _scalar(
+                    conn,
+                    "SELECT COALESCE(SUM(treasury_fee), 0) FROM pending_settlement",
+                ),
+                "net_amount_total": _scalar(
+                    conn, "SELECT COALESCE(SUM(net_amount), 0) FROM pending_settlement"
+                ),
+                "by_status": _status_counts(conn, "pending_settlement"),
+            }
+            result["recent_settlements"] = _recent_rows(
+                conn,
+                """
+                SELECT settlement_id, escrow_id, recipient_id, amount, treasury_fee,
+                       net_amount, status, event_type, created_at, settled_at, batch_id
+                FROM pending_settlement
+                ORDER BY created_at DESC, settlement_id DESC
+                LIMIT ?
+                """,
+                safe_limit,
+            )
+
+        if "settlement_batch" in tables:
+            result["cost_ledger"]["batches"] = {
+                "count_total": _scalar(conn, "SELECT COUNT(*) FROM settlement_batch"),
+                "amount_total": _scalar(
+                    conn, "SELECT COALESCE(SUM(total_amount), 0) FROM settlement_batch"
+                ),
+                "fee_total": _scalar(
+                    conn, "SELECT COALESCE(SUM(total_fee), 0) FROM settlement_batch"
+                ),
+                "by_status": _status_counts(conn, "settlement_batch"),
+            }
+
+        if "transaction_log" in tables:
+            result["cost_ledger"]["transactions"] = {
+                "count_total": _scalar(conn, "SELECT COUNT(*) FROM transaction_log"),
+                "amount_total": _scalar(
+                    conn, "SELECT COALESCE(SUM(amount), 0) FROM transaction_log"
+                ),
+            }
+            result["recent_transactions"] = _recent_rows(
+                conn,
+                """
+                SELECT tx_id, kind, escrow_id, settlement_id, batch_id, actor_id,
+                       amount, recorded_at, note
+                FROM transaction_log
+                ORDER BY recorded_at DESC, tx_id DESC
+                LIMIT ?
+                """,
+                safe_limit,
+            )
+
+        treasury = result["treasury"]
+        if "treasury_balance" in tables:
+            treasury["entry_count"] = _scalar(conn, "SELECT COUNT(*) FROM treasury_balance")
+            treasury["gross_amount_total"] = _scalar(
+                conn, "SELECT COALESCE(SUM(amount), 0) FROM treasury_balance"
+            )
+            treasury["fee_collected_total"] = _scalar(
+                conn, "SELECT COALESCE(SUM(fee_collected), 0) FROM treasury_balance"
+            )
+            treasury["bounty_share_total"] = _scalar(
+                conn, "SELECT COALESCE(SUM(bounty_share), 0) FROM treasury_balance"
+            )
+            treasury["treasury_retained_total"] = (
+                treasury["fee_collected_total"] - treasury["bounty_share_total"]
+            )
+            result["recent_treasury_entries"] = _recent_rows(
+                conn,
+                """
+                SELECT entry_id, source_tx_id, amount, take_rate_bp, fee_collected,
+                       bounty_share, recorded_at, note
+                FROM treasury_balance
+                ORDER BY recorded_at DESC, entry_id DESC
+                LIMIT ?
+                """,
+                safe_limit,
+            )
+
+        if "bounty_pool_balance" in tables:
+            treasury["bounty_pool_allocated_total"] = _scalar(
+                conn, "SELECT COALESCE(SUM(allocated), 0) FROM bounty_pool_balance"
+            )
+            treasury["bounty_pool_disbursed_total"] = _scalar(
+                conn, "SELECT COALESCE(SUM(disbursed), 0) FROM bounty_pool_balance"
+            )
+            treasury["bounty_pool_remaining_total"] = (
+                treasury["bounty_pool_allocated_total"]
+                - treasury["bounty_pool_disbursed_total"]
+            )
+
+        if "royalty_payout" in tables:
+            treasury["royalty_payout_total"] = _scalar(
+                conn, "SELECT COALESCE(SUM(royalty_amount), 0) FROM royalty_payout"
+            )
+            treasury["royalty_pending_total"] = _scalar(
+                conn,
+                """
+                SELECT COALESCE(SUM(royalty_amount), 0)
+                FROM royalty_payout
+                WHERE status = 'pending'
+                """,
+            )
+
+        return result

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -362,7 +362,8 @@ def universe(
             daemon_update_behavior, daemon_control_status,
             control_daemon; daemon memory: daemon_memory_capture,
             daemon_memory_search, daemon_memory_list, daemon_memory_review,
-            daemon_memory_promote, daemon_memory_status; config: set_tier_config;
+            daemon_memory_promote, daemon_memory_status; economy reads:
+            treasury_status; config: set_tier_config;
         universe_id: Target universe. Defaults to the active universe.
         text/path/filter_text: Action-specific content, file path, or filter.
         branch_id/request_type: Request routing fields.


### PR DESCRIPTION
Fixes #878

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-114-open-brain-v2-slice-c-read-only-cost-ledger-treasury-status-.md`
- GitHub issue: #878
- Branch task: `auto-change/issue-878`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.