### PR TITLE
FEAT-006 Slice 2: propagate provider chain diagnostics through CompilerError

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
@@ -45,7 +45,24 @@ logger = logging.getLogger(__name__)
 
 
 class CompilerError(Exception):
-    """Raised when the compiler cannot produce a runnable graph."""
+    """Raised when the compiler cannot produce a runnable graph.
+
+    FEAT-006: optionally carries the structured ``chain_state`` and
+    ``attempts`` from an underlying ``AllProvidersExhaustedError`` so
+    chatbots and the auto-fix loop can see *why* the chain exhausted
+    without having to walk ``__cause__`` themselves.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        chain_state: dict | None = None,
+        attempts: list | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.chain_state = chain_state
+        self.attempts = attempts
 
 
 class BranchValidationError(CompilerError, ValueError):
@@ -227,20 +244,78 @@ def _emit_failed_event(
     node_id: str,
     exc: BaseException,
 ) -> None:
-    """Emit a terminal failed event before re-raising CompilerError."""
+    """Emit a terminal failed event before re-raising CompilerError.
+
+    FEAT-006: when the underlying exception carries ``chain_state``
+    (an ``AllProvidersExhaustedError``), forward it as a structured
+    ``provider_chain`` field on the event so downstream consumers
+    (chatbots, auto-fix loop, get_run.events) can read per-provider
+    skip reasons without parsing the human-readable error string.
+    """
     if event_sink is None:
         return
+    chain_state = getattr(exc, "chain_state", None)
+    kwargs: dict[str, Any] = {
+        "node_id": node_id,
+        "phase": "failed",
+        "error": str(exc),
+        "error_type": type(exc).__name__,
+    }
+    if chain_state is not None:
+        kwargs["provider_chain"] = chain_state
     try:
-        event_sink(
-            node_id=node_id,
-            phase="failed",
-            error=str(exc),
-            error_type=type(exc).__name__,
-        )
+        event_sink(**kwargs)
+    except TypeError:
+        # Older event_sink signatures may not accept `provider_chain`;
+        # retry without it so a kwarg-mismatch never blocks the failed event.
+        try:
+            event_sink(
+                node_id=node_id,
+                phase="failed",
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+        except Exception as sink_exc:  # noqa: BLE001
+            if _is_cancel_exception(sink_exc):
+                raise
+            logger.exception("event_sink raised in %s (failed)", node_id)
     except Exception as sink_exc:  # noqa: BLE001
         if _is_cancel_exception(sink_exc):
             raise
         logger.exception("event_sink raised in %s (failed)", node_id)
+
+
+def _wrap_provider_failure(node_id: str, exc: BaseException) -> "CompilerError":
+    """Wrap a provider-side exception into a ``CompilerError``.
+
+    FEAT-006: when the cause carries ``chain_state`` / ``attempts``
+    (an ``AllProvidersExhaustedError`` from the router), copy them
+    onto the new ``CompilerError`` and append a compact JSON suffix
+    to the error message so chatbots and the auto-fix loop can see
+    per-provider skip reasons without walking ``__cause__``.
+
+    Without this, the wrap stringifies the cause to just
+    ``"All providers exhausted for role=writer. Daemon should retry
+    with backoff."`` and the structured diagnostics are silently
+    dropped — the failure mode that makes BUG-097's investigation
+    daemon recursively self-block on the same opaque error.
+    """
+    chain_state = getattr(exc, "chain_state", None)
+    attempts = getattr(exc, "attempts", None)
+    base_msg = f"Provider call failed in node '{node_id}': {exc}"
+    if chain_state is not None:
+        try:
+            suffix = json.dumps(chain_state, default=str, separators=(",", ":"))
+            base_msg = f"{base_msg} [chain_state]: {suffix}"
+        except Exception:  # noqa: BLE001
+            # Never let a serialization edge case prevent the wrap.
+            # `default=str` can re-enter into arbitrary user objects whose
+            # ``__repr__`` raises, so the catch must be broad.
+            logger.exception(
+                "Failed to serialize chain_state on provider failure in %s",
+                node_id,
+            )
+    return CompilerError(base_msg, chain_state=chain_state, attempts=attempts)
 
 
 def _dict_merge(left: dict[str, Any], right: dict[str, Any]) -> dict[str, Any]:
@@ -987,9 +1062,7 @@ def _build_prompt_template_node(
                 except Exception as exc:
                     logger.exception("Policy provider call failed in %s", node.node_id)
                     _emit_failed_event(event_sink, node.node_id, exc)
-                    raise CompilerError(
-                        f"Provider call failed in node '{node.node_id}': {exc}"
-                    ) from exc
+                    raise _wrap_provider_failure(node.node_id, exc) from exc
             else:
                 try:
                     response = _run_with_timeout(
@@ -1004,9 +1077,7 @@ def _build_prompt_template_node(
                 except Exception as exc:
                     logger.exception("Provider call failed in %s", node.node_id)
                     _emit_failed_event(event_sink, node.node_id, exc)
-                    raise CompilerError(
-                        f"Provider call failed in node '{node.node_id}': {exc}"
-                    ) from exc
+                    raise _wrap_provider_failure(node.node_id, exc) from exc
         finally:
             if concurrency_tracker is not None:
                 concurrency_tracker.release()

--- a/tests/test_graph_compiler_provider_chain_propagation.py
+++ b/tests/test_graph_compiler_provider_chain_propagation.py
@@ -1,0 +1,208 @@
+"""Tests for FEAT-006 Slice 2 — graph_compiler propagation of provider chain
+diagnostics through the ``CompilerError`` wrap and the ``failed`` event.
+
+The router (FEAT-006 Slice 1, already on main) attaches ``chain_state`` and
+``attempts`` to ``AllProvidersExhaustedError``. Before this slice, the
+graph_compiler wrap stripped both onto ``__cause__`` where chatbots and the
+auto-fix loop could not see them — the failure mode that makes BUG-097's
+investigation daemon recursively self-block on the same opaque error.
+
+This slice asserts:
+1. ``CompilerError`` accepts and stores ``chain_state`` / ``attempts``.
+2. ``_wrap_provider_failure`` copies them off an ``AllProvidersExhaustedError``
+   and appends a JSON ``[chain_state]:`` suffix to the message.
+3. ``_emit_failed_event`` forwards ``chain_state`` to the event sink as
+   ``provider_chain`` when available.
+4. Older event_sink signatures (no ``provider_chain`` kwarg) still receive
+   the failed event without raising.
+"""
+
+from __future__ import annotations
+
+import json
+
+from workflow.exceptions import AllProvidersExhaustedError
+from workflow.graph_compiler import (
+    CompilerError,
+    _emit_failed_event,
+    _wrap_provider_failure,
+)
+
+
+def _example_chain_state() -> dict:
+    return {
+        "role": "writer",
+        "chain": ["claude-code", "codex", "ollama-local"],
+        "attempts": [
+            {
+                "provider": "claude-code",
+                "status": "skipped",
+                "skip_class": "not_in_registry",
+                "detail": "",
+            },
+            {
+                "provider": "codex",
+                "status": "failed",
+                "skip_class": "auth_invalid",
+                "detail": "401 Unauthorized",
+            },
+            {
+                "provider": "ollama-local",
+                "status": "failed",
+                "skip_class": "endpoint_unreachable",
+                "detail": "connection refused",
+            },
+        ],
+        "api_key_providers_enabled": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CompilerError carries structured diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_compiler_error_backward_compat_no_chain_state() -> None:
+    err = CompilerError("Provider call failed in node 'x'")
+    assert str(err) == "Provider call failed in node 'x'"
+    assert err.chain_state is None
+    assert err.attempts is None
+
+
+def test_compiler_error_accepts_chain_state_and_attempts() -> None:
+    cs = _example_chain_state()
+    attempts = cs["attempts"]
+    err = CompilerError("boom", chain_state=cs, attempts=attempts)
+    assert err.chain_state == cs
+    assert err.attempts == attempts
+
+
+# ---------------------------------------------------------------------------
+# _wrap_provider_failure propagates router diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_provider_failure_preserves_chain_state_from_cause() -> None:
+    cs = _example_chain_state()
+    cause = AllProvidersExhaustedError(
+        "All providers exhausted for role=writer. Daemon should retry with backoff.",
+        attempts=cs["attempts"],
+        chain_state=cs,
+    )
+    wrapped = _wrap_provider_failure("intake_router", cause)
+
+    assert isinstance(wrapped, CompilerError)
+    assert wrapped.chain_state == cs
+    assert wrapped.attempts == cs["attempts"]
+
+    msg = str(wrapped)
+    assert "Provider call failed in node 'intake_router'" in msg
+    assert "All providers exhausted for role=writer" in msg
+    # JSON suffix the auto-fix loop / chatbot can parse without __cause__:
+    assert "[chain_state]:" in msg
+    suffix_json = msg.split("[chain_state]:", 1)[1].strip()
+    parsed = json.loads(suffix_json)
+    assert parsed["role"] == "writer"
+    assert parsed["api_key_providers_enabled"] is False
+    skip_classes = {a["skip_class"] for a in parsed["attempts"]}
+    assert {"not_in_registry", "auth_invalid", "endpoint_unreachable"} <= skip_classes
+
+
+def test_wrap_provider_failure_no_chain_state_when_cause_is_plain() -> None:
+    cause = RuntimeError("subprocess crashed")
+    wrapped = _wrap_provider_failure("some_node", cause)
+    assert wrapped.chain_state is None
+    assert wrapped.attempts is None
+    msg = str(wrapped)
+    assert msg == "Provider call failed in node 'some_node': subprocess crashed"
+    assert "[chain_state]:" not in msg
+
+
+def test_wrap_provider_failure_serialization_error_does_not_block_wrap(monkeypatch) -> None:
+    """A non-JSON-serializable chain_state must still produce a usable wrap."""
+    class _Unserializable:
+        def __repr__(self) -> str:
+            raise RuntimeError("no repr either")
+
+    cs = {"oops": _Unserializable()}
+    cause = AllProvidersExhaustedError("opaque", chain_state=cs)
+    wrapped = _wrap_provider_failure("node_x", cause)
+    # chain_state still preserved as attribute (for callers that introspect it),
+    # even though the JSON suffix had to be skipped.
+    assert wrapped.chain_state is cs
+    assert "Provider call failed in node 'node_x'" in str(wrapped)
+
+
+# ---------------------------------------------------------------------------
+# _emit_failed_event forwards provider_chain
+# ---------------------------------------------------------------------------
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def __call__(self, **kwargs: object) -> None:
+        self.calls.append(kwargs)
+
+
+def test_emit_failed_event_forwards_provider_chain_when_present() -> None:
+    cs = _example_chain_state()
+    cause = AllProvidersExhaustedError("opaque", chain_state=cs)
+    sink = _RecordingSink()
+    _emit_failed_event(sink, "intake_router", cause)
+    assert len(sink.calls) == 1
+    call = sink.calls[0]
+    assert call["node_id"] == "intake_router"
+    assert call["phase"] == "failed"
+    assert call["error_type"] == "AllProvidersExhaustedError"
+    assert call["provider_chain"] == cs
+
+
+def test_emit_failed_event_no_provider_chain_kwarg_when_absent() -> None:
+    sink = _RecordingSink()
+    _emit_failed_event(sink, "node_x", RuntimeError("plain error"))
+    assert len(sink.calls) == 1
+    assert "provider_chain" not in sink.calls[0]
+    assert sink.calls[0]["error_type"] == "RuntimeError"
+
+
+def test_emit_failed_event_old_sink_signature_does_not_raise() -> None:
+    """Older event_sink callbacks that do not accept ``provider_chain``
+    must still receive the failed event without the kwarg."""
+    calls: list[dict] = []
+
+    def old_sink(*, node_id: str, phase: str, error: str, error_type: str) -> None:
+        calls.append({
+            "node_id": node_id,
+            "phase": phase,
+            "error": error,
+            "error_type": error_type,
+        })
+
+    cs = _example_chain_state()
+    cause = AllProvidersExhaustedError("opaque", chain_state=cs)
+    _emit_failed_event(old_sink, "n1", cause)
+
+    assert len(calls) == 1
+    assert calls[0]["node_id"] == "n1"
+    assert calls[0]["phase"] == "failed"
+
+
+def test_emit_failed_event_none_sink_is_noop() -> None:
+    # No event_sink configured at all is a valid runtime state for the
+    # synchronous compile path. Must not raise.
+    cs = _example_chain_state()
+    cause = AllProvidersExhaustedError("opaque", chain_state=cs)
+    _emit_failed_event(None, "n", cause)
+
+
+def test_emit_failed_event_swallows_sink_exception_when_no_provider_chain() -> None:
+    """A sink that raises on the fallback (no-provider_chain) path must
+    still not bubble the exception — failed-event emission is best-effort."""
+    def broken_sink(**kwargs: object) -> None:
+        raise ValueError("sink broken")
+
+    # No chain_state on the exception => we go straight to the broad-kwarg
+    # call, which raises; the helper should swallow and log.
+    _emit_failed_event(broken_sink, "n", RuntimeError("plain"))

--- a/workflow/graph_compiler.py
+++ b/workflow/graph_compiler.py
@@ -45,7 +45,24 @@ logger = logging.getLogger(__name__)
 
 
 class CompilerError(Exception):
-    """Raised when the compiler cannot produce a runnable graph."""
+    """Raised when the compiler cannot produce a runnable graph.
+
+    FEAT-006: optionally carries the structured ``chain_state`` and
+    ``attempts`` from an underlying ``AllProvidersExhaustedError`` so
+    chatbots and the auto-fix loop can see *why* the chain exhausted
+    without having to walk ``__cause__`` themselves.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        chain_state: dict | None = None,
+        attempts: list | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.chain_state = chain_state
+        self.attempts = attempts
 
 
 class BranchValidationError(CompilerError, ValueError):
