### PR TITLE
[auto-change] WIKI-PATCH: Approve-with-amendment verdicts have no carrier — verdicts requiring operator decomposition stall silently when no operator session reads them

### DIFF
--- a/.github/workflows/auto-check-pr.yml
+++ b/.github/workflows/auto-check-pr.yml
@@ -204,11 +204,15 @@ jobs:
           Return your final answer with this exact first line:
           VERDICT: approve
           or:
+          VERDICT: approve_with_amendment
+          or:
           VERDICT: send_back
 
           Use approve only when the PR is safe to advance to the next gate for
-          the current head SHA. Use send_back for any blocking issue, missing
-          proof, wrong scope, stale/head mismatch, or unclear risk.
+          the current head SHA. Use approve_with_amendment only when the PR is
+          acceptable but needs an operator to decompose required follow-up work
+          before merge. Use send_back for any blocking issue, missing proof,
+          wrong scope, stale/head mismatch, or unclear risk.
           PROMPT
 
           if [ -n "$(git status --porcelain)" ]; then
@@ -221,8 +225,8 @@ jobs:
             mv "$RUNNER_TEMP/checker-dirty.md" "$RUNNER_TEMP/checker.md"
           fi
 
-          verdict="$(grep -Eim1 '^VERDICT:[[:space:]]*(approve|send_back)[[:space:]]*$' "$RUNNER_TEMP/checker.md" | sed -E 's/^VERDICT:[[:space:]]*//' | tr '[:upper:]' '[:lower:]' || true)"
-          if [ "$verdict" != "approve" ]; then
+          verdict="$(grep -Eim1 '^VERDICT:[[:space:]]*(approve|approve_with_amendment|send_back)[[:space:]]*$' "$RUNNER_TEMP/checker.md" | sed -E 's/^VERDICT:[[:space:]]*//' | tr '[:upper:]' '[:lower:]' || true)"
+          if [ "$verdict" != "approve" ] && [ "$verdict" != "approve_with_amendment" ]; then
             verdict="send_back"
           fi
 
@@ -273,6 +277,11 @@ jobs:
               'd93f0b',
               'Automatic checker worker failed or requested send-back.',
             );
+            await ensureLabel(
+              'auto-checker-amendment-required',
+              'fbca04',
+              'Checker approved with amendment; operator decomposition is required before merge.',
+            );
             if (!reviewSucceeded) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
@@ -292,19 +301,41 @@ jobs:
               });
               return;
             }
