### PR TITLE
fix(loop): retry-exhaustion + tier-fairness in auto-fix-bug discover (Slice B)

### DIFF
--- a/.github/workflows/auto-fix-bug.yml
+++ b/.github/workflows/auto-fix-bug.yml
@@ -98,7 +98,16 @@ jobs:
               'priority:primitive-layer',
               'priority:primitive-surface',
             ];
-            const skipLabels = ['await-primitive-layer', 'complete'];
+            const skipLabels = ['await-primitive-layer', 'complete', 'auto-fix-exhausted'];
+            const MAX_RETRIES = Number(process.env.LOOP_MAX_RETRIES || '5');
+
+            function retryCountForIssue(issue) {
+              const match = (issue.labels || [])
+                .map((label) => (typeof label === 'string' ? label : label.name || ''))
+                .map((name) => /^auto-fix-retries-(\d+)$/.exec(name))
+                .find(Boolean);
+              return match ? Number(match[1]) : 0;
+            }
             const hasWriterAuth = process.env.HAS_WRITER_AUTH === 'true';
             const hasWorkflowPushToken = process.env.HAS_WORKFLOW_PUSH_TOKEN === 'true';
             const autoFixDisabled = process.env.AUTO_FIX_DISABLED === 'true';
@@ -310,6 +319,18 @@ jobs:
                     direction: 'asc',
                     per_page: 100,
                   });
+                  // Tier fairness: deprioritize needs-human issues that have been retried many
+                  // times so a perpetually-retrying-but-failing issue can't starve fresh
+                  // candidates in the same tier (#918→#922 head-of-line blocking pattern).
+                  // Within retried set, sort by ascending retry count, then ascending issue#.
+                  issues.sort((a, b) => {
+                    const aRetries = retryCountForIssue(a);
+                    const bRetries = retryCountForIssue(b);
+                    if (aRetries !== bRetries) {
+                      return aRetries - bRetries;
+                    }
+                    return (a.number || 0) - (b.number || 0);
+                  });
                   core.info(`Scanning ${issues.length} open issue(s) for labels ${labelNames.join(',')}.`);
                   for (const issue of issues) {
                     if (
@@ -468,6 +489,11 @@ jobs:
                 name: 'auto-fix-blocked',
                 color: 'd93f0b',
                 description: 'Automated writer inspected the request but found no safe autonomous patch.',
+              },
+              {
+                name: 'auto-fix-exhausted',
+                color: '5319e7',
+                description: 'Automated writer exhausted its retry budget; the loop will not retry without explicit host re-open.',
               },
               {
                 name: 'auto-fix-pr-blocked',
@@ -1698,7 +1724,38 @@ jobs:
                   : codexNoChangeReason
                     ? `no-change-${codexNoChangeReason}`
                     : 'no-pr-artifact-created';
-            const labels = ['needs-human'];
+            // Retry-exhaustion: read the current retry counter from labels (label series
+            // `auto-fix-retries-N`), then either bump it or escalate to terminal
+            // `auto-fix-exhausted` if MAX_RETRIES is exceeded. Exhausted issues drop out of
+            // the discover step's active scan (see skipLabels) so a perpetually-failing
+            // request can't starve its tier. Host can re-open by clearing the exhausted
+            // label or via the loop-consent PR reopen path (Slice C).
+            const MAX_RETRIES = Number(process.env.LOOP_MAX_RETRIES || '5');
+            const { data: currentIssue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            });
+            const retryRe = /^auto-fix-retries-(\d+)$/;
+            const currentLabelNames = (currentIssue.labels || []).map((label) =>
+              typeof label === 'string' ? label : label.name || ''
+            );
+            let currentRetries = 0;
+            for (const name of currentLabelNames) {
+              const m = retryRe.exec(name);
+              if (m) {
+                currentRetries = Math.max(currentRetries, Number(m[1]));
+              }
+            }
+            const nextRetries = currentRetries + 1;
+            const exhausted = nextRetries > MAX_RETRIES;
+
+            const labels = [];
+            if (exhausted) {
+              labels.push('auto-fix-exhausted');
+            } else {
+              labels.push('needs-human', `auto-fix-retries-${nextRetries}`);
+            }
             if (codexNoChangeReason || codexPrBlocked || codexPushBlocked || (writerFailed && !codexAuthExpired)) {
               labels.push('auto-fix-reviewed');
             }
@@ -1726,18 +1783,55 @@ jobs:
               labels.push('auto-fix-codex-subscription-missing');
             }
 
