### PR TITLE
feat(loop): daily loop-consent PR + reopen-on-comment for host abandonment review (Slice C)

### DIFF
--- a/.github/workflows/loop-consent-digest.yml
+++ b/.github/workflows/loop-consent-digest.yml
@@ -1,0 +1,82 @@
+name: Loop consent digest
+
+# Slice C of the loop-discipline arc: surface the loop's autonomous abandonment decisions
+# (auto-fix-exhausted / auto-fix-blocked / auto-fix-pr-blocked / auto-fix-branch-push-blocked
+# / auto-fix-already-fixed) through the same merge-key gesture the host already uses for code
+# PRs. Merging this PR records host consent. Closing without merge + commenting
+# `reopen #N #M ...` on the PR re-opens those issues (see loop-consent-reopen.yml).
+
+on:
+  schedule:
+    - cron: "30 14 * * *"  # daily at 14:30 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: read
+  pull-requests: write
+
+concurrency:
+  group: loop-consent-digest
+  cancel-in-progress: false
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Configure git identity
+        run: |
+          git config user.name 'loop-consent-bot'
+          git config user.email 'noreply@anthropic.com'
+      - name: Generate digest
+        id: digest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          DATE=$(date -u +%Y-%m-%d)
+          OUT_PATH="docs/loop-decisions/${DATE}.md"
+          mkdir -p docs/loop-decisions
+          if python scripts/loop_consent_digest.py \
+              --repo "${GITHUB_REPOSITORY}" \
+              --out "${OUT_PATH}" \
+              --print-pr-body > /tmp/pr-body.md 2> /tmp/digest-stderr.log; then
+            cat /tmp/digest-stderr.log
+          else
+            echo "digest script failed"
+            cat /tmp/digest-stderr.log
+            exit 1
+          fi
+          if [[ ! -f "${OUT_PATH}" ]]; then
+            echo "no decisions to consent to; skipping PR open"
+            echo "should_open=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "should_open=true" >> "$GITHUB_OUTPUT"
+          echo "date=${DATE}" >> "$GITHUB_OUTPUT"
+          echo "out_path=${OUT_PATH}" >> "$GITHUB_OUTPUT"
+      - name: Branch + commit + open PR
+        if: steps.digest.outputs.should_open == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          DATE="${{ steps.digest.outputs.date }}"
+          OUT_PATH="${{ steps.digest.outputs.out_path }}"
+          BRANCH="loop-consent/${DATE}"
+          git switch -c "${BRANCH}"
+          git add "${OUT_PATH}"
+          git commit -m "loop-consent: abandonment decisions digest ${DATE}"
+          git push -u origin "${BRANCH}"
+          gh pr create \
+            --title "[loop-consent] Abandonment decisions — ${DATE}" \
+            --body-file /tmp/pr-body.md \
+            --label loop-consent \
+            --base main

--- a/.github/workflows/loop-consent-digest.yml
+++ b/.github/workflows/loop-consent-digest.yml
@@ -59,9 +59,11 @@ jobs:
             echo "should_open=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "should_open=true" >> "$GITHUB_OUTPUT"
-          echo "date=${DATE}" >> "$GITHUB_OUTPUT"
-          echo "out_path=${OUT_PATH}" >> "$GITHUB_OUTPUT"
+          {
+            echo "should_open=true"
+            echo "date=${DATE}"
+            echo "out_path=${OUT_PATH}"
+          } >> "$GITHUB_OUTPUT"
       - name: Branch + commit + open PR
         if: steps.digest.outputs.should_open == 'true'
         env:

--- a/.github/workflows/loop-consent-reopen.yml
+++ b/.github/workflows/loop-consent-reopen.yml
@@ -1,0 +1,139 @@
+name: Loop consent reopen
+
+# Triggered when the host comments on a loop-consent PR with `reopen #N #M ...` —
+# strips terminal-decision labels from the named issues so they re-enter the auto-fix
+# discover scan on the next cycle. Restricted to repo-owner / collaborator commenters so
+# drive-by users can't reopen abandoned issues. Pairs with loop-consent-digest.yml.
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: loop-consent-reopen-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  reopen:
+    if: ${{ github.event.issue.pull_request != null }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Parse + reopen
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const TERMINAL_LABELS = [
+              'auto-fix-exhausted',
+              'auto-fix-blocked',
+              'auto-fix-pr-blocked',
+              'auto-fix-branch-push-blocked',
+              'auto-fix-already-fixed',
+            ];
+            const RETRY_LABEL_RE = /^auto-fix-retries-\d+$/;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.issue.number;
+            // Gate 1: PR must carry the loop-consent label, otherwise this is not the right
+            // surface and we silently ignore.
+            const { data: pr } = await github.rest.issues.get({
+              owner, repo, issue_number: prNumber,
+            });
+            const prLabels = (pr.labels || []).map((l) => l.name || l);
+            if (!prLabels.includes('loop-consent')) {
+              core.info('PR does not carry loop-consent label; ignoring.');
+              return;
+            }
+            // Gate 2: commenter must be repo collaborator (host or invited reviewer).
+            const commenter = context.payload.comment.user.login;
+            let collaborator = false;
+            try {
+              await github.rest.repos.checkCollaborator({ owner, repo, username: commenter });
+              collaborator = true;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+            if (!collaborator) {
+              core.info(`Commenter ${commenter} is not a collaborator; ignoring reopen.`);
+              return;
+            }
+            // Parse `reopen #N #M ...` from the comment body. Mirror the script-side parser.
+            const body = (context.payload.comment.body || '').toLowerCase();
+            const numbers = new Set();
+            const re = /reopen\s+((?:#\d+[\s,]*)+)/g;
+            let match;
+            while ((match = re.exec(body)) !== null) {
+              const chunk = match[1];
+              for (const m of chunk.matchAll(/#(\d+)/g)) {
+                const value = Number(m[1]);
+                if (Number.isInteger(value) && value > 0) {
+                  numbers.add(value);
+                }
+              }
+            }
+            if (numbers.size === 0) {
+              core.info('No `reopen #N` directives found; nothing to do.');
+              return;
+            }
+            const summary = [];
+            for (const issueNumber of numbers) {
+              const { data: issue } = await github.rest.issues.get({
+                owner, repo, issue_number: issueNumber,
+              });
+              const currentLabels = (issue.labels || []).map((l) => l.name || l);
+              const removed = [];
+              for (const label of currentLabels) {
+                if (TERMINAL_LABELS.includes(label) || RETRY_LABEL_RE.test(label)) {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner, repo, issue_number: issueNumber, name: label,
+                    });
+                    removed.push(label);
+                  } catch (error) {
+                    if (error.status !== 404) {
+                      throw error;
+                    }
+                  }
+                }
+              }
+              if (issue.state === 'closed') {
+                await github.rest.issues.update({
+                  owner, repo, issue_number: issueNumber, state: 'open',
+                });
+              }
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issueNumber,
+                body: [
+                  `**Re-opened by host via loop-consent PR #${prNumber}** (${commenter}).`,
+                  '',
+                  removed.length
+                    ? `Cleared labels: ${removed.map((l) => `\`${l}\``).join(', ')}.`
+                    : 'No terminal labels found to clear.',
+                  '',
+                  'Issue re-enters the auto-fix discover scan on the next cycle.',
+                ].join('\n'),
+              });
+              summary.push(`#${issueNumber}: cleared ${removed.length} label(s)`);
+            }
+            // Acknowledge on the consent PR so the audit trail is visible.
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: prNumber,
+              body: [
+                `**Reopen acknowledged for ${numbers.size} issue(s)** (requested by ${commenter}):`,
+                '',
+                ...summary.map((line) => `- ${line}`),
+                '',
+                'Those issues will re-enter the auto-fix discover scan on the next cycle.',
+                'Close this PR without merging to refresh the digest with the remaining decisions.',
+              ].join('\n'),
+            });

