### PR TITLE
fix(loop-watch): downgrade Writer queue red→yellow when only needs_human and processor is productive (Slice A)

### DIFF
--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -95,6 +95,24 @@ WRITER_ELIGIBLE_QUEUE_DETAIL_KEYS = (
     "attempted_with_open_pr",
     "pending",
 )
+WRITER_QUEUE_RED_BLOCKING_DETAIL_KEYS = (
+    "old_pending",
+    "stale_gate",
+    "branch_push_blocked",
+    "pr_blocked",
+    "attempted_with_open_pr",
+)
+
+
+def _needs_human_ok_threshold() -> int:
+    """Read NEEDS_HUMAN_OK_THRESHOLD from env each call so tests can override it."""
+
+    raw = os.environ.get("LOOP_WATCH_NEEDS_HUMAN_OK_THRESHOLD", "3")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return 3
+    return value if value >= 0 else 3
 
 
 class WatchError(Exception):
@@ -1114,6 +1132,46 @@ def _is_stale_writer_schedule_stage(stage: dict[str, Any]) -> bool:
     )
 
 
+def _writer_queue_red_only_for_needs_human(stage: dict[str, Any]) -> bool:
+    """True when Writer queue is red and the *only* populated red-causing bucket is needs_human.
+
+    `needs_human` is the loop's correct escalation behavior — by-design pause when a writer
+    hit a transient block. It should not flip the loop overall red on its own, as long as the
+    population is bounded and no harder failure mode is also present.
+    """
+
+    if stage.get("name") != "Writer queue":
+        return False
+    if stage.get("status") != "red":
+        return False
+    details = stage.get("details")
+    if not isinstance(details, dict):
+        return False
+    needs_human = details.get("needs_human") or []
+    if not needs_human:
+        return False
+    if len(needs_human) > _needs_human_ok_threshold():
+        return False
+    for key in WRITER_QUEUE_RED_BLOCKING_DETAIL_KEYS:
+        if details.get(key):
+            return False
+    return True
+
+
+def _writer_workflow_is_productive(stage: dict[str, Any] | None) -> bool:
+    """True when the Writer workflow stage shows recent processor activity.
+
+    Green means scheduled success is fresh; yellow means scheduled success is stale but
+    a fallback event (workflow_run / workflow_dispatch / issues) succeeded recently. Either
+    is sufficient evidence that auto-fix-bug.yml is firing and the loop processor is alive.
+    Red on Writer workflow means no recent success at all — productivity is not proven.
+    """
+
+    if stage is None:
+        return False
+    return stage.get("status") in ("green", "yellow")
+
+
 def incident_stage(
     repo: str,
     *,
@@ -1320,6 +1378,34 @@ def build_status(args: argparse.Namespace, now: dt.datetime | None = None) -> di
         details = writer_workflow.get("details")
         if isinstance(details, dict):
             details["queue_downgrade"] = downgrade_reason
+    if (
+        writer_queue is not None
+        and _writer_queue_red_only_for_needs_human(writer_queue)
+        and _writer_workflow_is_productive(writer_workflow)
+    ):
+        details = writer_queue.get("details") or {}
+        needs_human_count = len(details.get("needs_human") or [])
+        threshold = _needs_human_ok_threshold()
+        workflow_status = writer_workflow.get("status") if writer_workflow else "unknown"
+        downgrade_reason = (
+            f"loop processor is productive (Writer workflow status={workflow_status}); "
+            f"{needs_human_count} needs-human escalation(s) within threshold {threshold} "
+            "are the loop's correct escalation behavior, not a stuck queue"
+        )
+        writer_queue["status"] = "yellow"
+        existing_summary = writer_queue.get("summary") or ""
+        writer_queue["summary"] = (
+            f"{existing_summary}; {downgrade_reason}" if existing_summary else downgrade_reason
+        )
+        existing_evidence = writer_queue.get("evidence")
+        writer_queue["evidence"] = (
+            f"{existing_evidence}; {downgrade_reason}"
+            if existing_evidence
+            else downgrade_reason
+        )
+        if isinstance(details, dict):
+            details["productive_loop_downgrade"] = downgrade_reason
+            details["needs_human_ok_threshold"] = threshold
     overall = classify(stages)
     return {
         "version": 1,

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -4,6 +4,7 @@ import argparse
 import datetime as dt
 import subprocess
 from pathlib import Path
+from typing import Any
 
 from scripts import community_loop_watch as watch
 
@@ -868,6 +869,246 @@ def test_queue_stage_summarizes_mixed_permission_blocks(monkeypatch):
     assert stage["details"]["branch_push_blocked"] == [87]
     assert stage["details"]["pr_blocked"] == [70]
     assert "branch-push and PR-creation permission blocks" in stage["summary"]
+
+
+def _productive_writer_workflow_runs(now: dt.datetime) -> dict[str, dict[str, Any]]:
+    """Build a Writer-workflow run set where schedule is stale but workflow_run is fresh.
+
+    Mirrors the 2026-05-19 live state where auto-fix-bug.yml schedule lagged its threshold
+    but workflow_run-triggered runs were succeeding inside the productivity window.
+    """
+    stale_schedule = {
+        "id": 1001,
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": (now - dt.timedelta(minutes=120)).isoformat().replace("+00:00", "Z"),
+        "updated_at": (now - dt.timedelta(minutes=120)).isoformat().replace("+00:00", "Z"),
+        "event": "schedule",
+        "html_url": "https://example.test/writer-schedule-stale",
+    }
+    fresh_workflow_run = {
+        "id": 1002,
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": (now - dt.timedelta(minutes=2)).isoformat().replace("+00:00", "Z"),
+        "updated_at": (now - dt.timedelta(minutes=2)).isoformat().replace("+00:00", "Z"),
+        "event": "workflow_run",
+        "html_url": "https://example.test/writer-workflow-run-fresh",
+    }
+    return {"stale_schedule": stale_schedule, "fresh_workflow_run": fresh_workflow_run}
+
+
+def _build_status_with_loop_issues_and_runs(monkeypatch, *, loop_issues, writer_runs, now):
+    def fake_recent_workflow_runs(_repo, workflow_id, **kwargs):
+        if workflow_id == watch.WORKFLOWS["writer"]:
+            if kwargs.get("event") == "schedule":
+                return [writer_runs["stale_schedule"]]
+            return [writer_runs["fresh_workflow_run"], writer_runs["stale_schedule"]]
+        # other workflows: keep them green for this test surface
+        return [
+            {
+                "id": 5000,
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": (now - dt.timedelta(minutes=5))
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "updated_at": (now - dt.timedelta(minutes=5))
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "event": "schedule",
+                "html_url": "https://example.test/other-workflow",
+            }
+        ]
+
+    monkeypatch.setattr(watch, "_recent_workflow_runs", fake_recent_workflow_runs)
+    monkeypatch.setattr(watch, "list_loop_issues", lambda *_args, **_kwargs: list(loop_issues))
+    monkeypatch.setattr(watch, "list_open_issues_by_label", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        watch,
+        "list_open_prs_by_closing_issue",
+        lambda *_args, **_kwargs: {},
+    )
+    monkeypatch.setattr(watch, "_github_token", lambda _args: None)
+    return watch.build_status(
+        argparse.Namespace(
+            repo="owner/repo",
+            api="https://api.github.test",
+            token=None,
+            timeout=1,
+            max_sync_age_min=90,
+            max_writer_age_min=90,
+            max_observation_age_min=90,
+            max_pending_age_min=45,
+        ),
+        now=now,
+    )
+
+
+def _needs_human_issue(number: int, *, created_at: str) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": f"writer auth expired before PR creation #{number}",
+        "created_at": created_at,
+        "html_url": f"https://example.test/issues/{number}",
+        "labels": [
+            {"name": watch.BLOCKED_LABEL},
+            {"name": watch.ATTEMPTED_LABEL},
+            {"name": watch.WRITER_FAILED_LABEL},
+            {"name": watch.AUTH_EXPIRED_LABEL},
+        ],
+    }
+
+
+def test_build_status_downgrades_writer_queue_when_loop_is_productive(monkeypatch):
+    """Locks in the 2026-05-19 live false-red: 1 needs-human + fresh workflow_run → yellow.
+
+    Reproduces #918 sitting needs-human while auto-fix-bug.yml workflow_run-triggered runs
+    succeed every cycle. Watcher must report yellow, not red, because the loop is doing what
+    the loop should do (escalate transient failures while continuing to process).
+    """
+
+    now = dt.datetime(2026, 5, 20, 2, 0, tzinfo=dt.timezone.utc)
+    status = _build_status_with_loop_issues_and_runs(
+        monkeypatch,
+        loop_issues=[
+            _needs_human_issue(918, created_at="2026-05-19T20:56:53Z"),
+        ],
+        writer_runs=_productive_writer_workflow_runs(now),
+        now=now,
+    )
+
+    queue_stage = [stage for stage in status["stages"] if stage["name"] == "Writer queue"][0]
+    writer_stage = [stage for stage in status["stages"] if stage["name"] == "Writer workflow"][0]
+    assert queue_stage["status"] == "yellow"
+    assert writer_stage["status"] in ("green", "yellow")
+    assert queue_stage["details"]["needs_human"] == [918]
+    assert queue_stage["details"]["needs_human_ok_threshold"] == 3
+    assert "productive" in queue_stage["details"]["productive_loop_downgrade"]
+    assert status["overall"] != "red"
+
+
+def test_build_status_keeps_writer_queue_red_when_needs_human_exceeds_threshold(monkeypatch):
+    """Escalation overflow stays red even when the processor is productive."""
+
+    now = dt.datetime(2026, 5, 20, 2, 0, tzinfo=dt.timezone.utc)
+    issues = [
+        _needs_human_issue(n, created_at="2026-05-19T20:56:53Z")
+        for n in (901, 902, 903, 904)
+    ]
+    status = _build_status_with_loop_issues_and_runs(
+        monkeypatch,
+        loop_issues=issues,
+        writer_runs=_productive_writer_workflow_runs(now),
+        now=now,
+    )
+
+    queue_stage = [stage for stage in status["stages"] if stage["name"] == "Writer queue"][0]
+    assert queue_stage["status"] == "red"
+    assert "productive_loop_downgrade" not in queue_stage.get("details", {})
+
+
+def test_build_status_keeps_writer_queue_red_when_processor_is_not_productive(monkeypatch):
+    """If the Writer workflow is itself red, needs-human is not downgraded — loop may be dead."""
+
+    now = dt.datetime(2026, 5, 20, 2, 0, tzinfo=dt.timezone.utc)
+    very_stale = {
+        "id": 2001,
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-05-18T00:00:00Z",
+        "updated_at": "2026-05-18T00:00:00Z",
+        "event": "schedule",
+        "html_url": "https://example.test/dead-schedule",
+    }
+
+    def fake_recent_workflow_runs(_repo, workflow_id, **kwargs):
+        if workflow_id == watch.WORKFLOWS["writer"]:
+            return [very_stale]
+        return [very_stale]
+
+    monkeypatch.setattr(watch, "_recent_workflow_runs", fake_recent_workflow_runs)
+    monkeypatch.setattr(
+        watch,
+        "list_loop_issues",
+        lambda *_args, **_kwargs: [_needs_human_issue(918, created_at="2026-05-19T20:56:53Z")],
+    )
+    monkeypatch.setattr(watch, "list_open_issues_by_label", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        watch,
+        "list_open_prs_by_closing_issue",
+        lambda *_args, **_kwargs: {},
+    )
+    monkeypatch.setattr(watch, "_github_token", lambda _args: None)
+
+    status = watch.build_status(
+        argparse.Namespace(
+            repo="owner/repo",
+            api="https://api.github.test",
+            token=None,
+            timeout=1,
+            max_sync_age_min=90,
+            max_writer_age_min=90,
+            max_observation_age_min=90,
+            max_pending_age_min=45,
+        ),
+        now=now,
+    )
+
+    queue_stage = [stage for stage in status["stages"] if stage["name"] == "Writer queue"][0]
+    assert queue_stage["status"] == "red"
+    assert "productive_loop_downgrade" not in queue_stage.get("details", {})
+
+
+def test_build_status_keeps_writer_queue_red_when_old_pending_also_present(monkeypatch):
+    """An old_pending escalation co-existing with needs_human keeps the stage red.
+
+    needs_human alone is by-design escalation; pending requests aging past the threshold are
+    a real backlog signal and must keep tripping red regardless of productivity.
+    """
+
+    now = dt.datetime(2026, 5, 20, 2, 0, tzinfo=dt.timezone.utc)
+    issues = [
+        _needs_human_issue(918, created_at="2026-05-19T20:56:53Z"),
+        {
+            "number": 757,
+            "title": "stale pending request never picked up",
+            "created_at": "2026-04-01T00:00:00Z",
+            "html_url": "https://example.test/issues/757",
+            "labels": [{"name": "daemon-request"}],
+        },
+    ]
+    status = _build_status_with_loop_issues_and_runs(
+        monkeypatch,
+        loop_issues=issues,
+        writer_runs=_productive_writer_workflow_runs(now),
+        now=now,
+    )
+
+    queue_stage = [stage for stage in status["stages"] if stage["name"] == "Writer queue"][0]
+    assert queue_stage["status"] == "red"
+    assert "productive_loop_downgrade" not in queue_stage.get("details", {})
+    assert queue_stage["details"]["old_pending"] == [757]
+
+
+def test_build_status_threshold_is_env_overridable(monkeypatch):
+    """LOOP_WATCH_NEEDS_HUMAN_OK_THRESHOLD env var raises/lowers the bar for downgrade."""
+
+    monkeypatch.setenv("LOOP_WATCH_NEEDS_HUMAN_OK_THRESHOLD", "1")
+    now = dt.datetime(2026, 5, 20, 2, 0, tzinfo=dt.timezone.utc)
+    issues = [
+        _needs_human_issue(n, created_at="2026-05-19T20:56:53Z") for n in (918, 920)
+    ]
+    status = _build_status_with_loop_issues_and_runs(
+        monkeypatch,
+        loop_issues=issues,
+        writer_runs=_productive_writer_workflow_runs(now),
+        now=now,
+    )
+
+    queue_stage = [stage for stage in status["stages"] if stage["name"] == "Writer queue"][0]
+    assert queue_stage["status"] == "red"
+    assert queue_stage["details"]["needs_human"] == [918, 920]
 
 
 def test_queue_stage_treats_attempted_loop_smoke_as_not_waiting(monkeypatch):


### PR DESCRIPTION
## Summary

- Watcher's `Writer queue` stage was reporting red on a single `needs-human` issue even when `auto-fix-bug.yml` was succeeding every cycle. Live trigger: 2026-05-19 22:42Z–onward, 3+ hours red while the processor was provably productive.
- `needs-human` is the loop's *correct* escalation behavior for transient writer failures (auth expired, branch-push blocked, etc.). It auto-retries when the root cause clears. Treating one escalation as red made the watcher noisy and the host blind to real reds.
- Strictness preserved: escalation overflow (`needs_human` count > threshold), `old_pending` backlog, `stale_gate`, `branch_push_blocked`/`pr_blocked`, dead processor — all still trip red.

## What changed

`scripts/community_loop_watch.py`:
- New constant `WRITER_QUEUE_RED_BLOCKING_DETAIL_KEYS` enumerating the real-red buckets.
- New helper `_needs_human_ok_threshold()` (env-overridable via `LOOP_WATCH_NEEDS_HUMAN_OK_THRESHOLD`, default `3`).
- New helpers `_writer_queue_red_only_for_needs_human()` and `_writer_workflow_is_productive()`.
- New downgrade block in `build_status()` mirroring the existing stale-schedule downgrade pattern. Sets `details["productive_loop_downgrade"]` + `details["needs_human_ok_threshold"]` for audit visibility.

## Tests (5 new, 42 total passing)

- `test_build_status_downgrades_writer_queue_when_loop_is_productive` — locks in the live 2026-05-19 false-red scenario.
- `test_build_status_keeps_writer_queue_red_when_needs_human_exceeds_threshold` — 4 escalations stays red.
- `test_build_status_keeps_writer_queue_red_when_processor_is_not_productive` — dead processor stays red.
- `test_build_status_keeps_writer_queue_red_when_old_pending_also_present` — real backlog stays red.
- `test_build_status_threshold_is_env_overridable` — env override works.

## Live verification

Run against `Jonnyton/Workflow` shows the fix correctly stays **red** on current state because there are now 14 `old_pending` issues and 5 `needs_human` (above threshold) — both real signals. The fix only downgrades when the signal is *purely* by-design escalation.

## Coordinated arc

Part 1 of 3. Slice B (retry-exhaustion + tier-fairness in `auto-fix-bug.yml` discover step — fixes #918-style head-of-line blocking starving #922 et al.) and Slice C (daily host-consent PR for the loop's abandonment decisions) ship separately.

## Test plan

- [x] `python -m pytest tests/test_community_loop_watch.py -q` (42 passed)
- [x] `python -m ruff check scripts/community_loop_watch.py tests/test_community_loop_watch.py` (clean)
- [x] Pre-commit invariants (mirror parity / mojibake / cross-provider drift / skills-valid)
- [x] Live `python scripts/community_loop_watch.py --repo Jonnyton/Workflow` — fix does not suppress current legitimate red (old_pending + over-threshold needs_human)

🤖 Generated with [Claude Code](https://claude.com/claude-code)