### PR TITLE
PLAN.md restructure: 30→11 modules + Brain Module + skills tie-in (supersedes #873)

### DIFF
--- a/.agents/skills/auto-iterate/SKILL.md
+++ b/.agents/skills/auto-iterate/SKILL.md
@@ -44,6 +44,15 @@ Reach for this skill when **any** of these is true:
   hook) is warranted instead.
 - Two similar incidents reach two different fixes. That divergence is
   the signal to consolidate behind a hook.
+- **The `improve-codebase-architecture` skill finds the same smell in
+  two consecutive audits of the same module.** Two consecutive matches
+  is the recurrence signal for module-shape drift. Ratchet via this
+  skill — the next rung depends on which already exists (PLAN.md
+  description → audit-script flag → pre-commit gate).
+- **`scripts/plan_module_audit.py` reports drift in the same module's
+  substrate paths across runs.** PLAN.md's working theory is diverging
+  from the code; either the code moved (update PLAN.md) or PLAN.md was
+  aspirational (decide: build it or remove the citation).
 
 **Not for:** one-shot code bugs in a feature branch. Use
 `debugging-and-error-recovery` for those. Use `auto-iterate` only when

--- a/.agents/skills/improve-codebase-architecture/SKILL.md
+++ b/.agents/skills/improve-codebase-architecture/SKILL.md
@@ -16,9 +16,25 @@ rewrites.
 ### 1. Orient on live truth
 
 - Read `STATUS.md` first.
-- Load only the relevant `PLAN.md` sections or design notes for the area.
+- **Read the relevant `## Module:` section in `PLAN.md`** before auditing
+  any code in that module's footprint. PLAN.md is the working theory of
+  what each module owns; the audit measures actual code against it.
 - If a documented principle conflicts with the current code, surface the
-  contradiction before proposing changes.
+  contradiction before proposing changes — that contradiction is the
+  audit's primary finding.
+
+### 1a. Run the stale-audit check
+
+Before claiming any module is fine, run:
+
+```
+python scripts/plan_module_audit.py
+```
+
+This lists `_Last audited: YYYY-MM-DD_` stamps per module plus any
+substrate paths that no longer exist on disk (drift). A module's last
+audit is the prior anchor; this audit either confirms the prior shape
+or records what changed.
 
 ### 2. Build the map
 
@@ -89,10 +105,26 @@ change except where intended.
 Start with findings, highest severity first. Use file references and concrete
 failure modes, not vague talk about "clean architecture."
 
+## After the audit — stamp + ratchet
+
+Two final steps that close the loop with PLAN.md and the prevention
+ladder:
+
+1. **Update the `_Last audited:` stamp.** In the module's section in
+   `PLAN.md`, set the date to today's audit. This is the visible signal
+   for the next session that the module was just reviewed.
+2. **Check for recurrence.** If a smell found in this audit was also
+   found in the *previous* audit of the same module (per git history
+   of PLAN.md or per audit doc trail), invoke the `auto-iterate` skill.
+   Two consecutive audits with the same finding = ratchet the
+   prevention layer (doc → script → hook → gate).
+
 ## Verification
 
 - [ ] Findings map to named module boundaries, not vibes
 - [ ] Recommended changes are incremental and testable
 - [ ] Changed boundaries have tests or existing tests proving behavior
-- [ ] Docs or `STATUS.md` are updated when a contradiction matters
+- [ ] PLAN.md module section reflects any architectural decisions the audit produced
+- [ ] `_Last audited:` stamp updated in PLAN.md
+- [ ] `STATUS.md` is updated when a contradiction matters
 - [ ] No unrelated cleanup leaked into the implementation

--- a/.claude/skills/auto-iterate/SKILL.md
+++ b/.claude/skills/auto-iterate/SKILL.md
@@ -44,6 +44,15 @@ Reach for this skill when **any** of these is true:
   hook) is warranted instead.
 - Two similar incidents reach two different fixes. That divergence is
   the signal to consolidate behind a hook.
+- **The `improve-codebase-architecture` skill finds the same smell in
+  two consecutive audits of the same module.** Two consecutive matches
+  is the recurrence signal for module-shape drift. Ratchet via this
+  skill — the next rung depends on which already exists (PLAN.md
+  description → audit-script flag → pre-commit gate).
+- **`scripts/plan_module_audit.py` reports drift in the same module's
+  substrate paths across runs.** PLAN.md's working theory is diverging
+  from the code; either the code moved (update PLAN.md) or PLAN.md was
+  aspirational (decide: build it or remove the citation).
 
 **Not for:** one-shot code bugs in a feature branch. Use
 `debugging-and-error-recovery` for those. Use `auto-iterate` only when

--- a/.claude/skills/improve-codebase-architecture/SKILL.md
+++ b/.claude/skills/improve-codebase-architecture/SKILL.md
@@ -16,9 +16,25 @@ rewrites.
 ### 1. Orient on live truth
 
 - Read `STATUS.md` first.
-- Load only the relevant `PLAN.md` sections or design notes for the area.
+- **Read the relevant `## Module:` section in `PLAN.md`** before auditing
+  any code in that module's footprint. PLAN.md is the working theory of
+  what each module owns; the audit measures actual code against it.
 - If a documented principle conflicts with the current code, surface the
-  contradiction before proposing changes.
+  contradiction before proposing changes — that contradiction is the
+  audit's primary finding.
+
+### 1a. Run the stale-audit check
+
+Before claiming any module is fine, run:
+
+```
+python scripts/plan_module_audit.py
+```
+
+This lists `_Last audited: YYYY-MM-DD_` stamps per module plus any
+substrate paths that no longer exist on disk (drift). A module's last
+audit is the prior anchor; this audit either confirms the prior shape
+or records what changed.
 
 ### 2. Build the map
 
@@ -89,10 +105,26 @@ change except where intended.
 Start with findings, highest severity first. Use file references and concrete
 failure modes, not vague talk about "clean architecture."
 
+## After the audit — stamp + ratchet
+
+Two final steps that close the loop with PLAN.md and the prevention
+ladder:
+
+1. **Update the `_Last audited:` stamp.** In the module's section in
+   `PLAN.md`, set the date to today's audit. This is the visible signal
+   for the next session that the module was just reviewed.
+2. **Check for recurrence.** If a smell found in this audit was also
+   found in the *previous* audit of the same module (per git history
+   of PLAN.md or per audit doc trail), invoke the `auto-iterate` skill.
+   Two consecutive audits with the same finding = ratchet the
+   prevention layer (doc → script → hook → gate).
+
 ## Verification
 
 - [ ] Findings map to named module boundaries, not vibes
 - [ ] Recommended changes are incremental and testable
 - [ ] Changed boundaries have tests or existing tests proving behavior
-- [ ] Docs or `STATUS.md` are updated when a contradiction matters
+- [ ] PLAN.md module section reflects any architectural decisions the audit produced
+- [ ] `_Last audited:` stamp updated in PLAN.md
+- [ ] `STATUS.md` is updated when a contradiction matters
 - [ ] No unrelated cleanup leaked into the implementation

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,8 +1,8 @@
 # Workflow — Plan
 
-How the system should work and why. Architecture, principles, and design decisions — high-level only. Implementation detail lives in the code.
+How the system should work and why. Architecture, principles, and the working theory of every module. PLAN.md is the reference everyone — humans, the auto-change loop, user chatbots — consults before building, so that the applicable module's shape is known before code is written.
 
-For live state, see STATUS.md. For how to work on the project, see AGENTS.md. Changes here require user approval.
+For live state, see STATUS.md. For how to work on the project, see AGENTS.md. **Changes here require user approval.**
 
 ---
 