+            // Remove the prior retry label (if any) so only one auto-fix-retries-N sticks.
+            if (currentRetries > 0) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: `auto-fix-retries-${currentRetries}`,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+            // On exhaustion, drop needs-human so the discover step doesn't re-pick.
+            if (exhausted && currentLabelNames.includes('needs-human')) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: 'needs-human',
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
               labels,
             });
+            const headlineRetry = exhausted
+              ? `**Auto-fix exhausted** - retry budget burned after ${currentRetries} attempt(s); MAX_RETRIES=${MAX_RETRIES}.`
+              : '**Auto-fix needs human review** - approved writer auth was present, but no automated PR was opened.';
+            const retryLine = exhausted
+              ? `- Retry budget: \`exhausted\` (${currentRetries}/${MAX_RETRIES} attempts; loop will not retry)`
+              : `- Retry counter: \`${nextRetries}/${MAX_RETRIES}\` (loop will retry when root cause clears)`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
               body: [
-                '**Auto-fix needs human review** - approved writer auth was present, but no automated PR was opened.',
+                headlineRetry,
                 '',
                 '## Request artifact reconciliation',
                 '',
@@ -1747,6 +1841,7 @@ jobs:
                 '- PR artifact: `not created`',
                 `- Child invocation receipt: ${runUrl}`,
                 `- Terminal outcome: \`${terminalOutcome}\``,
+                retryLine,
                 '',
                 `Detected auth mode: \`${{ steps.auth.outputs.mode }}\``,
                 `Claude OAuth present: \`${{ steps.auth.outputs.has_claude_oauth }}\``,
@@ -1796,7 +1891,13 @@ jobs:
                   ? 'No approved subscription-backed daemon lane was visible to GitHub Actions.'
                   : '',
                 'API-key billing lanes are intentionally not used for default daemon writers.',
-                'The issue is marked `needs-human` so it does not loop silently.',
+                exhausted
+                  ? 'The issue is marked `auto-fix-exhausted` and removed from the active scan. Host can re-open by removing the `auto-fix-exhausted` label, or via the loop-consent PR reopen path.'
+                  : 'The issue is marked `needs-human` so it does not loop silently.',
               ].filter(Boolean).join('\n'),
             });
-            core.warning('approved writer auth was present, but no auto-fix PR was opened');
+            core.warning(
+              exhausted
+                ? `auto-fix exhausted after ${currentRetries} retries; marked auto-fix-exhausted`
+                : 'approved writer auth was present, but no auto-fix PR was opened'
+            );

--- a/scripts/community_loop_watch.py
+++ b/scripts/community_loop_watch.py
@@ -73,6 +73,7 @@ ALREADY_FIXED_LABEL = "auto-fix-already-fixed"
 BLOCKED_REVIEWED_LABEL = "auto-fix-blocked"
 PR_BLOCKED_LABEL = "auto-fix-pr-blocked"
 BRANCH_PUSH_BLOCKED_LABEL = "auto-fix-branch-push-blocked"
