### PR TITLE
fix(provider-context-feed): prune _PURPOSE.md candidates from already-merged worktrees

### DIFF
--- a/scripts/provider_context_feed.py
+++ b/scripts/provider_context_feed.py
@@ -202,6 +202,23 @@ def default_specs(root: Path) -> list[SourceSpec]:
 def _worktree_purpose_paths(root: Path) -> list[Path]:
     candidates: set[Path] = set()
 
+    porcelain = _git_worktree_porcelain(root)
+    branch_map = _parse_worktree_branches(porcelain)
+    for worktree_path in branch_map:
+        candidates.add(worktree_path / "_PURPOSE.md")
+
+    if root.parent.is_dir():
+        for pattern in ("wf-*/_PURPOSE.md", "Workflow*/_PURPOSE.md"):
+            candidates.update(root.parent.glob(pattern))
+    candidates.update((root / ".claude" / "worktrees").glob("*/_PURPOSE.md"))
+    candidates.update((root / "origin").glob("*/_PURPOSE.md"))
+
+    existing = sorted(path.resolve() for path in candidates if path.is_file())
+    return _drop_dead_lane_purposes(existing, branch_map=branch_map, root=root)
+
+
+def _git_worktree_porcelain(root: Path) -> str:
+    """Raw output of `git worktree list --porcelain` (empty string on failure)."""
     try:
         result = subprocess.run(
             ["git", "worktree", "list", "--porcelain"],
@@ -211,19 +228,119 @@ def _worktree_purpose_paths(root: Path) -> list[Path]:
             timeout=15,
         )
     except (OSError, subprocess.SubprocessError):
-        result = subprocess.CompletedProcess([], 1, "", "")
-    if result.returncode == 0:
-        for line in result.stdout.splitlines():
-            if line.startswith("worktree "):
-                candidates.add(Path(line[len("worktree ") :]) / "_PURPOSE.md")
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout
 
-    if root.parent.is_dir():
-        for pattern in ("wf-*/_PURPOSE.md", "Workflow*/_PURPOSE.md"):
-            candidates.update(root.parent.glob(pattern))
-    candidates.update((root / ".claude" / "worktrees").glob("*/_PURPOSE.md"))
-    candidates.update((root / "origin").glob("*/_PURPOSE.md"))
 