@@ -74,13 +74,9 @@ Depth: lead memory `project_user_capability_axis.md`; host matrix `docs/design-n
 
 ---
 
-## Canonical Work Substrate Vocabulary
+## Canonical Vocabulary
 
-**Status: canonical as of 2026-05-10.** Workflow's foundational substrate
-vocabulary is six work concepts plus five permissioned MCP handles. Coding
-sessions should use this vocabulary when naming architecture, docs, tool
-metadata, and future design notes unless a narrower domain term is explicitly
-needed.
+**Status: canonical as of 2026-05-10.** Workflow's foundational substrate vocabulary is six work concepts plus five permissioned MCP handles. Coding sessions should use this vocabulary when naming architecture, docs, tool metadata, and future design notes unless a narrower domain term is explicitly needed.
 
 The six base concepts describe durable work at the graph layer:
 
@@ -93,8 +89,7 @@ The six base concepts describe durable work at the graph layer:
 | `Run` | An execution attempt with inputs, outputs, provider traces, checkpoints, and evidence. |
 | `Trigger` | The event or schedule that asks Workflow to start, resume, replay, or route work. |
 
-The five MCP handles describe the small permissioned control surface agents use
-to inspect and act on those concepts:
+The five MCP handles describe the small permissioned control surface agents use to inspect and act on those concepts:
 
 | Handle | Authority |
 |---|---|
@@ -104,20 +99,13 @@ to inspect and act on those concepts:
 | `read.page` | Read wiki, commons, docs, request, and explanation pages that contextualize the graph. |
 | `write.page` | Draft or update wiki, commons, docs, request, and explanation pages through the same reviewable artifact path. |
 
-These names are substrate vocabulary, not a mandate that every runtime function
-or MCP tool be named exactly this way. Concrete tool names may remain
-client-shaped for compatibility, but they should map back to one or more of
-these handles in docs, permission checks, and tool descriptions. The older
-8-engine-primitive framing in
-`docs/design-notes/2026-04-26-engine-primitive-substrate.md` remains a useful
-historical pressure test over implementation modules; it is no longer the
-canonical primitive count for project architecture. The canonical source for
-the promotion rationale is
-`docs/design-notes/proposed/2026-05-10-promote-work-substrate-vocabulary.md`.
+These names are substrate vocabulary, not a mandate that every runtime function or MCP tool be named exactly this way. Concrete tool names may remain client-shaped for compatibility, but they should map back to one or more of these handles in docs, permission checks, and tool descriptions. The older 8-engine-primitive framing in `docs/design-notes/2026-04-26-engine-primitive-substrate.md` remains a useful historical pressure test over implementation modules; it is no longer the canonical primitive count for project architecture. The canonical source for the promotion rationale is `docs/design-notes/proposed/2026-05-10-promote-work-substrate-vocabulary.md`.
 
 ---
 
 ## Cross-Cutting Principles
+
+These principles apply to every module. They do not own a module each; they constrain how modules behave.
 
 **Agentic hybrid search is memory.** Durable memory is a policy over multiple stores (KG traversal, vector similarity, hierarchical summaries, notes, world-state, direct tool calls). No single backend owns truth. Routing matters more than any one store.
 
@@ -139,75 +127,359 @@ the promotion rationale is
 
 **Evals grade process and outcome.** Final quality isn't enough. Inspect retrieval choices, tool usage, stopping behavior, handoff quality, grounding, artifacts. When a run fails, traces should explain why.
 
-**Module shape is part of the architecture.** A flat namespace of 35 modules at `workflow/` root signals "no opinion about boundaries." A god-module of 10k lines signals "boundaries deferred indefinitely." Both are forms of architectural debt. The Module Layout section below codifies the target shape.
+**Module shape is part of the architecture.** A flat namespace of 35 modules at `workflow/` root signals "no opinion about boundaries." A god-module of 10k lines signals "boundaries deferred indefinitely." Both are forms of architectural debt. The Module Map below codifies the target shape; the per-module sections that follow codify what each owns.
 
 **Cleanup operations against scene-attributed data must scope across all DBs that hold scene-attributed rows.** Generalizes the Fix E lesson (task #49): a cleanup path that prunes one DB but not its sibling leaves orphan derivatives that masquerade as canon on the next retrieval cycle. When a new DELETE or mutation operates on rows keyed to scene_id (or any cross-store attribution), scope it against both `knowledge.db` and `story.db` from the start, or explicitly document the opt-out with reason. Per the migration-audit follow-up at `docs/audits/2026-04-19-schema-migration-followups.md`.
 
 ---
 
-## Module Layout (target shape)
+## How to Use This PLAN
 
-The canonical subpackage layout the codebase is moving toward. Rooted in the spaghetti audit at `docs/audits/2026-04-19-project-folder-spaghetti.md`. Where the current state diverges from this target, the gap is in-flight work (rename end-state collapse + post-rename cleanup), not architectural disagreement.
+PLAN.md is the working theory of what each module is and how it works. **Everyone references it before building** — human contributors, the auto-change loop, the user chatbots, the agent teams. If your work doesn't fit one of the modules below, that gap is the design conversation.
 
-`workflow/` is the engine package. Domain packages (`fantasy_daemon/`, future `research_daemon/`, etc.) consume from it. The engine layout follows five canonical subpackages plus a small set of correctly-flat modules:
+**Skill anchors.** Each named project skill ties into one PLAN.md surface; invoke the skill before or during module work, not after:
+
+| Skill | When to invoke | What it does for PLAN.md |
+|---|---|---|
+| `improve-codebase-architecture` | Before refactoring a module; when a module feels spaghettified; when planning a decomposition | Module audit against this PLAN.md; surfaces drift between described shape and current code |
+| `auto-iterate` | Every time a behavioral failure recurs across sessions (the same mistake twice = ratchet) | Adds the next prevention layer (doc → script → hook → gate); each ratchet records the trigger in the module it touched |
+| `spec-driven-development` | Before writing code for any feature that spans >1 file or >30 minutes | Produces the spec; this PLAN.md is the PLAN-phase artifact for any spec that touches platform shape |
+| `planning-and-task-breakdown` | After a spec exists; when work needs to be broken into ordered tasks | Decomposes; module Substrate fields tell you what code paths are in scope |
+| `incremental-implementation` | During execution of any multi-file change | Thin vertical slices; the open-brain v2 A/B/C/D series is the exemplar |
+| `domain-model` | When a proposal feels fuzzy or names overload existing concepts | Challenges against the Canonical Vocabulary above + the relevant module |
+| `ubiquitous-language` | When terminology drifts (aliases, overloaded words) | Hardens PLAN.md as the canonical name source |
+| `api-and-interface-design` | When designing a new MCP action, module boundary, or contract | Maps to the API & MCP Interface Module |
+| `code-simplification` | After a feature is working but feels heavier than it should | No new abstractions before reducing existing ones |
+| `zoom-out` | Before any non-trivial code change | Build the high-level map first; required first step inside `improve-codebase-architecture` |
+
+**Auto-iteration of the modular skill.** The `improve-codebase-architecture` skill self-iterates against this PLAN.md via three lightweight mechanisms:
+
+1. **Per-module audit stamps.** Each module section carries a `_Last audited: YYYY-MM-DD_` line. The skill updates the stamp on every audit pass; `scripts/plan_module_audit.py` lists stale modules.
+2. **Drift detection.** The same script compares each module's Substrate field against the code paths actually present in the repo and flags mismatches.
+3. **Recurrence ratchet.** When the same architectural smell is found in two consecutive audits of any module, the auto-iterate ladder fires — adds the next prevention layer (doc → script → hook → gate).
+
+PLAN.md itself stays clean — the audit machinery lives in the skill + the script. PLAN.md only carries the stamp and the module shape.
+
+---
+
+## Module Map
+
+The codebase target shape, with each PLAN.md module mapped to its primary code package(s). Where the current state diverges from this target, the gap is in-flight work — not architectural disagreement. Anchored by the spaghetti audit at `docs/audits/2026-04-19-project-folder-spaghetti.md`.
+
+`workflow/` is the engine package. Domain packages (`fantasy_daemon/`, future `research_daemon/`, etc.) consume from it.
+
+| PLAN.md Module | Primary code package(s) |
+|---|---|
+| Engine & Domains | `workflow/`, `domains/<name>/` |
+| Daemon Platform | `workflow/identity.py`, `workflow/discovery.py`, `workflow/branch_tasks.py`, `workflow/runtime/` |
+| **Brain** | `workflow/memory/`, `workflow/retrieval/`, `workflow/knowledge/`, `workflow/storage/__init__.py` (memory_kinds), `workflow/learning/` |
+| Goals & Gates | `workflow/storage/goals_gates.py`, `workflow/api/market.py` (goals + gates actions) |
+| Evolution & Evaluation | `workflow/evaluation/`, `workflow/learning/`, autoresearch surface |
+| Providers | `workflow/providers/` |
+| API & MCP Interface | `workflow/api/` (mounted submodules per cluster), `workflow/servers/` |
+| Distribution & Discoverability | `packaging/`, `workflow/directory_server.py`, MCP registry |
+| Harness & Coordination | `AGENTS.md`, `STATUS.md`, `scripts/claim_check.py`, `scripts/worktree_status.py`, `scripts/provider_context_feed.py`, `.agents/`, `.claude/agents/` |
+| Uptime & Alarms | `deploy/`, `.github/workflows/uptime-canary.yml`, `.github/workflows/p0-outage-triage.yml`, `scripts/uptime_canary.py` |
+| Constraints | `workflow/constraints/`, `data/world_rules.lp` |
+
+Engine subpackage target shape (the durable commitment — anything new must fit one of these or earn its root spot with a one-line explanation):
 
 | Subpackage | Responsibility |
 |---|---|
-| `workflow/api/` | MCP tool surfaces. Mounted submodules per capability cluster. Landed today (2026-04-26): `api/helpers.py`, `api/wiki.py`, `api/status.py`. In-flight per `docs/audits/2026-04-25-universe-server-decomposition.md` 8-step plan: `api/runs.py`, `api/evaluation.py`, `api/runtime_ops.py`, `api/market.py`, `api/branches.py`. Per FastMCP `mount()` pattern. **No god-modules.** |
-| `workflow/storage/` | Schema + bounded-context storage layers (`storage/accounts.py`, `storage/universes_branches.py`, `storage/requests_votes.py`, `storage/notes_work_targets.py`, `storage/goals_gates.py`). Shared `_connect()` + migrations in `__init__.py`. |
-| `workflow/runtime/` | Run scheduling primitives. Consolidates `runs.py`, `work_targets.py`, `dispatcher.py`, `branch_tasks.py`, `subscriptions.py`, plus existing `producers/` + `executors/` subpackages. `runtime/__init__.py` re-exports the public API. |
-| `workflow/bid/` | Per-node paid-market mechanics. Consolidates `node_bid.py`, `bid_execution_log.py`, `bid_ledger.py`, `settlements.py`. |
-| `workflow/servers/` | Entry-point shells. The integration layer that mounts `api/` submodules. Hosts `workflow_server.py` (post-layer-3 rename), `daemon_server.py`, `mcp_server.py`. **Acts as routing surface, not the place action logic lives.** |
+| `workflow/api/` | MCP tool surfaces. Mounted submodules per capability cluster (FastMCP `mount()`). **No god-modules.** |
+| `workflow/storage/` | Schema + bounded-context storage layers. Shared `_connect()` + migrations in `__init__.py`. |
+| `workflow/runtime/` | Run scheduling primitives — runs, work_targets, dispatcher, branch_tasks, subscriptions, producers, executors. |
+| `workflow/bid/` | Per-node paid-market mechanics — node_bid, bid_execution_log, bid_ledger, settlements. |
+| `workflow/servers/` | Entry-point shells. Routes to `api/` submodules. **Not the place action logic lives.** |
 
-Existing subpackages that already conform: `auth/`, `catalog/`, `checkpointing/`, `constraints/`, `context/`, `evaluation/`, `ingestion/`, `knowledge/`, `learning/`, `memory/`, `planning/`, `providers/`, `retrieval/`, `desktop/`, `testing/`, `utils/`.
+Existing subpackages already conforming: `auth/`, `catalog/`, `checkpointing/`, `constraints/`, `context/`, `evaluation/`, `ingestion/`, `knowledge/`, `learning/`, `memory/`, `planning/`, `providers/`, `retrieval/`, `desktop/`, `testing/`, `utils/`. Correctly-flat root modules (small typed surfaces with no clear sibling): `protocols.py`, `exceptions.py`, `notes.py`, `packets.py`, `config.py`, `identity.py`, `discovery.py`, `singleton_lock.py`, `domain_registry.py`, `registry.py`, `preferences.py`, `compat.py` (post-Phase-5).
 
-Correctly-flat modules at root (small typed surfaces with no clear sibling): `protocols.py`, `exceptions.py`, `notes.py`, `packets.py`, `config.py`, `identity.py`, `discovery.py`, `singleton_lock.py`, `domain_registry.py`, `registry.py`, `preferences.py`, `compat.py` (post-Phase-5), `__init__.py`, `__main__.py`, `docview.py`.
-
-**Migration policy.** When a flat module crosses ~500 LOC OR overlaps a sibling's responsibility, it gets a subpackage. New work goes into the target shape; legacy gets refactored opportunistically (the spaghetti audit ranks the priority order). The five subpackages above are the durable commitment — anything new must fit one of them or earn its place at the root with a one-line explanation in this section.
+**Migration policy.** When a flat module crosses ~500 LOC OR overlaps a sibling's responsibility, it gets a subpackage. New work goes into the target shape; legacy gets refactored opportunistically (the spaghetti audit ranks priority order).
 
 ---
 
-## Design Decisions
+## Module Shape
 
-- **Universe = single consistent reality.** Alternative realities are separate universes. Data isolation between universes is the only hard boundary.
-- **Upload provenance.** Each upload is tagged ("published book", "rough notes") and the writer weights canon sources accordingly.
-- **Unified notes.** All feedback is timestamped, attributed notes on files. One system, one format, one durable store per universe. (Replaces the obsolete `STEERING.md` directive surface.)
-- **Writer self-indexes.** The writer produces entity and fact data when it commits. No separate extraction role is the end state.
-- **Editorial feedback, not scoring.** Natural-language notes about what works, what's concerning, and whether a concern is provably wrong. No numeric rubric in the core loop.
-- **Graph hierarchy is scaffolding.** Structure should emerge from the daemon's choices wherever possible, not fixed counters.
-- **Two review gates, one target registry.** Foundation review hard-blocks on unsynthesized uploads; authorial review may choose any justified work.
-- **Workflow Server, not single-user daemon.** The control plane runs in the cloud (currently the DO Droplet, formerly a host laptop); many named users connect through MCP clients. (Renamed from "Universe Server" — the platform-name rebrand. The MCP namespace is currently `workflow-universe-server` pending the layer-3 plugin-dir rename per `docs/design-notes/2026-04-19-universe-to-workflow-server-rename.md`.)
-- **Multi-tenant by design, single-tenant today as N=1.** Every daemon-related design — dispatcher, claim-lock, identity, heartbeat, host pool registry, cloud-worker supervisor — must scale from `(user, daemon)` to `(N users, M daemons per user)` without rewrite. Today's live system is one user + a small handful of daemons; that is the degenerate case of the general shape, not its target. Any architecture that would require a migration to multi-user is rejected. (Host directive 2026-04-22; memory `project_daemons_are_multi_tenant_by_design.md`.)
-- **Workflow-first, domain-agnostic identity.** Fantasy authoring is an early benchmark domain, not the trunk.
-- **Open workflow playground.** Open-source, social, remixable, viral enough to spread. Playful surface, serious utility.
-- **MCP clients + local host dashboard.** MCP is the shared collaborative surface; host operational controls live in a local dashboard.
-- **Two coexisting executors, one file-locked claim.** Node execution runs on the cloud-side `cloud_worker` supervisor (distinct identity `cloud-droplet`) *and* on any host-side tray (identity `host`). Both call `branch_tasks.claim_task`; the file-lock sidecar guarantees no double-claim. The cloud worker closes the "MCP reachable but nothing executes" gap — `last_activity_canary` is the proof signal. Host-tray remains valid for users who want local-model runs with their own keys. (Cloud-worker shipped in 4d1265c; supervises `fantasy_daemon` subprocess, inherits `/etc/workflow/env`.) Per-universe dashboards are orthogonal to executor identity.
-- **Private chats, public actions.** Conversations stay private; any universe-affecting action is publicly attributable.
-- **Daemons are the public agent identity.** Summonable, forkable, defined by durable soul files. Soul changes create new forks rather than overwriting. ("Author" → "daemon" rename in flight; agent-runtime concept is `daemon_id`, content-authorship concept stays `author_id` + `author_kind` discriminator. See `docs/exec-plans/active/2026-04-15-author-to-daemon-rename.md` §1.5.)
-- **Daemon identity is platform-wide, not domain-specific authoring.** The current `author_definitions` / soul-hash / runtime-instance substrate is transitional: preserve the useful soul, fork, fingerprint, and runtime concepts, but migrate or rename it into the general daemon registry rather than entrenching a fantasy-author-specific author model. Content provenance still uses `author_id` + `author_kind`; daemon soul identity is runtime identity, eligibility identity, and personality/policy.
-- **Branch-first collaboration.** Branches are first-class, long-lived, public-forkable. Reconciliation optional, no fixed mainline.
-- **Swarm runtime.** No universe-wide single active daemon. Runtime capacity and daemon identity are separate resources.
-- **Host daemon fleets are capacity-bounded, not product-capped.** The one-daemon host posture was a development/testing throttle, not product design. A host may summon as many daemons as they can afford and operate, including multiple daemons on the same provider. Second-and-later same-provider summons show warning-only subscription/rate-limit guidance with an estimated required provider plan; they do not enforce a platform subscription gate. Target scale is many hosts, potentially thousands, each running as many soul-bearing or soulless daemons as their provider capacity supports.
-- **GitHub is an export sink, not the canonical store.** Canonical state lives in Postgres (Supabase-hosted at launch). GitHub receives a periodic flat-YAML export of public goals/branches/nodes; contributions via GitHub PR are accepted via a round-trip YAML → webhook → Postgres import path. One-way-door decision (host-approved 2026-04-18, `docs/design-notes/2026-04-18-full-platform-architecture.md §4`) — reverting after realtime collaboration is active requires data migration.
-- **Local-first execution, git-native sync (bridge state).** The DO Droplet self-host migration (2026-04-20) is the current bridge. Postgres-canonical replaces local-first when the control-plane backend ships.
-- **User-controllable state architecture.** Users should eventually inspect, steer, and redesign workflow/state structure conversationally.
-- **Multi-host is the destination.** Local-host is important, but end-state is a network of hosts contributing model capacity to shared projects.
-- **The system must evolve itself.** Stagnation is the worst failure mode. Workflow, memory policy, retrieval, evaluation, naming should all learn from research and outcomes over time.
-- **Native optimization, not an ASI-Evolve clone.** Workflow adopts the ASI-Evolve/AlphaEvolve lesson as an engine-native pattern: users ask through any MCP-connected chatbot, the platform runs bounded evaluator-driven optimization over nodes, branches, evaluators, prompts, policies, and topology, and accepted changes land through normal versioned/provenance-aware branch history. Do not vendor or parallel-run a separate ASI pipeline that bypasses MCP, branch lineage, host-pool claiming, evaluator chains, privacy gates, or real-world outcome gates. Canonical rationale: `docs/audits/2026-05-02-asi-evolve-architecture-implications.md`; integration design: `docs/design-notes/2026-05-02-community-evolvable-optimization-integration.md`.
-- **Work targets are the unit of intentional work.** Any locus the daemon may work on next — uploads, canon repair, world notes, plans, scenes.
-- **Tags stay loose; role and lifecycle stay guarded.** Publishable-vs-notes role, publish stage, and true discard are explicit state transitions.
-- **Context is tools, not pre-assembly.** The writer should query through tools. Pre-assembly is a transitional compromise.
-- **Bad decisions are data.** When the daemon decides poorly, improve goals/tools/state/evals. Don't reflexively add rules.
-- **Scene commits emit structured packets.** Every accepted scene writes a validated JSON packet (facts, promises, entities, POV, deltas) beside the prose. Packets are the backbone for timelines, promise tracking, continuity, typed retrieval.
-- **Durable artifacts outlive context windows.** Plans, notes, checkpoints, logs, learned heuristics, subagent outputs belong in external storage.
-- **Human control belongs at irreversible boundaries.** Bounded loops for autonomy; pause/stop/takeover/confirmation at the edge.
-- **Engine is infrastructure, not topology.** `workflow/` is a shared library plus optional profiles. Each domain owns its own graph. The engine is judged by whether a *second* domain can adopt it without engine changes — fantasy is the benchmark, not the trunk.
-- **Memory interface is query semantics, not tier names.** Three tiers (core/episodic/archival) is conceptual; the public interface feels like faceted search, not tier addressing.
-- **Trust-critical tools are self-auditing.** Tools that touch privacy, cost, routing, scope, or moderation expose structured evidence + structured caveats; the chatbot composes the user-facing narrative on top of the evidence. The chatbot cannot rubber-stamp because the caveats are part of the tool's contract. (See `docs/design-notes/2026-04-19-self-auditing-tools.md` for the pattern + 5 instantiations: memory-scope, provider routing, privacy decisions, autoresearch fulfillment, moderation.)
+Every module section below follows the same shape so PLAN.md reads as reference:
+
+- **Purpose.** One sentence — what the module exists for.
+- **In scope.** What this module owns.
+- **Out of scope.** What it does NOT own (pointing to siblings).
+- **Principles.** The constraints that govern this module.
+- **Substrate.** Concrete code paths and current shape.
+- **Open evolution.** What is still being figured out.
+- _Last audited: YYYY-MM-DD_
 
 ---
 
-## System Shape
+## Module: Engine & Domains
+
+**Purpose:** `workflow/` is reusable infrastructure that any domain can adopt; `domains/*` own their graph topology and import what they need.
+
+**In scope:** Engine-shared primitives (state, edges, runs, triggers), the engine/domain seam, domain registration, scene/chapter/book/universe timescale hierarchy as a generic shape.
+
+**Out of scope:** Domain-specific graph topology (lives under `domains/<name>/`); paid-market mechanics (Daemon Platform); evaluation logic (Evolution & Evaluation).
+
+**Principles:**
+- *Extract infrastructure first, prove topology second.* A second domain pressures the engine to prove it's actually domain-agnostic — fantasy is the benchmark, not the trunk.
+- *Engine = `workflow/`. Domains = `domains/<name>/`.* The engine-vs-domain seam is named. Once the separation lands, every action lives in exactly one of: shared engine API (`workflow/api/`) or a domain API (`domains/<name>/api/`). No third location.
+- *State transitions are the core abstraction.* Orient → plan → draft → commit → learn → reflect → worldbuild → task selection. If the state model is wrong, the system feels smart locally and breaks over long runs.
+- *Scene Loop is a state-transition pattern, not a fiction-specific concept.* Orient → plan → draft → commit is useful only if each step adds value; flatten the loop when a stronger model + better tools can do equivalent work in fewer steps.
+
+**Substrate:** `workflow/` (engine package), `domains/fantasy_daemon/` (only live domain today), `workflow/domain_registry.py`, `workflow/registry.py`, `workflow/protocols.py`. Pending engine/domain API separation: `docs/design-notes/2026-04-17-engine-domain-api-separation.md`. Fantasy domain keeps scene/chapter/book/universe names in its own graph; shared `workflow/` infrastructure uses domain-agnostic names.
+
+**Open evolution:** Second domain adoption (research_daemon, journalism_daemon) is the unblocking proof that the engine is domain-agnostic. Until then, every "engine" decision risks fantasy-shaped bias.
+
+_Last audited: 2026-05-19_
+
+---
+
+## Module: Daemon Platform
+
+**Purpose:** A multi-tenant workflow platform where many users and daemons collaborate without collapsing into one shared chat or one hidden runtime.
+
+**In scope:** Daemon identity (souls, fingerprints, forks), runtime instance allocation, host pool registry, soul eligibility per node/gate, soul-guided dispatch, capacity-bounded fleet sizing, file-locked claim across cloud + host executors.
+
+**Out of scope:** What a daemon *knows* (Brain); what a daemon *evaluates* (Evolution & Evaluation); goal/gate ladder definitions (Goals & Gates); MCP tool surface (API & MCP Interface).
+
+**Principles:**
+- *Separate identity from runtime.* Daemons are public, forkable, summonable agent identities defined by soul files; runtime instances are resource allocations bound to providers, models, and executor hosts. Every `(user, daemon, executor)` tuple is independently addressable; today's N=1 is the degenerate case.
+- *Daemon-driven.* Let the daemon make creative and structural decisions whenever the model can reliably do so. Hardcoded thresholds and stage gates are scaffolding — test each by removing it. When the daemon decides badly, improve goals/context/tools/evals rather than layering recipes.
+- *Always ready for the next user and daemon fleet.* Multi-tenant from the first build. Storage, authorization, queues, budgets, audits, daemon bindings, and runtime activations carry tenant/owner boundaries.
+- *Zero daemons required for authoring.* Node/branch/goal creation, editing, forking, and collaboration work with no daemon running anywhere. Daemon hosting is opt-in for execution work. Load-bearing requirement — any architecture where authoring depends on a running daemon violates it.
+- *Host fleets are capacity-bounded, not product-capped.* A host may summon as many daemons as they can afford and operate, including multiple daemons on the same provider. Second-and-later same-provider summons show warning-only subscription/rate-limit guidance; no platform subscription gate.
+- *Soul eligibility.* Nodes and gates may declare whether daemon souls are allowed, forbidden, required, replaced, or combined with a temporary node/gate header. They may declare domain requirements (scientific, legal, artistic, local-model-only). Claim-time verification checks soul fingerprint + required claims/proofs before execution.
+- *Soul-guided dispatch.* A soul-bearing daemon returns to a decision step listing eligible work + soul policy + domain requirements + required capability + offer. The daemon may choose money, interests, reputation, public-good impact, or refusal per its soul. Soulless daemons use the default platform dispatcher.
+- *Two coexisting executors, one file-locked claim.* Cloud-side `cloud_worker` (identity `cloud-droplet`) + opt-in host-tray (identity `host`); both call `branch_tasks.claim_task`; file-lock sidecar guarantees no double-claim.
+
+**Substrate:** `workflow/identity.py`, `workflow/discovery.py`, `workflow/branch_tasks.py`, `workflow/runtime/`, `workflow/singleton_lock.py`. Soul/fork machinery currently lives in the `author_definitions` substrate transitioning to a domain-agnostic daemon registry (content provenance retains `author_id` + `author_kind` discriminator). Host pool registry: `docs/design-notes/2026-04-18-full-platform-architecture.md §5`. Soul-guided dispatch read path landed via open-brain v2 slice B 2026-05-19.
+
+**Open evolution:** Cross-host node-execution hopping is not supported (cross-host software donation IS, see Distribution). N-of-M multi-actor approval as a generic primitive (founder vote, treasury multisig, scientific publication co-signature) is unscoped.
+
+_Last audited: 2026-05-19_
+
+---
+
+## Module: Brain
+
+**Purpose:** The platform's memory + identity + authority substrate. The Brain holds what each universe / branch / daemon / contributor knows, what they've agreed to, and what they're eligible to do. Every other module consults the Brain before deciding.
+
+**In scope:**
+- Tiered memory across multiple stores (KG, vector, hierarchical summaries, world-state, notes, direct tool calls).
+- The `memory_kinds` typed catalog — canon fact, attribution snapshot, soul fingerprint, gate-evidence, contributor weight, etc.
+- Promotion state machine: candidate → accepted → promoted → rejected → superseded. No memory becomes load-bearing without earning promotion.
+- Soul-guided dispatch *read path* — what work is a daemon eligible to claim?
+- Treasury status *read path* — bounded budget + spend visibility.
+- Bounded autonomous spend guardrails — per-Goal / per-daemon / per-cycle caps.
+- Authority-condition policy (per `docs/design-notes/proposed/2026-05-19-external-write-authority-and-rewards.md`) — Brain conditions every external-write authority decision on past-decision memory.
+- Attribution graph snapshot at the moment a reward releases — authoritative for payout.
+
+**Out of scope:** Treasury *write path* (future Treasury Module); goal/gate ladder definitions (Goals & Gates); provider routing (Providers); evaluation logic (Evolution & Evaluation); MCP surface (API & MCP Interface).
+
+**Principles:**
+- *No single backend owns truth.* Routing across stores is the policy; routing matters more than any one backend.
+- *Memory interface is query semantics, not tier names.* The public interface feels like faceted search, not "core/episodic/archival" tier addressing.
+- *Generator, evaluator, and Brain stay separate.* Self-evaluation bias is real; the Brain is read-only to its own evaluations.
+- *Learning is write-back compression.* Stable lessons get promoted into the typed catalog; transcripts are not memory.
+- *Brain conditions every authority decision.* Permissive by default — Brain logs and hints. Per-Goal opt-in to strict mode where Brain may refuse to authorize a contradicting write.
+
+**Substrate:** `workflow/memory/`, `workflow/retrieval/`, `workflow/knowledge/`, `workflow/learning/`, `workflow/storage/__init__.py` (memory_kinds + promotion state). Open-brain v2 slices landed 2026-05-19: A=memory_kinds registry, B=soul-guided dispatch read, C=treasury status read, D=bounded autonomous spend. Companion artifacts on main: #903 amendment-verdict carrier, #870 wiki-bug body inclusion, #866 dedup safety net.
+
+**Open evolution:** Authority-condition strict-mode rollout (per the 2026-05-19 design note open questions). Brain's role in N-of-M multi-actor approval state. Brain ↔ Evolution feedback — which Brain-snapshotted attributions feed back into evaluator training signal? Cross-universe Brain federation (shared scientific corpus across Goals).
+
+_Last audited: 2026-05-19_
+
+---
+
+## Module: Goals & Gates
+
+**Purpose:** A Goal is a named pursuit ("research-paper", "fantasy-novel"); a Branch is one concrete take; many Branches bind to one Goal. Gates are the outcome ladder that turns Goal progress into a truth signal.
+
+**In scope:**
+- Goal as first-class object: `goals` table, `Branch.goal_id`, per-Goal browsing.
+- Work-target registry (the unit of intentional work — uploads, canon repair, world notes, plans, scenes). Foundation review hard-blocks on unsynthesized uploads only; authorial review may choose any justified move once hard blockers clear. Targets carry role (notes/publishable), publish stage, lifecycle, tags, artifact refs.
+- Outcome-gate ladders per Goal (draft → peer feedback → submission → acceptance → publication → citations → breakthrough for research; ladder shape varies per Goal).
+- Rung-claim recommendations on branch tasks.
+- `archive_consultation` parent-rank surface (quality + outcome + diversity).
+- Per-Goal leaderboards, cross-branch node library.
+- Outcome gates: rung claims are the trigger that fires external writes via the authority + idempotency model in the Brain (see 2026-05-19 design note).
+
+**Out of scope:** Brain memory (Brain); evaluation logic (Evolution & Evaluation); external-write execution (the *trigger* is here; the *execution* is policed by Brain + connector registration).
+
+**Principles:**
+- *Goal is first-class above Branch.* Many Branches bind to one Goal. "Simultaneously pursue the same Goal via different Branches" is the default collaboration pattern.
+- *Outcome gates — real-world impact is the truth signal.* Leaderboards rank on outcome progression, not draft polish.
+- *Tags stay loose; role and lifecycle stay guarded.* Publishable-vs-notes role, publish stage, and true discard are explicit state transitions; `marked_for_discard` is not the same as `discarded`.
+- *Two review gates, one target registry.* Foundation review hard-blocks; authorial review chooses.
+- *Diverse-by-default.* 100 different research-paper workflows from 100 users is a feature, not duplication. Consolidation into "the best" workflow is an anti-pattern.
+
+**Substrate:** `workflow/storage/goals_gates.py`, `workflow/api/market.py` (goals actions: propose, update, bind, list, get, search, leaderboard, common_nodes, archive_consultation, set_canonical). `BranchTask.rung_claim_recommendations` field landed via PR #899.
+
+**Open evolution:** Parent-rank scoring formula as an evolvable workflow node (see follow-up #913) — formula competes via autoresearch, not as a fixed platform constant. Tracking of outcome gates (self-report first, automated later via DOI / court-docket / sales / awards). Per-piece privacy: concept-public default, instance-private when user data involved, chatbot-judged per piece (refines earlier branch-private framing).
+
+_Last audited: 2026-05-19_
+
+---
+
+## Module: Evolution & Evaluation
+
+**Purpose:** Improve workflow quality through feedback, not brittle gates. Optimization is a native run type, not a sidecar.
+
+**In scope:** Layered evaluation (deterministic checks + editorial reader + environment-grounded artifacts + traces); the `Evaluator` primitive that unifies fantasy judges, autoresearch metrics, moderation rubrics, real-world outcomes, and discovery ranking; `OptimizationRun` surface; `EvalResult` schema; acceptance scenario packs; quality-diversity search; lineage; attribution; community remix.
+
+**Out of scope:** Goal/gate ladder definitions (Goals & Gates); provider routing for evaluator runs (Providers); MCP action surface (API & MCP Interface).
+
+**Principles:**
+- *Layered evaluation.* Deterministic checks for provable failures; an editorial reader for natural-language critique; environment-grounded artifacts + traces for verification. One strong independent reader beats a committee of shallow scorers.
+- *Evals grade process and outcome.* Inspect retrieval choices, tool usage, stopping behavior, handoff quality, grounding, artifacts. When a run fails, traces should explain why.
+- *Evaluation is platform-wide, not fantasy-specific.* Fantasy judges, autoresearch metrics, moderation rubrics, real-world outcomes, and discovery ranking are instantiations of one `Evaluator` primitive.
+- *Native optimization, not an ASI-Evolve clone.* Workflow adopts the ASI-Evolve / AlphaEvolve lesson as an engine-native pattern: users ask through any MCP-connected chatbot; the platform runs bounded evaluator-driven optimization over nodes, branches, evaluators, prompts, policies, topology; accepted changes land through normal versioned/provenance-aware branch history. Do not vendor or parallel-run a separate ASI pipeline.
+- *Community model.* Branches, nodes, evaluators, and lessons are remixable public commons when privacy policy permits. The platform preserves many competing solution families rather than collapsing to one "best" workflow.
+- *Safety model.* Candidate generators cannot edit the evaluator or the locked harness they are being judged by. Optimization runs declare editable surface, evaluator chain, budget, stop conditions, merge policy, provenance, and visibility up front. Private instance data must not be promoted into reusable cognition unless privacy layer permits.
+- *Acceptance Scenario Packs.* Host-approved 2026-05-02 direction (pending opposite-provider review): Workflow grows reusable long-horizon scenario packs combining user simulation, rubric checks, MCP/API or browser evidence, and artifact capture into `EvalResult` evidence. No vendoring of AgencyBench or its harness — define Workflow-native scenario contracts.
+
+**Substrate:** `workflow/evaluation/`, `workflow/learning/`. `EvalResult` evidence/artifact/cost/freshness contract landed 2026-05-02. Canonical rationale: `docs/audits/2026-05-02-asi-evolve-architecture-implications.md`; integration design: `docs/design-notes/2026-05-02-community-evolvable-optimization-integration.md`.
+
+**Open evolution:** `OptimizationRun` substrate spec (review-blocked on opposite-provider verdicts for ExperiencePool + GroupEvolutionRun, Acceptance Scenario Packs, Private Trace Commons, Origin Quantum Q0/Q1 — see STATUS Work table). Quality-diversity vs. linear ranking — the parent-rank formula divergence in Goals & Gates is a special case of this same evolvable-formula question.
+
+_Last audited: 2026-05-19_
+
+---
+
+## Module: Providers
+
+**Purpose:** Pick the best provider per role and preserve role separation without hiding failure.
+
+**In scope:** Provider registry, fallback chains, parallel diversity, the writer-pin override (`WORKFLOW_PIN_WRITER`), local-LLM endpoint binding (`OLLAMA_HOST`, `ANTHROPIC_BASE_URL`), provider-specific config.
+
+**Out of scope:** What a provider is asked to do (the requesting module); evaluation of provider output (Evolution & Evaluation).
+
+**Principles:**
+- *Error loudly when the remaining provider can't produce acceptable work.* Fake success is worse than failure. (Hard Rule #8.)
+- *Fallback chain correctness is a first-class invariant.* Every provider named in a fallback chain must be either registered AND reachable at startup, or explicitly excluded with a logged reason. Phantom chain entries are a bug. A chain that reads `[claude-code, codex, gemini-free, ...]` but whose first entry's CLI binary is absent silently degrades the whole chain; operators reading config see one chain, the runtime iterates a different one. Register-and-probe at startup; emit structured evidence of the effective chain via `get_status`; refuse to advertise unreachable providers. (Corroborated by BUG-025 + 2026-04-21 prod-LLM-binding incident + 2026-04-23 revert-loop P0.)
+- *Required files must be probed at startup and fail loud if missing.* When code declares a required on-disk artifact (ASP rule files, schema definitions, seeded fixtures, vendored configs), startup must probe for it and refuse to start if absent — not log a WARNING and continue with an empty fallback. Silent substrate-degradation from missing artifacts produces runs that report success while behaving as no-ops; that violates Hard Rule #8 at an earlier lifecycle phase. (Corroborated by BUG-026: `data/world_rules.lp` absent silently reduced the ASP constraint engine to a no-op.)
+
+**Substrate:** `workflow/providers/`. Required-files probe lives at startup; chain probe emits via `get_status`.
+
+**Open evolution:** Auth-parity work for non-Claude/ChatGPT providers in the MCP-host customer matrix.
+
+_Last audited: 2026-05-19_
+
+---
+
+## Module: API & MCP Interface
+
+**Purpose:** Let users steer through natural conversation and MCP tooling without letting any chat surface become the author.
+
+**In scope:** MCP tool surfaces, FastMCP `mount()` topology, tool/prompt discoverability metadata, control-station prompt, server shells.
+
+**Out of scope:** Action implementations behind the surface (each module owns its actions); the control plane wiring (Daemon Platform); discoverability outside MCP (Distribution & Discoverability).
+
+**Principles:**
+- *Any MCP-compatible client is a control station, not a creator.* The daemon does the creative work. If a chat surface writes story content itself, that indicates a missing daemon path.
+- *Tools publish explicit titles, tags, and behavior hints.* The daemon exposes a small number of coarse-grained tools; discoverability metadata is part of the interface contract.
+- *Trust-critical tools are self-auditing.* Tools that touch privacy, cost, routing, scope, or moderation expose structured evidence + structured caveats; the chatbot composes the user-facing narrative on top. Caveats are part of the tool's contract. (See `docs/design-notes/2026-04-19-self-auditing-tools.md`.)
+- *Module shape rule.* API surfaces live in `workflow/api/` as mounted submodules per capability cluster. Server shells in `workflow/servers/` route to them. **No god-modules.**
+
+**Substrate:** `workflow/api/` (helpers, wiki, status, runs, evaluation, runtime_ops, market, branches), `workflow/servers/` (workflow_server, daemon_server, mcp_server). Universe-server decomposition is in-flight per `docs/audits/2026-04-25-universe-server-decomposition.md` — universe_server.py is down from 14k peak to 972 LOC live in main.
+
+**Open evolution:** Final cluster extraction completion. ChatGPT-host first-response UX caveat (large MCP responses → "something went wrong"; see memory `project_chatgpt_response_too_large_failure.md`) — SUMMARY-by-default response shape with `verbose=true` opt-in is unscoped.
+
+_Last audited: 2026-05-19_
+
+---
+
+## Module: Distribution & Discoverability
+
+**Purpose:** Installable and discoverable across standard MCP surfaces, Anthropic packaging, and future packaging without changing the portable core.
+
+**In scope:** MCPB packages, Claude Code / Cowork plugins, registry metadata, ChatGPT app submission, MCP-directory tooling, the per-host customer matrix, install-readiness invariants, software-surface authorization (declarative + multi-layer).
+
+**Out of scope:** What the daemon does once installed (other modules); auth at the MCP edge (API & MCP Interface).
+
+**Principles:**
+- *Keep the core portable; add platform wrappers around it.* MCPB packages, Claude Code plugins, registry metadata, and future `.cnw.zip` packaging are distribution layers over the same daemon and tool surface, not replacement architectures.
+- *MCP host coverage is matrix-driven.* Claude and ChatGPT are P0 launch gates, but every MCP-capable host is a possible customer surface. Caveats + acceptance proofs live in `docs/design-notes/2026-05-01-mcp-host-customer-matrix.md`.
+- *Install-readiness is continuous.* Main is a downloadable release at all times. Every change preserves flawless first-install — packaging auto-builds via CI (import probe + plugin drift check), user-facing copy is branded and unambiguous, broken install is a production bug.
+- *Discovery via entry points, not filesystem scan.* Domain discovery uses `importlib.metadata.entry_points(group="workflow.domains")`. Filesystem scan of `domains/*/skill.py` is a dev-mode fallback for editable worktrees only. Compat aliases stay out of discovery — compat lives in import shims, not in the domain registry contract.
+- *Software surface is declarative and multi-layer-authorized.* Nodes declare `required_capabilities`. Per-host capability registry resolves what's installed. Missing software auto-installs (host-policy gated). Daemons can invoke arbitrary local software via a dedicated `external_tool_node` type that bypasses the Python sandbox but layers security: bundled handler signatures, binary signature verification, universe-level allow-list, per-software host approval, subprocess isolation. Any single layer fails, the others hold. Cross-host software donation supported; cross-host node-execution hopping is not.
+
+**Substrate:** `packaging/`, `workflow/directory_server.py`, MCP Registry surface, ChatGPT app submission packet, no-login deployment packs for Open WebUI / LibreChat.
+
+**Open evolution:** First-user evidence after no-dev-mode acceptance proofs land. ChatGPT-mobile proof.
+
+_Last audited: 2026-05-19_
+
+---
+
+## Module: Harness & Coordination
+
+**Purpose:** Make the system operable, testable, replayable, and improvable across both product runtime and AI-to-AI development. Harness is first-class architecture.
+
+**In scope:** Three Living Files (AGENTS.md / PLAN.md / STATUS.md); the GitHub-shaped lane spine (STATUS row → branch → worktree → PR/draft PR); provider-context feed; agent roles (verifier, navigator, dev, user-sim, lead); claim discipline; cross-provider drift detection.
+
+**Out of scope:** What individual roles produce (other modules); skill content (`.agents/skills/`, `.claude/skills/` — content is per-skill, the harness orchestrates invocation).
+
+**Principles:**
+- *Harness design is part of the cognition stack.* Browser harnesses, builder automation, traces, regression tests, dashboards, role-based agent coordination materially improve system intelligence by making behavior legible and correctable.
+- *Three Living Files separate process truth, design truth, and live state.* AGENTS.md = how to work. PLAN.md = how the system works. STATUS.md = what's happening now. Each is updated immediately when its slice of truth changes.
+- *GitHub/worktree coordination spine.* Buildable work flows through: STATUS Work row + purpose-named branch + sibling `../wf-<slug>` worktree + PR / draft PR. Relevant PLAN.md modules are the project understanding each lane reviews at planning, build, review, and fold-back. `ideas/INBOX.md` is a loose idea feed; entries park at the bottom of a lane as "Idea feed refs" — not design truth or build authority.
+- *Provider-context feed.* Provider-specific memory and automation are INPUTS to the GitHub/worktree spine, not separate planning authorities. `scripts/provider_context_feed.py` scans Claude/Codex/Cursor/shared memory + ideas + research + automation + worktree handoff surfaces at claim/plan/build/review/foldback/memory-write checkpoints. Hidden provider context cannot bypass community-visible project state.
+- *Roles are architectural capabilities.* Each provider implements them through its available harness rather than one universal team mechanism. Verifier/navigator/dev/user-sim are not Claude-Code-specific.
+
+**Substrate:** `AGENTS.md`, `STATUS.md`, `PLAN.md`, `scripts/claim_check.py`, `scripts/worktree_status.py`, `scripts/provider_context_feed.py`, `scripts/check_cross_provider_drift.py`, `.agents/`, `.claude/agents/`, `.claude/hooks/`.
+
+**Open evolution:** Continued auto-iteration of the harness itself — see `improve-codebase-architecture` + `auto-iterate` skills.
+
+_Last audited: 2026-05-19_
+
+---
+
+## Module: Uptime & Alarms
+
+**Purpose:** The complete system — MCP surface + node execution + collaboration surfaces + paid-market + moderation — stays up 24/7 with zero hosts online. The host machine being asleep for 24h must not extend any outage window past the pager's escalation ladder.
+
+**In scope:** Self-heal layers, alarm ladder, DR drill, canonical canary, loop-uptime-maintenance escape.
+
+**Out of scope:** Application-level bugs (other modules); deploy mechanics (Distribution).
+
+**Principles:**
+- *Defense in depth, and the alarm path itself is host-independent.* Every self-heal layer assumes the layers below it will fail; the alarm ladder assumes every self-heal layer will fail. None run on a host machine.
+- *Three self-heal layers, each catches a different class.* 1. Container restart (`systemd Restart=always` + `workflow-watchdog.timer`) — transient crashes, OOM recovery, hung-but-not-crashed. 2. GHA `p0-outage-triage.yml` auto-repair — six classes covered (OOM, disk-full, image-pull, watchdog-hot-loop, tunnel-token-manual, env-unreadable). 3. Deploy-side invariants — `deploy-prod.yml` asserts `/etc/workflow/env` is readable by the daemon user post-mutation and post-restart.
+- *Alarm ladder, host-phone-independent.* Pushover paging from GHA `alarm-sink` at threshold-cross (2 consecutive reds ≈ 10 min outage), `priority=2` + vibrate-tier initial, escalating re-page at 1h / 4h / 24h if `p0-outage` issue stays open with no human comment. Probe-without-paging is not an alarm path (2026-04-21 lesson).
+- *DR validated end-to-end.* Weekly drill provisions a fresh VM, bootstraps, restores `/etc/workflow/env` + data volume from offsite, starts daemon, asserts canary-green within SLA. Decoupled restore + start, exit-code propagation, SSH-tunnel probe; no host keystrokes bridge any step.
+- *Loop-uptime-maintenance is the authorized escape.* Skill at `.agents/skills/loop-uptime-maintenance/SKILL.md` handles failure classes not yet graduated to layers 1-3. Entry condition: the loop is too broken to self-heal via its own loop. Success metric: usage trends to zero — every incident graduates a failure class out of the skill into layers 1-3.
+- *Public-surface canary is required evidence, not final proof.* MCP/chatbot-facing changes also require live Claude.ai `ui-test` for final acceptance (Hard Rule #11).
+
+**Substrate:** `deploy/`, `.github/workflows/uptime-canary.yml`, `.github/workflows/p0-outage-triage.yml`, `.github/workflows/deploy-prod.yml`, `.github/workflows/dr-drill.yml`, `scripts/uptime_canary.py`, `scripts/mcp_public_canary.py`. Acceptance probe catalog: `docs/ops/acceptance-probe-catalog.md`.
+
+**Open evolution:** Validation of the testable assumption — if the host's phone is off for 24h, a secondary paging path (email / desktop / secondary device) still fires at the 4h escalation tick.
+
+_Last audited: 2026-05-19_
+
+---
+
+## Module: Constraints
+
+**Purpose:** Formally verify world rules only where symbolic checking clearly adds value.
+
+**In scope:** Neurosymbolic constraint engine (ASP rules), universe-specific rule packs, constraint evaluation as `Evaluator` primitive instantiation.
+
+**Out of scope:** General quality evaluation (Evolution & Evaluation); domain topology (Engine & Domains).
+
+**Principles:**
+- *Neurosymbolic methods are optional leverage.* Universe-specific rules are the only version likely to earn ongoing complexity; generic boilerplate constraints are not enough.
+- *Required-files probe applies.* `data/world_rules.lp` (or equivalent) must be probed at startup — silent absence reducing the engine to a no-op violates Hard Rule #8.
+
+**Substrate:** `workflow/constraints/`, `data/world_rules.lp` (universe-specific rule packs).
+
+**Open evolution:** Second universe's rule pack as the test that constraint engine is domain-agnostic.
+
+_Last audited: 2026-05-19_
+
+---
+
+## Reference: System Shape
 
 ```text
 Users / Hosts
