### PR TITLE
fix(deploy): persist codex auth across container restarts

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -275,13 +275,20 @@ jobs:
           WORKFLOW_UID=1001
           WORKFLOW_GID=1001
 
-          # Idempotent: create the directory with right ownership if missing.
+          # Create the directory if missing. mkdir -p is itself a no-op
+          # when the path already exists.
           if [ ! -d "$VOLUME_DIR" ]; then
             echo "creating codex auth persistent volume at $VOLUME_DIR"
             mkdir -p "$VOLUME_DIR"
-            chown "$WORKFLOW_UID:$WORKFLOW_GID" "$VOLUME_DIR"
-            chmod 700 "$VOLUME_DIR"
           fi
+
+          # Ownership + mode are repaired UNCONDITIONALLY every deploy.
+          # If a prior attempt left the dir root-owned (e.g. docker bind
+          # auto-create races the create-with-chown branch), this heals
+          # the posture so uid 1001 can write. Both chown and chmod are
+          # themselves idempotent — no-op when state already matches.
+          chown "$WORKFLOW_UID:$WORKFLOW_GID" "$VOLUME_DIR"
+          chmod 700 "$VOLUME_DIR"
 
           # Migration: if the volume is empty but a workflow-worker container is
           # currently running with a /app/.codex/auth.json inside it (= we're rolling

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -248,6 +248,61 @@ jobs:
           fi
           SH
 
+      # Codex CLI rotates single-use OAuth refresh tokens in-place inside
+      # the container. PR #965 binds /var/lib/workflow-codex -> /app/.codex
+      # so the rotated chain survives container restart. This step makes
+      # that volume self-provisioning on every deploy — idempotent, no
+      # host hands required, per the Forever Rule (24/7 uptime, zero
+      # hosts online).
+      #
+      # Three idempotent branches:
+      #   - dir already present  -> skip creation
+      #   - auth.json already in volume -> skip migration (entrypoint preserves it)
+      #   - no running container with /app/.codex/auth.json -> skip migration
+      #     (new container will seed from WORKFLOW_CODEX_AUTH_JSON_B64 on first boot)
+      #
+      # The migration branch only fires once: the first deploy after
+      # PR #965 merges onto a live droplet where workflow-worker has a
+      # rotated auth.json that pre-dates the persistent volume.
+      - name: Prepare codex auth persistent volume
+        run: |
+          ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
+              "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
+              'sudo bash -s' <<'SH'
+          set -euo pipefail
+
+          VOLUME_DIR="/var/lib/workflow-codex"
+          WORKFLOW_UID=1001
+          WORKFLOW_GID=1001
+
+          # Idempotent: create the directory with right ownership if missing.
+          if [ ! -d "$VOLUME_DIR" ]; then
+            echo "creating codex auth persistent volume at $VOLUME_DIR"
+            mkdir -p "$VOLUME_DIR"
+            chown "$WORKFLOW_UID:$WORKFLOW_GID" "$VOLUME_DIR"
+            chmod 700 "$VOLUME_DIR"
+          fi
+
+          # Migration: if the volume is empty but a workflow-worker container is
+          # currently running with a /app/.codex/auth.json inside it (= we're rolling
+          # out PR #965 onto an existing live system), copy the live refresh chain
+          # into the volume so the new container preserves it instead of falling
+          # back to the stale env-var secret.
+          if [ ! -f "$VOLUME_DIR/auth.json" ]; then
+            if docker inspect workflow-worker >/dev/null 2>&1; then
+              if docker exec workflow-worker test -f /app/.codex/auth.json 2>/dev/null; then
+                echo "migrating live codex auth.json from workflow-worker into persistent volume"
+                docker cp workflow-worker:/app/.codex/auth.json "$VOLUME_DIR/auth.json"
+                chown "$WORKFLOW_UID:$WORKFLOW_GID" "$VOLUME_DIR/auth.json"
+                chmod 600 "$VOLUME_DIR/auth.json"
+              fi
+            fi
+          fi
+
+          # Confirm final state for the log.
+          ls -la "$VOLUME_DIR" || true
+          SH
+
       - name: Deploy new image
         id: deploy
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,11 +55,16 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
 # Install codex CLI to an explicit prefix so the path is deterministic
 # across distros. npm global prefix under nodesource Debian may be
 # /usr/lib/node_modules (not /usr/local/lib), so we pin to /opt/codex-install
-# and symlink the bin — then COPY --from=builder targets a known path.
+# — then COPY --from=builder targets a known path.
+#
+# Smoke-test the install via the absolute path. The final-stage image
+# does NOT symlink the bare codex bin to /usr/local/bin; it copies the
+# flock wrapper there instead (see below). Adding the same wrapper in
+# the builder stage would just be dead weight, so we run the binary
+# directly here.
 RUN mkdir -p /opt/codex-install && \
     npm install --prefix /opt/codex-install @openai/codex && \
-    ln -s /opt/codex-install/node_modules/.bin/codex /usr/local/bin/codex && \
-    codex --version
+    /opt/codex-install/node_modules/.bin/codex --version
 
 WORKDIR /build
 
@@ -96,6 +101,7 @@ RUN apt-get update && \
         curl \
         libgomp1 \
         tini \
+        util-linux \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs \
     && apt-get purge -y curl \
@@ -103,10 +109,18 @@ RUN apt-get update && \
     groupadd --system --gid 1001 workflow && \
     useradd --system --uid 1001 --gid workflow --home /app --shell /bin/bash workflow
 