--- a/scripts/loop_consent_digest.py
+++ b/scripts/loop_consent_digest.py
@@ -1,0 +1,471 @@
+"""Loop consent digest - batch the loop's autonomous abandonment decisions into a PR.
+
+The auto-fix loop applies several terminal labels when it decides an issue cannot be
+progressed autonomously: `auto-fix-exhausted` (retry budget burned, Slice B), `auto-fix-blocked`
+(writer rejected the design), `auto-fix-already-fixed`, `auto-fix-pr-blocked`,
+`auto-fix-branch-push-blocked`. Each is a decision the loop made without the host in the
+loop. Slice C makes those decisions auditable + reversible by surfacing them through the
+same merge-key gesture the host already uses for code PRs.
+
+This script:
+- Lists open issues currently carrying a terminal-abandonment label.
+- Filters to those whose terminal label landed *since* the most recently merged loop-consent
+  PR (or all of them, on first run).
+- Emits an append-only audit log file at `docs/loop-decisions/<UTC-date>.md`.
+- Prints a PR-body markdown summary to stdout.
+
+The caller (the GitHub Actions workflow) is responsible for committing the file, pushing the
+branch, and opening the PR. Keeping the script reasoning separate from the git plumbing
+keeps the unit-testable surface small.
+
+The output deliberately does NOT include workflow-state mutations. Reopen-on-comment is a
+separate workflow (`loop-consent-reopen.yml`) so this script can stay read-only and idempotent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+DEFAULT_REPO = "Jonnyton/Workflow"
+DEFAULT_API = "https://api.github.com"
+DEFAULT_TIMEOUT = 20.0
+CONSENT_PR_LABEL = "loop-consent"
+CONSENT_PR_BRANCH_PREFIX = "loop-consent/"
+DECISIONS_DIR = Path("docs/loop-decisions")
+
+# Labels the loop applies when it decides an issue cannot be progressed autonomously. Order
+# matters only for display grouping.
+TERMINAL_DECISION_LABELS: tuple[str, ...] = (
+    "auto-fix-exhausted",
+    "auto-fix-blocked",
+    "auto-fix-pr-blocked",
+    "auto-fix-branch-push-blocked",
+    "auto-fix-already-fixed",
+)
+
+# Human-readable summary of each terminal category for the digest.
+DECISION_LABEL_SUMMARY: dict[str, str] = {
+    "auto-fix-exhausted": "retry budget burned (Slice B)",
+    "auto-fix-blocked": "writer rejected the design as unbuildable",
+    "auto-fix-pr-blocked": "branch pushed but PR creation blocked",
+    "auto-fix-branch-push-blocked": "patch produced but branch push blocked",
+    "auto-fix-already-fixed": "request already addressed, no PR needed",
+}
+
+
+def _utc_now() -> dt.datetime:
+    return dt.datetime.now(tz=dt.timezone.utc)
+
+
+def _gh_request(
+    url: str,
+    *,
+    token: str | None,
+    timeout: float,
+    method: str = "GET",
+) -> Any:
+    req = urllib.request.Request(url, method=method)
+    req.add_header("Accept", "application/vnd.github+json")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"GitHub API error {exc.code} for {url}: {exc.reason}") from exc
+
+
+def _gh_paginate(url: str, *, token: str | None, timeout: float) -> list[dict[str, Any]]:
+    """Paginate over GitHub API responses; cap at 10 pages to bound runtime cost."""
+    results: list[dict[str, Any]] = []
+    next_url: str | None = url
+    pages = 0
+    while next_url and pages < 10:
+        req = urllib.request.Request(next_url)
+        req.add_header("Accept", "application/vnd.github+json")
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+            if isinstance(payload, list):
+                results.extend(payload)
+            else:
+                results.append(payload)
+            link = response.headers.get("Link", "")
+        next_url = _parse_next_link(link)
+        pages += 1
+    return results
+
+
+def _parse_next_link(link_header: str) -> str | None:
+    if not link_header:
+        return None
+    for piece in link_header.split(","):
+        match = re.search(r'<([^>]+)>;\s*rel="next"', piece.strip())
+        if match:
+            return match.group(1)
+    return None
+
+
+def _github_token(args: argparse.Namespace) -> str | None:
+    if getattr(args, "token", None):
+        return args.token
+    env_token = os.environ.get("GITHUB_TOKEN")
+    if env_token:
+        return env_token
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        candidate = (result.stdout or "").strip()
+        if result.returncode == 0 and candidate:
+            return candidate
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    return None
+
+
+def list_open_issues_with_any_label(
+    repo: str,
+    labels: tuple[str, ...],
+    *,
+    api: str,
+    token: str | None,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    """Open issues with at least one of the terminal-decision labels.
+
+    GitHub's `labels=a,b` parameter does AND, not OR, so we issue one paginated request per
+    label and dedupe by issue number.
+    """
+    by_number: dict[int, dict[str, Any]] = {}
+    for label in labels:
+        params = urllib.parse.urlencode(
+            {"state": "open", "labels": label, "per_page": 100}
+        )
+        url = f"{api}/repos/{repo}/issues?{params}"
+        for issue in _gh_paginate(url, token=token, timeout=timeout):
+            # filter out pull requests masquerading as issues in the same endpoint
+            if isinstance(issue, dict) and "pull_request" not in issue:
+                number = issue.get("number")
+                if isinstance(number, int):
+                    by_number[number] = issue
+    return sorted(by_number.values(), key=lambda issue: issue.get("number", 0))
+
+
+def find_last_merged_consent_pr(
+    repo: str,
+    *,
+    api: str,
+    token: str | None,
+    timeout: float,
+) -> dict[str, Any] | None:
+    """Most recently merged PR carrying the loop-consent label, for the digest cutoff."""
+    params = urllib.parse.urlencode(
+        {
+            "state": "closed",
+            "labels": CONSENT_PR_LABEL,
+            "per_page": 30,
+            "sort": "updated",
+            "direction": "desc",
+        }
+    )
+    url = f"{api}/repos/{repo}/issues?{params}"
+    candidates = _gh_paginate(url, token=token, timeout=timeout)
+    for candidate in candidates:
+        # only PRs (issue endpoint returns both)
+        if "pull_request" not in candidate:
+            continue
+        # Was it merged (not just closed)? Need to fetch the PR object.
+        pr_number = candidate.get("number")
+        if not isinstance(pr_number, int):
+            continue
+        pr = _gh_request(
+            f"{api}/repos/{repo}/pulls/{pr_number}",
+            token=token,
+            timeout=timeout,
+        )
+        if pr.get("merged_at"):
+            return pr
+    return None
+
+
+def find_open_consent_pr(
+    repo: str,
+    *,
+    api: str,
+    token: str | None,
+    timeout: float,
+) -> dict[str, Any] | None:
+    """Any currently-open loop-consent PR. If one exists, the workflow should skip filing a
+    new one and instead update the existing diff (handled by the workflow caller)."""
+    params = urllib.parse.urlencode(
+        {"state": "open", "labels": CONSENT_PR_LABEL, "per_page": 5}
+    )
+    url = f"{api}/repos/{repo}/issues?{params}"
+    for candidate in _gh_paginate(url, token=token, timeout=timeout):
+        if "pull_request" in candidate:
+            return candidate
+    return None
+
+
+def _classify_decision(labels: set[str]) -> str:
+    """First-match-wins; auto-fix-exhausted is most specific so it wins over generic blocked."""
+    for label in TERMINAL_DECISION_LABELS:
+        if label in labels:
+            return label
+    return "unknown"
+
+
+def _issue_labels(issue: dict[str, Any]) -> set[str]:
+    raw = issue.get("labels") or []
+    out: set[str] = set()
+    for item in raw:
+        name = item.get("name") if isinstance(item, dict) else str(item)
+        if name:
+            out.add(name)
+    return out
+
+
+def _retry_count_from_labels(labels: set[str]) -> int:
+    retry_re = re.compile(r"^auto-fix-retries-(\d+)$")
+    counts = [int(match.group(1)) for label in labels if (match := retry_re.match(label))]
+    return max(counts) if counts else 0
+
+
+def build_digest(
+    repo: str,
+    *,
+    api: str,
+    token: str | None,
+    timeout: float,
+    cutoff: dt.datetime | None,
+    now: dt.datetime,
+) -> dict[str, Any]:
+    """Build a digest payload describing all loop decisions since cutoff.
+
+    Returns a dict with keys:
+      - `decisions`: list of per-issue dicts
+      - `summary_counts`: count per terminal label
+      - `cutoff`: ISO string or None
+      - `generated_at`: ISO string
+      - `should_open_pr`: True if there are any decisions to surface
+    """
+    issues = list_open_issues_with_any_label(
+        repo,
+        TERMINAL_DECISION_LABELS,
+        api=api,
+        token=token,
+        timeout=timeout,
+    )
+    decisions: list[dict[str, Any]] = []
+    summary_counts: dict[str, int] = {label: 0 for label in TERMINAL_DECISION_LABELS}
+    for issue in issues:
+        labels = _issue_labels(issue)
+        decision = _classify_decision(labels)
+        if decision == "unknown":
+            continue
+        updated_at = issue.get("updated_at")
+        # Cutoff filter: skip issues whose terminal label landed *before* the last consent PR
+        # merged. updated_at is a coarse proxy — refining it would require iterating events.
+        if cutoff is not None and updated_at:
+            try:
+                updated_dt = dt.datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+                if updated_dt < cutoff:
+                    continue
+            except ValueError:
+                pass
+        summary_counts[decision] += 1
+        decisions.append(
+            {
+                "number": issue.get("number"),
+                "title": issue.get("title", ""),
+                "url": issue.get("html_url", ""),
+                "decision": decision,
+                "labels": sorted(labels),
+                "updated_at": updated_at,
+                "retry_count": _retry_count_from_labels(labels),
+            }
+        )
+    return {
+        "decisions": decisions,
+        "summary_counts": summary_counts,
+        "cutoff": cutoff.isoformat().replace("+00:00", "Z") if cutoff else None,
+        "generated_at": now.isoformat().replace("+00:00", "Z"),
+        "should_open_pr": bool(decisions),
+    }
+
+
+def render_audit_log(digest: dict[str, Any]) -> str:
+    """Render the digest as the markdown that will land at docs/loop-decisions/<date>.md."""
+    lines: list[str] = []
+    date_label = digest["generated_at"][:10]
+    lines.append(f"# Loop decisions consent — {date_label}")
+    lines.append("")
+    lines.append(f"Generated: {digest['generated_at']}")
+    if digest.get("cutoff"):
+        lines.append(f"Decisions since: {digest['cutoff']}")
+    else:
+        lines.append(
+            "Decisions since: (no prior consent PR; covering all currently-terminal issues)"
+        )
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    for label in TERMINAL_DECISION_LABELS:
+        count = digest["summary_counts"].get(label, 0)
+        descriptor = DECISION_LABEL_SUMMARY.get(label, label)
+        lines.append(f"- {count} {label} ({descriptor})")
+    lines.append("")
+    if not digest["decisions"]:
+        lines.append("No decisions to record.")
+        return "\n".join(lines) + "\n"
+    lines.append("## Decisions")
+    lines.append("")
+    for decision in digest["decisions"]:
+        lines.append(f"### #{decision['number']} — {decision['decision']}")
+        lines.append("")
+        lines.append(f"**Title:** {decision['title']}")
+        lines.append(f"**URL:** {decision['url']}")
+        lines.append(f"**Last touch:** {decision.get('updated_at') or 'unknown'}")
+        if decision.get("retry_count"):
+            lines.append(f"**Retry count:** {decision['retry_count']}")
+        lines.append(f"**Labels:** {', '.join(decision['labels'])}")
+        lines.append("")
+        lines.append(
+            "To dissent: comment `reopen #" + str(decision["number"])
+            + "` on the consent PR before merging."
+        )
+        lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        "Merging this PR records host consent for all decisions above. To dissent on "
+        "specific items, comment `reopen #N1 #N2 ...` on this PR and close-without-merge; "
+        "the next digest will include unreopened decisions."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def parse_reopen_numbers(comment_body: str) -> list[int]:
+    """Extract `reopen #N #M ...` numbers from a host comment on the consent PR.
+
+    Used by the reopen-on-comment workflow to strip terminal labels from the named issues.
+    Accepts `reopen #123`, `reopen #123, #456`, `reopen #123 #456`. Whitespace and commas
+    tolerated. Case-insensitive. Other text in the comment is ignored.
+    """
+    lower = comment_body.lower()
+    out: list[int] = []
+    for match in re.finditer(r"reopen\s+((?:#\d+[\s,]*)+)", lower):
+        chunk = match.group(1)
+        for number_match in re.finditer(r"#(\d+)", chunk):
+            try:
+                value = int(number_match.group(1))
+            except ValueError:
+                continue
+            if value > 0 and value not in out:
+                out.append(value)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--api", default=DEFAULT_API)
+    parser.add_argument("--token", default=None)
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Path to write the audit log file (default: docs/loop-decisions/<date>.md).",
+    )
+    parser.add_argument(
+        "--print-pr-body",
+        action="store_true",
+        help="Print a PR-body markdown summary to stdout after writing the audit log.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the audit log to stdout instead of writing.",
+    )
+    args = parser.parse_args(argv)
+
+    token = _github_token(args)
+    now = _utc_now()
+
+    open_consent_pr = find_open_consent_pr(
+        args.repo, api=args.api, token=token, timeout=args.timeout
+    )
+    if open_consent_pr is not None:
+        sys.stderr.write(
+            f"open consent PR already exists: #{open_consent_pr.get('number')} — "
+            "skipping new digest\n"
+        )
+        return 0
+
+    last_merged = find_last_merged_consent_pr(
+        args.repo, api=args.api, token=token, timeout=args.timeout
+    )
+    cutoff: dt.datetime | None = None
+    if last_merged and last_merged.get("merged_at"):
+        try:
+            cutoff = dt.datetime.fromisoformat(
+                last_merged["merged_at"].replace("Z", "+00:00")
+            )
+        except ValueError:
+            cutoff = None
+
+    digest = build_digest(
+        args.repo,
+        api=args.api,
+        token=token,
+        timeout=args.timeout,
+        cutoff=cutoff,
+        now=now,
+    )
+
+    if not digest["should_open_pr"]:
+        sys.stderr.write("no new loop decisions since cutoff; nothing to consent to\n")
+        return 0
+
+    audit_log = render_audit_log(digest)
+
+    if args.dry_run:
+        sys.stdout.write(audit_log)
+        return 0
+
+    out_path = Path(args.out) if args.out else (
+        REPO_ROOT / DECISIONS_DIR / f"{now.date().isoformat()}.md"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(audit_log, encoding="utf-8")
+    sys.stderr.write(f"wrote audit log: {out_path}\n")
+
+    if args.print_pr_body:
+        sys.stdout.write(audit_log)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_loop_consent_digest.py
+++ b/tests/test_loop_consent_digest.py
@@ -1,0 +1,308 @@
+"""Tests for scripts/loop_consent_digest.py.
+
+Unit-scope: pure-function helpers (parse_reopen_numbers, render_audit_log, build_digest with
+mocked HTTP) plus a YAML structural test on the consent-digest + reopen workflows.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts import loop_consent_digest as digest_mod
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DIGEST_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "loop-consent-digest.yml"
+REOPEN_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "loop-consent-reopen.yml"
+
+
+# ---------------------------------------------------------------------------
+# parse_reopen_numbers
+# ---------------------------------------------------------------------------
+
+
+def test_parse_reopen_numbers_single():
+    assert digest_mod.parse_reopen_numbers("reopen #918") == [918]
+
+
+def test_parse_reopen_numbers_multiple_space_separated():
+    assert digest_mod.parse_reopen_numbers("reopen #918 #922 #877") == [918, 922, 877]
+
+
+def test_parse_reopen_numbers_multiple_comma_separated():
+    assert digest_mod.parse_reopen_numbers("reopen #918, #922, #877") == [918, 922, 877]
+
+
+def test_parse_reopen_numbers_case_insensitive():
+    assert digest_mod.parse_reopen_numbers("REOPEN #918") == [918]
+    assert digest_mod.parse_reopen_numbers("Reopen #918") == [918]
+
+
+def test_parse_reopen_numbers_ignores_surrounding_text():
+    body = (
+        "Looks good overall but reopen #918, #922 — I want to redesign those before they "
+        "die."
+    )
+    assert digest_mod.parse_reopen_numbers(body) == [918, 922]
+
+
+def test_parse_reopen_numbers_dedupes_and_preserves_order():
+    assert digest_mod.parse_reopen_numbers("reopen #918 #918 #922") == [918, 922]
+
+
+def test_parse_reopen_numbers_returns_empty_for_unrelated_comment():
+    assert digest_mod.parse_reopen_numbers("LGTM") == []
+    assert digest_mod.parse_reopen_numbers("#918 is interesting") == []
+
+
+def test_parse_reopen_numbers_handles_multiline_directives():
+    body = "reopen #918\n\nAlso reopen #922 #923 because shared root cause."
+    assert digest_mod.parse_reopen_numbers(body) == [918, 922, 923]
+
+
+# ---------------------------------------------------------------------------
+# render_audit_log
+# ---------------------------------------------------------------------------
+
+
+def _sample_digest_with_decisions() -> dict:
+    return {
+        "decisions": [
+            {
+                "number": 918,
+                "title": "External long-run checkpoint/resume provenance primitive",
+                "url": "https://github.com/Jonnyton/Workflow/issues/918",
+                "decision": "auto-fix-exhausted",
+                "labels": [
+                    "auto-fix-exhausted",
+                    "auto-fix-retries-5",
+                    "auto-fix-writer-failed",
+                    "daemon-request",
+                ],
+                "updated_at": "2026-05-20T01:30:00Z",
+                "retry_count": 5,
+            },
+            {
+                "number": 877,
+                "title": "Open-brain v2 slice B — soul-guided dispatch",
+                "url": "https://github.com/Jonnyton/Workflow/issues/877",
+                "decision": "auto-fix-already-fixed",
+                "labels": ["auto-fix-already-fixed", "daemon-request"],
+                "updated_at": "2026-05-19T05:26:00Z",
+                "retry_count": 0,
+            },
+        ],
+        "summary_counts": {
+            "auto-fix-exhausted": 1,
+            "auto-fix-blocked": 0,
+            "auto-fix-pr-blocked": 0,
+            "auto-fix-branch-push-blocked": 0,
+            "auto-fix-already-fixed": 1,
+        },
+        "cutoff": "2026-05-19T08:15:00Z",
+        "generated_at": "2026-05-20T14:30:00Z",
+        "should_open_pr": True,
+    }
+
+
+def test_render_audit_log_includes_summary_counts_and_per_issue_sections():
+    rendered = digest_mod.render_audit_log(_sample_digest_with_decisions())
+    assert "# Loop decisions consent — 2026-05-20" in rendered
+    assert "Generated: 2026-05-20T14:30:00Z" in rendered
+    assert "Decisions since: 2026-05-19T08:15:00Z" in rendered
+    assert "1 auto-fix-exhausted" in rendered
+    assert "1 auto-fix-already-fixed" in rendered
+    assert "### #918 — auto-fix-exhausted" in rendered
+    assert "### #877 — auto-fix-already-fixed" in rendered
+    assert "**Retry count:** 5" in rendered
+    # zero-retry decisions should not surface a stray Retry count line
+    section_877 = rendered.split("### #877")[1]
+    assert "**Retry count:**" not in section_877
+    assert "reopen #918" in rendered
+    assert "reopen #877" in rendered
+    assert "Merging this PR records host consent" in rendered
+
+
+def test_render_audit_log_handles_empty_decision_set():
+    digest = {
+        "decisions": [],
+        "summary_counts": {label: 0 for label in digest_mod.TERMINAL_DECISION_LABELS},
+        "cutoff": None,
+        "generated_at": "2026-05-20T14:30:00Z",
+        "should_open_pr": False,
+    }
+    rendered = digest_mod.render_audit_log(digest)
+    assert "No decisions to record." in rendered
+    assert "(no prior consent PR" in rendered
+
+
+# ---------------------------------------------------------------------------
+# _classify_decision
+# ---------------------------------------------------------------------------
+
+
+def test_classify_decision_prefers_exhausted_over_blocked():
+    """auto-fix-exhausted is the more specific decision and should win when both labels are
+    co-present (which can happen if retry-exhaustion landed on a previously-blocked issue)."""
+    labels = {"auto-fix-exhausted", "auto-fix-blocked"}
+    assert digest_mod._classify_decision(labels) == "auto-fix-exhausted"
+
+
+def test_classify_decision_falls_back_to_unknown_when_no_terminal_label():
+    assert digest_mod._classify_decision({"daemon-request", "needs-human"}) == "unknown"
+
+
+def test_classify_decision_recognizes_each_terminal_label():
+    for label in digest_mod.TERMINAL_DECISION_LABELS:
+        assert digest_mod._classify_decision({label}) == label
+
+
+# ---------------------------------------------------------------------------
+# build_digest with mocked HTTP
+# ---------------------------------------------------------------------------
+
+
+def test_build_digest_filters_decisions_before_cutoff(monkeypatch):
+    def fake_list_open_issues(repo, labels, *, api, token, timeout):
+        return [
+            {
+                "number": 918,
+                "title": "Recent decision",
+                "html_url": "https://example.test/918",
+                "labels": [{"name": "auto-fix-exhausted"}, {"name": "auto-fix-retries-5"}],
+                "updated_at": "2026-05-20T01:30:00Z",
+            },
+            {
+                "number": 100,
+                "title": "Old decision pre-cutoff",
+                "html_url": "https://example.test/100",
+                "labels": [{"name": "auto-fix-blocked"}],
+                "updated_at": "2026-05-15T01:30:00Z",
+            },
+        ]
+
+    monkeypatch.setattr(digest_mod, "list_open_issues_with_any_label", fake_list_open_issues)
+    cutoff = dt.datetime(2026, 5, 19, 8, 15, tzinfo=dt.timezone.utc)
+    now = dt.datetime(2026, 5, 20, 14, 30, tzinfo=dt.timezone.utc)
+    digest = digest_mod.build_digest(
+        "owner/repo", api="https://api.test", token=None, timeout=1, cutoff=cutoff, now=now
+    )
+    numbers = [d["number"] for d in digest["decisions"]]
+    assert 918 in numbers
+    assert 100 not in numbers
+    assert digest["should_open_pr"] is True
+
+
+def test_build_digest_returns_no_open_pr_when_no_terminal_issues(monkeypatch):
+    monkeypatch.setattr(
+        digest_mod,
+        "list_open_issues_with_any_label",
+        lambda *_args, **_kwargs: [],
+    )
+    digest = digest_mod.build_digest(
+        "owner/repo",
+        api="https://api.test",
+        token=None,
+        timeout=1,
+        cutoff=None,
+        now=dt.datetime(2026, 5, 20, 14, 30, tzinfo=dt.timezone.utc),
+    )
+    assert digest["should_open_pr"] is False
+    assert digest["decisions"] == []
+
+
+def test_build_digest_records_retry_count_from_labels(monkeypatch):
+    def fake_list_open_issues(repo, labels, *, api, token, timeout):
+        return [
+            {
+                "number": 918,
+                "title": "Exhausted after several retries",
+                "html_url": "https://example.test/918",
+                "labels": [
+                    {"name": "auto-fix-exhausted"},
+                    {"name": "auto-fix-retries-5"},
+                ],
+                "updated_at": "2026-05-20T01:30:00Z",
+            }
+        ]
+
+    monkeypatch.setattr(digest_mod, "list_open_issues_with_any_label", fake_list_open_issues)
+    digest = digest_mod.build_digest(
+        "owner/repo",
+        api="https://api.test",
+        token=None,
+        timeout=1,
+        cutoff=None,
+        now=dt.datetime(2026, 5, 20, 14, 30, tzinfo=dt.timezone.utc),
+    )
+    assert digest["decisions"][0]["retry_count"] == 5
+
+
+# ---------------------------------------------------------------------------
+# workflow YAML structure
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def digest_workflow() -> dict:
+    return yaml.safe_load(DIGEST_WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def reopen_workflow() -> dict:
+    return yaml.safe_load(REOPEN_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_digest_workflow_runs_on_schedule_and_dispatch(digest_workflow):
+    triggers = digest_workflow.get(True, digest_workflow.get("on", {}))
+    assert "schedule" in triggers
+    assert "workflow_dispatch" in triggers
+
+
+def test_digest_workflow_invokes_the_script(digest_workflow):
+    script_steps = digest_workflow["jobs"]["digest"]["steps"]
+    run_steps = [str(s.get("run", "")) for s in script_steps if "run" in s]
+    combined = "\n".join(run_steps)
+    assert "scripts/loop_consent_digest.py" in combined
+    assert "--print-pr-body" in combined
+
+
+def test_digest_workflow_creates_consent_pr_with_label(digest_workflow):
+    steps_text = "\n".join(
+        str(s.get("run", "")) for s in digest_workflow["jobs"]["digest"]["steps"]
+    )
+    assert "gh pr create" in steps_text
+    assert "--label loop-consent" in steps_text
+
+
+def test_reopen_workflow_triggers_on_issue_comment(reopen_workflow):
+    triggers = reopen_workflow.get(True, reopen_workflow.get("on", {}))
+    assert "issue_comment" in triggers
+
+
+def test_reopen_workflow_gates_on_loop_consent_label_and_collaborator(reopen_workflow):
+    script = str(reopen_workflow["jobs"]["reopen"]["steps"][-1]["with"]["script"])
+    assert "loop-consent" in script
+    assert "checkCollaborator" in script
+    job_if = str(reopen_workflow["jobs"]["reopen"].get("if", ""))
+    assert "github.event.issue.pull_request" in job_if
+
+
+def test_reopen_workflow_clears_terminal_labels_and_retry_series(reopen_workflow):
+    script = str(reopen_workflow["jobs"]["reopen"]["steps"][-1]["with"]["script"])
+    assert "auto-fix-exhausted" in script
+    assert "auto-fix-blocked" in script
+    assert "auto-fix-pr-blocked" in script
+    assert "auto-fix-branch-push-blocked" in script
+    assert "auto-fix-already-fixed" in script
+    assert "auto-fix-retries-" in script
+    assert "removeLabel" in script
+
+
+def test_reopen_workflow_posts_audit_comment_on_consent_pr(reopen_workflow):
+    script = str(reopen_workflow["jobs"]["reopen"]["steps"][-1]["with"]["script"])
+    assert "Reopen acknowledged" in script
+    assert "createComment" in script


### PR DESCRIPTION
## Summary

Final slice of the loop-discipline arc. The auto-fix loop applies several **terminal labels** when it decides an issue cannot be progressed autonomously: `auto-fix-exhausted` (Slice B retry-budget), `auto-fix-blocked`, `auto-fix-pr-blocked`, `auto-fix-branch-push-blocked`, `auto-fix-already-fixed`. Without a surface, those decisions sit in a closed/labeled state and the host has no way to audit or reverse them.

This PR routes all loop-autonomous abandonment decisions through **the same merge-key gesture the host already uses for code PRs** — a daily "loop-consent" PR with a markdown audit log of the loop's decisions. Merge = blanket consent. Comment `reopen #N #M ...` + close-without-merge = dissent on specific items, those issues re-enter active scan.

## What changed

### `scripts/loop_consent_digest.py` (new)

- Lists open issues currently carrying a terminal-decision label since the last merged loop-consent PR (or all of them on first run).
- Classifies each by decision type (exhausted / blocked / already-fixed / pr-blocked / branch-push-blocked).
- Records retry counter from `auto-fix-retries-N` label series (composes with Slice B).
- Renders an append-only audit log to `docs/loop-decisions/<UTC-date>.md`.
- Pure-function helpers — `parse_reopen_numbers`, `render_audit_log`, `build_digest`, `_classify_decision` — fully unit-testable.

### `.github/workflows/loop-consent-digest.yml` (new)

- Daily cron at 14:30 UTC + `workflow_dispatch`.
- Runs the script, commits the audit log to a `loop-consent/<date>` branch, opens a PR labeled `loop-consent`.
- Skips if any consent PR is already open OR if there are no new decisions since the last cutoff.

### `.github/workflows/loop-consent-reopen.yml` (new)

- Triggered when the host comments `reopen #N #M ...` on any loop-consent PR.
- **Gate 1:** PR must carry the `loop-consent` label.
- **Gate 2:** Commenter must be a repo collaborator (no drive-by reopens).
- On match: strips terminal-decision labels + `auto-fix-retries-N` from the named issues so they re-enter the discover scan; reopens the GitHub issue if it was closed; posts audit comments on both sides.

## Tests (23 new, all passing)

`tests/test_loop_consent_digest.py`:
- `parse_reopen_numbers` — 7 cases covering single / multi / case-insensitive / surrounding text / dedup / unrelated / multiline.
- `render_audit_log` — summary counts, per-issue sections, retry-count surfacing, empty-decision case.
- `_classify_decision` — exhausted-over-blocked priority, unknown fallback, full label recognition.
- `build_digest` (with mocked HTTP) — cutoff filtering, empty-no-PR case, retry-count extraction.
- Workflow YAML structure — schedule/dispatch triggers, script invocation, PR-create call, label gate, collaborator gate, terminal-label clearing list, audit-comment shape.

## Composes with the rest of the arc

- **Slice A** (PR #927): watcher correctly downgrades false-reds when the loop is escalating-by-design.
- **Slice B** (PR #929): retry-budget caps + exhaustion + tier-fairness keep the queue clean.
- **Slice C** (this PR): host gets a single PR-shaped surface to consent to or reverse the loop's abandonment decisions.

Together: loop processes → escalates → exhausts → host consents (or reopens). No silent abandonment. No queue pollution. No false-red noise.

## Test plan

- [x] `python -m pytest tests/test_loop_consent_digest.py -q` (23 passed)
- [x] `python -m ruff check` (clean)
- [x] YAML parses cleanly via `yaml.safe_load`
- [x] Pre-commit invariants (mirror parity / mojibake / cross-provider drift / skills-valid)
- [ ] First live run via `workflow_dispatch` once merged (host action)
- [ ] First `reopen #N` comment round-trip on a real consent PR (host action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)