@@ -225,248 +497,68 @@ State/Artifacts Search/Tools  Evaluation    Providers
 Harness / Traces / Tests / Coordination
 ```
 
-The daemon writes autonomously. MCP clients and the host dashboard are the user-facing interfaces. Communication is file- and artifact-based: daemon writes to disk, API/MCP expose state and actions, harness inspects artifacts and traces. AGENTS.md, PLAN.md, STATUS.md, notes.json, checkpoints, logs, tests are part of the same design philosophy.
+The daemon writes autonomously. MCP clients and the host dashboard are the user-facing interfaces. Communication is file- and artifact-based: daemon writes to disk, API/MCP expose state and actions, harness inspects artifacts and traces.
 
-**Backend stack (target):** Supabase — Postgres (catalog + ledger + inbox), Realtime broadcast (presence + change broadcast), Auth (GitHub OAuth + sessions), Row-Level Security (visibility + sensitivity at DB layer), Storage (S3-compatible canon uploads). One stack covers five concerns otherwise requiring separate glue. Postgres exit path is self-hostable without application rewrite. Rejected: Convex (TypeScript lock-in), Firebase (pay-per-read unpredictable, no Postgres), custom realtime on small VPS (negative ROI at current scale). (Decision rationale: `docs/design-notes/2026-04-18-full-platform-architecture.md §3.2`.)
+**Backend stack (target):** Supabase — Postgres (catalog + ledger + inbox), Realtime broadcast (presence + change broadcast), Auth (GitHub OAuth + sessions), Row-Level Security (visibility + sensitivity at DB layer), Storage (S3-compatible canon uploads). One stack covers five concerns otherwise requiring separate glue. Postgres exit path is self-hostable without application rewrite. Decision: `docs/design-notes/2026-04-18-full-platform-architecture.md §3.2`.
 
-**Auth + identity:** GitHub OAuth as the single identity primitive at launch, covering all three tiers without account stitching. OAuth 2.1 + PKCE at the MCP edge (MCP spec 2025-11-25 mandate). Session tokens scoped per user; RLS enforces per-user visibility at the DB layer. Native accounts (email/passkey) added when >~15% of sign-up attempts bounce at the GitHub wall. (Decision rationale: `docs/design-notes/2026-04-18-full-platform-architecture.md §7`.)
+**Auth + identity:** GitHub OAuth as the single identity primitive at launch, covering all three tiers without account stitching. OAuth 2.1 + PKCE at the MCP edge (MCP spec 2025-11-25 mandate). Session tokens scoped per user; RLS enforces per-user visibility at the DB layer. Native accounts (email/passkey) added when >~15% of sign-up attempts bounce. Decision: `docs/design-notes/2026-04-18-full-platform-architecture.md §7`.
 
-**Real-time strategy — versioned rows + broadcast, NOT CRDT.** User collaboration is coarse-grained: users edit different nodes concurrently, or edit the same node with last-write-wins + update-since-you-viewed conflicts. Comments are append-only. Versioned Postgres rows + Supabase Realtime + presence channels covers this at a fraction of CRDT's complexity. CRDT is an escalation path for any specific artifact needing it later, not a baseline requirement. (Decision rationale: `docs/design-notes/2026-04-18-full-platform-architecture.md §2.2`.)
+**Real-time strategy — versioned rows + broadcast, NOT CRDT.** User collaboration is coarse-grained: users edit different nodes concurrently, or edit the same node with last-write-wins + update-since-you-viewed conflicts. Comments are append-only. Versioned Postgres rows + Supabase Realtime + presence channels covers this at a fraction of CRDT's complexity. CRDT is an escalation path for any specific artifact needing it later, not a baseline. Decision: `docs/design-notes/2026-04-18-full-platform-architecture.md §2.2`.
 
-**Single canonical public entry point.** The daemon surface has exactly one public URL: `https://tinyassets.io/mcp`. Debug/diagnostic access is via Cloudflare Worker observability + tunnel logs, NOT a second public DNS record. Tradeoff explicitly accepted: losing the cheap dual-probe URL localization trick in exchange for a smaller attack surface and zero ambiguity about what users should connect to. The 2026-04-19 P0 outage (`api.tinyassets.io` appearing then disappearing) is additional evidence against multiple public entry points. Implementation caveat: the Cloudflare Worker requires a `mcp.tinyassets.io` hostname for internal tunnel-routing subrequests; this record is retained as Access-gated internal plumbing, not a second public surface. The principle is "one URL users connect to"; the implementation allows an Access-protected internal record that is functionally unreachable from the public internet. (Host directive 2026-04-20; options analysis: `docs/design-notes/2026-04-20-single-entry-execution-options.md`; cutover runbook: `docs/ops/dns-tunnel-single-entry-cutover.md`.)
-
----
-
-## Full-Platform Architecture (Canonical)
-
-**Status: integrated.** The architectural commitments below — multi-tenant multiplayer platform, Postgres-canonical catalog with GitHub as export sink, versioned-rows real-time strategy, opt-in daemon hosting, paid-market on top of a free authoring substrate, full uptime with zero hosts online, three user tiers, evaluation-as-platform-primitive, node discovery + remix surface — are the durable canonical architecture. They are not a future proposal.
-
-**Single source of detail:** `docs/design-notes/2026-04-18-full-platform-architecture.md` (~3000 LOC) carries the full reasoning, tradeoff analysis, scale-audit numbers, and host-decision lineage. PLAN.md is the principle-level reference; the design note is the integrated detail. Future readers consult both — PLAN.md to understand WHY each principle holds, the design note to understand HOW each principle was reached.
-
-**Phased rollout — explicitly rejected.** The earlier "Phase 1 thin relay → Phase 2 state migration → Phase 3 paid failover" plan was rejected by host on 2026-04-18 on the grounds that (a) authoring must work with zero daemons running, which Phase 1 ships 0% of, and (b) building the final shape in one push avoids three throwaway migrations that each require re-teaching users + re-cutting Claude.ai connectors. The single-build target ("weeks not months") is the canonical sequencing model. The historical phased plan (`docs/design-notes/2026-04-18-persistent-uptime-architecture.md`) is retained as superseded historical context only.
-
-**Where the design note lives in PLAN.md:** the principles below already cite specific sections of the design note as decision rationale — Supabase stack (§3.2), GitHub OAuth at MCP edge (§7), versioned-rows over CRDT (§2.2), host-pool registry (§5), zero-daemons-for-authoring (§1), per-piece privacy (§17). When in doubt about an architectural commitment, the citation chain is: PLAN.md principle → design-note section → host-decision lineage. No layer is skipped.
+**Single canonical public entry point.** The daemon surface has exactly one public URL: `https://tinyassets.io/mcp`. Debug/diagnostic access is via Cloudflare Worker observability + tunnel logs, NOT a second public DNS record. The Worker requires a `mcp.tinyassets.io` hostname for internal tunnel-routing subrequests; this record is retained as Access-gated internal plumbing, not a second public surface. Host directive 2026-04-20; runbook: `docs/ops/dns-tunnel-single-entry-cutover.md`.
 
 ---
 