-# Copy the codex install tree from builder and recreate the symlink.
-# /opt/codex-install is a deterministic path set in the builder stage.
+# Copy the codex install tree from builder and install the flock
+# wrapper as /usr/local/bin/codex. The wrapper takes an exclusive
+# flock on a sentinel in /app/.codex before exec'ing the real codex
+# binary — required because PR #965 binds the codex auth directory
+# across the daemon + worker containers, and Codex's official CI/CD
+# auth guide forbids sharing one auth.json across concurrent runners
+# without serialization (concurrent refresh attempts race rotation
+# and trigger `refresh_token_reused`). See deploy/codex-flock-wrapper.sh.
 COPY --from=builder /opt/codex-install /opt/codex-install
-RUN ln -s /opt/codex-install/node_modules/.bin/codex /usr/local/bin/codex
+COPY deploy/codex-flock-wrapper.sh /usr/local/bin/codex
+RUN chmod 0755 /usr/local/bin/codex && \
+    /usr/local/bin/codex --version
 
 WORKDIR /app
 

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -128,8 +128,11 @@ refresh attempt fails with `refresh_token_reused`. Design source:
 `.github/workflows/deploy-prod.yml` has a `Prepare codex auth
 persistent volume` step that runs on every deploy. It is idempotent:
 
-- Creates `/var/lib/workflow-codex` (mode 700, owner uid 1001) when
-  missing; no-ops when present.
+- Creates `/var/lib/workflow-codex` when missing (`mkdir -p`); repairs
+  ownership (`uid 1001:1001`) and mode (`700`) unconditionally every
+  deploy so a root-owned dir left by a docker-bind auto-create or a
+  failed earlier attempt gets healed back to a state uid 1001 can
+  write.
 - On the very first deploy onto a pre-existing live droplet, copies
   the rotated `auth.json` out of the running `workflow-worker`
   container into the new volume so the post-restart container
@@ -137,6 +140,17 @@ persistent volume` step that runs on every deploy. It is idempotent:
 - After that, every subsequent deploy is a complete no-op for this
   section — the volume + `auth.json` are already in place and the
   entrypoint preserves the file on restart.
+
+The auth file is shared across the `workflow-daemon` and
+`workflow-worker` containers (both call `codex exec`: the daemon's
+in-process executor handles `run_branch` MCP calls; the worker's
+`fantasy_daemon` subprocess handles queued BranchTasks). Concurrent
+refresh attempts are serialized by `/usr/local/bin/codex` (which is
+`deploy/codex-flock-wrapper.sh`, installed by the Dockerfile in place
+of the bare codex symlink) — it takes an exclusive `flock -x` on
+`/app/.codex/.lock` before every invocation. This mitigates the
+`refresh_token_reused` race that Codex's official CI/CD auth guide
+warns about for shared-auth scenarios (Codex Issue #10332).
 
 **Host action is only needed in two rare cases:**
 

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -114,58 +114,45 @@ ls -la /etc/workflow/env
 If ownership/mode differs, re-run the bootstrap — it resets to
 `root:workflow 640`.
 
-## Step 3b — Provision the codex auth volume (~30 sec, one-time)
+## Step 3b — Codex auth persistent volume (no host action needed)
 
 Codex CLI uses single-use OAuth refresh tokens that rotate in-place
-during normal operation. The compose stack now persists Codex's auth
-state across container restarts via a bind mount at
+during normal operation. The compose stack persists Codex's auth state
+across container restarts via a bind mount at
 `/var/lib/workflow-codex` → `/app/.codex` (see `deploy/compose.yml`).
 Without this, every restart throws away rotated tokens and the next
-refresh attempt fails with `refresh_token_reused`, killing every codex
-call until the host re-seeds `WORKFLOW_CODEX_AUTH_JSON_B64` manually.
-Documented design source:
+refresh attempt fails with `refresh_token_reused`. Design source:
 <https://developers.openai.com/codex/auth/ci-cd-auth>.
 
-One-time prep BEFORE the first start of this revision:
+**The deploy workflow handles the volume + migration automatically.**
+`.github/workflows/deploy-prod.yml` has a `Prepare codex auth
+persistent volume` step that runs on every deploy. It is idempotent:
 
-```bash
-# Create the persistent volume directory owned by the in-container UID
-# (workflow user is uid 1001 per Dockerfile).
-sudo install -d -m 700 -o 1001 -g 1001 /var/lib/workflow-codex
+- Creates `/var/lib/workflow-codex` (mode 700, owner uid 1001) when
+  missing; no-ops when present.
+- On the very first deploy onto a pre-existing live droplet, copies
+  the rotated `auth.json` out of the running `workflow-worker`
+  container into the new volume so the post-restart container
+  preserves the live refresh chain.
+- After that, every subsequent deploy is a complete no-op for this
+  section — the volume + `auth.json` are already in place and the
+  entrypoint preserves the file on restart.
 
