### PR TITLE
[codex] Fix MCP discovery for JSON and default GET probes

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -1096,10 +1096,10 @@ _mcp_get_status = _register_structured_tool(
 # MCP endpoint discovery (substrate-fix #11 / Family A Phase 1.A)
 # ═══════════════════════════════════════════════════════════════════════════
 # When a browser, recruiter, or fresh AI session GETs /mcp or /mcp-directory
-# with Accept: text/html (no MCP transport handshake), return a discovery
-# page explaining what the endpoint is and how to connect via MCP client.
+# without an MCP transport handshake, return discovery metadata explaining
+# what the endpoint is and how to connect via MCP client.
 # MCP clients (POST with JSON-RPC, GET with text/event-stream for SSE leg,
-# or any request with MCP-Protocol-Version header) pass through unchanged.
+# or any request with MCP transport/session headers) pass through unchanged.
 
 _MCP_DISCOVERY_HTML = """<!doctype html>
 <html lang="en">
@@ -1169,32 +1169,56 @@ Workflow MCP Server &middot; Streamable HTTP transport (MCP spec) &middot; 2026
 """
 
 
-def _wants_discovery_html(request) -> bool:  # type: ignore[no-untyped-def]
-    """Return True iff this is a browser-style GET that should see the
-    discovery HTML page rather than the MCP transport surface.
+_MCP_DISCOVERY_JSON = {
+    "name": "workflow",
+    "type": "mcp_server_endpoint",
+    "transport": "streamable-http",
+    "description": (
+        "Workflow is a domain-agnostic multi-step AI workflow platform. "
+        "This URL is an MCP endpoint, not a normal JSON API route."
+    ),
+    "how_to_connect": {
+        "url": "https://tinyassets.io/mcp",
+        "client_accept_header": "application/json, text/event-stream",
+        "protocol_header": "MCP-Protocol-Version: 2025-03-26",
+        "method": "POST JSON-RPC initialize, then MCP Streamable HTTP",
+    },
+    "related": {
+        "landing_page": "https://tinyassets.io/",
+        "source": "https://github.com/Jonnyton/Workflow",
+        "directory_endpoint": "https://tinyassets.io/mcp-directory",
+    },
+}
 
-    Keep narrow: GET only, Accept includes text/html, NO MCP-Protocol-Version
-    header (real MCP clients send that), Accept does NOT include
-    text/event-stream (real Streamable HTTP clients send that).
-    """
+
+def _is_mcp_transport_request(request) -> bool:  # type: ignore[no-untyped-def]
     if request.method.upper() not in {"GET", "HEAD"}:
-        return False
+        return True
     if request.headers.get("mcp-protocol-version"):
-        return False
-    accept = request.headers.get("accept", "")
-    if "text/event-stream" in accept:
-        return False
+        return True
+    if request.headers.get("mcp-session-id"):
+        return True
+    accept = request.headers.get("accept", "").lower()
+    return "text/event-stream" in accept
+
+
+def _wants_discovery_html(request) -> bool:  # type: ignore[no-untyped-def]
+    accept = request.headers.get("accept", "").lower()
     return "text/html" in accept
 
 
 class _MCPDiscoveryMiddleware:
-    """Starlette middleware: serve discovery HTML on /mcp + /mcp-directory
-    GETs from browser-like clients; pass everything else through to the
-    FastMCP Streamable HTTP transport unchanged.
+    """Serve discovery output on non-transport /mcp + /mcp-directory GETs.
+
+    Browser-like clients receive HTML. Default curl and JSON probes receive
+    compact JSON. FastMCP transport traffic passes through unchanged.
     """
 
     def __init__(self, app):  # type: ignore[no-untyped-def]
         self.app = app
+
+    def __getattr__(self, name):  # type: ignore[no-untyped-def]
+        return getattr(self.app, name)
 
     async def __call__(self, scope, receive, send):  # type: ignore[no-untyped-def]
         if scope.get("type") != "http":
@@ -1208,12 +1232,15 @@ class _MCPDiscoveryMiddleware:
         from starlette.requests import Request
 
         request = Request(scope, receive=receive)
-        if not _wants_discovery_html(request):
+        if _is_mcp_transport_request(request):
             await self.app(scope, receive, send)
             return
-        from starlette.responses import HTMLResponse
+        from starlette.responses import HTMLResponse, JSONResponse
 
-        response = HTMLResponse(_MCP_DISCOVERY_HTML)
+        if _wants_discovery_html(request):
+            response = HTMLResponse(_MCP_DISCOVERY_HTML)
+        else:
+            response = JSONResponse(_MCP_DISCOVERY_JSON)
         await response(scope, receive, send)
 
 

--- a/tests/test_mcp_discovery_html.py
+++ b/tests/test_mcp_discovery_html.py
@@ -1,9 +1,10 @@
-"""Tests for substrate-fix #11 / Family A Phase 1.A: MCP endpoint discovery HTML.
+"""Tests for substrate-fix #11 / Family A Phase 1.A: MCP endpoint discovery.
 
 When a browser GETs /mcp or /mcp-directory with Accept: text/html, the server
 should return a discovery HTML page explaining the endpoint and how to connect.
-MCP transport requests (POST with JSON-RPC, GET with text/event-stream, or
-any request with MCP-Protocol-Version header) must pass through unchanged.
+Default curl and JSON probes should receive compact discovery JSON. MCP
+transport requests (POST with JSON-RPC, GET with text/event-stream, or any
+request with MCP transport/session headers) must pass through unchanged.
 """
 
 from __future__ import annotations
@@ -43,6 +44,35 @@ def test_browser_get_mcp_directory_returns_discovery_html(client):
     assert "Workflow MCP Server" in response.text
 
 
+def test_default_get_mcp_returns_discovery_json(client):
+    """Default curl-style GET returns discovery JSON, not a transport error."""
+    response = client.get("/mcp", headers={"Accept": "*/*"})
+    assert response.status_code == 200
+    assert "application/json" in response.headers["content-type"]
+    payload = response.json()
+    assert payload["type"] == "mcp_server_endpoint"
+    assert payload["transport"] == "streamable-http"
+    assert "text/event-stream" in payload["how_to_connect"]["client_accept_header"]
+
+
+def test_json_get_mcp_directory_returns_discovery_json(client):
+    """GET /mcp-directory with Accept: application/json returns discovery JSON."""
+    response = client.get(
+        "/mcp-directory",
+        headers={"Accept": "application/json"},
+    )
+    assert response.status_code == 200
+    assert response.json()["related"]["directory_endpoint"].endswith("/mcp-directory")
+
+
+def test_head_mcp_returns_discovery_headers(client):
+    """HEAD /mcp returns discovery headers for browser-like probes."""
+    response = client.head("/mcp", headers={"Accept": "text/html"})
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert response.text == ""
+
+
 def test_get_with_mcp_protocol_version_header_passes_through(client):
     """Real MCP client GET with MCP-Protocol-Version header passes through to
     transport (returns whatever FastMCP returns — usually 405 or transport
@@ -56,3 +86,33 @@ def test_get_with_mcp_protocol_version_header_passes_through(client):
     )
     # Whatever FastMCP returns; the key is it should NOT be the discovery HTML
     assert "Workflow MCP Server" not in response.text
+
+
+def test_get_with_sse_accept_passes_through(client):
+    """Streamable HTTP SSE leg should not receive discovery output."""
+    response = client.get("/mcp", headers={"Accept": "text/event-stream"})
+    assert "Workflow MCP Server" not in response.text
+    assert "mcp_server_endpoint" not in response.text
+
+
+def test_get_with_mcp_session_header_passes_through(client):
+    """Existing Streamable HTTP sessions should not receive discovery JSON."""
+    response = client.get(
+        "/mcp",
+        headers={
+            "Accept": "application/json",
+            "mcp-session-id": "session-1",
+        },
+    )
+    assert response.status_code != 200 or "mcp_server_endpoint" not in response.text
+
+
+def test_post_mcp_passes_through(client):
+    """POST requests must stay owned by the MCP transport."""
+    response = client.post(
+        "/mcp",
+        headers={"Accept": "text/html"},
+        json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+    )
+    assert "Workflow MCP Server" not in response.text
+    assert "mcp_server_endpoint" not in response.text

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -1096,10 +1096,10 @@ _mcp_get_status = _register_structured_tool(
 # MCP endpoint discovery (substrate-fix #11 / Family A Phase 1.A)
 # ═══════════════════════════════════════════════════════════════════════════
 # When a browser, recruiter, or fresh AI session GETs /mcp or /mcp-directory
-# with Accept: text/html (no MCP transport handshake), return a discovery
-# page explaining what the endpoint is and how to connect via MCP client.
+# without an MCP transport handshake, return discovery metadata explaining
+# what the endpoint is and how to connect via MCP client.
 # MCP clients (POST with JSON-RPC, GET with text/event-stream for SSE leg,
-# or any request with MCP-Protocol-Version header) pass through unchanged.
+# or any request with MCP transport/session headers) pass through unchanged.
 
 _MCP_DISCOVERY_HTML = """<!doctype html>
 <html lang="en">
@@ -1169,32 +1169,56 @@ Workflow MCP Server &middot; Streamable HTTP transport (MCP spec) &middot; 2026
 """
 
 
-def _wants_discovery_html(request) -> bool:  # type: ignore[no-untyped-def]
-    """Return True iff this is a browser-style GET that should see the
-    discovery HTML page rather than the MCP transport surface.
+_MCP_DISCOVERY_JSON = {
+    "name": "workflow",
+    "type": "mcp_server_endpoint",
+    "transport": "streamable-http",
+    "description": (
+        "Workflow is a domain-agnostic multi-step AI workflow platform. "
+        "This URL is an MCP endpoint, not a normal JSON API route."
+    ),
+    "how_to_connect": {
+        "url": "https://tinyassets.io/mcp",
+        "client_accept_header": "application/json, text/event-stream",
+        "protocol_header": "MCP-Protocol-Version: 2025-03-26",
+        "method": "POST JSON-RPC initialize, then MCP Streamable HTTP",
+    },
+    "related": {
+        "landing_page": "https://tinyassets.io/",
+        "source": "https://github.com/Jonnyton/Workflow",
+        "directory_endpoint": "https://tinyassets.io/mcp-directory",
+    },
+}
 
-    Keep narrow: GET only, Accept includes text/html, NO MCP-Protocol-Version
-    header (real MCP clients send that), Accept does NOT include
-    text/event-stream (real Streamable HTTP clients send that).
-    """
+
+def _is_mcp_transport_request(request) -> bool:  # type: ignore[no-untyped-def]
     if request.method.upper() not in {"GET", "HEAD"}:
-        return False
+        return True
     if request.headers.get("mcp-protocol-version"):
-        return False
-    accept = request.headers.get("accept", "")
-    if "text/event-stream" in accept:
-        return False
+        return True
+    if request.headers.get("mcp-session-id"):
+        return True
+    accept = request.headers.get("accept", "").lower()
+    return "text/event-stream" in accept
+
+
+def _wants_discovery_html(request) -> bool:  # type: ignore[no-untyped-def]
+    accept = request.headers.get("accept", "").lower()
     return "text/html" in accept
 
 
 class _MCPDiscoveryMiddleware:
-    """Starlette middleware: serve discovery HTML on /mcp + /mcp-directory
-    GETs from browser-like clients; pass everything else through to the
-    FastMCP Streamable HTTP transport unchanged.
+    """Serve discovery output on non-transport /mcp + /mcp-directory GETs.
+
+    Browser-like clients receive HTML. Default curl and JSON probes receive
+    compact JSON. FastMCP transport traffic passes through unchanged.
     """
 
     def __init__(self, app):  # type: ignore[no-untyped-def]
         self.app = app
+
+    def __getattr__(self, name):  # type: ignore[no-untyped-def]
+        return getattr(self.app, name)
 
     async def __call__(self, scope, receive, send):  # type: ignore[no-untyped-def]
         if scope.get("type") != "http":
@@ -1208,12 +1232,15 @@ class _MCPDiscoveryMiddleware:
         from starlette.requests import Request
 
         request = Request(scope, receive=receive)
-        if not _wants_discovery_html(request):
+        if _is_mcp_transport_request(request):
             await self.app(scope, receive, send)
             return
-        from starlette.responses import HTMLResponse
+        from starlette.responses import HTMLResponse, JSONResponse
 
-        response = HTMLResponse(_MCP_DISCOVERY_HTML)
+        if _wants_discovery_html(request):
+            response = HTMLResponse(_MCP_DISCOVERY_HTML)
+        else:
+            response = JSONResponse(_MCP_DISCOVERY_JSON)
         await response(scope, receive, send)
 
 


### PR DESCRIPTION
## Summary

- Extends the `/mcp` and `/mcp-directory` discovery middleware so non-transport GET/HEAD probes receive discovery output instead of FastMCP's transport 406.
- Keeps browser-style `Accept: text/html` responses as discovery HTML, while default curl (`Accept: */*`) and `Accept: application/json` now get compact discovery JSON.
- Preserves real MCP traffic pass-through for POST, `Accept: text/event-stream`, `MCP-Protocol-Version`, and `mcp-session-id` requests.
- Keeps the packaged Claude plugin runtime copy in parity with `workflow/universe_server.py`.

## Root Cause

PR #720 only intercepted browser-like `Accept: text/html` probes. Fresh AI sessions and curl-style probes using `Accept: */*` or `Accept: application/json` still reached the Streamable HTTP transport and received `Not Acceptable: Client must accept text/event-stream`, which reads like a broken endpoint instead of discovery metadata.

## Validation

- `python -m pytest tests/test_mcp_discovery_html.py tests/test_universe_server_directory_app.py -q` => 10 passed
- `python -m ruff check workflow/universe_server.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py tests/test_mcp_discovery_html.py tests/test_universe_server_directory_app.py` => all checks passed
- Commit hook parity/import/mojibake checks passed during commit

Fixes #946.
Related: #961 tracks the broader online approval/session speed gap separately.