-## Multiplayer Daemon Platform
+## Reference: State & Artifacts
 
-**Goal:** A multi-tenant workflow platform where many users and daemons collaborate without collapsing into one shared chat or one hidden runtime.
+Strong agents run on explicit typed state and external artifacts, not hidden chat memory. If state shapes drift or artifacts become untrustworthy, the system looks smart locally and fails over time.
 
-**Principle:** Separate identity from runtime. Daemons are public, forkable, summonable agent identities defined by soul files; runtime instances are resource allocations bound to providers, models, and executor hosts. Every `(user, daemon, executor)` tuple is independently addressable; today's degenerate case is N=1 of the general shape. Host fleet size is an operating-cost decision, not a platform cap: hosts can run many daemons, including many on one provider, with warning-only provider-plan/rate-limit estimates for additional same-provider daemons.
+**Live state stays thin.** Identity, intent, control flags, and artifact handles. Rich context, prior outputs, and durable memory belong in saved artifacts and registries. Persist each step immediately; the next node may cache the just-finished result locally, but saved refs are authoritative.
 
-**Always ready for the next user and daemon fleet.** A host-only or private-alpha rollout is an exposure gate, not a single-user architecture. Storage, authorization, queues, budgets, audits, daemon bindings, and runtime activations carry tenant/owner boundaries from the first build so more users and more daemons can join by changing exposure and capacity limits, not by redesigning the substrate.
+**Durable artifacts outlive context windows.** Plans, notes, checkpoints, logs, learned heuristics, subagent outputs belong in external storage.
 