-# Seed it with the current rotated auth.json so the new container
-# preserves a known-good auth from the very first start. Two paths:
-#
-# Path A — copy the live container's auth.json before the upgrade:
-sudo docker cp workflow-daemon:/app/.codex/auth.json /tmp/codex-auth.json
-sudo install -m 600 -o 1001 -g 1001 /tmp/codex-auth.json \
-    /var/lib/workflow-codex/auth.json
-sudo shred -u /tmp/codex-auth.json
-#
-# Path B — decode WORKFLOW_CODEX_AUTH_JSON_B64 from /etc/workflow/env
-# (use this if the live container is already dead):
-sudo bash -c '
-    set -euo pipefail
-    src=$(grep -E "^WORKFLOW_CODEX_AUTH_JSON_B64=" /etc/workflow/env | cut -d= -f2-)
-    [[ -n "$src" ]] || { echo "env var empty"; exit 1; }
-    printf "%s" "$src" | base64 -d > /var/lib/workflow-codex/auth.json
-    chmod 600 /var/lib/workflow-codex/auth.json
-    chown 1001:1001 /var/lib/workflow-codex/auth.json
-'
-```
+**Host action is only needed in two rare cases:**
 
-Verify:
+1. **Brand-new droplet, no live container to migrate from.** The
+   workflow step creates the empty volume; the new container then
+   seeds `auth.json` from `WORKFLOW_CODEX_AUTH_JSON_B64` (GitHub
+   Actions secret) on first boot. Host action: keep
+   `WORKFLOW_CODEX_AUTH_JSON_B64` rotated in GitHub secrets so a
+   fresh-droplet bootstrap has a known-good seed available.
+2. **Persistent volume wiped (disaster recovery).** Same as case 1:
+   the entrypoint reseeds from the env-var on the next boot. Host
+   action: same — keep the GitHub Actions secret fresh.
 
-```bash
-sudo ls -la /var/lib/workflow-codex/
-# expect:  -rw-------  1 1001 1001  ...  auth.json
-```
-
-After this prep, the entrypoint preserves `auth.json` on every restart
-instead of overwriting it. The `WORKFLOW_CODEX_AUTH_JSON_B64` env var
-is still read as a fallback for first-boot / volume-recovery cases, so
-it can remain set in `/etc/workflow/env`; it just stops getting applied
-on every restart.
+In normal steady-state operation (volume intact, container restarts
+for image bumps), Codex's in-place refresh chain survives indefinitely
+with no host intervention.
 
 ## Step 4 — Start the daemon (~30 sec)
 

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -114,6 +114,59 @@ ls -la /etc/workflow/env
 If ownership/mode differs, re-run the bootstrap — it resets to
 `root:workflow 640`.
 
+## Step 3b — Provision the codex auth volume (~30 sec, one-time)
+
+Codex CLI uses single-use OAuth refresh tokens that rotate in-place
+during normal operation. The compose stack now persists Codex's auth
+state across container restarts via a bind mount at
+`/var/lib/workflow-codex` → `/app/.codex` (see `deploy/compose.yml`).
+Without this, every restart throws away rotated tokens and the next
+refresh attempt fails with `refresh_token_reused`, killing every codex
+call until the host re-seeds `WORKFLOW_CODEX_AUTH_JSON_B64` manually.
+Documented design source:
+<https://developers.openai.com/codex/auth/ci-cd-auth>.
+
+One-time prep BEFORE the first start of this revision:
+
+```bash
+# Create the persistent volume directory owned by the in-container UID
+# (workflow user is uid 1001 per Dockerfile).
+sudo install -d -m 700 -o 1001 -g 1001 /var/lib/workflow-codex
+
+# Seed it with the current rotated auth.json so the new container
+# preserves a known-good auth from the very first start. Two paths:
+#
+# Path A — copy the live container's auth.json before the upgrade:
+sudo docker cp workflow-daemon:/app/.codex/auth.json /tmp/codex-auth.json
+sudo install -m 600 -o 1001 -g 1001 /tmp/codex-auth.json \
+    /var/lib/workflow-codex/auth.json
+sudo shred -u /tmp/codex-auth.json
+#
+# Path B — decode WORKFLOW_CODEX_AUTH_JSON_B64 from /etc/workflow/env
+# (use this if the live container is already dead):
+sudo bash -c '
+    set -euo pipefail
+    src=$(grep -E "^WORKFLOW_CODEX_AUTH_JSON_B64=" /etc/workflow/env | cut -d= -f2-)
+    [[ -n "$src" ]] || { echo "env var empty"; exit 1; }
+    printf "%s" "$src" | base64 -d > /var/lib/workflow-codex/auth.json
+    chmod 600 /var/lib/workflow-codex/auth.json
+    chown 1001:1001 /var/lib/workflow-codex/auth.json
+'
+```
+
+Verify:
+
+```bash
+sudo ls -la /var/lib/workflow-codex/
+# expect:  -rw-------  1 1001 1001  ...  auth.json
+```
+
+After this prep, the entrypoint preserves `auth.json` on every restart
+instead of overwriting it. The `WORKFLOW_CODEX_AUTH_JSON_B64` env var
+is still read as a fallback for first-boot / volume-recovery cases, so
+it can remain set in `/etc/workflow/env`; it just stops getting applied
+on every restart.
+
 ## Step 4 — Start the daemon (~30 sec)
 
 ```bash

