### PR TITLE
AcceptanceScenario Slice 2: thin dispatcher runtime (closes the third lane's substantive work)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/evaluation/scenario_runner.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/evaluation/scenario_runner.py
@@ -1,0 +1,258 @@
+"""AcceptanceScenario runtime — thin dispatcher to existing primitives.
+
+Per `docs/design-notes/2026-05-02-acceptance-scenario-packs.md` + spec
+`docs/specs/2026-05-02-acceptance-scenario-minimal-schema.md` (landed via
+PR #936). Slice 2 of the AcceptanceScenario lane.
+
+The runner is intentionally a thin dispatcher. It does NOT execute
+user-sim sessions, branch runs, or MCP calls itself — it routes a typed
+`AcceptanceScenario` contract to the appropriate existing runtime
+(registered as a dispatcher per `target_surface`) and bundles the
+result as a standard `EvalResult`.
+
+Design constraints (per the audit verdict, REAFFIRMED):
+- No new EvaluatorKind. Scenario results use the existing `custom` kind.
+- No parallel runner. The dispatcher routes to existing primitives.
+- No new sandbox. Universes register dispatchers that use their own
+  sandbox model (typically the `external_tool_node` multi-layer auth
+  surface for code, the ui-test single-tab discipline for browser
+  scenarios).
+- Cost budget enforcement is the dispatcher's responsibility. The
+  runner verifies a budget was declared; the dispatcher honors it.
+- Visibility is a tag carried on the result; universes compose
+  enforcement via gates (per the PrivateTraceCommons pattern, #935).
+
+Slice 3+ scope:
+- Concrete dispatcher implementations per target_surface.
+- Optimization-gate integration (route scenario PASS/FAIL into rung
+  claim evidence per Goals & Gates).
+- Community scenario library + remix.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Literal
+
+from workflow.evaluation import EvalResult, EvalVerdict
+
+TargetSurface = Literal[
+    "mcp_call",
+    "ui_test_mission",
+    "branch_run",
+    "external_effect",
+    "session_trace_summary",
+]
+PrivacyScope = Literal[
+    "scenario_internal",
+    "universe_only",
+    "commons_publishable",
+]
+VALID_TARGET_SURFACES = frozenset(
+    ("mcp_call", "ui_test_mission", "branch_run", "external_effect", "session_trace_summary")
+)
+VALID_PRIVACY_SCOPES = frozenset(
+    ("scenario_internal", "universe_only", "commons_publishable")
+)
+
+
+@dataclass
+class AcceptanceScenario:
+    """Typed contract for a long-horizon acceptance check.
+
+    11 fields per the Slice 1 spec; each justified by a concrete failure
+    mode it prevents (see the design note).
+    """
+
+    scenario_id: str
+    target_surface: TargetSurface
+    user_story: str
+    allowed_tools: list[str]
+    evaluator_chain: list[str]
+    artifact_requirements: list[dict]
+    pass_threshold: dict
+    cost_budget: dict
+    privacy_scope: PrivacyScope
+    idempotency_key_constructor: str
+    setup: list[dict] = field(default_factory=list)
+    supersedes_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.scenario_id or not self.scenario_id.startswith("scenario:"):
+            raise ValueError(
+                f"AcceptanceScenario.scenario_id must be non-empty and start "
+                f"with 'scenario:' (got {self.scenario_id!r})"
+            )
+        if self.target_surface not in VALID_TARGET_SURFACES:
+            raise ValueError(
+                f"AcceptanceScenario.target_surface must be one of "
+                f"{sorted(VALID_TARGET_SURFACES)} (got {self.target_surface!r})"
+            )
+        if self.privacy_scope not in VALID_PRIVACY_SCOPES:
+            raise ValueError(
+                f"AcceptanceScenario.privacy_scope must be one of "
+                f"{sorted(VALID_PRIVACY_SCOPES)} (got {self.privacy_scope!r})"
+            )
+        if not 200 <= len(self.user_story) <= 2000:
+            raise ValueError(
+                f"AcceptanceScenario.user_story length must be in [200, 2000] "
+                f"chars; got {len(self.user_story)}"
+            )
+        if not self.evaluator_chain:
+            raise ValueError(
+                "AcceptanceScenario.evaluator_chain must list at least one "
+                "evaluator ID; scenarios without evaluators produce opinion, "
+                "not evidence"
+            )
+        if not self.artifact_requirements:
+            raise ValueError(
+                "AcceptanceScenario.artifact_requirements must list at least "
+                "one required artifact descriptor"
+            )
+        if "min_score" not in self.pass_threshold:
+            raise ValueError(
+                "AcceptanceScenario.pass_threshold must include 'min_score'"
+            )
+        for required_cost_field in ("max_tokens", "max_wall_time_seconds"):
+            if required_cost_field not in self.cost_budget:
+                raise ValueError(
+                    f"AcceptanceScenario.cost_budget must include "
+                    f"{required_cost_field!r} (bounded autonomous spend; "
+                    f"see Brain Module principle)"
+                )
+        if not self.idempotency_key_constructor:
+            raise ValueError(
+                "AcceptanceScenario.idempotency_key_constructor must be "
+                "declared at registration (per #914 external-write authority "
+                "strict idempotency contract)"
+            )
+
+
+# Dispatcher = callable that executes a scenario against a candidate ref
+# and returns a dict of {score, verdict, label, details}. The runner
+# wraps that into a standard EvalResult.
+#
+# Signature:
+#   dispatcher(scenario: AcceptanceScenario, candidate_ref: str, **kwargs)
+#       -> dict[str, Any]
+Dispatcher = Callable[..., dict[str, Any]]
+
+_DISPATCHERS: dict[str, Dispatcher] = {}
+
+
+def register_dispatcher(target_surface: str, dispatcher: Dispatcher) -> None:
+    """Register a dispatcher for a target_surface.
+
+    Universes register dispatchers at startup. The runner uses them; no
+    dispatcher means scenarios for that surface return ``skip`` verdict
+    with a clear note.
+    """
+    if target_surface not in VALID_TARGET_SURFACES:
+        raise ValueError(
+            f"unknown target_surface {target_surface!r}; valid: "
+            f"{sorted(VALID_TARGET_SURFACES)}"
+        )
+    _DISPATCHERS[target_surface] = dispatcher
+
+
+def unregister_dispatcher(target_surface: str) -> None:
+    """Remove a registered dispatcher (primarily for tests)."""
+    _DISPATCHERS.pop(target_surface, None)
+
+
+def registered_dispatchers() -> dict[str, Dispatcher]:
+    """Return a shallow copy of the dispatcher registry (read-only view)."""
+    return dict(_DISPATCHERS)
+
+
+def run_scenario(
+    scenario: AcceptanceScenario,
+    candidate_ref: str,
+    **kwargs: Any,
+) -> EvalResult:
+    """Dispatch a scenario against a candidate; return a standard EvalResult.
+
+    Args:
+        scenario: validated AcceptanceScenario contract.
+        candidate_ref: opaque reference to whatever is being tested (a
+            branch_def_id, an MCP tool spec, a ui-test mission id, etc.).
+        **kwargs: passed through to the dispatcher unchanged.
+
+    Returns:
+        A standard EvalResult with kind="custom". If no dispatcher is
+        registered for the scenario's target_surface, returns a SKIP
+        verdict with a clear note in details. If the dispatcher raises,
+        returns an ERROR verdict with the exception text in details.
+    """
+    dispatcher = _DISPATCHERS.get(scenario.target_surface)
+    if dispatcher is None:
+        return EvalResult(
+            score=-1.0,
+            verdict="skip",
+            kind="custom",
+            label=f"scenario:{scenario.scenario_id}",
+            details={
+                "reason": "no_dispatcher_registered",
+                "target_surface": scenario.target_surface,
+                "scenario_id": scenario.scenario_id,
+                "candidate_ref": candidate_ref,
+                "registered_surfaces": sorted(_DISPATCHERS.keys()),
+            },
+        )
+
+    try:
+        raw = dispatcher(scenario, candidate_ref, **kwargs)
+    except Exception as exc:  # noqa: BLE001 — surface any dispatcher error
+        return EvalResult(
+            score=-1.0,
+            verdict="error",
+            kind="custom",
+            label=f"scenario:{scenario.scenario_id}",
+            details={
+                "reason": "dispatcher_raised",
+                "exception_type": type(exc).__name__,
+                "exception_message": str(exc),
+                "target_surface": scenario.target_surface,
+                "scenario_id": scenario.scenario_id,
+                "candidate_ref": candidate_ref,
+            },
+        )
+
+    # Normalize the dispatcher's return into an EvalResult.
+    score = float(raw.get("score", 0.0))
+    verdict_raw = raw.get("verdict")
+    if verdict_raw in ("pass", "fail", "skip", "error"):
+        verdict: EvalVerdict = verdict_raw
+    else:
+        # Derive PASS/FAIL from threshold if dispatcher didn't supply one.
+        min_score = float(scenario.pass_threshold.get("min_score", 0.0))
+        verdict = "pass" if score >= min_score else "fail"
+
+    details = dict(raw.get("details", {}))
+    details.setdefault("scenario_id", scenario.scenario_id)
+    details.setdefault("target_surface", scenario.target_surface)
+    details.setdefault("candidate_ref", candidate_ref)
+    details.setdefault("privacy_scope", scenario.privacy_scope)
+    details.setdefault("pass_threshold", scenario.pass_threshold)
+
+    return EvalResult(
+        score=max(-1.0, min(1.0, score)),
+        verdict=verdict,
+        kind="custom",
+        label=raw.get("label", f"scenario:{scenario.scenario_id}"),
+        details=details,
+    )
+
+
+__all__ = [
+    "AcceptanceScenario",
+    "Dispatcher",
+    "PrivacyScope",
+    "TargetSurface",
+    "VALID_PRIVACY_SCOPES",
+    "VALID_TARGET_SURFACES",
+    "register_dispatcher",
+    "registered_dispatchers",
+    "run_scenario",
+    "unregister_dispatcher",
+]

--- a/tests/test_scenario_runner.py
+++ b/tests/test_scenario_runner.py
@@ -1,0 +1,247 @@
+"""Tests for AcceptanceScenario runtime (Slice 2 of the lane).
+
+Per docs/design-notes/2026-05-02-acceptance-scenario-packs.md (#936).
+
+The runner is a thin dispatcher: validates the contract, routes to a
+registered dispatcher per target_surface, and wraps the dispatcher's
+return into a standard EvalResult. These tests exercise the contract +
+dispatch + wrap behavior without invoking real user-sim, branch runs,
+or live MCP calls (those would require heavy infrastructure).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from workflow.evaluation import EvalResult
+from workflow.evaluation.scenario_runner import (
+    AcceptanceScenario,
+    register_dispatcher,
+    registered_dispatchers,
+    run_scenario,
+    unregister_dispatcher,
+)
+
+
+def _valid_scenario(**overrides) -> AcceptanceScenario:
+    """Build a valid AcceptanceScenario for tests, overridable per case."""
+    base = {
+        "scenario_id": "scenario:test-happy-path-v1",
+        "target_surface": "mcp_call",
+        "user_story": (
+            "A new user opens their MCP-connected chatbot and asks "
+            "for a Goal to be proposed for their new project. The "
+            "chatbot should call goals action=propose, return a "
+            "goal_id, and confirm the proposal in plain language. "
+            "Acceptance requires both the goal_id and a confirmation "
+            "narrative. This story is at least two hundred chars."
+        ),
+        "allowed_tools": ["goals", "universe"],
+        "evaluator_chain": ["evaluator:goal-record-shape-check"],
+        "artifact_requirements": [
+            {"kind": "packet", "scope": "final", "redact_pattern": None}
+        ],
+        "pass_threshold": {"min_score": 0.5, "score_aggregation": "mean"},
+        "cost_budget": {"max_tokens": 4000, "max_wall_time_seconds": 60},
+        "privacy_scope": "commons_publishable",
+        "idempotency_key_constructor": "sha256({scenario_id}|{candidate_ref}|{date_hour})",
+    }
+    base.update(overrides)
+    return AcceptanceScenario(**base)
+
+
+@pytest.fixture(autouse=True)
+def _clean_dispatcher_registry():
+    """Each test starts with an empty dispatcher registry."""
+    initial = list(registered_dispatchers().keys())
+    yield
+    for target_surface in list(registered_dispatchers().keys()):
+        unregister_dispatcher(target_surface)
+
+
+# ── Validation tests ──────────────────────────────────────────────────────────
+
+
+def test_valid_scenario_constructs() -> None:
+    scenario = _valid_scenario()
+    assert scenario.scenario_id == "scenario:test-happy-path-v1"
+    assert scenario.target_surface == "mcp_call"
+
+
+def test_scenario_id_must_be_namespaced() -> None:
+    with pytest.raises(ValueError, match="scenario_id"):
+        _valid_scenario(scenario_id="no-namespace-prefix")
+
+
+def test_target_surface_must_be_valid_enum() -> None:
+    with pytest.raises(ValueError, match="target_surface"):
+        _valid_scenario(target_surface="bogus_surface")
+
+
+def test_privacy_scope_must_be_valid_enum() -> None:
+    with pytest.raises(ValueError, match="privacy_scope"):
+        _valid_scenario(privacy_scope="bogus_scope")
+
+
+def test_user_story_length_bounds_enforced() -> None:
+    with pytest.raises(ValueError, match="user_story length"):
+        _valid_scenario(user_story="too short")
+    with pytest.raises(ValueError, match="user_story length"):
+        _valid_scenario(user_story="x" * 2001)
+
+
+def test_evaluator_chain_must_be_non_empty() -> None:
+    with pytest.raises(ValueError, match="evaluator_chain"):
+        _valid_scenario(evaluator_chain=[])
+
+
+def test_artifact_requirements_must_be_non_empty() -> None:
+    with pytest.raises(ValueError, match="artifact_requirements"):
+        _valid_scenario(artifact_requirements=[])
+
+
+def test_pass_threshold_must_have_min_score() -> None:
+    with pytest.raises(ValueError, match="min_score"):
+        _valid_scenario(pass_threshold={})
+
+
+def test_cost_budget_must_have_required_fields() -> None:
+    with pytest.raises(ValueError, match="max_tokens"):
+        _valid_scenario(cost_budget={"max_wall_time_seconds": 60})
+    with pytest.raises(ValueError, match="max_wall_time_seconds"):
+        _valid_scenario(cost_budget={"max_tokens": 4000})
+
+
+def test_idempotency_key_constructor_must_be_declared() -> None:
+    with pytest.raises(ValueError, match="idempotency_key_constructor"):
+        _valid_scenario(idempotency_key_constructor="")
+
+
+# ── Dispatch tests ───────────────────────────────────────────────────────────
+
+
+def test_skip_verdict_when_no_dispatcher_registered() -> None:
+    scenario = _valid_scenario()
+    result = run_scenario(scenario, candidate_ref="branch:test")
+    assert isinstance(result, EvalResult)
+    assert result.verdict == "skip"
+    assert result.kind == "custom"
+    assert result.details["reason"] == "no_dispatcher_registered"
+    assert result.details["scenario_id"] == scenario.scenario_id
+
+
+def test_dispatcher_pass_result_wrapped_into_evalresult() -> None:
+    def fake_dispatcher(scenario, candidate_ref, **kwargs):
+        return {
+            "score": 0.85,
+            "verdict": "pass",
+            "label": "fake-evaluator",
+            "details": {"observation": "all assertions passed"},
+        }
+
+    register_dispatcher("mcp_call", fake_dispatcher)
+    scenario = _valid_scenario()
+    result = run_scenario(scenario, candidate_ref="branch:test")
+
+    assert result.verdict == "pass"
+    assert result.score == 0.85
+    assert result.kind == "custom"
+    assert result.label == "fake-evaluator"
+    assert result.details["observation"] == "all assertions passed"
+    # Runner-injected defaults
+    assert result.details["scenario_id"] == scenario.scenario_id
+    assert result.details["target_surface"] == "mcp_call"
+    assert result.details["privacy_scope"] == "commons_publishable"
+
+
+def test_dispatcher_score_below_threshold_yields_fail_when_verdict_omitted() -> None:
+    def low_score_dispatcher(scenario, candidate_ref, **kwargs):
+        # Returns no verdict; runner derives from pass_threshold.min_score
+        return {"score": 0.3}
+
+    register_dispatcher("mcp_call", low_score_dispatcher)
+    scenario = _valid_scenario()  # min_score=0.5
+    result = run_scenario(scenario, candidate_ref="branch:test")
+
+    assert result.verdict == "fail"
+    assert result.score == 0.3
+
+
+def test_dispatcher_score_above_threshold_yields_pass_when_verdict_omitted() -> None:
+    def high_score_dispatcher(scenario, candidate_ref, **kwargs):
+        return {"score": 0.8}
+
+    register_dispatcher("mcp_call", high_score_dispatcher)
+    scenario = _valid_scenario()  # min_score=0.5
+    result = run_scenario(scenario, candidate_ref="branch:test")
+
+    assert result.verdict == "pass"
+    assert result.score == 0.8
+
+
+def test_dispatcher_exception_yields_error_verdict() -> None:
+    def crashing_dispatcher(scenario, candidate_ref, **kwargs):
+        raise RuntimeError("simulated dispatcher failure")
+
+    register_dispatcher("mcp_call", crashing_dispatcher)
+    scenario = _valid_scenario()
+    result = run_scenario(scenario, candidate_ref="branch:test")
+
+    assert result.verdict == "error"
+    assert result.score == -1.0
+    assert result.details["reason"] == "dispatcher_raised"
+    assert result.details["exception_type"] == "RuntimeError"
+    assert "simulated dispatcher failure" in result.details["exception_message"]
+
+
+def test_dispatcher_invalid_verdict_falls_back_to_threshold_derivation() -> None:
+    def weird_verdict_dispatcher(scenario, candidate_ref, **kwargs):
+        return {"score": 0.7, "verdict": "definitely_pass"}  # not in enum
+
+    register_dispatcher("mcp_call", weird_verdict_dispatcher)
+    scenario = _valid_scenario()  # min_score=0.5
+    result = run_scenario(scenario, candidate_ref="branch:test")
+
+    # Falls back to threshold-derived verdict
+    assert result.verdict == "pass"  # 0.7 > 0.5
+    assert result.score == 0.7
+
+
+def test_registry_isolates_per_target_surface() -> None:
+    def mcp_dispatcher(scenario, candidate_ref, **kwargs):
+        return {"score": 0.9, "verdict": "pass", "label": "mcp"}
+
+    def ui_dispatcher(scenario, candidate_ref, **kwargs):
+        return {"score": 0.6, "verdict": "pass", "label": "ui"}
+
+    register_dispatcher("mcp_call", mcp_dispatcher)
+    register_dispatcher("ui_test_mission", ui_dispatcher)
+
+    mcp_scenario = _valid_scenario(scenario_id="scenario:mcp-v1", target_surface="mcp_call")
+    ui_scenario = _valid_scenario(scenario_id="scenario:ui-v1", target_surface="ui_test_mission")
+
+    mcp_result = run_scenario(mcp_scenario, candidate_ref="branch:x")
+    ui_result = run_scenario(ui_scenario, candidate_ref="branch:x")
+
+    assert mcp_result.label == "mcp"
+    assert ui_result.label == "ui"
+
+
+def test_register_dispatcher_rejects_unknown_target_surface() -> None:
+    def some_dispatcher(scenario, candidate_ref, **kwargs):
+        return {"score": 1.0, "verdict": "pass"}
+
+    with pytest.raises(ValueError, match="unknown target_surface"):
+        register_dispatcher("bogus_surface", some_dispatcher)
+
+
+def test_dispatcher_score_clamped_to_valid_range() -> None:
+    def out_of_range_dispatcher(scenario, candidate_ref, **kwargs):
+        return {"score": 5.0, "verdict": "pass"}  # > 1.0
+
+    register_dispatcher("mcp_call", out_of_range_dispatcher)
+    scenario = _valid_scenario()
+    result = run_scenario(scenario, candidate_ref="branch:test")
+
+    assert result.score == 1.0  # clamped to upper bound
+    assert result.verdict == "pass"

--- a/workflow/evaluation/scenario_runner.py
+++ b/workflow/evaluation/scenario_runner.py
@@ -1,0 +1,258 @@
+"""AcceptanceScenario runtime — thin dispatcher to existing primitives.
+
+Per `docs/design-notes/2026-05-02-acceptance-scenario-packs.md` + spec
+`docs/specs/2026-05-02-acceptance-scenario-minimal-schema.md` (landed via
+PR #936). Slice 2 of the AcceptanceScenario lane.
+
+The runner is intentionally a thin dispatcher. It does NOT execute
+user-sim sessions, branch runs, or MCP calls itself — it routes a typed
+`AcceptanceScenario` contract to the appropriate existing runtime
+(registered as a dispatcher per `target_surface`) and bundles the
+result as a standard `EvalResult`.
+
+Design constraints (per the audit verdict, REAFFIRMED):
+- No new EvaluatorKind. Scenario results use the existing `custom` kind.
+- No parallel runner. The dispatcher routes to existing primitives.
+- No new sandbox. Universes register dispatchers that use their own
+  sandbox model (typically the `external_tool_node` multi-layer auth
+  surface for code, the ui-test single-tab discipline for browser
+  scenarios).
+- Cost budget enforcement is the dispatcher's responsibility. The
+  runner verifies a budget was declared; the dispatcher honors it.
+- Visibility is a tag carried on the result; universes compose
+  enforcement via gates (per the PrivateTraceCommons pattern, #935).
+
+Slice 3+ scope:
+- Concrete dispatcher implementations per target_surface.
+- Optimization-gate integration (route scenario PASS/FAIL into rung
+  claim evidence per Goals & Gates).
+- Community scenario library + remix.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Literal
+
+from workflow.evaluation import EvalResult, EvalVerdict
+
+TargetSurface = Literal[
+    "mcp_call",
+    "ui_test_mission",
+    "branch_run",
+    "external_effect",
+    "session_trace_summary",
+]
+PrivacyScope = Literal[
+    "scenario_internal",
+    "universe_only",
+    "commons_publishable",
+]
+VALID_TARGET_SURFACES = frozenset(
+    ("mcp_call", "ui_test_mission", "branch_run", "external_effect", "session_trace_summary")
+)
+VALID_PRIVACY_SCOPES = frozenset(
+    ("scenario_internal", "universe_only", "commons_publishable")
+)
+
+
+@dataclass
+class AcceptanceScenario:
+    """Typed contract for a long-horizon acceptance check.
+
+    11 fields per the Slice 1 spec; each justified by a concrete failure
+    mode it prevents (see the design note).
+    """
+
+    scenario_id: str
+    target_surface: TargetSurface
+    user_story: str
+    allowed_tools: list[str]
+    evaluator_chain: list[str]
+    artifact_requirements: list[dict]
+    pass_threshold: dict
+    cost_budget: dict
+    privacy_scope: PrivacyScope
+    idempotency_key_constructor: str
+    setup: list[dict] = field(default_factory=list)
+    supersedes_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.scenario_id or not self.scenario_id.startswith("scenario:"):
+            raise ValueError(
+                f"AcceptanceScenario.scenario_id must be non-empty and start "
+                f"with 'scenario:' (got {self.scenario_id!r})"
+            )
+        if self.target_surface not in VALID_TARGET_SURFACES:
+            raise ValueError(
+                f"AcceptanceScenario.target_surface must be one of "
+                f"{sorted(VALID_TARGET_SURFACES)} (got {self.target_surface!r})"
+            )
+        if self.privacy_scope not in VALID_PRIVACY_SCOPES:
+            raise ValueError(
+                f"AcceptanceScenario.privacy_scope must be one of "
+                f"{sorted(VALID_PRIVACY_SCOPES)} (got {self.privacy_scope!r})"
+            )
+        if not 200 <= len(self.user_story) <= 2000:
+            raise ValueError(
+                f"AcceptanceScenario.user_story length must be in [200, 2000] "
+                f"chars; got {len(self.user_story)}"
+            )
+        if not self.evaluator_chain:
+            raise ValueError(
+                "AcceptanceScenario.evaluator_chain must list at least one "
+                "evaluator ID; scenarios without evaluators produce opinion, "
+                "not evidence"
+            )
+        if not self.artifact_requirements:
+            raise ValueError(
+                "AcceptanceScenario.artifact_requirements must list at least "
+                "one required artifact descriptor"
+            )
+        if "min_score" not in self.pass_threshold:
+            raise ValueError(
+                "AcceptanceScenario.pass_threshold must include 'min_score'"
+            )
+        for required_cost_field in ("max_tokens", "max_wall_time_seconds"):
+            if required_cost_field not in self.cost_budget:
+                raise ValueError(
+                    f"AcceptanceScenario.cost_budget must include "
+                    f"{required_cost_field!r} (bounded autonomous spend; "
+                    f"see Brain Module principle)"
+                )
+        if not self.idempotency_key_constructor:
+            raise ValueError(
+                "AcceptanceScenario.idempotency_key_constructor must be "
+                "declared at registration (per #914 external-write authority "
+                "strict idempotency contract)"
+            )
+
+
+# Dispatcher = callable that executes a scenario against a candidate ref
+# and returns a dict of {score, verdict, label, details}. The runner
+# wraps that into a standard EvalResult.
+#
+# Signature:
+#   dispatcher(scenario: AcceptanceScenario, candidate_ref: str, **kwargs)
+#       -> dict[str, Any]
+Dispatcher = Callable[..., dict[str, Any]]
+
+_DISPATCHERS: dict[str, Dispatcher] = {}
+
+
+def register_dispatcher(target_surface: str, dispatcher: Dispatcher) -> None:
+    """Register a dispatcher for a target_surface.
+
+    Universes register dispatchers at startup. The runner uses them; no
+    dispatcher means scenarios for that surface return ``skip`` verdict
+    with a clear note.
+    """
+    if target_surface not in VALID_TARGET_SURFACES:
+        raise ValueError(
+            f"unknown target_surface {target_surface!r}; valid: "
+            f"{sorted(VALID_TARGET_SURFACES)}"
+        )
+    _DISPATCHERS[target_surface] = dispatcher
+
+
+def unregister_dispatcher(target_surface: str) -> None:
+    """Remove a registered dispatcher (primarily for tests)."""
+    _DISPATCHERS.pop(target_surface, None)
+
+
+def registered_dispatchers() -> dict[str, Dispatcher]:
+    """Return a shallow copy of the dispatcher registry (read-only view)."""
+    return dict(_DISPATCHERS)
+
+
+def run_scenario(
+    scenario: AcceptanceScenario,
+    candidate_ref: str,
+    **kwargs: Any,
+) -> EvalResult:
+    """Dispatch a scenario against a candidate; return a standard EvalResult.
+
+    Args:
+        scenario: validated AcceptanceScenario contract.
+        candidate_ref: opaque reference to whatever is being tested (a
+            branch_def_id, an MCP tool spec, a ui-test mission id, etc.).
+        **kwargs: passed through to the dispatcher unchanged.
+
+    Returns:
+        A standard EvalResult with kind="custom". If no dispatcher is
+        registered for the scenario's target_surface, returns a SKIP
+        verdict with a clear note in details. If the dispatcher raises,
+        returns an ERROR verdict with the exception text in details.
+    """
+    dispatcher = _DISPATCHERS.get(scenario.target_surface)
+    if dispatcher is None:
+        return EvalResult(
+            score=-1.0,
+            verdict="skip",
+            kind="custom",
+            label=f"scenario:{scenario.scenario_id}",
+            details={
+                "reason": "no_dispatcher_registered",
+                "target_surface": scenario.target_surface,
+                "scenario_id": scenario.scenario_id,
+                "candidate_ref": candidate_ref,
+                "registered_surfaces": sorted(_DISPATCHERS.keys()),
+            },
+        )
+
+    try:
+        raw = dispatcher(scenario, candidate_ref, **kwargs)
+    except Exception as exc:  # noqa: BLE001 — surface any dispatcher error
+        return EvalResult(
+            score=-1.0,
+            verdict="error",
+            kind="custom",
+            label=f"scenario:{scenario.scenario_id}",
+            details={
+                "reason": "dispatcher_raised",
+                "exception_type": type(exc).__name__,
+                "exception_message": str(exc),
+                "target_surface": scenario.target_surface,
+                "scenario_id": scenario.scenario_id,
+                "candidate_ref": candidate_ref,
+            },
+        )
+
+    # Normalize the dispatcher's return into an EvalResult.
+    score = float(raw.get("score", 0.0))
+    verdict_raw = raw.get("verdict")
+    if verdict_raw in ("pass", "fail", "skip", "error"):
+        verdict: EvalVerdict = verdict_raw
+    else:
+        # Derive PASS/FAIL from threshold if dispatcher didn't supply one.
+        min_score = float(scenario.pass_threshold.get("min_score", 0.0))
+        verdict = "pass" if score >= min_score else "fail"
+
+    details = dict(raw.get("details", {}))
+    details.setdefault("scenario_id", scenario.scenario_id)
+    details.setdefault("target_surface", scenario.target_surface)
+    details.setdefault("candidate_ref", candidate_ref)
+    details.setdefault("privacy_scope", scenario.privacy_scope)
+    details.setdefault("pass_threshold", scenario.pass_threshold)
+
+    return EvalResult(
+        score=max(-1.0, min(1.0, score)),
+        verdict=verdict,
+        kind="custom",
+        label=raw.get("label", f"scenario:{scenario.scenario_id}"),
+        details=details,
+    )
+
+
+__all__ = [
+    "AcceptanceScenario",
+    "Dispatcher",
+    "PrivacyScope",
+    "TargetSurface",
+    "VALID_PRIVACY_SCOPES",
+    "VALID_TARGET_SURFACES",
+    "register_dispatcher",
+    "registered_dispatchers",
+    "run_scenario",
+    "unregister_dispatcher",
+]


### PR DESCRIPTION
## Summary

Slice 2 runtime for the AcceptanceScenario lane (Slice 1 design landed via #936). Ships a thin dispatcher that takes an AcceptanceScenario contract + a candidate, routes to a registered dispatcher per target_surface, and emits a standard EvalResult.

## Diff stats

- 3 files changed, **763 insertions** (much larger than the Slice 2s for the other two lanes because this is the actual runtime, not just a memory_kind addition)
- 19 new tests, all passing
- Mirror parity ✓ (canonical + plugin mirror byte-identical)
- All pre-commit invariants green

## What ships

1. **`workflow/evaluation/scenario_runner.py`** — the runtime module
   - `AcceptanceScenario` dataclass: 11 fields per the Slice 1 spec, with `__post_init__` validation enforcing every field's required shape + bounds (scenario_id namespace, target_surface enum, privacy_scope enum, user_story length 200-2000, non-empty evaluator_chain, non-empty artifact_requirements, pass_threshold has min_score, cost_budget has max_tokens + max_wall_time_seconds, idempotency_key_constructor declared)
   - Dispatcher registry: `register_dispatcher` / `unregister_dispatcher` / `registered_dispatchers`
   - `run_scenario(scenario, candidate_ref) -> EvalResult`: dispatcher entry point; validates, routes, normalizes return into a standard EvalResult with kind=\"custom\"

2. **Plugin mirror** at `packaging/.../runtime/workflow/evaluation/scenario_runner.py`: byte-for-byte identical to canonical.

3. **`tests/test_scenario_runner.py`** — 19 tests covering:
   - Scenario construction validation (10 tests, one per required-field constraint)
   - Dispatcher pass/fail/skip/error behaviors
   - Score threshold derivation when dispatcher omits verdict
   - Dispatcher exception handling (errors don't crash the runner)
   - Registry isolation per target_surface
   - Score clamping to valid `[-1.0, 1.0]` range

## Design constraints honored (per audit verdict REAFFIRMS)

| Constraint | Honored |
|---|---|
| No new EvaluatorKind | ✅ scenario results use existing `custom` kind |
| No parallel runner | ✅ thin dispatcher routes to existing primitives via registry |
| No new sandbox primitive | ✅ dispatchers use their own sandbox; runner is sandbox-agnostic |
| No replacement of `ui-test` as final proof | ✅ runner produces EvalResult; Hard Rule #11 unchanged |
| No platform-enforced visibility coupling | ✅ privacy_scope is a tag in EvalResult.details; universes compose gates |
| No AgencyBench code vendored | ✅ zero AgencyBench refs |
| Cost budget validated at registration | ✅ `__post_init__` refuses scenarios without budget declaration |

## What's NOT in this PR

- **Concrete dispatcher implementations** per target_surface — Slice 3+ work. When the first concrete scenario ships end-to-end, a dispatcher for its target_surface will register at universe startup.
- **Setup-action execution** — `setup` field is on the contract but the runner doesn't act on it yet; Slice 3 design pass picks how setup actions run.
- **Optimization-gate integration** — Slice 4. Goals & Gates rung-claim flow will eventually route through scenario PASS/FAIL evidence.
- **Community scenario library** — Slice 5.

## How a universe uses this today

```python
from workflow.evaluation.scenario_runner import (
    AcceptanceScenario, register_dispatcher, run_scenario,
)

# Universe registers a dispatcher at startup
def my_mcp_dispatcher(scenario, candidate_ref, **kwargs):
    # ... actual MCP-call execution; respects cost_budget; produces evidence
    return {
        "score": 0.85,
        "verdict": "pass",
        "details": {"artifacts": [...], "cost": {...}}
    }

register_dispatcher("mcp_call", my_mcp_dispatcher)

# Build a scenario from the Slice 1 spec
scenario = AcceptanceScenario(
    scenario_id="scenario:my-test-v1",
    target_surface="mcp_call",
    # ... etc.
)

# Run it
result = run_scenario(scenario, candidate_ref="branch:abc123")
# result is a standard EvalResult ready to feed into existing flows
```

## Composes with prior session work

- #914 (external-write authority) — idempotency_key_constructor required at registration (validated)
- #915 (PLAN.md restructure) — Evolution & Evaluation Module is the authoritative reference
- #928 (4 audits) — APPROVE verdict authority
- #931/#933/#935 (PrivateTraceCommons) — privacy_scope-as-tag pattern verbatim
- #936 (AcceptanceScenario Slice 1) — implements the Slice 1 spec
- #937/#938 (ExperiencePool) — held-out scenarios cross-reference

## Lane status after this merges

All three unblocked lanes have substantive shipped state:

| Lane | Status |
|---|---|
| PrivateTraceCommons | ✅ fully shipped |
| ExperiencePool | ✅ fully shipped |
| AcceptanceScenario | ✅ Slice 1 + Slice 2 (this PR); Slice 3+ is concrete dispatchers + optimization gate + community library |

## Test plan

- [ ] `python -m pytest tests/test_scenario_runner.py -x -q` (expect 19 passed)
- [ ] Verify mirror parity (`diff workflow/evaluation/scenario_runner.py packaging/.../runtime/workflow/evaluation/scenario_runner.py` shows nothing)
- [ ] Read the validation logic in `AcceptanceScenario.__post_init__`; confirm each constraint matches the Slice 1 spec
- [ ] Read the dispatcher contract in `run_scenario` docstring; confirm the EvalResult wrap behavior matches expectations
- [ ] Turn the host merge key when satisfied