-**Soul eligibility.** Nodes and gates may declare whether daemon souls are allowed, forbidden, required, replaced by a node/gate-provided soul, or combined with a temporary node/gate header. They may also declare domain requirements for eligible souls, such as scientific, legal, artistic, local-model-only, or other community-defined qualifications. Claim-time verification checks the daemon soul fingerprint and required claims/proofs before execution; prompt composition then applies the accepted host soul, provided soul, or temporary header according to the node/gate policy.
-
-**Soul-guided dispatch.** After a daemon finishes a node or gate, a soul-bearing daemon returns to a decision step that lists all work it is eligible to claim, including node/gate soul policy, domain requirements, required provider/capability, and any offer. The daemon may choose highest money, specific interests, reputation, public-good impact, or refusal to work on soul-incompatible nodes according to its soul. Soulless daemons use the default platform dispatcher policy.
-
-Defaults: cloud control plane with named accounts; private per-user MCP sessions; shared tool contract; per-universe dashboards; public attributable actions; public read + public fork; no fixed mainline; long-lived branch coexistence; admin-gated runtime capacity; user votes for daemon forks; multi-host execution from day one (cloud-droplet + opt-in host-tray coexist via file-locked claim).
-
-**Zero daemons required for authoring.** Node/branch/goal creation, editing, forking, and collaboration work with no daemon running anywhere. Daemon hosting is opt-in for execution work. This is a load-bearing requirement — any architecture where authoring depends on a running daemon violates it. (The phased plan was rejected on this basis; see `docs/design-notes/2026-04-18-full-platform-architecture.md §1`.)
-
-**Host pool registry.** Every daemon host declares capabilities (node types, LLM models, price), visibility (`self` / `network` / `paid`), and heartbeat state to the control plane. Daemons are execution-tier, not control-plane. The control plane dispatches paid work to hosts and settles via the ledger; daemons poll outbound. (Decision rationale: `docs/design-notes/2026-04-18-full-platform-architecture.md §5`.)
+**Scene commits emit structured packets.** Every accepted scene writes a validated JSON packet (facts, promises, entities, POV, deltas) beside the prose. Packets are the backbone for timelines, promise tracking, continuity, typed retrieval.
 
 ---
 