--- a/deploy/codex-flock-wrapper.sh
+++ b/deploy/codex-flock-wrapper.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Codex CLI cross-container serialization wrapper.
+#
+# PR #965 binds /var/lib/workflow-codex -> /app/.codex into both the
+# workflow-daemon and workflow-worker containers so Codex's in-place
+# refresh chain survives container restarts. Codex's official CI/CD
+# auth guide warns that one auth.json must NOT be shared across
+# concurrent runners — concurrent refresh attempts race the rotation
+# and trigger the exact `refresh_token_reused` class we are fixing
+# (see OpenAI Codex issue #10332).
+#
+# Mitigation: every `codex` invocation goes through this wrapper, which
+# takes an exclusive flock on a sentinel file inside the shared auth
+# directory. The lock file lives next to auth.json so containers that
+# bind the same host directory see the same lock and serialize their
+# `codex exec` calls. Per-invocation lock, not held across calls —
+# refresh + write happen inside one `codex exec` process, so the
+# serialization window matches the rotation window exactly.
+#
+# When /app/.codex is not present (local dev, Docker run without the
+# compose bind mount), the wrapper falls back to a per-process lock in
+# /tmp. Single-container correctness is not at risk because there's no
+# second container competing for the auth file.
+
+set -euo pipefail
+
+CODEX_BIN="/opt/codex-install/node_modules/.bin/codex"
+CODEX_LOCK_DIR="${HOME:-/app}/.codex"
+CODEX_LOCK_FALLBACK_DIR="/tmp"
+
+if [[ -d "${CODEX_LOCK_DIR}" ]]; then
+    LOCK_FILE="${CODEX_LOCK_DIR}/.lock"
+else
+    LOCK_FILE="${CODEX_LOCK_FALLBACK_DIR}/codex.lock"
+fi
+
+# Create the lock sentinel if missing. Use a tight chmod so the file
+# doesn't leak readability beyond the codex auth dir's own posture
+# (mode 700 on the dir + 600 on auth.json).
+if [[ ! -e "${LOCK_FILE}" ]]; then
+    # touch may race with a concurrent invocation; ignore the race —
+    # whichever process wins still ends up with a valid lock target.
+    touch "${LOCK_FILE}" 2>/dev/null || true
+    chmod 600 "${LOCK_FILE}" 2>/dev/null || true
+fi
+
+# Pass the lock fd through flock; -x = exclusive, no timeout (codex
+# refresh + write completes in well under a second; if codex itself
+# hangs that's an unrelated problem and the call timeout handles it).
+exec flock -x "${LOCK_FILE}" "${CODEX_BIN}" "$@"

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -54,6 +54,14 @@ services:
       - /etc/workflow/env
     volumes:
       - workflow-data:/data
+      # Persist codex OAuth state across container restarts. Codex CLI
+      # rotates single-use refresh tokens in-place; without persistence,
+      # every restart throws away the rotated token and the next refresh
+      # hits `refresh_token_reused`. Shared bind so `daemon` + `worker`
+      # see the same auth.json. Host one-time prep is documented in
+      # deploy/DEPLOY.md (create /var/lib/workflow-codex chown'd to
+      # uid 1001 before first start of this revision).
+      - /var/lib/workflow-codex:/app/.codex
     healthcheck:
       # Use the same canary shape as Layer-1 / tier-3 / docker-build
       # CI. Python already in the image.
@@ -159,6 +167,11 @@ services:
       - /etc/workflow/env
     volumes:
       - workflow-data:/data
+      # Same shared codex auth bind as `daemon`. The worker is the
+      # process that actually invokes `codex exec` for node execution,
+      # so persistence here is what keeps node execution alive across
+      # restarts.
+      - /var/lib/workflow-codex:/app/.codex
     depends_on:
       daemon:
         condition: service_healthy

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -58,9 +58,15 @@ services:
       # rotates single-use refresh tokens in-place; without persistence,
       # every restart throws away the rotated token and the next refresh
       # hits `refresh_token_reused`. Shared bind so `daemon` + `worker`
-      # see the same auth.json. Host one-time prep is documented in
-      # deploy/DEPLOY.md (create /var/lib/workflow-codex chown'd to
-      # uid 1001 before first start of this revision).
+      # see the same auth.json (the daemon's in-process executor pool
+      # calls `codex exec` synchronously for `run_branch` MCP calls; the
+      # worker's `fantasy_daemon` subprocess does the same for queued
+      # BranchTasks). Cross-container refresh races are serialized by
+      # /usr/local/bin/codex (-> deploy/codex-flock-wrapper.sh), which
+      # takes an exclusive flock on /app/.codex/.lock before every
+      # invocation. The persistent volume is auto-provisioned by the
+      # `Prepare codex auth persistent volume` step in
+      # .github/workflows/deploy-prod.yml — no host action required.
       - /var/lib/workflow-codex:/app/.codex
     healthcheck:
       # Use the same canary shape as Layer-1 / tier-3 / docker-build
@@ -167,10 +173,12 @@ services:
       - /etc/workflow/env
     volumes:
       - workflow-data:/data
-      # Same shared codex auth bind as `daemon`. The worker is the
-      # process that actually invokes `codex exec` for node execution,
-      # so persistence here is what keeps node execution alive across
-      # restarts.
+      # Same shared codex auth bind as `daemon`. The worker's
+      # `fantasy_daemon` subprocess invokes `codex exec` for queued
+      # BranchTask execution; refresh races against the daemon's
+      # in-process executor are serialized by the codex-flock-wrapper
+      # via /app/.codex/.lock. See the `daemon` service block above
+      # for the full rationale.
       - /var/lib/workflow-codex:/app/.codex
     depends_on:
       daemon:

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -76,10 +76,27 @@ else
 fi
 
 # Codex stores auth in ~/.codex/auth.json relative to the running user.
+#
+# Codex CLI uses OAuth single-use refresh tokens — it rotates them
+# in-container during normal operation, writing the new token back to
+# auth.json. Overwriting that file on every container start throws away
+# rotated tokens, so the next refresh attempt sends a token that's
+# already been used -> `refresh_token_reused` error -> codex calls die.
+#
+# Fix per OpenAI's official Codex CI/CD auth guide
+# (https://developers.openai.com/codex/auth/ci-cd-auth): seed auth.json
+# only when missing, and persist it across container restarts via a
+# volume mount on the parent directory (deploy/compose.yml binds
+# /app/.codex to a host path so the in-place refresh chain survives).
+#
+# Three branches:
+#   1. env set, file missing  -> seed (first boot / volume recovery)
+#   2. env set, file present  -> preserve (in-place refresh chain alive)
+#   3. env unset, file present -> preserve (volume-only operation)
 CODEX_AUTH_FILE="${HOME:-/app}/.codex/auth.json"
 