-    return sorted(path.resolve() for path in candidates if path.is_file())
+def _parse_worktree_branches(porcelain: str) -> dict[Path, str]:
+    """Parse `git worktree list --porcelain` into a {worktree_path: branch_name} dict.
+
+    The porcelain format emits one block per worktree, blank-line separated. Each block
+    starts with a `worktree <path>` line and (for branch worktrees) carries a
+    `branch refs/heads/<name>` line. Detached worktrees omit the branch line; we skip those.
+    """
+    out: dict[Path, str] = {}
+    current: Path | None = None
+    for raw in porcelain.splitlines():
+        line = raw.rstrip()
+        if line.startswith("worktree "):
+            current = Path(line[len("worktree "):])
+        elif line.startswith("branch ") and current is not None:
+            ref = line[len("branch "):].strip()
+            branch = ref[len("refs/heads/"):] if ref.startswith("refs/heads/") else ref
+            try:
+                key = current.resolve()
+            except OSError:
+                key = current
+            out[key] = branch
+            current = None
+        elif not line:
+            current = None
+    return out
+
+
+def _branch_is_merged_to(branch: str, root: Path, base: str = "origin/main") -> bool:
+    """True iff `branch` is fully an ancestor of `base` (no unmerged commits ahead).
+
+    Used to identify dead lanes — a worktree whose branch is already merged into main is
+    not a place for the lead to look for new work. Returns False on any error so the feed
+    defaults to surfacing candidates rather than silently hiding them.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "merge-base", "--is-ancestor", branch, base],
+            capture_output=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+def _drop_dead_lane_purposes(
+    paths: list[Path],
+    *,
+    branch_map: dict[Path, str],
+    root: Path,
+) -> list[Path]:
+    """Filter _PURPOSE.md candidates to only those belonging to live (unmerged) worktrees.
+
+    Worktrees whose branch is fully an ancestor of origin/main represent landed work and
+    should not surface as actionable lanes for the lead. Set
+    `WORKFLOW_FEED_INCLUDE_DEAD_LANES=1` to bypass this filter (useful for archaeology).
+    """
+    import os as _os
+
+    if _os.environ.get("WORKFLOW_FEED_INCLUDE_DEAD_LANES", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }:
+        return paths
+    if not branch_map:
+        return paths
+    dead_worktrees: set[Path] = set()
+    merge_cache: dict[str, bool] = {}
+    for worktree_path, branch in branch_map.items():
+        if branch not in merge_cache:
+            merge_cache[branch] = _branch_is_merged_to(branch, root)
+        if merge_cache[branch]:
+            dead_worktrees.add(worktree_path)
+    if not dead_worktrees:
+        return paths
+    live: list[Path] = []
+    for path in paths:
+        ancestor = _closest_worktree_ancestor(path, branch_map.keys())
+        if ancestor is not None and ancestor in dead_worktrees:
+            continue
+        live.append(path)
+    return live
+
+
+def _closest_worktree_ancestor(path: Path, worktrees: Iterable[Path]) -> Path | None:
+    """Pick the deepest worktree path that contains `path`."""
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return None
+    best: Path | None = None
+    best_len = -1
+    for wt in worktrees:
+        try:
+            wt_resolved = wt if wt.is_absolute() else wt.resolve()
+        except OSError:
+            continue
+        try:
+            resolved.relative_to(wt_resolved)
+        except ValueError:
+            continue
+        length = len(str(wt_resolved))
+        if length > best_len:
+            best = wt_resolved
+            best_len = length
+    return best
 
 
 def _is_text_path(path: Path) -> bool:

--- a/tests/test_provider_context_feed.py
+++ b/tests/test_provider_context_feed.py
@@ -331,3 +331,153 @@ def test_hook_render_context_is_compact_and_actionable() -> None:
 
     assert "Provider-context feed checkpoint: build" in rendered
     assert "STATUS/worktree/PR" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Dead-lane pruning (kills the SessionStart-feed staleness problem where
+# every candidate worktree pointed to already-merged work).
+# ---------------------------------------------------------------------------
+
+
+def test_parse_worktree_branches_extracts_branch_per_worktree() -> None:
+    porcelain = (
+        "worktree C:/repo\n"
+        "HEAD aaaaaaa\n"
+        "branch refs/heads/main\n"
+        "\n"
+        "worktree C:/repo/.claude/worktrees/feature-x\n"
+        "HEAD bbbbbbb\n"
+        "branch refs/heads/worktree-feature-x\n"
+        "\n"
+        "worktree C:/repo/.claude/worktrees/detached\n"
+        "HEAD ccccccc\n"
+        "detached\n"
+    )
+    result = provider_context_feed._parse_worktree_branches(porcelain)
+    branches = {str(path).replace("\\", "/"): branch for path, branch in result.items()}
+    assert any(b == "worktree-feature-x" for b in branches.values())
+    assert any(b == "main" for b in branches.values())
+    # detached worktrees omit the branch line and are skipped
+    assert "ref/heads/detached" not in branches
+    assert all("detached" not in b for b in branches.values())
+
+
+def test_drop_dead_lane_purposes_filters_merged_branches(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A _PURPOSE.md sitting in a worktree whose branch is already an ancestor of
+    origin/main is no longer actionable — the lead does not need to see it as a
+    candidate lane."""
+    dead_wt = tmp_path / "wf-dead"
+    live_wt = tmp_path / "wf-live"
+    dead_wt.mkdir()
+    live_wt.mkdir()
+    dead_purpose = dead_wt / "_PURPOSE.md"
+    live_purpose = live_wt / "_PURPOSE.md"
+    dead_purpose.write_text("Purpose: this lane was already merged.\n", encoding="utf-8")
+    live_purpose.write_text("Purpose: this lane still has unmerged work.\n", encoding="utf-8")
+
+    branch_map = {
+        dead_wt.resolve(): "codex/dead-lane",
+        live_wt.resolve(): "codex/live-lane",
+    }
+
+    def fake_is_merged(branch: str, root: Path, base: str = "origin/main") -> bool:
+        return branch == "codex/dead-lane"
+
+    monkeypatch.setattr(provider_context_feed, "_branch_is_merged_to", fake_is_merged)
+
+    kept = provider_context_feed._drop_dead_lane_purposes(
+        [dead_purpose, live_purpose],
+        branch_map=branch_map,
+        root=tmp_path,
+    )
+
+    assert live_purpose in kept
+    assert dead_purpose not in kept
+
+
+def test_drop_dead_lane_purposes_passes_through_when_env_flag_set(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """`WORKFLOW_FEED_INCLUDE_DEAD_LANES=1` lets archaeologists see everything."""
+    dead_wt = tmp_path / "wf-dead"
+    dead_wt.mkdir()
+    dead_purpose = dead_wt / "_PURPOSE.md"
+    dead_purpose.write_text("Purpose: merged lane.\n", encoding="utf-8")
+    branch_map = {dead_wt.resolve(): "codex/dead-lane"}
+
+    monkeypatch.setattr(
+        provider_context_feed, "_branch_is_merged_to", lambda *_a, **_kw: True
+    )
+    monkeypatch.setenv("WORKFLOW_FEED_INCLUDE_DEAD_LANES", "1")
+
+    kept = provider_context_feed._drop_dead_lane_purposes(
+        [dead_purpose], branch_map=branch_map, root=tmp_path
+    )
+
+    assert dead_purpose in kept
+
+
+def test_drop_dead_lane_purposes_keeps_paths_outside_any_worktree(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A _PURPOSE.md that isn't under any tracked worktree (e.g. an ad-hoc origin/
+    snapshot) should pass through untouched — we only prune when we have confident
+    branch info."""
+    stranger_dir = tmp_path / "origin" / "ad-hoc"
+    stranger_dir.mkdir(parents=True)
+    stranger_purpose = stranger_dir / "_PURPOSE.md"
+    stranger_purpose.write_text("Purpose: not a worktree.\n", encoding="utf-8")
+
+    dead_wt = tmp_path / "wf-dead"
+    dead_wt.mkdir()
+    dead_purpose = dead_wt / "_PURPOSE.md"
+    dead_purpose.write_text("Purpose: merged lane.\n", encoding="utf-8")
+
+    branch_map = {dead_wt.resolve(): "codex/dead-lane"}
+
+    monkeypatch.setattr(
+        provider_context_feed, "_branch_is_merged_to", lambda *_a, **_kw: True
+    )
+
+    kept = provider_context_feed._drop_dead_lane_purposes(
+        [stranger_purpose, dead_purpose],
+        branch_map=branch_map,
+        root=tmp_path,
+    )
+
+    assert stranger_purpose in kept
+    assert dead_purpose not in kept
+
+
+def test_closest_worktree_ancestor_picks_deepest_match(tmp_path: Path) -> None:
+    """If a purpose path lives several directories deep inside a worktree, the
+    matching worktree must still be detected as its ancestor."""
+    worktree = tmp_path / "wf-foo"
+    nested_purpose = worktree / "sub" / "dir" / "_PURPOSE.md"
+    nested_purpose.parent.mkdir(parents=True)
+    nested_purpose.write_text("anything", encoding="utf-8")
+
+    other_worktree = tmp_path / "wf-bar"
+    other_worktree.mkdir()
+
+    ancestor = provider_context_feed._closest_worktree_ancestor(
+        nested_purpose, [other_worktree, worktree]
+    )
+
+    assert ancestor == worktree.resolve()
+
+
+def test_drop_dead_lane_purposes_returns_input_when_branch_map_empty(
+    tmp_path: Path,
+) -> None:
+    """If we couldn't read the worktree porcelain (empty branch_map), passthrough."""
+    purpose = tmp_path / "_PURPOSE.md"
+    purpose.write_text("anything", encoding="utf-8")
+
+    kept = provider_context_feed._drop_dead_lane_purposes(
+        [purpose], branch_map={}, root=tmp_path
+    )
+
+    assert kept == [purpose]


### PR DESCRIPTION
## Summary

The SessionStart context feed was surfacing **dead lanes** — worktrees whose branch is already fully merged into `origin/main`. Lead sessions kept claiming work that was either landed (`codex-auth-expired-loop-health`, `checker-worker-dispatch`, `pr354-cowork-env`, `pr828-skill-sync-refactor`, ...) or empty.

Smoke test on the live repo: **30 of 90 git-tracked worktrees are dead lanes** that would have surfaced as candidates. That's a 33% noise rate on the most-read context block.

Concrete encounter: today's session's SessionStart feed listed 10 candidate worktrees; on inspection, every single one was either already-merged, closed, or empty. The feed sent me chasing dead lanes for several turns.

## What changed (`scripts/provider_context_feed.py`)

- Replaces the inline porcelain parse in `_worktree_purpose_paths` with two pure helpers (`_git_worktree_porcelain`, `_parse_worktree_branches`) that expose the worktree→branch map for filtering.
- Adds `_branch_is_merged_to(branch, root, base="origin/main")` using `git merge-base --is-ancestor`. Returns `False` on any subprocess error so the feed errs toward surfacing candidates rather than silently hiding them.
- Adds `_drop_dead_lane_purposes()` — drops `_PURPOSE.md` paths under worktrees whose branch is fully ancestor of `origin/main`. Caches one merge-base check per branch per call.
- Adds `_closest_worktree_ancestor()` so paths nested below the worktree root are still correctly matched.

## Escape hatch

`WORKFLOW_FEED_INCLUDE_DEAD_LANES=1` bypasses the filter (archaeology / debugging).

## Tests (6 new, 20 total passing)

- `test_parse_worktree_branches_extracts_branch_per_worktree` — porcelain parsing, including detached-worktree skip.
- `test_drop_dead_lane_purposes_filters_merged_branches` — the core filter.
- `test_drop_dead_lane_purposes_passes_through_when_env_flag_set` — escape hatch works.
- `test_drop_dead_lane_purposes_keeps_paths_outside_any_worktree` — ad-hoc paths under `origin/` etc. still pass through.
- `test_closest_worktree_ancestor_picks_deepest_match` — nested files still find their worktree.
- `test_drop_dead_lane_purposes_returns_input_when_branch_map_empty` — empty porcelain output = passthrough (no false hides).

## Test plan

- [x] `python -m pytest tests/test_provider_context_feed.py -q` (20 passed)
- [x] `python -m ruff check` (clean)
- [x] Live smoke test on real repo: prunes 30/90 dead worktrees as expected
- [x] Pre-commit invariants (mojibake / cross-provider drift / skills-valid)

## Composes with

This is the meta-fix for the noise that delayed the loop-discipline arc (#927/#929/#930). Without this, every future lead session would keep getting handed the same stale candidate list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)