### PR TITLE
AcceptanceScenario Slice 3: mcp_call dispatcher + end-to-end goals.propose scenario

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/evaluation/scenario_dispatchers/__init__.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/evaluation/scenario_dispatchers/__init__.py
@@ -1,0 +1,9 @@
+"""Concrete dispatcher implementations for AcceptanceScenario runtime.
+
+Each module in this package implements a dispatcher for one target_surface
+per the Slice 1 design (docs/design-notes/2026-05-02-acceptance-scenario-
+packs.md). Dispatchers register themselves with the scenario_runner's
+registry at universe startup.
+
+Slice 3 ships the first concrete dispatcher: `mcp_call`.
+"""

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/evaluation/scenario_dispatchers/mcp_call.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/evaluation/scenario_dispatchers/mcp_call.py
@@ -1,0 +1,225 @@
+"""mcp_call dispatcher — Slice 3 of the AcceptanceScenario lane.
+
+Concrete dispatcher for `target_surface="mcp_call"`: invokes a single
+MCP action handler with declared kwargs, parses the JSON response, runs
+evaluator callables against the parsed response, returns aggregated
+score + verdict.
+
+This is the SIMPLEST realistic dispatcher and the natural first slice
+per the Slice 1 design's recommendation:
+
+> Slice 3: one concrete scenario shipped end-to-end. Recommendation: a
+> small MCP scenario for an existing `goals` action (e.g., `goals
+> action=propose` correctly creates a Goal record + binds the chatbot's
+> request). Smallest possible real test of the full contract.
+
+Slice 4+ scope: dispatchers for ui_test_mission (compose with existing
+user-sim discipline), branch_run (compose with workflow.api.runs),
+external_effect (compose with the #914 external-write authority design),
+session_trace_summary (review-against-summary check).
+
+Cost-budget enforcement is intentionally minimal here: the dispatcher
+records `wall_time_seconds` actually elapsed in the response and lets
+the scenario's evaluators inspect it. Hard kills on long-running calls
+are a Slice 4+ refinement that needs a process-isolation primitive.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Callable
+
+from workflow.evaluation.scenario_runner import AcceptanceScenario
+
+# Evaluator signature: (parsed_response) -> {"score": float, "label": str, "details": dict}
+EvaluatorCallable = Callable[[dict], dict]
+
+
+def mcp_call_dispatcher(
+    scenario: AcceptanceScenario,
+    candidate_ref: str,
+    *,
+    action_handler: Callable[[dict], str] | None = None,
+    invocation_kwargs: dict[str, Any] | None = None,
+    evaluators: list[EvaluatorCallable] | None = None,
+    **_extra: Any,
+) -> dict[str, Any]:
+    """Invoke an MCP action handler and evaluate its response.
+
+    Args:
+        scenario: the AcceptanceScenario being run (validated by runner).
+        candidate_ref: identifier of what is being tested (e.g., "goals.propose").
+        action_handler: callable matching the MCP-action contract
+            (`(kwargs: dict) -> json_str`). For platform-side action
+            handlers, this is the function from `workflow/api/market.py`
+            or equivalent. Required.
+        invocation_kwargs: kwargs the dispatcher passes to action_handler.
+            Required for non-trivial cases.
+        evaluators: ordered list of evaluator callables to run against
+            the parsed response. Each evaluator returns
+            `{"score": float, "label": str, "details": dict}`.
+            Defaults to a single status-check evaluator if omitted.
+
+    Returns:
+        A dict matching the scenario_runner's expected dispatcher return
+        shape: `{"score": float, "verdict": str, "label": str, "details": dict}`.
+        The runner wraps this into a standard EvalResult.
+    """
+    if scenario.target_surface != "mcp_call":
+        raise ValueError(
+            f"mcp_call_dispatcher invoked for unsupported target_surface "
+            f"{scenario.target_surface!r}"
+        )
+    if action_handler is None:
+        raise ValueError(
+            "mcp_call_dispatcher requires `action_handler=` kwarg "
+            "(the MCP action callable to invoke)"
+        )
+    invocation_kwargs = dict(invocation_kwargs or {})
+
+    start = time.monotonic()
+    raw_response_text: str
+    parse_error: str | None = None
+    parsed: dict[str, Any] = {}
+    handler_exception: str | None = None
+
+    try:
+        raw_response_text = action_handler(invocation_kwargs)
+    except Exception as exc:  # noqa: BLE001 — surface for evaluator review
+        handler_exception = f"{type(exc).__name__}: {exc}"
+        raw_response_text = ""
+
+    wall_time_seconds = max(0.0, time.monotonic() - start)
+
+    if not handler_exception:
+        try:
+            parsed = json.loads(raw_response_text) if raw_response_text else {}
+        except json.JSONDecodeError as exc:
+            parse_error = f"json decode failed: {exc}"
+
+    evaluator_results: list[dict[str, Any]] = []
+
+    if evaluators is None:
+        # Default evaluator: response must have non-error status.
+        evaluators = [_default_status_check_evaluator]
+
+    for evaluator in evaluators:
+        try:
+            result = evaluator(parsed)
+            if not isinstance(result, dict):
+                raise TypeError(
+                    f"evaluator {evaluator!r} must return a dict; got "
+                    f"{type(result).__name__}"
+                )
+            score = float(result.get("score", 0.0))
+            label = str(result.get("label", evaluator.__name__))
+            details = dict(result.get("details", {}))
+            evaluator_results.append({
+                "score": max(-1.0, min(1.0, score)),
+                "label": label,
+                "details": details,
+            })
+        except Exception as exc:  # noqa: BLE001
+            evaluator_results.append({
+                "score": 0.0,
+                "label": getattr(evaluator, "__name__", "anonymous_evaluator"),
+                "details": {
+                    "evaluator_exception": f"{type(exc).__name__}: {exc}",
+                },
+            })
+
+    # Aggregate scores per the scenario's pass_threshold.
+    score_aggregation = scenario.pass_threshold.get("score_aggregation", "mean")
+    scores = [r["score"] for r in evaluator_results]
+    final_score = _aggregate_scores(scores, score_aggregation, scenario.pass_threshold)
+
+    details_out: dict[str, Any] = {
+        "candidate_ref": candidate_ref,
+        "invocation_kwargs": invocation_kwargs,
+        "raw_response_text": raw_response_text,
+        "parsed_response": parsed,
+        "wall_time_seconds": wall_time_seconds,
+        "evaluator_results": evaluator_results,
+        "score_aggregation": score_aggregation,
+    }
+    if handler_exception:
+        details_out["handler_exception"] = handler_exception
+        final_score = -1.0
+    if parse_error:
+        details_out["parse_error"] = parse_error
+        final_score = min(final_score, 0.0)
+
+    # Cost-budget reporting (enforcement comes in Slice 4+).
+    cost_budget = scenario.cost_budget
+    over_budget_wall_time = wall_time_seconds > cost_budget.get(
+        "max_wall_time_seconds", float("inf")
+    )
+    if over_budget_wall_time:
+        details_out["over_budget"] = {
+            "wall_time_seconds": wall_time_seconds,
+            "max_wall_time_seconds": cost_budget.get("max_wall_time_seconds"),
+        }
+
+    return {
+        "score": final_score,
+        "details": details_out,
+        "label": f"mcp_call:{candidate_ref}",
+    }
+
+
+def _default_status_check_evaluator(parsed: dict[str, Any]) -> dict[str, Any]:
+    """Default evaluator when scenario does not supply its own.
+
+    Passes when the parsed response carries a non-error status. Useful
+    for trivial happy-path scenarios; real scenarios should supply their
+    own evaluator list.
+    """
+    status = parsed.get("status", "")
+    is_error = "error" in parsed or status in {"rejected", "error", "failed"}
+    return {
+        "score": 0.0 if is_error else 1.0,
+        "label": "default_status_check",
+        "details": {
+            "status": status,
+            "is_error": is_error,
+        },
+    }
+
+
+def _aggregate_scores(
+    scores: list[float],
+    aggregation: str,
+    pass_threshold: dict[str, Any],
+) -> float:
+    """Aggregate per-evaluator scores into a single scenario score."""
+    if not scores:
+        return 0.0
+    if aggregation == "min":
+        return min(scores)
+    if aggregation == "weighted":
+        weights = pass_threshold.get("weights") or {}
+        # Slice 3 simplification: ignore label-keyed weights; fallback to
+        # uniform mean. Slice 4 can layer in proper weighted aggregation
+        # once evaluator IDs are stable.
+        return sum(scores) / len(scores)
+    # mean (default)
+    return sum(scores) / len(scores)
+
+
+def register() -> None:
+    """Register this dispatcher with the scenario_runner registry.
+
+    Universes call this at startup if they want mcp_call scenarios to be
+    runnable. Tests call it explicitly per case (the fixture clears the
+    registry between tests).
+    """
+    from workflow.evaluation.scenario_runner import register_dispatcher
+    register_dispatcher("mcp_call", mcp_call_dispatcher)
+
+
+__all__ = [
+    "EvaluatorCallable",
+    "mcp_call_dispatcher",
+    "register",
+]

--- a/tests/test_scenario_dispatcher_mcp_call.py
+++ b/tests/test_scenario_dispatcher_mcp_call.py
@@ -1,0 +1,265 @@
+"""End-to-end test for the mcp_call dispatcher (Slice 3 of the lane).
+
+Tests the full AcceptanceScenario path against a real platform action
+handler — `_action_goal_propose` from `workflow.api.market`. The
+scenario specifies a Goal-propose invocation; the dispatcher invokes
+the handler; the evaluator chain confirms the response shape; the
+runner wraps the result into a standard EvalResult.
+
+This is the smallest realistic end-to-end test of the AcceptanceScenario
+runtime per the Slice 1 design's recommendation.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from workflow.api.market import _action_goal_propose
+from workflow.evaluation.scenario_dispatchers.mcp_call import (
+    mcp_call_dispatcher,
+    register as register_mcp_call_dispatcher,
+)
+from workflow.evaluation.scenario_runner import (
+    AcceptanceScenario,
+    registered_dispatchers,
+    run_scenario,
+    unregister_dispatcher,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_dispatcher_registry():
+    """Each test starts + ends with an empty scenario_runner registry."""
+    yield
+    for target_surface in list(registered_dispatchers().keys()):
+        unregister_dispatcher(target_surface)
+
+
+def _goals_propose_scenario(scenario_id: str = "scenario:goals-propose-happy-path-v1") -> AcceptanceScenario:
+    return AcceptanceScenario(
+        scenario_id=scenario_id,
+        target_surface="mcp_call",
+        user_story=(
+            "A user opens their MCP-connected chatbot and asks to propose "
+            "a new Goal for a side project. The chatbot calls "
+            "goals action=propose with a name, the platform creates the "
+            "Goal record + commits it, and the response carries "
+            "status=proposed plus the saved Goal data so the chatbot can "
+            "confirm the proposal in plain language. The acceptance check "
+            "verifies the saved record + status."
+        ),
+        allowed_tools=["goals", "universe"],
+        evaluator_chain=["evaluator:goal-record-shape-check"],
+        artifact_requirements=[
+            {"kind": "packet", "scope": "final", "redact_pattern": None}
+        ],
+        pass_threshold={"min_score": 0.75, "score_aggregation": "mean"},
+        cost_budget={"max_tokens": 4000, "max_wall_time_seconds": 60},
+        privacy_scope="commons_publishable",
+        idempotency_key_constructor="sha256({scenario_id}|{candidate_ref}|{date_hour})",
+    )
+
+
+def _goal_record_shape_evaluator(parsed_response: dict) -> dict:
+    """Slice 3 evaluator: verify goals.propose returned a valid Goal record."""
+    if "error" in parsed_response or parsed_response.get("status") == "rejected":
+        return {
+            "score": 0.0,
+            "label": "goal-record-shape-check",
+            "details": {"verified": False, "reason": "error_or_rejected"},
+        }
+    if parsed_response.get("status") != "proposed":
+        return {
+            "score": 0.0,
+            "label": "goal-record-shape-check",
+            "details": {
+                "verified": False,
+                "reason": f"unexpected status {parsed_response.get('status')!r}",
+            },
+        }
+    goal = parsed_response.get("goal") or {}
+    has_required_fields = bool(goal.get("name")) and "visibility" in goal
+    return {
+        "score": 1.0 if has_required_fields else 0.5,
+        "label": "goal-record-shape-check",
+        "details": {
+            "verified": has_required_fields,
+            "name_present": bool(goal.get("name")),
+            "visibility_present": "visibility" in goal,
+        },
+    }
+
+
+def test_register_helper_populates_runner_registry() -> None:
+    register_mcp_call_dispatcher()
+    assert "mcp_call" in registered_dispatchers()
+    assert registered_dispatchers()["mcp_call"] is mcp_call_dispatcher
+
+
+def test_dispatcher_rejects_wrong_target_surface() -> None:
+    # Construct a scenario with a different target_surface but try to call
+    # the mcp_call dispatcher directly with it.
+    scenario = _goals_propose_scenario()
+    scenario_with_wrong_surface = AcceptanceScenario(
+        scenario_id="scenario:bogus-v1",
+        target_surface="branch_run",
+        user_story=scenario.user_story,
+        allowed_tools=scenario.allowed_tools,
+        evaluator_chain=scenario.evaluator_chain,
+        artifact_requirements=scenario.artifact_requirements,
+        pass_threshold=scenario.pass_threshold,
+        cost_budget=scenario.cost_budget,
+        privacy_scope=scenario.privacy_scope,
+        idempotency_key_constructor=scenario.idempotency_key_constructor,
+    )
+
+    with pytest.raises(ValueError, match="unsupported target_surface"):
+        mcp_call_dispatcher(
+            scenario_with_wrong_surface,
+            candidate_ref="goals.propose",
+            action_handler=_action_goal_propose,
+            invocation_kwargs={"name": "Test"},
+        )
+
+
+def test_dispatcher_requires_action_handler() -> None:
+    scenario = _goals_propose_scenario()
+    with pytest.raises(ValueError, match="action_handler"):
+        mcp_call_dispatcher(
+            scenario,
+            candidate_ref="goals.propose",
+            invocation_kwargs={"name": "Test"},
+        )
+
+
+def test_dispatcher_uses_default_status_check_when_no_evaluators(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("WORKFLOW_STORAGE_BACKEND", "sqlite")
+
+    scenario = _goals_propose_scenario()
+    raw = mcp_call_dispatcher(
+        scenario,
+        candidate_ref="goals.propose",
+        action_handler=_action_goal_propose,
+        invocation_kwargs={"name": "Default Eval Project"},
+        # evaluators omitted → default status check kicks in
+    )
+
+    assert raw["score"] == 1.0
+    er = raw["details"]["evaluator_results"]
+    assert len(er) == 1
+    assert er[0]["label"] == "default_status_check"
+    assert er[0]["details"]["status"] == "proposed"
+
+
+def test_dispatcher_rejects_missing_name_via_evaluator(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("WORKFLOW_STORAGE_BACKEND", "sqlite")
+
+    scenario = _goals_propose_scenario(scenario_id="scenario:goals-propose-missing-name-v1")
+    raw = mcp_call_dispatcher(
+        scenario,
+        candidate_ref="goals.propose",
+        action_handler=_action_goal_propose,
+        invocation_kwargs={},  # missing name → handler returns error
+        evaluators=[_goal_record_shape_evaluator],
+    )
+
+    # Evaluator should catch the rejected response and score 0.
+    assert raw["score"] == 0.0
+    assert raw["details"]["evaluator_results"][0]["details"]["verified"] is False
+
+
+def test_end_to_end_goals_propose_passes(tmp_path, monkeypatch) -> None:
+    """The full Slice 3 path: scenario + dispatcher + evaluator + runner.
+
+    Verifies that AcceptanceScenario actually exercises a real platform
+    action and produces a standard EvalResult with PASS verdict.
+    """
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("WORKFLOW_STORAGE_BACKEND", "sqlite")
+
+    # Universe-side startup: register the dispatcher.
+    register_mcp_call_dispatcher()
+
+    # A real platform action invocation passed as kwargs.
+    scenario = _goals_propose_scenario()
+    result = run_scenario(
+        scenario,
+        candidate_ref="goals.propose",
+        action_handler=_action_goal_propose,
+        invocation_kwargs={"name": "Slice 3 End-to-End Test Project"},
+        evaluators=[_goal_record_shape_evaluator],
+    )
+
+    # Standard EvalResult shape, PASS verdict, correct score.
+    assert result.verdict == "pass"
+    assert result.kind == "custom"
+    assert result.label == "mcp_call:goals.propose"
+    assert result.score == 1.0
+
+    # Evidence captured: raw response + evaluator outcome + cost.
+    assert "raw_response_text" in result.details
+    parsed = result.details["parsed_response"]
+    assert parsed["status"] == "proposed"
+    assert parsed["goal"]["name"] == "Slice 3 End-to-End Test Project"
+
+    eval_results = result.details["evaluator_results"]
+    assert len(eval_results) == 1
+    assert eval_results[0]["label"] == "goal-record-shape-check"
+    assert eval_results[0]["details"]["verified"] is True
+
+    # Runner-injected defaults present (per scenario_runner contract).
+    assert result.details["scenario_id"] == scenario.scenario_id
+    assert result.details["target_surface"] == "mcp_call"
+    assert result.details["privacy_scope"] == "commons_publishable"
+
+    # Wall-time budget honored (real handler completes well under the cap).
+    assert result.details["wall_time_seconds"] < scenario.cost_budget["max_wall_time_seconds"]
+    assert "over_budget" not in result.details
+
+
+def test_end_to_end_goals_propose_fails_on_missing_name(tmp_path, monkeypatch) -> None:
+    """The same scenario but with a malformed invocation: must FAIL cleanly."""
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("WORKFLOW_STORAGE_BACKEND", "sqlite")
+
+    register_mcp_call_dispatcher()
+    scenario = _goals_propose_scenario(scenario_id="scenario:goals-propose-fail-v1")
+    result = run_scenario(
+        scenario,
+        candidate_ref="goals.propose",
+        action_handler=_action_goal_propose,
+        invocation_kwargs={},  # missing required `name`
+        evaluators=[_goal_record_shape_evaluator],
+    )
+
+    assert result.verdict == "fail"
+    assert result.score == 0.0
+    parsed = result.details["parsed_response"]
+    assert "error" in parsed
+    assert "name is required" in parsed["error"]
+
+
+def test_dispatcher_records_handler_exception_as_minus_one(tmp_path, monkeypatch) -> None:
+    """When the action handler itself raises, score is -1.0 and reason is recorded."""
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+
+    scenario = _goals_propose_scenario(scenario_id="scenario:goals-propose-crash-v1")
+
+    def crashing_handler(_kwargs):
+        raise RuntimeError("simulated handler crash")
+
+    raw = mcp_call_dispatcher(
+        scenario,
+        candidate_ref="goals.propose",
+        action_handler=crashing_handler,
+        invocation_kwargs={"name": "Crash Test"},
+        evaluators=[_goal_record_shape_evaluator],
+    )
+
+    assert raw["score"] == -1.0
+    assert "handler_exception" in raw["details"]
+    assert "simulated handler crash" in raw["details"]["handler_exception"]

--- a/workflow/evaluation/scenario_dispatchers/__init__.py
+++ b/workflow/evaluation/scenario_dispatchers/__init__.py
@@ -1,0 +1,9 @@
+"""Concrete dispatcher implementations for AcceptanceScenario runtime.
+
+Each module in this package implements a dispatcher for one target_surface
+per the Slice 1 design (docs/design-notes/2026-05-02-acceptance-scenario-
+packs.md). Dispatchers register themselves with the scenario_runner's
+registry at universe startup.
+
+Slice 3 ships the first concrete dispatcher: `mcp_call`.
+"""

--- a/workflow/evaluation/scenario_dispatchers/mcp_call.py
+++ b/workflow/evaluation/scenario_dispatchers/mcp_call.py
@@ -1,0 +1,225 @@
+"""mcp_call dispatcher — Slice 3 of the AcceptanceScenario lane.
+
+Concrete dispatcher for `target_surface="mcp_call"`: invokes a single
+MCP action handler with declared kwargs, parses the JSON response, runs
+evaluator callables against the parsed response, returns aggregated
+score + verdict.
+
+This is the SIMPLEST realistic dispatcher and the natural first slice
+per the Slice 1 design's recommendation:
+
+> Slice 3: one concrete scenario shipped end-to-end. Recommendation: a
+> small MCP scenario for an existing `goals` action (e.g., `goals
+> action=propose` correctly creates a Goal record + binds the chatbot's
+> request). Smallest possible real test of the full contract.
+
+Slice 4+ scope: dispatchers for ui_test_mission (compose with existing
+user-sim discipline), branch_run (compose with workflow.api.runs),
+external_effect (compose with the #914 external-write authority design),
+session_trace_summary (review-against-summary check).
+
+Cost-budget enforcement is intentionally minimal here: the dispatcher
+records `wall_time_seconds` actually elapsed in the response and lets
+the scenario's evaluators inspect it. Hard kills on long-running calls
+are a Slice 4+ refinement that needs a process-isolation primitive.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Callable
+
+from workflow.evaluation.scenario_runner import AcceptanceScenario
+
+# Evaluator signature: (parsed_response) -> {"score": float, "label": str, "details": dict}
+EvaluatorCallable = Callable[[dict], dict]
+
+
+def mcp_call_dispatcher(
+    scenario: AcceptanceScenario,
+    candidate_ref: str,
+    *,
+    action_handler: Callable[[dict], str] | None = None,
+    invocation_kwargs: dict[str, Any] | None = None,
+    evaluators: list[EvaluatorCallable] | None = None,
+    **_extra: Any,
+) -> dict[str, Any]:
+    """Invoke an MCP action handler and evaluate its response.
+
+    Args:
+        scenario: the AcceptanceScenario being run (validated by runner).
+        candidate_ref: identifier of what is being tested (e.g., "goals.propose").
+        action_handler: callable matching the MCP-action contract
+            (`(kwargs: dict) -> json_str`). For platform-side action
+            handlers, this is the function from `workflow/api/market.py`
+            or equivalent. Required.
+        invocation_kwargs: kwargs the dispatcher passes to action_handler.
+            Required for non-trivial cases.
+        evaluators: ordered list of evaluator callables to run against
+            the parsed response. Each evaluator returns
+            `{"score": float, "label": str, "details": dict}`.
+            Defaults to a single status-check evaluator if omitted.
+
+    Returns:
+        A dict matching the scenario_runner's expected dispatcher return
+        shape: `{"score": float, "verdict": str, "label": str, "details": dict}`.
+        The runner wraps this into a standard EvalResult.
+    """
+    if scenario.target_surface != "mcp_call":
+        raise ValueError(
+            f"mcp_call_dispatcher invoked for unsupported target_surface "
+            f"{scenario.target_surface!r}"
+        )
+    if action_handler is None:
+        raise ValueError(
+            "mcp_call_dispatcher requires `action_handler=` kwarg "
+            "(the MCP action callable to invoke)"
+        )
+    invocation_kwargs = dict(invocation_kwargs or {})
+
+    start = time.monotonic()
+    raw_response_text: str
+    parse_error: str | None = None
+    parsed: dict[str, Any] = {}
+    handler_exception: str | None = None
+
+    try:
+        raw_response_text = action_handler(invocation_kwargs)
+    except Exception as exc:  # noqa: BLE001 — surface for evaluator review
+        handler_exception = f"{type(exc).__name__}: {exc}"
+        raw_response_text = ""
+
+    wall_time_seconds = max(0.0, time.monotonic() - start)
+
+    if not handler_exception:
+        try:
+            parsed = json.loads(raw_response_text) if raw_response_text else {}
+        except json.JSONDecodeError as exc:
+            parse_error = f"json decode failed: {exc}"
+
+    evaluator_results: list[dict[str, Any]] = []
+
+    if evaluators is None:
+        # Default evaluator: response must have non-error status.
+        evaluators = [_default_status_check_evaluator]
+
+    for evaluator in evaluators:
+        try:
+            result = evaluator(parsed)
+            if not isinstance(result, dict):
+                raise TypeError(
+                    f"evaluator {evaluator!r} must return a dict; got "
+                    f"{type(result).__name__}"
+                )
+            score = float(result.get("score", 0.0))
+            label = str(result.get("label", evaluator.__name__))
+            details = dict(result.get("details", {}))
+            evaluator_results.append({
+                "score": max(-1.0, min(1.0, score)),
+                "label": label,
+                "details": details,
+            })
+        except Exception as exc:  # noqa: BLE001
+            evaluator_results.append({
+                "score": 0.0,
+                "label": getattr(evaluator, "__name__", "anonymous_evaluator"),
+                "details": {
+                    "evaluator_exception": f"{type(exc).__name__}: {exc}",
+                },
+            })
+
+    # Aggregate scores per the scenario's pass_threshold.
+    score_aggregation = scenario.pass_threshold.get("score_aggregation", "mean")
+    scores = [r["score"] for r in evaluator_results]
+    final_score = _aggregate_scores(scores, score_aggregation, scenario.pass_threshold)
+
+    details_out: dict[str, Any] = {
+        "candidate_ref": candidate_ref,
+        "invocation_kwargs": invocation_kwargs,
+        "raw_response_text": raw_response_text,
+        "parsed_response": parsed,
+        "wall_time_seconds": wall_time_seconds,
+        "evaluator_results": evaluator_results,
+        "score_aggregation": score_aggregation,
+    }
+    if handler_exception:
+        details_out["handler_exception"] = handler_exception
+        final_score = -1.0
+    if parse_error:
+        details_out["parse_error"] = parse_error
+        final_score = min(final_score, 0.0)
+
+    # Cost-budget reporting (enforcement comes in Slice 4+).
+    cost_budget = scenario.cost_budget
+    over_budget_wall_time = wall_time_seconds > cost_budget.get(
+        "max_wall_time_seconds", float("inf")
+    )
+    if over_budget_wall_time:
+        details_out["over_budget"] = {
+            "wall_time_seconds": wall_time_seconds,
+            "max_wall_time_seconds": cost_budget.get("max_wall_time_seconds"),
+        }
+
+    return {
+        "score": final_score,
+        "details": details_out,
+        "label": f"mcp_call:{candidate_ref}",
+    }
+
+
+def _default_status_check_evaluator(parsed: dict[str, Any]) -> dict[str, Any]:
+    """Default evaluator when scenario does not supply its own.
+
+    Passes when the parsed response carries a non-error status. Useful
+    for trivial happy-path scenarios; real scenarios should supply their
+    own evaluator list.
+    """
+    status = parsed.get("status", "")
+    is_error = "error" in parsed or status in {"rejected", "error", "failed"}
+    return {
+        "score": 0.0 if is_error else 1.0,
+        "label": "default_status_check",
+        "details": {
+            "status": status,
+            "is_error": is_error,
+        },
+    }
+
+
+def _aggregate_scores(
+    scores: list[float],
+    aggregation: str,
+    pass_threshold: dict[str, Any],
+) -> float:
+    """Aggregate per-evaluator scores into a single scenario score."""
+    if not scores:
+        return 0.0
+    if aggregation == "min":
+        return min(scores)
+    if aggregation == "weighted":
+        weights = pass_threshold.get("weights") or {}
+        # Slice 3 simplification: ignore label-keyed weights; fallback to
+        # uniform mean. Slice 4 can layer in proper weighted aggregation
+        # once evaluator IDs are stable.
+        return sum(scores) / len(scores)
+    # mean (default)
+    return sum(scores) / len(scores)
+
+
+def register() -> None:
+    """Register this dispatcher with the scenario_runner registry.
+
+    Universes call this at startup if they want mcp_call scenarios to be
+    runnable. Tests call it explicitly per case (the fixture clears the
+    registry between tests).
+    """
+    from workflow.evaluation.scenario_runner import register_dispatcher
+    register_dispatcher("mcp_call", mcp_call_dispatcher)
+
+
+__all__ = [
+    "EvaluatorCallable",
+    "mcp_call_dispatcher",
+    "register",
+]


### PR DESCRIPTION
## Summary

First concrete dispatcher for the AcceptanceScenario lane + the first end-to-end scenario shipped through the full contract: scenario → dispatcher → real platform action → evaluator chain → standard EvalResult. Demonstrates the runtime is functional against actual platform code.

## Diff stats

- 5 files changed, **733 insertions**
- 8 new end-to-end tests (27 passing total across the lane)
- Mirror parity ✓
- All pre-commit invariants green

## What ships

1. **`workflow/evaluation/scenario_dispatchers/` package** — concrete dispatcher implementations live here; each module per target_surface.

2. **`workflow/evaluation/scenario_dispatchers/mcp_call.py`** — concrete dispatcher for `target_surface="mcp_call"`. Invokes a single MCP action handler with declared kwargs, parses the JSON response, runs evaluator callables against the parsed response, returns aggregated score + verdict + evidence bundle. Includes a default status-check evaluator for trivial happy-path cases. Records `wall_time_seconds`; emits `over_budget` annotation when exceeded (hard kill on overrun is Slice 4+).

3. **Plugin mirror** byte-identical at `packaging/.../runtime/workflow/evaluation/scenario_dispatchers/`.

4. **`tests/test_scenario_dispatcher_mcp_call.py`** — 8 tests covering:
   - `register()` helper populates the runner's registry
   - Dispatcher rejects wrong target_surface
   - Dispatcher requires `action_handler` kwarg
   - Default status-check evaluator works when none specified
   - Missing-name invocation → evaluator catches the rejection
   - **End-to-end happy path:** scenario + runner + dispatcher + real `_action_goal_propose` handler + custom evaluator → standard EvalResult with PASS verdict
   - **End-to-end fail path:** same scenario with malformed invocation → FAIL
   - Handler exception → score=-1.0, exception recorded

## The smallest realistic end-to-end proof

```python
register_mcp_call_dispatcher()
scenario = AcceptanceScenario(
    scenario_id="scenario:goals-propose-happy-path-v1",
    target_surface="mcp_call",
    user_story="A user opens their chatbot and asks to propose...",
    # ... etc.
)
result = run_scenario(
    scenario,
    candidate_ref="goals.propose",
    action_handler=_action_goal_propose,        # real platform code
    invocation_kwargs={"name": "Slice 3 Test Project"},
    evaluators=[goal_record_shape_evaluator],   # custom check
)

assert result.verdict == "pass"
assert result.score == 1.0
assert result.details["parsed_response"]["status"] == "proposed"
```

The full Slice 1/2/3 contract works end-to-end against a real platform action handler.

## Design constraints honored

- ❌ NO new EvaluatorKind (EvalResult.kind="custom")
- ❌ NO new sandbox (dispatcher just calls the handler directly)
- ❌ NO new evaluator primitive (evaluators are callables; universe maps "evaluator IDs" to callables at register time)
- ❌ NO AgencyBench code
- ❌ NO platform privacy enforcement
- ❌ Cost-budget hard kill (recorded but not enforced — Slice 4+ scope)

## Lane status after this merges

| Slice | State |
|---|---|
| Slice 1 (design + spec) | ✅ #936 |
| Slice 2 (runner + registry) | ✅ #954 |
| Slice 3 (mcp_call dispatcher + e2e) | 🟡 this PR |
| Slice 4+ (other dispatchers, optimization gate, community library) | future |

After Slice 3, a universe can call `workflow.evaluation.scenario_dispatchers.mcp_call.register()` at startup and immediately run AcceptanceScenarios against any platform MCP action handler. The contract is real.

## Test plan

- [ ] `python -m pytest tests/test_scenario_runner.py tests/test_scenario_dispatcher_mcp_call.py -q` (expect 27 passed)
- [ ] Verify mirror parity (`diff workflow/evaluation/scenario_dispatchers/mcp_call.py packaging/.../runtime/workflow/evaluation/scenario_dispatchers/mcp_call.py` shows nothing)
- [ ] Read the end-to-end test `test_end_to_end_goals_propose_passes` and the corresponding fail-path test; confirm the full chain works
- [ ] Read the dispatcher's docstring + default status-check evaluator to confirm the API shape
- [ ] Turn the host merge key when satisfied