-            const markerVerdict = verdict === 'approve' ? 'approve' : 'send_back';
+            const markerVerdict = verdict === 'approve'
+              ? 'approve'
+              : verdict === 'approve_with_amendment'
+                ? 'approve_with_amendment'
+                : 'send_back';
+            const renderedVerdict = markerVerdict === 'approve'
+              ? 'approve'
+              : markerVerdict === 'approve_with_amendment'
+                ? 'approve-with-amendment'
+                : 'send-back/amend';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
               body: [
                 `<!-- workflow-checker-verdict:v1 family=codex verdict=${markerVerdict} head=${process.env.HEAD_SHA} run=${process.env.GITHUB_RUN_ID} -->`,
-                `**Automated independent Codex checker verdict:** ${markerVerdict === 'approve' ? 'approve' : 'send-back/amend'}`,
+                `**Automated independent Codex checker verdict:** ${renderedVerdict}`,
                 '',
                 checkerBody,
               ].join('\n'),
             });
             if (markerVerdict === 'approve') {
+              for (const label of ['auto-checker-dispatched', 'auto-checker-failed', 'auto-checker-auth-missing', 'auto-checker-amendment-required']) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    name: label,
+                  });
+                } catch (error) {
+                  if (error.status !== 404) throw error;
+                }
+              }
+            } else if (markerVerdict === 'approve_with_amendment') {
               for (const label of ['auto-checker-dispatched', 'auto-checker-failed', 'auto-checker-auth-missing']) {
                 try {
                   await github.rest.issues.removeLabel({
@@ -317,6 +348,12 @@ jobs:
                   if (error.status !== 404) throw error;
                 }
               }
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: ['auto-checker-amendment-required'],
+              });
             } else {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,

--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -662,6 +662,9 @@ def checker_queue_stage(
         for result in results
         if result.state in {"needs_codex_checker", "needs_claude_checker"}
     ]
+    operator_decomposition_required = [
+        result for result in results if result.state == "needs_operator_decomposition"
+    ]
     details = {
         "ready_for_checker_prs": [pr.get("number") for pr in prs],
         "by_state": by_state,
@@ -669,6 +672,9 @@ def checker_queue_stage(
         "self_heal_dispatches": self_heal_dispatches,
         "already_dispatched_independent_checkers": already_dispatched,
         "failed_independent_checker_dispatches": failed_dispatches,
+        "operator_decomposition_required": [
+            result.number for result in operator_decomposition_required
+        ],
     }
     if self_heal_dispatches:
         first = independent_blockers[0]
@@ -706,6 +712,17 @@ def checker_queue_stage(
                 "to independent checker workers"
             ),
             evidence=f"PR #{first.number}: waiting on dispatched independent checker",
+            url=first_pr.get("html_url"),
+            details=details,
+        )
+    if operator_decomposition_required:
+        first = operator_decomposition_required[0]
+        first_pr = next((pr for pr in prs if pr.get("number") == first.number), {})
+        return _stage(
+            "Checker queue",
+            "yellow",
+            f"{len(operator_decomposition_required)} ready PR(s) need operator decomposition",
+            evidence=f"PR #{first.number}: {first.next_action}",
             url=first_pr.get("html_url"),
             details=details,
         )

--- a/scripts/merge_readiness.py
+++ b/scripts/merge_readiness.py
@@ -126,6 +126,7 @@ class PullRequestFacts:
     host_keyed: bool = False
     checks_green: bool | None = None
     send_back_advisory: bool = False
+    approve_with_amendment: bool = False
     precheck_blocked: bool = False
     checker_executor_ineligible: bool = False
     consensus_mirror: ConsensusMirrorFacts = ConsensusMirrorFacts()
@@ -160,6 +161,14 @@ class PullRequestFacts:
                 pr.get("send_back_advisory")
                 or _has_send_back_advisory(comments)
                 or _has_checker_send_back_verdict(comments, checker_family, head_oid)
+            ),
+            approve_with_amendment=bool(
+                pr.get("approve_with_amendment")
+                or _has_checker_approve_with_amendment_verdict(
+                    comments,
+                    checker_family,
+                    head_oid,
+                )
             ),
             precheck_blocked=bool(pr.get("precheck_blocked") or _has_precheck_blocker(comments)),
             checker_executor_ineligible=bool(
@@ -261,6 +270,16 @@ def classify_pr(facts: PullRequestFacts) -> ReadinessResult:
             risk_class,
             "blocked",
             ["consensus or advisory says send-back/amend"],
+        )
+
+    if facts.approve_with_amendment:
+        return _result(
+            facts,
+            "needs_operator_decomposition",
+            "decompose checker amendment into follow-up work",
+            risk_class,
+            "blocked_operator_decomposition",
+            ["checker approved with amendment; operator decomposition required"],
         )
 
     if READY_FOR_CHECKER_LABEL not in facts.labels:
@@ -456,6 +475,22 @@ def _has_checker_send_back_verdict(
     return False
 
 
+def _has_checker_approve_with_amendment_verdict(
+    comments: Any,
+    checker_family: str | None,
+    head_oid: Any,
+) -> bool:
+    for verdict in _checker_verdicts(comments):
+        family_matches = not checker_family or verdict.get("family") == checker_family
+        if (
+            family_matches
+            and verdict.get("verdict") == "approve_with_amendment"
+            and _head_matches(verdict, head_oid)
+        ):
+            return True
+    return False
+
+
 def _has_checker_executor_ineligibility(comments: Any, checker_family: str | None) -> bool:
     if not checker_family:
         return False
@@ -573,6 +608,8 @@ def _next_action_owner_for_state(state: str) -> str:
         return "checker_required"
     if state == "consensus_mirror_self_clearance_canary":
         return "policy_canary_review_required"
+    if state == "needs_operator_decomposition":
+        return "operator_decomposition_required"
     if state == "needs_host_key":
         return "host_key_required"
     if state == "needs_check_evidence":
@@ -583,6 +620,8 @@ def _next_action_owner_for_state(state: str) -> str:
 def _next_action_payload_for_state(state: str, reasons: list[str]) -> dict[str, Any]:
     if state == "send_back_amend":
         return {"blocking_findings": list(reasons)}
+    if state == "needs_operator_decomposition":
+        return {"amendment_findings": list(reasons)}
     return {}
 
 

--- a/tests/test_auto_check_workflow.py
+++ b/tests/test_auto_check_workflow.py
@@ -57,6 +57,8 @@ def test_auto_check_codex_lane_posts_structured_verdict_marker():
     assert "WORKFLOW_CODEX_AUTH_JSON_B64" in text
     assert "workflow-checker-verdict:v1 family=codex" in text
     assert "verdict=${markerVerdict}" in text
+    assert "approve_with_amendment" in text
+    assert "auto-checker-amendment-required" in text
     assert "head=${process.env.HEAD_SHA}" in text
     assert "Do not commit, push, merge" in text
 

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -1158,6 +1158,55 @@ def test_checker_queue_surfaces_failed_checker_dispatch(monkeypatch):
     assert stage["details"]["self_heal_dispatches"] == []
 
 
+def test_checker_queue_surfaces_approve_with_amendment_decomposition(monkeypatch):
+    def fake_list_open_issues_by_label(*_args, **_kwargs):
+        return [
+            {
+                "number": 720,
+                "title": "Recruiter-readiness bundle",
+                "state": "open",
+                "html_url": "https://example.test/pull/720",
+                "pull_request": {},
+                "labels": [
+                    {"name": "writer:claude"},
+                    {"name": "checker:codex"},
+                    {"name": watch.READY_FOR_CHECKER_LABEL},
+                    {"name": "priority:urgent"},
+                ],
+            }
+        ]
+
+    def fake_gh_get_paginated(path, **_kwargs):
+        if path == "/repos/owner/repo/issues/720/comments":
+            return [
+                {
+                    "body": (
+                        "<!-- workflow-checker-verdict:v1 family=codex "
+                        "verdict=approve_with_amendment head=abc123 run=42 -->\n"
+                        "**Automated independent Codex checker verdict:** "
+                        "approve-with-amendment"
+                    )
+                }
+            ]
+        raise AssertionError(path)
+
+    monkeypatch.setattr(watch, "list_open_issues_by_label", fake_list_open_issues_by_label)
+    monkeypatch.setattr(watch, "_gh_get_paginated", fake_gh_get_paginated)
+
+    stage = watch.checker_queue_stage(
+        "owner/repo",
+        api="https://api.github.test",
+        token=None,
+        timeout=1,
+    )
+
+    assert stage["status"] == "yellow"
+    assert "operator decomposition" in stage["summary"]
+    assert stage["details"]["by_state"] == {"needs_operator_decomposition": [720]}
+    assert stage["details"]["operator_decomposition_required"] == [720]
+    assert stage["details"]["self_heal_dispatches"] == []
+
+
 def test_checker_queue_green_when_no_ready_prs(monkeypatch):
     monkeypatch.setattr(watch, "list_open_issues_by_label", lambda *_args, **_kwargs: [])
 

--- a/tests/test_merge_readiness.py
+++ b/tests/test_merge_readiness.py
@@ -160,6 +160,39 @@ def test_structured_checker_send_back_blocks_routing():
     }
 
 
+def test_structured_checker_approve_with_amendment_routes_to_operator_decomposition():
+    result = classify_pr(
+        PullRequestFacts.from_mapping(
+            _claude_pr(
+                headRefOid="abc123",
+                comments=[
+                    {
+                        "body": (
+                            "<!-- workflow-checker-verdict:v1 "
+                            "family=codex verdict=approve_with_amendment "
+                            "head=abc123 run=42 -->\n"
+                            "**Automated independent Codex checker verdict:** "
+                            "approve-with-amendment\n\n"
+                            "Operator decomposition required: split follow-up "
+                            "docs from runtime changes before merge."
+                        )
+                    }
+                ],
+            )
+        )
+    )
+
+    assert result.state == "needs_operator_decomposition"
+    assert result.merge_executor_state == "blocked_operator_decomposition"
+    assert result.next_action == "decompose checker amendment into follow-up work"
+    assert result.next_action_owner == "operator_decomposition_required"
+    assert result.next_action_payload == {
+        "amendment_findings": [
+            "checker approved with amendment; operator decomposition required"
+        ],
+    }
+
+
 def test_consensus_send_back_advisory_blocks_checker_routing():
     result = classify_pr(
         PullRequestFacts.from_mapping(


### PR DESCRIPTION
Fixes #880

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-116-approve-with-amendment-verdicts-have-no-carrier-verdicts-req.md`
- GitHub issue: #880
- Branch task: `auto-change/issue-880`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.