-if [[ -n "${WORKFLOW_CODEX_AUTH_JSON_B64:-}" ]]; then
-    echo "[entrypoint] installing codex subscription auth bundle"
+if [[ -n "${WORKFLOW_CODEX_AUTH_JSON_B64:-}" && ! -f "${CODEX_AUTH_FILE}" ]]; then
+    echo "[entrypoint] seeding codex auth.json (first boot / volume recovery)"
     CODEX_AUTH_DIR="$(dirname "${CODEX_AUTH_FILE}")"
     mkdir -p "${CODEX_AUTH_DIR}"
     CODEX_AUTH_TMP="$(mktemp "${CODEX_AUTH_DIR}/auth.json.XXXXXX")"
@@ -91,8 +108,10 @@ if [[ -n "${WORKFLOW_CODEX_AUTH_JSON_B64:-}" ]]; then
         echo "[entrypoint] failed to decode WORKFLOW_CODEX_AUTH_JSON_B64" >&2
         exit 1
     fi
-    unset WORKFLOW_CODEX_AUTH_JSON_B64
+elif [[ -f "${CODEX_AUTH_FILE}" ]]; then
+    echo "[entrypoint] preserving existing codex auth.json (in-place refresh chain)"
 fi
+unset WORKFLOW_CODEX_AUTH_JSON_B64
 
 _workflow_bash_path() {
     local _path="${1:-}"

--- a/tests/test_deploy_prod_workflow.py
+++ b/tests/test_deploy_prod_workflow.py
@@ -370,3 +370,143 @@ def test_deploy_requires_llm_binding_even_without_visible_deploy_secret():
     assert "--retries 12" in run_script
     assert "--retry-delay 10" in run_script
     assert "::warning::No deploy-visible WORKFLOW_CODEX_AUTH_JSON_B64" not in run_script
+
+
+# ---------------------------------------------------------------------------
+# Codex auth persistent volume (PR #965) — idempotence + ownership repair
+# ---------------------------------------------------------------------------
+
+
+def _codex_volume_step(wf: dict) -> dict:
+    step = next(
+        (
+            s for s in _steps(wf)
+            if s.get("name") == "Prepare codex auth persistent volume"
+        ),
+        None,
+    )
+    assert step is not None, (
+        "deploy must include a 'Prepare codex auth persistent volume' "
+        "step that provisions /var/lib/workflow-codex on every deploy "
+        "(Forever Rule — no host-action required)"
+    )
+    return step
+
+
+def test_codex_volume_step_runs_before_deploy():
+    wf = _load()
+    steps = _steps(wf)
+    names = [s.get("name", "") for s in steps]
+    volume_idx = names.index("Prepare codex auth persistent volume")
+    deploy_idx = next(
+        i for i, step in enumerate(steps)
+        if step.get("id") == "deploy"
+    )
+    assert volume_idx < deploy_idx, (
+        "Codex auth volume must be provisioned BEFORE the daemon "
+        "container restarts; otherwise the first restart would not "
+        "see the persistent bind mount populated."
+    )
+
+
+def test_codex_volume_step_chown_is_unconditional():
+    """Regression guard for Codex round-2 Finding 2.
+
+    Round-1 placed `chown` inside the `if [ ! -d "$VOLUME_DIR" ]` branch.
+    If a prior deploy attempt left the dir root-owned, subsequent
+    deploys silently skipped the ownership repair and uid 1001 couldn't
+    write. Fix: run chown unconditionally every deploy.
+    """
+    wf = _load()
+    step = _codex_volume_step(wf)
+    run_script = step.get("run", "") or ""
+
+    # Extract the heredoc body so we can reason about block structure.
+    # The heredoc starts after `<<'SH'` and ends at a line containing `SH`.
+    lines = run_script.splitlines()
+    start = next(
+        (i for i, line in enumerate(lines) if line.endswith("<<'SH'")),
+        None,
+    )
+    end = next(
+        (i for i, line in enumerate(lines[start + 1:], start=start + 1)
+         if line.strip() == "SH"),
+        None,
+    ) if start is not None else None
+    assert start is not None and end is not None, (
+        "Could not locate heredoc body in 'Prepare codex auth persistent volume'"
+    )
+    body = lines[start + 1: end]
+
+    chown_line_idx = next(
+        (i for i, line in enumerate(body)
+         if line.strip().startswith('chown "$WORKFLOW_UID:$WORKFLOW_GID" "$VOLUME_DIR"')),
+        None,
+    )
+    chmod_line_idx = next(
+        (i for i, line in enumerate(body)
+         if line.strip().startswith('chmod 700 "$VOLUME_DIR"')),
+        None,
+    )
+    assert chown_line_idx is not None, "chown on $VOLUME_DIR must be present"
+    assert chmod_line_idx is not None, "chmod 700 on $VOLUME_DIR must be present"
+
+    # Walk backwards from each line; the most recent unmatched `if [` must
+    # NOT be the `[ ! -d "$VOLUME_DIR" ]` branch. Track indent depth via
+    # leading whitespace as a coarse signal — both unconditional lines
+    # should sit at the heredoc's base indent.
+    def _indent(line: str) -> int:
+        return len(line) - len(line.lstrip(" "))
+
+    base_indent = min(
+        (_indent(line) for line in body if line.strip()),
+        default=0,
+    )
+    chown_indent = _indent(body[chown_line_idx])
+    chmod_indent = _indent(body[chmod_line_idx])
+    assert chown_indent == base_indent, (
+        f"chown line must sit at heredoc base indent ({base_indent}); "
+        f"got indent {chown_indent}. Being nested inside `if [ ! -d ]` "
+        "is exactly the Finding-2 regression we are guarding against."
+    )
+    assert chmod_indent == base_indent, (
+        f"chmod line must sit at heredoc base indent ({base_indent}); "
+        f"got indent {chmod_indent}."
+    )
+
+
+def test_codex_volume_step_creates_dir_idempotently():
+    wf = _load()
+    step = _codex_volume_step(wf)
+    run_script = step.get("run", "") or ""
+    assert 'mkdir -p "$VOLUME_DIR"' in run_script, (
+        "directory creation must use `mkdir -p` so re-running the step "
+        "is a no-op when the dir already exists"
+    )
+    assert 'if [ ! -d "$VOLUME_DIR" ]' in run_script, (
+        "dir-create branch must be guarded by an existence check so the "
+        "create-log line is skipped when the dir already exists"
+    )
+
+
+def test_codex_volume_step_migrates_from_running_container_once():
+    """First deploy after PR #965 onto a live droplet must copy the
+    rotated auth.json out of the running workflow-worker into the
+    persistent volume. Subsequent deploys skip (auth.json already
+    present). No-op when no live source container exists.
+    """
+    wf = _load()
+    step = _codex_volume_step(wf)
+    run_script = step.get("run", "") or ""
+    assert 'if [ ! -f "$VOLUME_DIR/auth.json" ]' in run_script, (
+        "migration branch must be guarded so it fires exactly once"
+    )
+    assert "docker inspect workflow-worker" in run_script, (
+        "migration must check workflow-worker presence before docker cp"
+    )
+    assert 'docker exec workflow-worker test -f /app/.codex/auth.json' in run_script, (
+        "migration must confirm the live container has an auth.json before copying"
+    )
+    assert "docker cp workflow-worker:/app/.codex/auth.json" in run_script
+    assert 'chown "$WORKFLOW_UID:$WORKFLOW_GID" "$VOLUME_DIR/auth.json"' in run_script
+    assert 'chmod 600 "$VOLUME_DIR/auth.json"' in run_script

--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -1,0 +1,213 @@
+"""Tests for deploy/docker-entrypoint.sh codex auth conditional.
+
+The entrypoint must NOT overwrite a present `auth.json` on container
+start. Codex CLI rotates single-use OAuth refresh tokens in-place;
+overwriting on every restart throws away the rotated token and the
+next refresh attempt hits `refresh_token_reused`. Triggered the
+2026-05-20 production codex outage.
+
+Design source: https://developers.openai.com/codex/auth/ci-cd-auth
+
+Three-branch behavior verified here:
+  1. env set, file missing  -> seed (first boot / volume recovery)
+  2. env set, file present  -> preserve (in-place refresh chain alive)
+  3. env unset, file present -> preserve (volume-only operation)
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+ENTRYPOINT = REPO / "deploy" / "docker-entrypoint.sh"
+
+_BASH = shutil.which("bash")
+
+pytestmark = pytest.mark.skipif(_BASH is None, reason="bash not available")
+
+
+def _is_wsl_bash() -> bool:
+    return (
+        os.name == "nt"
+        and _BASH is not None
+        and Path(_BASH).name.lower() == "bash.exe"
+        and "system32" in str(Path(_BASH).parent).lower()
+    )
+
+
+def _bash_path(path: Path) -> str:
+    resolved = path.resolve()
+    if os.name != "nt":
+        return str(resolved)
+    if _is_wsl_bash():
+        drive = resolved.drive.rstrip(":").lower()
+        rest = resolved.as_posix()[2:]
+        return f"/mnt/{drive}{rest}"
+    return resolved.as_posix()
+
+
+def _run_entrypoint(
+    tmp_path: Path,
+    env_extra: dict,
+    *,
+    create_existing_auth: str | None = None,
+) -> tuple[subprocess.CompletedProcess, Path]:
+    """Run the entrypoint with a temp HOME + stubbed data file.
+
+    Returns (process result, auth_file_path).
+    """
+    # Synthesize a HOME with optional pre-existing auth.json.
+    home = tmp_path / "home"
+    codex_dir = home / ".codex"
+    codex_dir.mkdir(parents=True)
+    auth_file = codex_dir / "auth.json"
+    if create_existing_auth is not None:
+        auth_file.write_text(create_existing_auth, encoding="utf-8")
+        # Match the chmod 600 the entrypoint would have set.
+        try:
+            auth_file.chmod(0o600)
+        except OSError:
+            pass
+
+    # Stub the required data file the entrypoint checks for so it doesn't
+    # blow up before reaching the codex branch / exec.
+    pkg_root = tmp_path / "pkg"
+    (pkg_root / "data").mkdir(parents=True)
+    (pkg_root / "data" / "world_rules.lp").write_text("% stub\n", encoding="utf-8")
+
+    # CMD must succeed (we're not testing the real daemon). `true`
+    # is on PATH everywhere bash runs.
+    cmd_args = ["true"]
+
+    env = {
+        # ENV-UNREADABLE sentinel — at least one must be set.
+        "WORKFLOW_IMAGE": "test:stub",
+        # Keep API-key stripping silent (truthy).
+        "WORKFLOW_ALLOW_API_KEY_PROVIDERS": "0",
+        "HOME": _bash_path(home),
+        "WORKFLOW_PACKAGE_ROOT": _bash_path(pkg_root),
+    }
+    env.update(env_extra)
+
+    if _is_wsl_bash():
+        assignments = " ".join(
+            f"{name}={shlex.quote(str(value))}"
+            for name, value in env.items()
+        )
+        command = " ".join(
+            [
+                "/usr/bin/env",
+                assignments,
+                shlex.quote(_bash_path(ENTRYPOINT)),
+                *(shlex.quote(arg) for arg in cmd_args),
+            ]
+        )
+        result = subprocess.run(
+            [_BASH, "-lc", command], capture_output=True, text=True
+        )
+    else:
+        full_env = {**os.environ, **env}
+        # Drop any inherited codex env that would confuse the test.
+        full_env.pop("WORKFLOW_CODEX_AUTH_JSON_B64", None)
+        if "WORKFLOW_CODEX_AUTH_JSON_B64" in env_extra:
+            full_env["WORKFLOW_CODEX_AUTH_JSON_B64"] = env_extra[
+                "WORKFLOW_CODEX_AUTH_JSON_B64"
+            ]
+        cmd = [_BASH, _bash_path(ENTRYPOINT), *cmd_args]
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, env=full_env
+        )
+    return result, auth_file
+
+
+def _b64(payload: str) -> str:
+    return base64.b64encode(payload.encode("utf-8")).decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# Branch 1: env set + file missing -> seed
+# ---------------------------------------------------------------------------
+
+
+def test_seeds_auth_when_env_set_and_file_missing(tmp_path):
+    seed_payload = '{"OPENAI_API_KEY":"sk-seeded","tokens":{"id_token":"seeded"}}'
+    result, auth_file = _run_entrypoint(
+        tmp_path,
+        env_extra={"WORKFLOW_CODEX_AUTH_JSON_B64": _b64(seed_payload)},
+        create_existing_auth=None,
+    )
+    # First start: prep code creates parent dir; this test pre-creates it
+    # to mirror what the volume mount would. We remove the empty
+    # auth.json scenario by deleting the file the helper would have
+    # made — but the helper only creates it when create_existing_auth is
+    # not None. Confirm baseline.
+    assert result.returncode == 0, (
+        f"entrypoint exit {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert auth_file.exists(), "auth.json should have been seeded"
+    assert auth_file.read_text(encoding="utf-8") == seed_payload
+    assert "seeding codex auth.json" in (result.stdout + result.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Branch 2: env set + file present -> preserve (the regression-blocker)
+# ---------------------------------------------------------------------------
+
+
+def test_preserves_auth_when_env_set_and_file_present(tmp_path):
+    """REGRESSION GUARD for 2026-05-20 outage.
+
+    A rotated auth.json must NOT be overwritten by an older
+    WORKFLOW_CODEX_AUTH_JSON_B64 value on container restart.
+    """
+    rotated_payload = '{"tokens":{"refresh_token":"rotated-fresh-token-v3"}}'
+    stale_env_payload = '{"tokens":{"refresh_token":"stale-bootstrap-token-v1"}}'
+    result, auth_file = _run_entrypoint(
+        tmp_path,
+        env_extra={"WORKFLOW_CODEX_AUTH_JSON_B64": _b64(stale_env_payload)},
+        create_existing_auth=rotated_payload,
+    )
+    assert result.returncode == 0, (
+        f"entrypoint exit {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert auth_file.exists()
+    assert auth_file.read_text(encoding="utf-8") == rotated_payload, (
+        "rotated auth.json must be preserved verbatim across restart; "
+        "stale env-var payload must NOT overwrite it"
+    )
+    combined = result.stdout + result.stderr
+    assert "preserving existing codex auth.json" in combined
+    assert "seeding codex auth.json" not in combined
+
+
+# ---------------------------------------------------------------------------
+# Branch 3: env unset + file present -> preserve (volume-only operation)
+# ---------------------------------------------------------------------------
+
+
+def test_preserves_auth_when_env_unset_and_file_present(tmp_path):
+    rotated_payload = '{"tokens":{"refresh_token":"volume-only-token"}}'
+    result, auth_file = _run_entrypoint(
+        tmp_path,
+        env_extra={},  # no WORKFLOW_CODEX_AUTH_JSON_B64
+        create_existing_auth=rotated_payload,
+    )
+    assert result.returncode == 0, (
+        f"entrypoint exit {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert auth_file.exists()
+    assert auth_file.read_text(encoding="utf-8") == rotated_payload
+    combined = result.stdout + result.stderr
+    assert "preserving existing codex auth.json" in combined
+    assert "seeding codex auth.json" not in combined

--- a/tests/test_dockerfile_shape.py
+++ b/tests/test_dockerfile_shape.py
@@ -85,6 +85,78 @@ def test_dockerfile_codex_version_smoke():
     )
 
 
+# ---------------------------------------------------------------------------
+# Dockerfile — codex flock wrapper (PR #965 Codex round-2 Finding 1)
+# ---------------------------------------------------------------------------
+
+
+def test_dockerfile_installs_codex_flock_wrapper():
+    """Final stage must install deploy/codex-flock-wrapper.sh as /usr/local/bin/codex.
+
+    PR #965 binds /var/lib/workflow-codex -> /app/.codex across daemon
+    + worker. Codex's official CI/CD auth guide forbids sharing one
+    auth.json across concurrent runners; the wrapper serializes
+    invocations via an exclusive flock on /app/.codex/.lock.
+
+    Round-1 of PR #965 used a bare symlink (`ln -s ... /usr/local/bin/codex`),
+    which is the exact pattern Codex Issue #10332 calls out as broken
+    when the auth dir is shared. The wrapper replaces it.
+    """
+    text = DOCKERFILE.read_text(encoding="utf-8")
+    assert "COPY deploy/codex-flock-wrapper.sh /usr/local/bin/codex" in text, (
+        "Dockerfile must COPY deploy/codex-flock-wrapper.sh to /usr/local/bin/codex "
+        "so every `codex` invocation goes through the cross-container flock"
+    )
+    # The legacy bare symlink must be gone. Regression guard.
+    assert "ln -s /opt/codex-install/node_modules/.bin/codex /usr/local/bin/codex" not in text, (
+        "Dockerfile must not install codex via bare symlink; concurrent "
+        "containers sharing /app/.codex would race the OAuth refresh "
+        "(Codex Issue #10332). Use the flock wrapper instead."
+    )
+
+
+def test_dockerfile_installs_util_linux_for_flock():
+    """flock(1) lives in util-linux. The final stage apt layer must include it
+    explicitly so the wrapper works even if the base image trims util-linux
+    in a future python-slim revision.
+    """
+    text = DOCKERFILE.read_text(encoding="utf-8")
+    assert "util-linux" in text, (
+        "Final stage must apt-install util-linux; flock(1) is part of "
+        "that package and codex-flock-wrapper.sh exec's flock on every call"
+    )
+
+
+def test_codex_flock_wrapper_script_present():
+    """The wrapper script itself must exist + be executable + lock the shared dir."""
+    wrapper = REPO_ROOT / "deploy" / "codex-flock-wrapper.sh"
+    assert wrapper.exists(), "deploy/codex-flock-wrapper.sh must exist"
+    text = wrapper.read_text(encoding="utf-8")
+    # Bash strict-mode header.
+    assert text.startswith("#!/usr/bin/env bash"), (
+        "wrapper must declare #!/usr/bin/env bash shebang"
+    )
+    assert "set -euo pipefail" in text, "wrapper must use strict bash"
+    # Lock target must live next to auth.json so the shared bind-mount
+    # makes the lock visible across containers.
+    assert ".codex" in text and ".lock" in text, (
+        "wrapper must lock a sentinel inside the codex auth directory"
+    )
+    assert "flock -x" in text, (
+        "wrapper must use exclusive flock (`flock -x`) — shared locks "
+        "would not serialize refresh writes"
+    )
+    # The actual codex binary should be the exec target.
+    assert "/opt/codex-install/node_modules/.bin/codex" in text, (
+        "wrapper must exec the real codex bin under flock"
+    )
+    assert text.rstrip().endswith('exec flock -x "${LOCK_FILE}" "${CODEX_BIN}" "$@"'), (
+        "wrapper's final line must `exec flock -x ... codex \"$@\"` so the "
+        "wrapper process is replaced (no double-fork) and signals + exit codes "
+        "propagate from codex to the daemon/worker caller"
+    )
+
+
 def test_dockerfile_ships_plan_md_for_live_review_context():
     """PLAN.md must be present at /app/PLAN.md in the runtime image."""
     text = DOCKERFILE.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Stop rewriting `~/.codex/auth.json` on every container start. Codex CLI
uses single-use OAuth refresh tokens, rotated in-place — overwriting on
every restart throws away the rotated token and the next refresh hits
`refresh_token_reused`, killing every codex call until the host
manually re-seeds the env-var. Triggered the **2026-05-20 production
codex outage**.

Design source: OpenAI's official Codex CI/CD auth guide —
<https://developers.openai.com/codex/auth/ci-cd-auth>. "Seed the file
only when missing; persist the directory across restarts."

## Three-branch entrypoint behavior

| Env var set? | File present? | Action |
|---|---|---|
| yes | no  | seed (first boot / volume recovery) |
| yes | yes | preserve (in-place refresh chain alive) |
| no  | yes | preserve (volume-only operation) |

`WORKFLOW_CODEX_AUTH_JSON_B64` is always unset at the end of the codex
section so it never leaks into the daemon process — unchanged from
before. The OPENAI_API_KEY stripping logic at the top of the
entrypoint is preserved verbatim (separate security control).

## Files

- `deploy/docker-entrypoint.sh` — conditional seed (three-branch).
- `deploy/compose.yml` — bind `/var/lib/workflow-codex` -> `/app/.codex`
  on both `daemon` and `worker` so the rotated auth survives restart
  and both containers share the same in-place refresh chain. Container
  HOME is `/app` (Dockerfile L104), runs as uid 1001 `workflow`.
- `deploy/DEPLOY.md` — new **Step 3b** documenting the one-time host
  prep (create `/var/lib/workflow-codex` chown'd to uid 1001 + seed
  with the current rotated `auth.json`) so the first start of this
  revision preserves a known-good auth.
- `tests/test_docker_entrypoint.py` — regression guard for all three
  branches, including the explicit assertion that a rotated auth.json
  must NOT be overwritten by a stale env-var payload.

## One-time droplet-prep step (post-merge, before new container starts)

```bash
sudo install -d -m 700 -o 1001 -g 1001 /var/lib/workflow-codex
sudo docker cp workflow-daemon:/app/.codex/auth.json /tmp/codex-auth.json
sudo install -m 600 -o 1001 -g 1001 /tmp/codex-auth.json /var/lib/workflow-codex/auth.json
sudo shred -u /tmp/codex-auth.json
# then docker compose down && docker compose up -d
```

Full instructions + Path-B (decode from env-var when live container is
already dead) live in `deploy/DEPLOY.md` Step 3b.

## Test plan

- [x] `python -m pytest tests/test_docker_entrypoint.py -p no:cacheprovider -v` — 3 passed, all three branches green
- [x] `bash -n deploy/docker-entrypoint.sh` — syntax clean
- [x] `python packaging/claude-plugin/build_plugin.py` — probe-ok (deploy/ is not mirrored, as expected)
- [ ] Post-merge: host runs the one-time prep step from `deploy/DEPLOY.md` Step 3b
- [ ] Post-merge: `docker compose down && docker compose up -d`, confirm `[entrypoint] preserving existing codex auth.json (in-place refresh chain)` in logs (not `seeding`)
- [ ] Post-merge: wait ≥24h, restart container, codex calls still work (proves the refresh chain survived restart)

## Cross-family review

**Codex round-2 verdict needed before merge** — this is a substrate
fix, not user-facing, but still cross-family-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)