-## State And Artifacts
+## Reference: Full-Platform Architecture
 
-**Goal:** Make long-horizon reasoning legible, durable, and inspectable.
+**Status: integrated.** The architectural commitments — multi-tenant multiplayer platform, Postgres-canonical catalog with GitHub as export sink, versioned-rows real-time strategy, opt-in daemon hosting, paid-market on top of a free authoring substrate, full uptime with zero hosts online, three user tiers, evaluation-as-platform-primitive, node discovery + remix surface — are the durable canonical architecture, distributed across the modules above.
 
-**Principle:** Strong agents run on explicit typed state and external artifacts, not hidden chat memory. If state shapes drift or artifacts become untrustworthy, the system looks smart locally and fails over time.
+**Single source of detail:** `docs/design-notes/2026-04-18-full-platform-architecture.md` (~3000 LOC) carries the full reasoning, tradeoff analysis, scale-audit numbers, and host-decision lineage. PLAN.md modules are the principle-level reference; the design note is the integrated detail. Citation chain: PLAN.md module principle → design-note section → host-decision lineage. No layer skipped.
 
----
-
-## Daemon-Driven
-
-**Goal:** Let the daemon make creative and structural decisions whenever the model can reliably do so.
-
-**Principle:** Hardcoded thresholds and stage gates are scaffolding. Test each by removing it. When the daemon makes a bad decision, improve the goal/context/tools/evals rather than layering on recipes.
+**Phased rollout — explicitly rejected.** The earlier "Phase 1 thin relay → Phase 2 state migration → Phase 3 paid failover" plan was rejected 2026-04-18 because (a) authoring must work with zero daemons running, which Phase 1 ships 0% of, and (b) building the final shape in one push avoids three throwaway migrations that each require re-teaching users + re-cutting Claude.ai connectors. The single-build target ("weeks not months") is canonical sequencing. Historical phased plan retained as superseded context only.
 
 ---
 