@@ -227,20 +244,78 @@ def _emit_failed_event(
     node_id: str,
     exc: BaseException,
 ) -> None:
-    """Emit a terminal failed event before re-raising CompilerError."""
+    """Emit a terminal failed event before re-raising CompilerError.
+
+    FEAT-006: when the underlying exception carries ``chain_state``
+    (an ``AllProvidersExhaustedError``), forward it as a structured
+    ``provider_chain`` field on the event so downstream consumers
+    (chatbots, auto-fix loop, get_run.events) can read per-provider
+    skip reasons without parsing the human-readable error string.
+    """
     if event_sink is None:
         return
+    chain_state = getattr(exc, "chain_state", None)
+    kwargs: dict[str, Any] = {
+        "node_id": node_id,
+        "phase": "failed",
+        "error": str(exc),
+        "error_type": type(exc).__name__,
+    }
+    if chain_state is not None:
+        kwargs["provider_chain"] = chain_state
     try:
-        event_sink(
-            node_id=node_id,
-            phase="failed",
-            error=str(exc),
-            error_type=type(exc).__name__,
-        )
+        event_sink(**kwargs)
+    except TypeError:
+        # Older event_sink signatures may not accept `provider_chain`;
+        # retry without it so a kwarg-mismatch never blocks the failed event.
+        try:
+            event_sink(
+                node_id=node_id,
+                phase="failed",
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+        except Exception as sink_exc:  # noqa: BLE001
+            if _is_cancel_exception(sink_exc):
+                raise
+            logger.exception("event_sink raised in %s (failed)", node_id)
     except Exception as sink_exc:  # noqa: BLE001
         if _is_cancel_exception(sink_exc):
             raise
         logger.exception("event_sink raised in %s (failed)", node_id)
+
+
+def _wrap_provider_failure(node_id: str, exc: BaseException) -> "CompilerError":
+    """Wrap a provider-side exception into a ``CompilerError``.
+
+    FEAT-006: when the cause carries ``chain_state`` / ``attempts``
+    (an ``AllProvidersExhaustedError`` from the router), copy them
+    onto the new ``CompilerError`` and append a compact JSON suffix
+    to the error message so chatbots and the auto-fix loop can see
+    per-provider skip reasons without walking ``__cause__``.
+
+    Without this, the wrap stringifies the cause to just
+    ``"All providers exhausted for role=writer. Daemon should retry
+    with backoff."`` and the structured diagnostics are silently
+    dropped — the failure mode that makes BUG-097's investigation
+    daemon recursively self-block on the same opaque error.
+    """
+    chain_state = getattr(exc, "chain_state", None)
+    attempts = getattr(exc, "attempts", None)
+    base_msg = f"Provider call failed in node '{node_id}': {exc}"
+    if chain_state is not None:
+        try:
+            suffix = json.dumps(chain_state, default=str, separators=(",", ":"))
+            base_msg = f"{base_msg} [chain_state]: {suffix}"
+        except Exception:  # noqa: BLE001
+            # Never let a serialization edge case prevent the wrap.
+            # `default=str` can re-enter into arbitrary user objects whose
+            # ``__repr__`` raises, so the catch must be broad.
+            logger.exception(
+                "Failed to serialize chain_state on provider failure in %s",
+                node_id,
+            )
+    return CompilerError(base_msg, chain_state=chain_state, attempts=attempts)
 
 
 def _dict_merge(left: dict[str, Any], right: dict[str, Any]) -> dict[str, Any]:
@@ -987,9 +1062,7 @@ def _build_prompt_template_node(
                 except Exception as exc:
                     logger.exception("Policy provider call failed in %s", node.node_id)
                     _emit_failed_event(event_sink, node.node_id, exc)
-                    raise CompilerError(
-                        f"Provider call failed in node '{node.node_id}': {exc}"
-                    ) from exc
+                    raise _wrap_provider_failure(node.node_id, exc) from exc
             else:
                 try:
                     response = _run_with_timeout(
@@ -1004,9 +1077,7 @@ def _build_prompt_template_node(
                 except Exception as exc:
                     logger.exception("Provider call failed in %s", node.node_id)
                     _emit_failed_event(event_sink, node.node_id, exc)
-                    raise CompilerError(
-                        f"Provider call failed in node '{node.node_id}': {exc}"
-                    ) from exc
+                    raise _wrap_provider_failure(node.node_id, exc) from exc
         finally:
             if concurrency_tracker is not None:
                 concurrency_tracker.release()


### PR DESCRIPTION
## Summary

Closes the chain-of-custody gap that left **BUG-097** self-blocking. The router (FEAT-006 Slice 1, already on `main` at `workflow/providers/diagnostics.py`) attaches structured `chain_state` + per-provider `attempts` to `AllProvidersExhaustedError`, but `graph_compiler` strips both onto `__cause__` where chatbots and the auto-fix loop cannot see them.

Symptom: every writer-role exhaustion across domains (Castles, Echoes, Archon game, Meridian prose-lab, the reusable game forge — third+ filing of the same root) surfaces as the same opaque `"All providers exhausted for role=writer. Daemon should retry with backoff."` with no actionable per-provider triage. Even the auto-fix investigation daemon's own `intake_router` node hits this and **recursively self-blocks** on the same error class it was dispatched to investigate.

## Changes (additive, no behavior change for callers that don't introspect)

- `workflow/graph_compiler.py`
  - `CompilerError(message, chain_state=None, attempts=None)` — mirrors `AllProvidersExhaustedError`'s constructor pattern; backward-compat with all existing call sites.
  - New `_wrap_provider_failure(node_id, exc)` helper copies `chain_state` + `attempts` off the cause and appends a compact JSON suffix to the message: `"... [chain_state]: {...}"`. Chatbots and the auto-fix loop parse the suffix without walking `__cause__`.
  - `_emit_failed_event` forwards `chain_state` to the event sink as `provider_chain` kwarg when available; TypeError-guarded retry without the kwarg for older sink signatures.
  - Both provider-call wrap sites (policy path + role path) use the new helper.
- `tests/test_graph_compiler_provider_chain_propagation.py` — **10 new tests** covering CompilerError attributes, helper message/attribute propagation, JSON-serialization-edge-case resilience, and `_emit_failed_event` forwarding for both new and legacy sink signatures.
- Plugin mirror rebuilt via `packaging/claude-plugin/build_plugin.py`.

## Scope intentionally narrow

Per the FEAT-006 4-part ask:
- This is **parts 1+2** (per-provider classification + structured exposure through the failure surface). Slice 1 was the router-side collection (already on `main`).
- Parts **3** (`provider_chain_health` in `get_status`) and **4** (probe-only `extensions.test_provider_chain` action) are independent later slices that benefit from a separate review pass.

## Refs

- FEAT-006: feature-requests/feat-006-feature-request-provider-router-must-expose-per-provider-ski (cosigned 2026-05-17, third evidence pass)
- BUG-097 (filed 2026-05-20): the reusable game branch hit `AllProvidersExhausted` and the investigation daemon's own intake node recursed on the same exception class
- Companion filings: BUG-038, BUG-039, BUG-087, BUG-089, PR-079 (artifact receipt gate)

## Test plan

- [x] `pytest tests/test_graph_compiler_provider_chain_propagation.py -p no:cacheprovider` — **10/10 green**
- [x] `pytest tests/test_graph_compiler_failed_event.py tests/test_graph_compiler_isolation_diagnostics.py tests/test_graph_topology.py tests/test_api_runs.py tests/test_api.py tests/test_provider_router_diagnostics.py -p no:cacheprovider` — **327/327 green**
- [x] `ruff check workflow/graph_compiler.py tests/test_graph_compiler_provider_chain_propagation.py` clean
- [x] Plugin mirror parity (`diff -q` empty) + import probe ok via `build_plugin.py`
- [x] Pre-commit invariants: mirror parity / mojibake / import-graph / cross-provider drift / skills-valid — all green
- [ ] Cross-family review by `checker:codex`

Pre-existing failures in `tests/test_provider_router_bug029.py::TestChainDrainBackoff` (3 tests) are present on `main` without my change — confirmed via `git stash` — and are unrelated to this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)