### PR TITLE
PrivateTraceCommons Slice 2: ship session_trace_summary memory_kind (closes the lane minus 2 small follow-ups)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_brain.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_brain.py
@@ -31,6 +31,7 @@ MEMORY_KIND_REGISTRY = {
     "open_loop": "Unresolved follow-up, watch item, or incomplete learning thread.",
     "contradiction": "Conflicting claims or evidence that require reconciliation.",
     "soul_proposal": "Candidate change to the daemon's identity or role contract.",
+    "session_trace_summary": "Reviewed narrative summary of one session (run/mission/cadence); references raw artifacts, not raw payloads.",
 }
 VALID_MEMORY_KINDS = frozenset(MEMORY_KIND_REGISTRY)
 DEFAULT_MEMORY_KIND = "semantic"

--- a/tests/test_daemon_brain.py
+++ b/tests/test_daemon_brain.py
@@ -193,6 +193,61 @@ def test_daemon_memory_lifecycle_blocks_invalid_transitions(tmp_path: Path) -> N
     else:
         raise AssertionError("rejected memory was promoted")
 
+def test_session_trace_summary_is_recognized_kind_with_full_lifecycle(
+    tmp_path: Path,
+) -> None:
+    """Slice 2 of PrivateTraceCommons (per docs/design-notes/2026-05-02-private-trace-commons.md).
+
+    Verifies session_trace_summary is a recognized memory_kind that moves
+    through the existing promotion state machine like any other kind:
+    candidate (capture) → accepted (review) → promoted (publish to wiki).
+
+    Slice 1 spec proposed a `host_private`-blocks-promotion enforcement;
+    Slice 2 implementation found that contradicts the existing default
+    visibility semantics (host_private is the DEFAULT for new entries, and
+    every normal promotion flow today walks through host_private →
+    promoted). Per Scoping Rules 2 + 3, visibility enforcement is
+    community-composed via gates anyway, not a platform primitive. The
+    enforcement is intentionally NOT shipped; visibility tagging
+    + community-composed gate enforcement is the path. Follow-up filing
+    will retract that part of the Slice 1 spec.
+    """
+    daemon = _create_daemon(tmp_path, "Trace Daemon")
+
+    entry = capture_daemon_memory(
+        tmp_path,
+        daemon_id=daemon["daemon_id"],
+        memory_kind="session_trace_summary",
+        content=(
+            "Run of branch X completed. 3 artifacts captured. "
+            "No sensitive content exposed."
+        ),
+        source_type="run",
+        source_id="run-abc123",
+        reliability="host_observed",
+        language_type="summary",
+        visibility="borrowable_role_context",
+    )
+    assert entry["memory_kind"] == "session_trace_summary"
+    assert entry["promotion_state"] == "candidate"
+
+    review_daemon_memory(
+        tmp_path,
+        daemon_id=daemon["daemon_id"],
+        entry_id=entry["entry_id"],
+        decision="accept",
+        note="Summary reviewed; safe to surface.",
+    )
+
+    result = promote_daemon_memory_to_wiki(
+        tmp_path,
+        daemon_id=daemon["daemon_id"],
+        entry_ids=[entry["entry_id"]],
+        summary="Session trace summary promotion sanity check.",
+    )
+    assert result["promoted_count"] == 1
+
+
 def test_daemon_memory_cost_ledger_is_read_only_status(tmp_path: Path) -> None:
     ada = _create_daemon(tmp_path, "Cost Ada")
     capture_daemon_memory(

--- a/workflow/daemon_brain.py
+++ b/workflow/daemon_brain.py
@@ -31,6 +31,7 @@ MEMORY_KIND_REGISTRY = {
     "open_loop": "Unresolved follow-up, watch item, or incomplete learning thread.",
     "contradiction": "Conflicting claims or evidence that require reconciliation.",
     "soul_proposal": "Candidate change to the daemon's identity or role contract.",
+    "session_trace_summary": "Reviewed narrative summary of one session (run/mission/cadence); references raw artifacts, not raw payloads.",
 }
 VALID_MEMORY_KINDS = frozenset(MEMORY_KIND_REGISTRY)
 DEFAULT_MEMORY_KIND = "semantic"


### PR DESCRIPTION
## Summary

Slice 2 implementation for the PrivateTraceCommons lane (Slice 1 design landed via #931). Ships the new `session_trace_summary` memory_kind into the Brain Module's existing registry.

## Diff stats

- 3 files changed, 57 insertions (~15 LOC code + ~42 LOC test)
- 6 daemon_brain tests pass (was 5; +1 from the new lifecycle test)
- Mirror parity ✓ (canonical + plugin mirror have identical content)
- All pre-commit invariants green

## What ships

1. **`MEMORY_KIND_REGISTRY` addition** in `workflow/daemon_brain.py`: new key `session_trace_summary` with one-line description.
2. **Plugin mirror parity** in `packaging/.../runtime/workflow/daemon_brain.py`: same key.
3. **`test_session_trace_summary_is_recognized_kind_with_full_lifecycle`** in `tests/test_daemon_brain.py`: exercises candidate → accepted → promoted lifecycle on the new kind.

## What this PR explicitly DROPS from the Slice 1 spec

The Slice 1 spec (#931) proposed a `host_private`-blocks-promotion enforcement rule. Implementation found this contradicts existing default visibility semantics:

- `host_private` is the **DEFAULT** visibility for new memories (per `workflow/daemon_brain.py:446`).
- Every normal promotion flow today walks through `host_private → promoted`.
- The existing smoke test `test_daemon_brain_smoke_roundtrip` already promotes a default-visibility entry.

Adding the proposed enforcement would break existing promotion behavior across all memory_kinds. Per Scoping Rules 2 + 3 (community-build over platform-build; no platform privacy taxonomy), visibility enforcement is community-composed via gates per Goal anyway, NOT a platform primitive.

**Dropped the enforcement.** Visibility is a tag, not a platform-enforced gate. Universes that want strict host_private-never-promotes wire a gate on the Goal ladder.

This finding is itself a Scoping-Rule-2 lesson worth noting: even my own ADAPT-narrowed proposal still overshipped enforcement that should be community-composed.

## Wiki composition-pattern page (separate follow-up)

The wiki page `pages/plans/composing-session-trace-summaries.md` was authored but the live MCP brain returned a 502 (Cloudflare origin error) on the write attempt. The full page content is in the commit message body of #931 + this PR's commit; will retry the wiki write after Slice 2 lands.

## Remaining lane follow-ups (small)

After this PR lands:

1. **Retry wiki page write** (`pages/plans/composing-session-trace-summaries.md`) — same content I had ready, retry when the live MCP brain is healthy. Tiny.
2. **Retract enforcement paragraph from Slice 1 spec** (`docs/specs/2026-05-02-session-trace-minimal-schema.md` § "Visibility-state interaction") — replace the enforcement rule with a community-composes-via-gates pointer to the wiki page. ~5-line doc patch.

After those two land, the PrivateTraceCommons lane is fully shipped.

## Composes with prior session work

- #904 (open-brain v2 slice A) — memory_kinds registry pattern reused verbatim
- #906 (open-brain v2 slice C) — `cost_estimate` field alignment in metadata
- #914 (external-write authority) — Goal scope manifest carries cadence overrides
- #915 (PLAN.md restructure) — Brain Module section is the authoritative reference
- #928 (4 Claude audit verdicts) — ADAPT verdict from the OpenTraces audit is the design authority
- #931 (PrivateTraceCommons Slice 1 design + spec)

## Test plan

- [ ] `python -m pytest tests/test_daemon_brain.py -x -q` (expect 6 passed)
- [ ] Verify mirror parity (`workflow/daemon_brain.py` and the plugin mirror have identical content)
- [ ] Read the new memory_kind line + the new test; confirm shape matches Slice 1 design
- [ ] Verify the dropped-enforcement reasoning makes sense given the existing host_private default
- [ ] Turn the host merge key when satisfied