-## Scene Loop
-
-**Goal:** Produce one unit of work that is grounded, coherent, ambitious, and improves through external feedback.
-
-**Principle:** Orient → plan → draft → commit is useful only if each step adds value. If a stronger model with better tools can do equivalent work in fewer steps, flatten the loop.
-
----
-
-## Work Targets And Review Gates
-
-**Goal:** Let the daemon choose the next most justified locus of work.
-
-**Principle:** One unified work-target registry. Foundation review hard-blocks on unsynthesized uploads only; authorial review may choose any justified move once hard blockers are clear. Targets carry role (notes | publishable), publish stage, lifecycle, tags, and artifact refs. notes → publishable must pass through provisional first. `marked_for_discard` is not the same as `discarded` — true discard is a later review decision, recoverable.
-
----
-
-## Retrieval And Memory
-
-**Goal:** Ground every decision in the best available evidence without flooding the model with irrelevant context.
-
-**Principle:** Retrieval and memory are one system with multiple backends (KG, vector, hierarchical summaries, world-state DB, notes, direct tool calls). The routing policy matters more than any individual backend.
-
----
-
-## Evaluation
-
-**Goal:** Improve quality through feedback, not brittle gates.
-
-**Principle:** Layered — deterministic checks for provable failures, an editorial reader for natural-language critique, environment-grounded artifacts and traces for verification. One strong independent reader beats a committee of shallow scorers. **Evaluation is platform-wide, not fantasy-specific** — the §33 unifying frame (`docs/design-notes/2026-04-15-evaluation-layers.md` if landed; otherwise the §33 framing in the full-platform note) treats fantasy judges, autoresearch metrics, moderation rubrics, real-world outcomes, and discovery ranking as instantiations of one `Evaluator` primitive.
-
-**Accepted direction: Acceptance Scenario Packs.** Host approved the AgencyBench-derived direction on 2026-05-02: Workflow should grow reusable long-horizon scenario packs that combine user simulation, rubric checks, MCP/API or browser evidence, and artifact capture into `EvalResult` evidence. Do not vendor AgencyBench or its harness; define Workflow-native scenario contracts after the required opposite-provider research review. Canonical rationale: `docs/audits/2026-05-02-frontier-repo-radar-2.md`.
-
----
-
-## Community Evolvable Optimization
-
-**Goal:** Make every useful piece of the platform improvable by users and daemons without requiring the project maintainers to be online.
-
-**Principle:** Optimization is a native run type, not a sidecar research script. A user with any MCP-connected chatbot should be able to say "improve this branch overnight under this budget and ask before merging"; Workflow then creates versioned candidates, runs locked evaluators, records typed lessons, preserves lineage, and proposes or applies changes according to the user's merge policy.
-
-**User model:** The primary user is not a Python researcher running a local experiment. The primary user is a person steering through Claude.ai, ChatGPT, Open WebUI, LibreChat, a local IDE, or any future MCP client. Chat remains the control station. The daemon and host network do the work. Users can redesign branches, evaluators, and optimization policy conversationally; the platform translates that into bounded specs, not hidden prompt magic.
-
-**Community model:** Branches, nodes, evaluators, and lessons are remixable public commons when privacy policy permits. The platform should preserve many competing solution families rather than collapse to one global "best" workflow. Quality-diversity search, lineage, attribution, and real-world outcome gates are core to keeping the project alive and community-evolvable.
-
-**Safety model:** Candidate generators cannot edit the evaluator or the locked harness they are being judged by. Optimization runs declare editable surface, evaluator chain, budget, stop conditions, merge policy, provenance, and visibility up front. Private instance data must not be promoted into reusable cognition unless the privacy layer explicitly permits it.
-
-**Implementation stance:** First ship contracts: `EvaluatorResult`, `OptimizationRun`, typed analyzer lessons, and MCP-facing actions that compose existing `runs`, `branches`, `evaluation`, `host_pool`, and provenance primitives. Runtime refactors must strengthen those primitives instead of adding a parallel ASI-Evolve-style control plane.
-
----
-
-## Constraints
-
-**Goal:** Formally verify world rules only where symbolic checking clearly adds value.
-
-**Principle:** Neurosymbolic methods are optional leverage. Universe-specific rules are the only version likely to earn ongoing complexity; generic boilerplate constraints are not enough.
-
----
-
-## Providers
-
-**Goal:** Keep the system running and preserve role separation without hiding failure.
-
-**Principle:** Pick the best provider per role, then use fallback chains and parallel diversity where they improve resilience. Error loudly when the remaining provider can't produce acceptable work. Fake success is worse than failure.
-
-**Principle (fallback chain correctness is a first-class invariant):** Every provider named in a fallback chain must be either registered AND reachable at startup, or explicitly excluded at startup with a logged reason. Phantom chain entries are a bug. A chain that reads `[claude-code, codex, gemini-free, ...]` but whose first entry's CLI binary is absent from the container silently degrades the whole chain — operators reading config see one chain; the runtime iterates a different one. Register-and-probe at startup; emit structured evidence of the effective chain via `get_status`; refuse to advertise unreachable providers as available. (Corroborated by BUG-025 + 2026-04-21 prod-LLM-binding incident; Gemini/Groq unregistered in prod fallback plus claude-code phantom registration together produced the 2026-04-23 revert-loop P0.)
-
-**Principle (required files must be probed at startup and fail loud if missing):** When code declares a required on-disk artifact (ASP rule files, schema definitions, seeded fixtures, vendored configs), startup must probe for it and refuse to start if absent — not log a WARNING and continue with an empty fallback. Silent substrate-degradation from missing artifacts produces runs that report success while behaving as no-ops; that violates Hard Rule #8 (fail loudly, never silently) at an earlier lifecycle phase. Deploy-pipeline discipline extends to runtime file probes, not just image-layer contents. (Corroborated by BUG-026: `data/world_rules.lp` absent from container image silently reduced the ASP constraint engine to a no-op; BUG-027 proposes the general startup-probe invariant.)
-
----
-
-## API And MCP Interface
-
-**Goal:** Let the user steer through natural conversation and MCP tooling without letting any chat surface become the author.
-
-**Principle:** Any MCP-compatible client is a control station, not a creator. The daemon does the creative work. If a chat surface writes story content itself, that indicates a missing daemon path.
-
-**Shipping rule:** MCP tools and prompts publish explicit titles, tags, and behavior hints through the registered FastMCP surface — the daemon exposes a small number of coarse-grained tools, so discoverability metadata is part of the interface contract.
-
-**Module shape rule:** API surfaces live in `workflow/api/` as mounted submodules per capability cluster (FastMCP `mount()` pattern). Server shells in `workflow/servers/` route to them. **No god-modules.** `workflow/universe_server.py` (12.4k LOC as of 2026-04-26, down from 14k peak) is in-flight refactor scope per `docs/audits/2026-04-25-universe-server-decomposition.md` — 3 of 8 steps landed (helpers, wiki, status); 5 remain (runs, evaluation, runtime_ops, market, branches).
-
----
-
-## Distribution And Discoverability
-
-**Goal:** Installable and discoverable across standard MCP surfaces, Anthropic packaging, and future Conway packaging without changing the portable core.
-
-**Principle:** Keep the core portable; add platform wrappers around it. MCPB packages, Claude Code / Cowork plugins, registry metadata, and future `.cnw.zip` packaging are distribution layers over the same daemon and tool surface, not replacement architectures.
-
-**Principle (MCP host coverage):** Discoverability work is matrix-driven. Claude and ChatGPT are P0 launch gates, but every MCP-capable host is a possible customer surface. The current host support list, caveats, and acceptance proofs live in `docs/design-notes/2026-05-01-mcp-host-customer-matrix.md`.
-
-**Principle (install-readiness is continuous):** Main is a downloadable release at all times. Every change preserves flawless first-install — packaging auto-builds via CI (import probe + plugin drift check), user-facing copy is branded and unambiguous, broken install is a production bug (not a latent issue). Viral spread can happen any day; optimize throughout, not as a pre-release phase.
-
-**Principle (discovery via entry points, not filesystem scan):** Domain discovery uses `importlib.metadata.entry_points(group="workflow.domains")` per PyPA spec. Filesystem scan of `domains/*/skill.py` is a dev-mode fallback for editable worktrees only. Compat aliases stay out of discovery — compat lives in import shims, not in the domain registry contract. (See spaghetti audit hotspot #6.)
-
-**Principle (software surface is declarative and multi-layer-authorized):** The daemon's software surface is declarative, host-registered, and multi-layer-authorized. Nodes declare `required_capabilities` as a first-class field. Per-host capability registry resolves what's installed. Missing software auto-installs (host-policy gated). Daemons can invoke arbitrary local software — graphics engines, games, LLMs — via a dedicated `external_tool_node` type that bypasses the Python sandbox but layers security: bundled handler signatures, binary signature verification, universe-level allow-list, per-software host approval, subprocess isolation. Any single layer fails, the others hold. Cross-host software donation (Host A cached installer → Host B on demand) is supported; cross-host node-execution hopping is not.
-
----
-
-## Harness And Coordination
-
-**Goal:** Make the system operable, testable, replayable, and improvable across both product runtime and AI-to-AI development.
-
-**Principle:** Harnesses are first-class architecture. Browser harnesses, builder automation, traces, regression tests, dashboards, and role-based agent coordination materially improve system intelligence by making behavior legible and correctable. The same principle applies to the development process — the **Three Living Files** (AGENTS.md / PLAN.md / STATUS.md, see `AGENTS.md`) and the verifier/navigator/dev/user-sim roles separate process truth, design truth, live state, quality, direction, and live-mission validation. These roles are architectural capabilities; each provider implements them through its available harness rather than one universal team mechanism. That's not just process; it's part of the theory of durable agentic work.
-
-**GitHub/worktree coordination spine:** Buildable work flows through GitHub-shaped lanes: a current `STATUS.md` Work row, a purpose-named branch, a sibling `../wf-<slug>` worktree, and a PR or draft PR as the fold-back object. Relevant `PLAN.md` modules are the project/module understanding that each lane must review during planning, build, review, and fold-back. `ideas/INBOX.md` is a loose idea feed; its entries can be parked at the bottom of a lane as "Idea feed refs" so they are not forgotten, but they are not design truth or build authority. `ideas/PIPELINE.md`, provider memories, audits, specs, and exec plans are context feeds that must be refactored into current STATUS/worktree/PR state before build. This keeps community ideas and external-research implications alive without turning old docs into parallel build queues.
-
-**Provider-context feed:** Provider-specific memory and automation systems are inputs to the GitHub/worktree spine, not separate planning authorities. `scripts/provider_context_feed.py` scans Claude/Codex/Cursor/shared memory, idea, research, automation, and worktree handoff surfaces at claim, plan, build, review, fold-back, and memory-write checkpoints. Relevant findings are promoted into STATUS/worktree/PR lanes; irrelevant or stale findings are noted or ignored. This keeps hidden provider context from bypassing the community-visible project state.
-
----
-
-## Live State Shape
-
-**Goal:** Keep live state thin; durable artifacts are the source of truth.
-
-**Principle:** Live state carries identity, intent, control flags, and artifact handles. Rich context, prior outputs, and durable memory belong in saved artifacts and registries. Persist each step immediately; the next node may cache the just-finished result locally, but saved refs are authoritative.
-
----
-
-## Engine And Domains
-
-**Goal:** `workflow/` is reusable infrastructure; `domains/*` own their graph topology and import what they need.
-
-**Principle:** Extract infrastructure first, prove topology second. Skills (swappable phase implementations, domain tools, eval criteria, state extensions) remain valuable within a graph but don't dictate graph shape. A second domain pressures the engine to prove it's actually domain-agnostic.
-
-**Module-shape commitment (refined):** Engine = `workflow/`. Domains = `domains/<name>/`. Currently fantasy_daemon is the only live domain; the pending engine/domain API separation work (`docs/design-notes/2026-04-17-engine-domain-api-separation.md`) extracts domain-specific MCP actions out of the engine shell into `domains/fantasy_daemon/api/` (or equivalent). The engine shell becomes a routing surface; domains register their actions on startup. The engine-vs-domain seam is *named* — once the separation lands, every action lives in exactly one of: shared engine API (`workflow/api/`) or a domain API (`domains/<name>/api/`). No third location.
-
-Fantasy domain keeps scene/chapter/book/universe names in its own graph. Shared `workflow/` infrastructure uses domain-agnostic names.
-
----
-
-## Multi-User Evolutionary Design
-
-**Vision:** The world simultaneously pursues shared broad Goals — "research papers", "fantasy writing", "investigative journalism", "scientific meta-analysis", "screenplay production", and more. Each Goal is a first-class shared pursuit; the internet contributes Branches toward it in parallel. The result is not one correct workflow per Goal but a legion of diverse evolving public workflows, all chasing the same ultimate outcome, all improving each other.
-
-**Goal is first-class above Branch.** A Goal is a named pursuit (`research-paper`, `fantasy-novel`). A Branch is one user's concrete take. Many Branches bind to one Goal. "Simultaneously pursue the same Goal via different Branches" is the default collaboration pattern, not forking one canonical Branch. Goals are extensible — any user can propose one; popular Goals accrete Branches, unpopular ones fade.
-
-**Diverse-by-default.** 100 different research-paper workflows from 100 users is a feature, not duplication. Consolidation into "the best" workflow is an anti-pattern; the value is the ecology.
-
-**Outcome gates — real-world impact is the truth signal.** Each Goal declares a ladder of real-world gates beyond the workflow's immediate output. Research papers: draft → peer feedback → submission → acceptance → publication → citations → breakthrough. Legal briefs: draft → attorney review → filing → survives dismissal → trial → conviction. Workflows succeed when outputs advance up the ladder, not when drafts merely look polished. Leaderboards rank on outcome progression. Tracking is self-report first, automated later (DOI, court-docket, sales, awards).
-
-**Required surfaces (not yet built):**
-- Goal as first-class object: `goals` table, `Branch.goal_id`, per-Goal browsing.
-- Node identity across branches — forks preserve lineage so improvements flow between variants.
-- Fork and invent as parallel first-class actions — "improve this one" and "try a different approach" both bind to the same Goal.
-- Filter/search over the public Branch corpus per Goal.
-- Per-Goal leaderboards (most-run, highest-judged, most-forked, highest-gate-progress).
-- Aggregated social judgment signals per node/branch/Goal.
-- Authorship + attribution lineage chains.
-- Cross-Branch node library per Goal — patterns that work become shared primitives.
-
-**Privacy default:** Per-piece, chatbot-judged. Concept-public by default; instance-private when user data is involved. Chatbot makes per-piece visibility decisions dynamically. (See `docs/design-notes/2026-04-18-full-platform-architecture.md` §17 + memory `project_privacy_per_piece_chatbot_judged.md`.) The earlier "public-by-default; users can mark a branch private for drafting" framing has been refined to per-piece granularity.
-
-**Non-goals for now:** account system MVP scope under Q1; monetization scoped to 1% crypto fee on paid-market bids only; moderation = community-flagged with volunteer-mod review (Q10-host RESOLVED).
-
-**Currency naming + test rail:** The real currency reference is `Destiny (tiny)` with symbol `tiny`. Current Workflow monetization and paid-market tests use `test tiny` on Base Sepolia only. Mainnet Destiny/tiny settlement, staking, DAO voting, and treasury flows are deferred until a later real-currency integration phase; current contract references are naming anchors, not active Workflow rails. See `docs/design-notes/2026-04-29-token-naming-and-test-currency.md`.
-
----
-
-## Uptime And Alarm Path
-
-**Goal:** The complete system — MCP surface + node execution + collaboration surfaces + paid-market + moderation — stays up 24/7 with zero hosts online. The host machine being asleep for 24h must not extend any outage window past the pager's escalation ladder.
-
-**Principle:** Defense in depth *and* the alarm path itself is host-independent. Every self-heal layer assumes the layers below it will fail; the alarm ladder assumes every self-heal layer will fail. None run on a host machine.
-
-**Three self-heal layers, each catches a different class:**
-
-1. **Container restart (`systemd Restart=always` + `workflow-watchdog.timer`).** Catches transient crashes, OOM-recovery, and hung-but-not-crashed processes. Blind to filesystem-bricked states by design; those fall through to layer 2.
-2. **GHA `p0-outage-triage.yml` auto-repair.** Triggered by the `p0-outage` issue label. Before attempting restart, inspects `journalctl` for known-class markers and applies the canonical repair. Six classes covered (5a6b645): OOM, disk-full, image-pull, watchdog-hot-loop, tunnel-token-manual, env-unreadable (the `ENV-UNREADABLE` marker shipped in a62ae30). Self-repair is encoded, not generalized — each class is a witnessed failure with a known remedy. New classes are added as they are witnessed.
-3. **Deploy-side invariants.** `deploy-prod.yml` asserts `/etc/workflow/env` is readable by the daemon user immediately after every `sudo sed -i` mutation and independently post-restart (0217175). Prevents the 2026-04-21 perm-regression class at the source.
-
-**Alarm ladder, host-phone-independent:** Pushover paging from the GHA `alarm-sink` step at threshold-cross (2 consecutive reds = ~10 min outage), `priority=2` + vibrate-tier for the initial page, escalating re-page at 1h / 4h / 24h if the `p0-outage` issue remains open with no human comment (19c2261). The probe (uptime-canary at 5-min GHA cron) is the signal source; Pushover is the delivery. Neither runs on a host. The 2026-04-21 P0 (~18h dark) exposed that probe-without-paging is not an alarm path — the canary had fired every tick for 18 hours; nothing paged.
-
-**DR validated end-to-end 2026-04-22.** The drill provisions a fresh Debian VM, bootstraps via `hetzner-bootstrap.sh`, restores `/etc/workflow/env` from offsite (GH release backup assets), restores the data volume from offsite, starts the daemon, and asserts canonical canary-green within SLA. Decoupling of restore + start steps (a8fdb97) + owner-path sweep (9ef6c3d) + exit-code propagation (4f936fe) + SSH-tunnel probe (c50b6e8) together make the drill honest — no host keystrokes bridge any step. Weekly recurrence is the always-on regression check.
-
-**Loop uptime maintenance skill (2026-05-03 add).** A fourth path lives at .agents/skills/loop-uptime-maintenance/SKILL.md — the discipline for handling failure classes not yet graduated to layers 1-3. Entry condition: the loop is too broken to self-heal via its own loop (dispatcher wedged, supervisor in restart loop, daemon subprocess wedged, MCP surface 502, filesystem-bricked state). Every application produces an incident log + substrate improvement + (usually) a PLAN.md update. Success metric is usage trending to zero — every incident graduates a failure class out of the skill into one of the three layers above. The skill is the authorized escape from the user-sim discipline when (and only when) the user-sim path is itself the broken thing.
-
-**What is explicitly *not* in this layer:**
-- On-box pagers (share host-fate with the daemon).
-- Third-party uptime monitors (probe is not the gap; delivery is).
-- "Restart will fix it" as a universal remedy (witnessed to fail when the fault is on the filesystem, not in memory).
-
-**Testable assumption:** If the host's phone is off for 24h, a secondary paging path (email / desktop / secondary device subscribed to the Pushover channel) still fires at the 4h escalation tick. Unvalidated today; validation depends on host's secondary-device setup.
+## Design Decisions
+
+ADR-style index of decisions that don't fit cleanly inside one module.
+
+- **Universe = single consistent reality.** Alternative realities are separate universes. Data isolation between universes is the only hard boundary.
+- **Upload provenance.** Each upload is tagged ("published book", "rough notes") and the writer weights canon sources accordingly.
+- **Unified notes.** All feedback is timestamped, attributed notes on files. One system, one format, one durable store per universe.
+- **Writer self-indexes.** The writer produces entity and fact data when it commits. No separate extraction role is the end state.
+- **Editorial feedback, not scoring.** Natural-language notes about what works, what's concerning, and whether a concern is provably wrong. No numeric rubric in the core loop.
+- **Graph hierarchy is scaffolding.** Structure should emerge from the daemon's choices wherever possible, not fixed counters.
+- **Workflow Server, not single-user daemon.** Control plane runs in the cloud (currently DO Droplet, formerly a host laptop); many named users connect through MCP clients.
+- **Multi-tenant by design, single-tenant today as N=1.** Every daemon-related design must scale from `(user, daemon)` to `(N users, M daemons per user)` without rewrite. Any architecture that would require a migration to multi-user is rejected. Memory `project_daemons_are_multi_tenant_by_design.md`.
+- **Workflow-first, domain-agnostic identity.** Fantasy authoring is an early benchmark domain, not the trunk.
+- **MCP clients + local host dashboard.** MCP is the shared collaborative surface; host operational controls live in a local dashboard.
+- **Daemons are the public agent identity.** Summonable, forkable, defined by durable soul files. Soul changes create new forks rather than overwriting.
+- **Daemon identity is platform-wide, not domain-specific authoring.** Migrate or rename the current `author_definitions` substrate into the general daemon registry. Content provenance retains `author_id` + `author_kind` discriminator.
+- **Branch-first collaboration.** Branches are first-class, long-lived, public-forkable. Reconciliation optional, no fixed mainline.
+- **Swarm runtime.** No universe-wide single active daemon. Runtime capacity and daemon identity are separate resources.
+- **GitHub is an export sink, not the canonical store.** Canonical state lives in Postgres (Supabase-hosted at launch). GitHub receives a periodic flat-YAML export of public goals/branches/nodes; contributions via GitHub PR are accepted via a round-trip YAML → webhook → Postgres import path. One-way-door decision (host-approved 2026-04-18).
+- **Local-first execution, git-native sync (bridge state).** DO Droplet self-host is the current bridge. Postgres-canonical replaces local-first when the control-plane backend ships.
+- **User-controllable state architecture.** Users should eventually inspect, steer, and redesign workflow/state structure conversationally.
+- **Multi-host is the destination.** Local-host is important, but end-state is a network of hosts contributing model capacity to shared projects.
+- **The system must evolve itself.** Stagnation is the worst failure mode.
+- **Context is tools, not pre-assembly.** The writer should query through tools. Pre-assembly is transitional.
+- **Bad decisions are data.** When the daemon decides poorly, improve goals/tools/state/evals. Don't reflexively add rules.
+- **Human control belongs at irreversible boundaries.** Bounded loops for autonomy; pause/stop/takeover/confirmation at the edge.
+- **Engine is infrastructure, not topology.** `workflow/` is a shared library plus optional profiles. Each domain owns its own graph.
+- **Currency naming + test rail.** Real currency reference is `Destiny (tiny)` with symbol `tiny`. Current paid-market tests use `test tiny` on Base Sepolia only. Mainnet Destiny/tiny settlement, staking, DAO voting, and treasury flows are deferred. See `docs/design-notes/2026-04-29-token-naming-and-test-currency.md`.
 
 ---
 
@@ -474,7 +566,9 @@ Fantasy domain keeps scene/chapter/book/universe names in its own graph. Shared 
 
 - **Tool-driven context is the target; pre-assembly is transitional.** If the writer is mostly fed pre-assembled blobs, this architecture is not finished.
 - **Structural scaffolding should shrink** as models improve — hard maxima and routing thresholds only survive if evals prove they help.
-- **Hybrid memory must become one policy.** Retrieval and memory may be separate implementations, but they should behave like one coherent decision system from the daemon's perspective.
+- **Hybrid memory must become one policy.** Retrieval and memory may be separate implementations but should behave like one coherent decision system from the daemon's perspective (Brain Module is the convergence point).
 - **State contract mismatches are bugs.** TypedDicts, node outputs, and downstream consumers must agree.
-- **God-module decomposition is in-flight, not done.** `workflow/universe_server.py` (12.4k LOC, down from 14k peak; 3 of 8 audit-prescribed extractions landed 2026-04-26) and `workflow/daemon_server.py` (3.6k LOC) are the dominant violations of the Module Layout commitment above. Decomp is sequenced ahead of the rename Phase 5 collapse per the active session's ordering — see `docs/audits/2026-04-25-universe-server-decomposition.md` for the 8-step migration shape.
-- **Postgres-canonical vs GitHub-canonical (Q1 in full-platform note) is the largest unresolved architectural decision.** Until host answers, two design shapes coexist in this document. The decision should land in the next few cycles to avoid further documentation divergence.
+- **God-module decomposition is in-flight, not done.** `workflow/universe_server.py` is down from 14k peak to 972 LOC live in main; remaining cluster extractions sequenced per `docs/audits/2026-04-25-universe-server-decomposition.md`.
+- **Postgres-canonical vs GitHub-canonical is the largest unresolved architectural decision.** Until host answers, two design shapes coexist in this document. Decision should land soon to avoid further documentation divergence.
+- **External-write authority + idempotency + reward release.** Per the 2026-05-19 design note draft, the holistic model is awaiting host steering on 6 open questions before implementation begins.
+- **Per-Goal strict-mode rollout for Brain authority-condition policy.** Permissive by default; strict-mode opt-in is unscoped.

--- a/scripts/plan_module_audit.py
+++ b/scripts/plan_module_audit.py
@@ -1,0 +1,150 @@
+"""PLAN.md module audit helper.
+
+Lists the audit-stamp + substrate paths for each `## Module:` section in
+PLAN.md. Flags stale modules (no audit stamp in N days) and drift candidates
+(substrate paths that no longer exist on disk).
+
+This is a reference tool for the `improve-codebase-architecture` and
+`auto-iterate` skills. It does not gate commits or builds.
+
+Usage:
+    python scripts/plan_module_audit.py                 # show all modules
+    python scripts/plan_module_audit.py --stale 30      # only modules unaudited >30 days
+    python scripts/plan_module_audit.py --drift         # only modules with missing substrate paths
+    python scripts/plan_module_audit.py --module Brain  # one module's full report
+
+Exit code: 0 always. The script is informational, not a gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+PLAN_PATH = REPO_ROOT / "PLAN.md"
+
+MODULE_HEADING_RE = re.compile(r"^## Module:\s*(?P<name>.+)$", re.MULTILINE)
+STAMP_RE = re.compile(r"_Last audited:\s*(?P<date>\d{4}-\d{2}-\d{2})_")
+SUBSTRATE_RE = re.compile(r"\*\*Substrate.*?\*\*\s*(?P<body>.*?)(?=\n\n\*\*|\n_Last audited|\n---)", re.DOTALL)
+PATH_TOKEN_RE = re.compile(r"`([^`]+)`")
+
+
+def parse_modules(plan_text: str) -> list[dict]:
+    modules: list[dict] = []
+    headings = list(MODULE_HEADING_RE.finditer(plan_text))
+    for i, m in enumerate(headings):
+        name = m.group("name").strip()
+        start = m.end()
+        end = headings[i + 1].start() if i + 1 < len(headings) else _next_h2_after(plan_text, start)
+        body = plan_text[start:end]
+
+        stamp_match = STAMP_RE.search(body)
+        last_audited = stamp_match.group("date") if stamp_match else None
+
+        substrate_match = SUBSTRATE_RE.search(body)
+        substrate_paths: list[str] = []
+        if substrate_match:
+            for token in PATH_TOKEN_RE.findall(substrate_match.group("body")):
+                if _looks_like_path(token):
+                    substrate_paths.append(token)
+
+        modules.append({
+            "name": name,
+            "last_audited": last_audited,
+            "substrate_paths": substrate_paths,
+        })
+    return modules
+
+
+def _next_h2_after(text: str, start: int) -> int:
+    nxt = re.search(r"^## ", text[start:], re.MULTILINE)
+    return start + nxt.start() if nxt else len(text)
+
+
+def _looks_like_path(token: str) -> bool:
+    if "/" in token or token.endswith(".py") or token.endswith(".md") or token.endswith(".yml"):
+        return True
+    return False
+
+
+def staleness_days(module: dict, today: dt.date) -> int | None:
+    if not module["last_audited"]:
+        return None
+    audited = dt.date.fromisoformat(module["last_audited"])
+    return (today - audited).days
+
+
+def missing_paths(module: dict) -> list[str]:
+    missing: list[str] = []
+    for path_token in module["substrate_paths"]:
+        candidate = REPO_ROOT / path_token.rstrip("/")
+        if not candidate.exists():
+            missing.append(path_token)
+    return missing
+
+
+def format_module(module: dict, today: dt.date, *, verbose: bool = False) -> str:
+    stamp = module["last_audited"] or "UNSTAMPED"
+    age = staleness_days(module, today)
+    age_str = f"{age}d" if age is not None else "n/a"
+    missing = missing_paths(module)
+    drift_str = f"  DRIFT: {', '.join(missing)}" if missing else ""
+
+    if not verbose:
+        return f"  {module['name']:36s}  audited={stamp}  age={age_str:>5s}{drift_str}"
+
+    lines = [f"## {module['name']}", f"  last_audited: {stamp}", f"  age_days: {age_str}"]
+    lines.append(f"  substrate_paths ({len(module['substrate_paths'])}):")
+    for path in module["substrate_paths"]:
+        marker = "  MISSING" if path in missing else ""
+        lines.append(f"    - {path}{marker}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stale", type=int, default=None,
+                        help="Only show modules unaudited for >N days.")
+    parser.add_argument("--drift", action="store_true",
+                        help="Only show modules with missing substrate paths.")
+    parser.add_argument("--module", type=str, default=None,
+                        help="Show full report for a single module by name (substring match).")
+    args = parser.parse_args(argv)
+
+    if not PLAN_PATH.exists():
+        print(f"PLAN.md not found at {PLAN_PATH}", file=sys.stderr)
+        return 0
+
+    plan_text = PLAN_PATH.read_text(encoding="utf-8")
+    modules = parse_modules(plan_text)
+    today = dt.date.today()
+
+    if args.module:
+        needle = args.module.lower()
+        for m in modules:
+            if needle in m["name"].lower():
+                print(format_module(m, today, verbose=True))
+                print()
+        return 0
+
+    filtered = modules
+    if args.stale is not None:
+        filtered = [m for m in filtered
+                    if (age := staleness_days(m, today)) is not None and age > args.stale]
+    if args.drift:
+        filtered = [m for m in filtered if missing_paths(m)]
+
+    print(f"PLAN.md modules ({len(filtered)} / {len(modules)} shown, today={today.isoformat()})")
+    if not filtered:
+        print("  (no matches)")
+    for m in filtered:
+        print(format_module(m, today))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Restructures PLAN.md from a spaghettified 30-H2-section layout into 11 well-shaped modules + 5 preamble sections + 3 references + Design Decisions + Open Tensions. Adds the new **Brain Module** built on the open-brain v2 substrate that landed via slices A/B/C/D this week. Wires modular-coding skills (`improve-codebase-architecture`, `auto-iterate`) to PLAN.md so the working theory of each module stays calibrated.

**Host-approved 2026-05-19 (big swing, all-in-one PR).** Supersedes PR #873.

## Why

PLAN.md is meant to be the working theory of what each module is and how it works — the reference everyone (humans, the auto-change loop, user chatbots) consults before building, so the applicable module's shape is known before code is written.

Before this PR:
- 30 H2 sections with massive overlap (\`Daemon-Driven\` + \`Multiplayer Daemon Platform\` + \`Full-Platform Architecture\` all carried daemon principles).
- Several 4-line stubs (\`Retrieval And Memory\`, \`Daemon-Driven\`, \`Scene Loop\`).
- A target \`Module Layout\` section that PLAN.md's own structure didn't follow.
- Cross-Cutting Principles doing triple duty (principles + cleanup invariants + module-shape commentary).

## What changes

### Module shape (every module section now follows the same template)

\`\`\`
Purpose / In scope / Out of scope / Principles / Substrate / Open evolution
+ _Last audited: YYYY-MM-DD_
\`\`\`

### 11 modules (down from 30 H2 sections)

Engine & Domains · Daemon Platform · **Brain (new)** · Goals & Gates · Evolution & Evaluation · Providers · API & MCP Interface · Distribution & Discoverability · Harness & Coordination · Uptime & Alarms · Constraints

### Brain Module

Built on the open-brain v2 slices landed this week (#904/#900/#901/#902) plus #903 amendment-verdict carrier and #870 wiki-bug body inclusion. Holds memory, identity, authority-condition policy, attribution snapshots at reward release. Reserves the hook for the authority-condition policy described in the 2026-05-19 external-write design note draft (PR #914).

### Cross-Cutting Principles preserved

Per the #873 concern. Content stays; the module-shape paragraph at the end now points at the new Module Map + per-module sections that codify what each owns.

### Skills tie-in — \"How to Use This PLAN\" preamble

Names 10 project skills and when to invoke each. Explicit invocation guidance for \`improve-codebase-architecture\`, \`auto-iterate\`, and \`spec-driven-development\` (which has PLAN.md as its PLAN-phase artifact for any spec touching platform shape).

### Auto-iteration loop (lightweight, keeps PLAN.md clean)

1. **Per-module \`_Last audited:\` stamps** — skill updates on each audit pass.
2. **Drift detection** via new \`scripts/plan_module_audit.py\` — lists stale modules + substrate paths missing on disk.
3. **Recurrence ratchet** — \`improve-codebase-architecture\` finding the same smell in two consecutive audits triggers \`auto-iterate\` (doc → script → hook → gate ladder).

PLAN.md itself stays clean. The audit machinery lives in the skill + the script.

### Skill updates

- \`improve-codebase-architecture\` — explicitly references PLAN.md modules as the working theory the audit measures against; requires running \`plan_module_audit.py\` before claiming a module is fine; requires updating the \`_Last audited:\` stamp + invoking \`auto-iterate\` on two-consecutive-match smells.
- \`auto-iterate\` — treats two-consecutive-audit module-shape drift + \`plan_module_audit.py\` drift recurrence as ratchet triggers.

## Verification

- \`scripts/plan_module_audit.py\` runs clean and **already caught real drift** (cited audit docs that don't exist on disk: \`docs/audits/2026-05-02-asi-evolve-architecture-implications.md\`, \`docs/design-notes/2026-05-02-community-evolvable-optimization-integration.md\`).
- Pre-commit gates green: cross-provider-drift clean, skills-valid passed, mojibake scan clean, plugin mirror parity N/A (no canonical workflow/ changes).

## Test plan

- [ ] Review PLAN.md as the new working theory — does the 11-module shape map to how you'd describe the system to a new contributor?
- [ ] Brain Module: does it accurately reflect the open-brain v2 substrate that landed?
- [ ] Cross-Cutting Principles content preserved as-is?
- [ ] Skills preamble: are the 10 skills called out in the right order and with crisp \"when to invoke\"?
- [ ] Run \`python scripts/plan_module_audit.py --drift\` and confirm the drift findings are real (cited docs that should be filed, or citations that should be removed).
- [ ] Turn the host merge key when satisfied.

## Follow-ups after merge

- Close PR #873 with a reference to this PR.
- Optional next session: file an issue for each drift finding (missing audit doc) — either build the doc or remove the broken citation.