+EXHAUSTED_LABEL = "auto-fix-exhausted"
 TERMINAL_REVIEW_LABELS = frozenset(
     {
         REVIEWED_LABEL,
@@ -80,6 +81,7 @@ TERMINAL_REVIEW_LABELS = frozenset(
         BLOCKED_REVIEWED_LABEL,
         PR_BLOCKED_LABEL,
         BRANCH_PUSH_BLOCKED_LABEL,
+        EXHAUSTED_LABEL,
     }
 )
 

--- a/tests/test_auto_fix_workflow.py
+++ b/tests/test_auto_fix_workflow.py
@@ -1035,3 +1035,116 @@ def test_expired_codex_auth_stays_human_visible_not_reviewed_terminal(wf):
     assert "writerFailed && !codexAuthExpired" in script
     assert "auto-fix-auth-expired" in script
     assert "Remaining blocker: refresh `WORKFLOW_CODEX_AUTH_JSON_B64`" in script
+
+
+# ---------------------------------------------------------------------------
+# Slice B: retry-exhaustion + tier-fairness
+# ---------------------------------------------------------------------------
+
+
+def test_discover_treats_exhausted_label_as_terminal_skip(wf):
+    """Issues labeled auto-fix-exhausted must be skipped by the discover scan."""
+    discover_step = wf["jobs"]["discover"]["steps"][0]
+    script = str(discover_step.get("with", {}).get("script", ""))
+    assert "'auto-fix-exhausted'" in script
+    # The skipLabels constant must include the exhausted label so shouldSkipIssue rejects it.
+    assert (
+        "const skipLabels = ['await-primitive-layer', 'complete', 'auto-fix-exhausted']" in script
+    ), "auto-fix-exhausted must be in skipLabels so exhausted issues drop from active scan"
+
+
+def test_discover_sorts_needs_human_retries_to_back_for_tier_fairness(wf):
+    """Within a label tier, needs-human retries should sort by ascending retry count so they
+    don't starve fresh candidates (the #918→#922 head-of-line blocking pattern)."""
+    discover_step = wf["jobs"]["discover"]["steps"][0]
+    script = str(discover_step.get("with", {}).get("script", ""))
+    assert "function retryCountForIssue(issue)" in script
+    assert "auto-fix-retries-(\\d+)" in script or "auto-fix-retries-" in script
+    assert "issues.sort(" in script
+    assert "retryCountForIssue(a)" in script
+    assert "retryCountForIssue(b)" in script
+    # Tier fairness comment must explain the rationale.
+    lower = script.lower()
+    assert "head-of-line" in lower or "starv" in lower or "fairness" in lower
+
+
+def test_no_pr_step_reads_current_retry_count_and_computes_next(wf):
+    """The needs-human terminal step must compute the next retry count and decide whether to
+    exhaust based on MAX_RETRIES."""
+    steps = wf["jobs"]["fix"]["steps"]
+    no_pr_step = next(
+        (s for s in steps if s.get("name") == "Mark needs-human if no PR opened"),
+        None,
+    )
+    assert no_pr_step is not None
+    script = str(no_pr_step.get("with", {}).get("script", ""))
+    assert "MAX_RETRIES" in script
+    assert "process.env.LOOP_MAX_RETRIES" in script
+    assert "github.rest.issues.get" in script  # must refetch to read current labels
+    assert "auto-fix-retries-" in script
+    assert "nextRetries = currentRetries + 1" in script
+    assert "exhausted = nextRetries > MAX_RETRIES" in script
+
+
+def test_no_pr_step_applies_exhausted_label_when_budget_burned(wf):
+    """At MAX_RETRIES, the step must label auto-fix-exhausted and drop needs-human so the
+    discover scan stops re-picking the issue."""
+    steps = wf["jobs"]["fix"]["steps"]
+    no_pr_step = next(
+        (s for s in steps if s.get("name") == "Mark needs-human if no PR opened"),
+        None,
+    )
+    assert no_pr_step is not None
+    script = str(no_pr_step.get("with", {}).get("script", ""))
+    # exhausted branch applies auto-fix-exhausted instead of needs-human
+    assert "labels.push('auto-fix-exhausted')" in script
+    assert "labels.push('needs-human', `auto-fix-retries-${nextRetries}`)" in script
+    # needs-human must be removed on exhaustion so retry-condition can't fire on next scan
+    assert "removeLabel" in script
+    assert "name: 'needs-human'" in script
+
+
+def test_no_pr_step_removes_prior_retry_label_to_keep_series_unique(wf):
+    """Only one auto-fix-retries-N label should be live at a time — bumping requires removing
+    the prior label before adding the new one. Otherwise the regex max() would pick the wrong
+    value over time and counters would drift."""
+    steps = wf["jobs"]["fix"]["steps"]
+    no_pr_step = next(
+        (s for s in steps if s.get("name") == "Mark needs-human if no PR opened"),
+        None,
+    )
+    assert no_pr_step is not None
+    script = str(no_pr_step.get("with", {}).get("script", ""))
+    assert "name: `auto-fix-retries-${currentRetries}`" in script
+    # 404 (label not present) must be tolerated, not thrown.
+    assert "error.status !== 404" in script
+
+
+def test_no_pr_step_comment_records_retry_count_and_exhaustion_status(wf):
+    """The comment posted on each retry/exhaustion event must surface the retry counter so
+    host can see it without inspecting labels."""
+    steps = wf["jobs"]["fix"]["steps"]
+    no_pr_step = next(
+        (s for s in steps if s.get("name") == "Mark needs-human if no PR opened"),
+        None,
+    )
+    assert no_pr_step is not None
+    script = str(no_pr_step.get("with", {}).get("script", ""))
+    assert "Auto-fix exhausted" in script
+    assert "Retry budget" in script or "Retry counter" in script
+    assert "loop will retry when root cause clears" in script
+    assert "loop-consent PR" in script or "host can re-open" in script.lower()
+
+
+def test_ensure_labels_step_defines_auto_fix_exhausted(wf):
+    """The label management step must pre-declare auto-fix-exhausted with a stable color and
+    description so GH Actions doesn't have to invent one on first apply."""
+    steps = wf["jobs"]["fix"]["steps"]
+    ensure_step = next(
+        (s for s in steps if s.get("name") == "Ensure automation labels"),
+        None,
+    )
+    assert ensure_step is not None
+    script = str(ensure_step.get("with", {}).get("script", ""))
+    assert "name: 'auto-fix-exhausted'" in script
+    assert "exhausted its retry budget" in script

--- a/tests/test_community_loop_watch.py
+++ b/tests/test_community_loop_watch.py
@@ -8,6 +8,14 @@ from pathlib import Path
 from scripts import community_loop_watch as watch
 
 
+def test_exhausted_label_is_terminal_review():
+    """auto-fix-exhausted (applied by retry-budget exhaustion in auto-fix-bug.yml) must be
+    recognized by the watcher as a terminal review state so exhausted issues drop out of the
+    Writer queue's active accounting."""
+    assert watch.EXHAUSTED_LABEL == "auto-fix-exhausted"
+    assert watch.EXHAUSTED_LABEL in watch.TERMINAL_REVIEW_LABELS
+
+
 def test_github_token_prefers_explicit_argument(monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "env-token")
 


### PR DESCRIPTION
## Summary

Closes a queue-discipline gap surfaced while planning the Slice A watcher fix: a perpetually-failing `needs-human` issue could starve its priority tier because the discover step picked first-eligible and needs-human issues with "writer auth is now visible" retry-conditions floated to the top of every scan.

Live demonstration: today's #918 retried every cycle for hours, blocking #922 and 11 other primitive-layer candidates from getting their turn.

## What changed

### `.github/workflows/auto-fix-bug.yml`

**1. Retry counter via `auto-fix-retries-N` label series**
- Bumped in the `Mark needs-human if no PR opened` step before applying needs-human.
- At `MAX_RETRIES` (default 5, env-overridable via `LOOP_MAX_RETRIES`), the step instead applies new terminal label `auto-fix-exhausted` AND removes any prior `needs-human` so the discover scan stops re-picking.
- Only one retry label is live at a time — bumping removes the prior one (404 tolerated).
- Comment posted on each retry/exhaustion event surfaces the retry budget (`N/MAX_RETRIES`) and exhaustion re-open instructions.

**2. Tier fairness sort in `scanLabelQuery`**
- Within an eligible candidate set, sort by `(retryCountForIssue, issue.number)` ascending.
- Fresh first-attempt issues come before any retry; within retries, lower retry count comes first.
- A perpetually-retrying issue drifts to the back of its own tier instead of starving fresh ones.

**3. New label `auto-fix-exhausted`**
- Pre-declared in `Ensure automation labels` step with stable color + description.
- Added to `skipLabels` in discover step so exhausted issues drop out of the active scan.

### `scripts/community_loop_watch.py`

- Added `EXHAUSTED_LABEL = "auto-fix-exhausted"` and included in `TERMINAL_REVIEW_LABELS` so the Writer queue stage treats exhausted issues as terminal-skipped (consistent with discover step's skipLabels behavior).

## Tests (8 new, 120 total passing)

`tests/test_auto_fix_workflow.py`:
- `test_discover_treats_exhausted_label_as_terminal_skip`
- `test_discover_sorts_needs_human_retries_to_back_for_tier_fairness`
- `test_no_pr_step_reads_current_retry_count_and_computes_next`
- `test_no_pr_step_applies_exhausted_label_when_budget_burned`
- `test_no_pr_step_removes_prior_retry_label_to_keep_series_unique`
- `test_no_pr_step_comment_records_retry_count_and_exhaustion_status`
- `test_ensure_labels_step_defines_auto_fix_exhausted`

`tests/test_community_loop_watch.py`:
- `test_exhausted_label_is_terminal_review`

## Coordinated arc

- **Slice A** (PR #927): watcher false-red downgrade — keeps watcher strict where it should be, downgrades to yellow only when needs-human is the loop's by-design escalation.
- **Slice B** (this PR): caps the needs-human retry budget so no single failing issue can pollute the queue forever or starve its tier.
- **Slice C** (next): daily host-consent PR batching abandonment decisions (`auto-fix-exhausted`/`auto-fix-blocked`/etc.) so host can audit + dissent at the same merge-key gesture used for code PRs.

## Test plan

- [x] `python -m pytest tests/test_auto_fix_workflow.py tests/test_community_loop_watch.py -q` (120 passed)
- [x] `python -m ruff check` (clean)
- [x] `yaml.safe_load(workflow)` parses cleanly
- [x] Pre-commit invariants (mirror parity / mojibake / cross-provider drift / skills-valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)