### PR TITLE
PR-123 substrate (M2): quality_leaderboard + recommended_parent_for_fork

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
@@ -66,6 +66,7 @@ from workflow.api.evaluation import (
     _JUDGMENT_ACTIONS,
     _dispatch_judgment_action,
 )
+from workflow.api.extensions_leaderboard_actions import _LEADERBOARD_ACTIONS
 from workflow.api.helpers import _base_path, _read_json
 from workflow.api.market import (
     _ATTRIBUTION_ACTIONS,
@@ -635,6 +636,22 @@ def _extensions_impl(
         }
         return attribution_handler(attr_kwargs)
 
+    # ── Quality leaderboard / parent selection (PR-123 substrate M2) ───────
+    leaderboard_handler = _LEADERBOARD_ACTIONS.get(action)
+    if leaderboard_handler is not None:
+        lb_kwargs: dict[str, Any] = {
+            "goal_id": goal_id,
+            "author": author,
+            "force": force,
+        }
+        # ``author`` carries the optional viewer override; ``force`` is
+        # the include_private flag (host / internal callers only).
+        # Field reuse keeps the extensions() tool signature stable —
+        # no new kwargs added in this slice.
+        lb_kwargs["viewer"] = author or ""
+        lb_kwargs["include_private"] = force
+        return leaderboard_handler(lb_kwargs)
+
     return json.dumps({
         "error": f"Unknown action '{action}'.",
         "available_actions": [
@@ -665,6 +682,7 @@ def _extensions_impl(
             "pause_schedule", "unpause_schedule", "list_scheduler_subscriptions",
             "record_outcome", "list_outcomes", "get_outcome",
             "record_remix", "get_provenance",
+            "quality_leaderboard", "recommended_parent_for_fork",
         ],
     })
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
@@ -639,18 +639,16 @@ def _extensions_impl(
     # ── Quality leaderboard / parent selection (PR-123 substrate M2) ───────
     leaderboard_handler = _LEADERBOARD_ACTIONS.get(action)
     if leaderboard_handler is not None:
-        lb_kwargs: dict[str, Any] = {
-            "goal_id": goal_id,
-            "author": author,
-            "force": force,
-        }
-        # ``author`` carries the optional viewer override; ``force`` is
-        # the include_private flag (host / internal callers only).
-        # Field reuse keeps the extensions() tool signature stable —
-        # no new kwargs added in this slice.
-        lb_kwargs["viewer"] = author or ""
-        lb_kwargs["include_private"] = force
-        return leaderboard_handler(lb_kwargs)
+        # P1.1 fix (round 2) — the dispatch MUST NOT forward
+        # caller-supplied ``author`` / ``force`` into the leaderboard
+        # handler's visibility surface. Round-1 mapped
+        # ``author -> viewer`` and ``force -> include_private``, which
+        # let an MCP caller see private branches authored by anyone
+        # they could name. The handler now resolves viewer identity
+        # server-side via ``_current_actor()``; visibility is
+        # public-or-author-owned for the actual caller, never the
+        # caller-named identity.
+        return leaderboard_handler({"goal_id": goal_id})
 
     return json.dumps({
         "error": f"Unknown action '{action}'.",

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions_leaderboard_actions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions_leaderboard_actions.py
@@ -1,0 +1,208 @@
+"""MCP action handlers for the quality leaderboard — PR-123 substrate (M2).
+
+Wires ``workflow.api.quality_leaderboard`` into the ``extensions`` MCP
+tool surface so chatbots can call:
+
+- ``extensions action=quality_leaderboard goal_id=<goal>`` — ranked
+  list of branches bound to this Goal with per-entry signal summaries.
+- ``extensions action=recommended_parent_for_fork goal_id=<goal>`` —
+  top branch_def_id + rationale string. Thin wrapper for community
+  designers asking "what should I fork from?".
+
+Goal-generic by design — same primitive works for patch-loops AND
+fantasy-writing AND recipe-trackers AND any community.
+
+The dispatch dict shape matches the other ``_*_ACTIONS`` modules under
+``workflow/api/``: each handler takes a single ``kwargs: dict`` and
+returns a JSON string for the MCP response. The text channel renders
+a phone-legible mermaid-free summary; raw entries live in
+``structuredContent`` for downstream tools.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _base_universe_dir():
+    from workflow.api.helpers import _base_path
+    return _base_path()
+
+
+def _action_quality_leaderboard(kwargs: dict[str, Any]) -> str:
+    """Return the ranked leaderboard for a Goal.
+
+    Required: ``goal_id``. Optional: ``viewer`` (defaults to current
+    actor), ``include_private`` (default False).
+    """
+    goal_id = (kwargs.get("goal_id") or "").strip()
+    if not goal_id:
+        return json.dumps({
+            "error": "quality_leaderboard requires 'goal_id'",
+            "failure_class": "missing_goal_id",
+            "actionable_by": "chatbot",
+        })
+    viewer = (kwargs.get("viewer") or "").strip()
+    if not viewer:
+        try:
+            from workflow.api.engine_helpers import _current_actor
+            viewer = _current_actor()
+        except Exception:
+            viewer = ""
+    include_private = _bool_kwarg(kwargs.get("include_private"))
+
+    try:
+        from workflow.api.quality_leaderboard import build_quality_leaderboard
+        board = build_quality_leaderboard(
+            _base_universe_dir(),
+            goal_id=goal_id,
+            viewer=viewer,
+            include_private=include_private,
+        )
+    except Exception as exc:
+        logger.exception("quality_leaderboard failed for %s", goal_id)
+        return json.dumps({
+            "error": f"quality_leaderboard failed: {exc}",
+            "failure_class": "storage_error",
+            "actionable_by": "host",
+        })
+
+    board["text"] = _render_leaderboard_text(board)
+    return json.dumps(board, default=str)
+
+
+def _action_recommended_parent_for_fork(kwargs: dict[str, Any]) -> str:
+    """Return the top leaderboard entry + rationale for forking.
+
+    Required: ``goal_id``. Same viewer / include_private kwargs as
+    ``quality_leaderboard``.
+    """
+    goal_id = (kwargs.get("goal_id") or "").strip()
+    if not goal_id:
+        return json.dumps({
+            "error": "recommended_parent_for_fork requires 'goal_id'",
+            "failure_class": "missing_goal_id",
+            "actionable_by": "chatbot",
+        })
+    viewer = (kwargs.get("viewer") or "").strip()
+    if not viewer:
+        try:
+            from workflow.api.engine_helpers import _current_actor
+            viewer = _current_actor()
+        except Exception:
+            viewer = ""
+    include_private = _bool_kwarg(kwargs.get("include_private"))
+
+    try:
+        from workflow.api.quality_leaderboard import recommend_parent_for_fork
+        result = recommend_parent_for_fork(
+            _base_universe_dir(),
+            goal_id=goal_id,
+            viewer=viewer,
+            include_private=include_private,
+        )
+    except Exception as exc:
+        logger.exception(
+            "recommended_parent_for_fork failed for %s", goal_id,
+        )
+        return json.dumps({
+            "error": f"recommended_parent_for_fork failed: {exc}",
+            "failure_class": "storage_error",
+            "actionable_by": "host",
+        })
+
+    result["text"] = _render_recommendation_text(result)
+    return json.dumps(result, default=str)
+
+
+def _bool_kwarg(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _render_leaderboard_text(board: dict[str, Any]) -> str:
+    entries = board.get("entries") or []
+    goal = board.get("goal") or {}
+    goal_label = (
+        f"'{goal.get('name')}' ({board.get('goal_id')})"
+        if goal else f"Goal {board.get('goal_id')}"
+    )
+    if not entries:
+        return (
+            f"No Branches are currently bound to {goal_label}. "
+            "Use `extensions action=build_branch goal_id=...` to "
+            "create the first entry."
+        )
+
+    lines: list[str] = [
+        f"**Quality leaderboard for {goal_label}** "
+        f"({len(entries)} entries):",
+        "",
+        "| Rank | Branch | Author | Score | Runs | Forks | Recency |",
+        "|------|--------|--------|-------|------|-------|---------|",
+    ]
+    for entry in entries[:15]:
+        signals = entry.get("signals") or {}
+        name = entry.get("name") or "(unnamed)"
+        if len(name) > 30:
+            name = name[:30].rstrip() + "…"
+        age = signals.get("age_days_since_success")
+        if age is None:
+            age_text = "never"
+        elif age < 1:
+            age_text = "<1d"
+        else:
+            age_text = f"{int(age)}d ago"
+        lines.append(
+            f"| {entry.get('rank')} "
+            f"| `{entry.get('branch_def_id', '')[:12]}` {name} "
+            f"| {entry.get('author', '')} "
+            f"| {entry.get('score', 0.0):.2f} "
+            f"| {int(signals.get('completed_run_count') or 0)} "
+            f"| {int(signals.get('fork_count') or 0)} "
+            f"| {age_text} |"
+        )
+    if len(entries) > 15:
+        lines.append("")
+        lines.append(f"… and {len(entries) - 15} more entries.")
+    lines.append("")
+    lines.append(
+        "_Best-effort v1 ranking. Use "
+        "`extensions action=recommended_parent_for_fork goal_id=…` "
+        "for the top entry plus a rationale._"
+    )
+    return "\n".join(lines)
+
+
+def _render_recommendation_text(result: dict[str, Any]) -> str:
+    parent = result.get("recommended_parent")
+    rationale = result.get("rationale") or ""
+    if parent is None:
+        return rationale
+    name = parent.get("name") or "(unnamed)"
+    bid = parent.get("branch_def_id") or ""
+    return (
+        f"**Recommended parent for fork:** `{bid}` — '{name}' "
+        f"(score {parent.get('score', 0.0):.2f}).\n\n"
+        f"{rationale}"
+    )
+
+
+_LEADERBOARD_ACTIONS: dict[str, Any] = {
+    "quality_leaderboard": _action_quality_leaderboard,
+    "recommended_parent_for_fork": _action_recommended_parent_for_fork,
+}
+
+
+__all__ = [
+    "_LEADERBOARD_ACTIONS",
+    "_action_quality_leaderboard",
+    "_action_recommended_parent_for_fork",
+]

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions_leaderboard_actions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions_leaderboard_actions.py
@@ -33,11 +33,34 @@ def _base_universe_dir():
     return _base_path()
 
 
+def _resolve_caller_viewer() -> str:
+    """Resolve the viewer identity ONLY from the daemon-side actor.
+
+    Round-2 P1.1 fix — the round-1 handler trusted a caller-supplied
+    ``viewer`` kwarg, which let an MCP caller passing
+    ``author="someone-else"`` see that user's private branches. This
+    helper drops the kwarg entirely and reads ``_current_actor()`` as
+    the single source of truth. Defensive try/except so a misconfigured
+    daemon falls back to the "strictly public" filter rather than
+    leaking private rows on import failure.
+    """
+    try:
+        from workflow.api.engine_helpers import _current_actor
+        return _current_actor() or ""
+    except Exception:
+        logger.exception("failed to resolve _current_actor for viewer")
+        return ""
+
+
 def _action_quality_leaderboard(kwargs: dict[str, Any]) -> str:
     """Return the ranked leaderboard for a Goal.
 
-    Required: ``goal_id``. Optional: ``viewer`` (defaults to current
-    actor), ``include_private`` (default False).
+    Required: ``goal_id``.
+
+    NOTE: any caller-supplied ``viewer`` / ``include_private`` / ``force``
+    keys in ``kwargs`` are IGNORED for visibility purposes. Visibility
+    is always derived server-side from the current actor — see the
+    round-2 PR comment on #970 for the auth-boundary rationale.
     """
     goal_id = (kwargs.get("goal_id") or "").strip()
     if not goal_id:
@@ -46,14 +69,7 @@ def _action_quality_leaderboard(kwargs: dict[str, Any]) -> str:
             "failure_class": "missing_goal_id",
             "actionable_by": "chatbot",
         })
-    viewer = (kwargs.get("viewer") or "").strip()
-    if not viewer:
-        try:
-            from workflow.api.engine_helpers import _current_actor
-            viewer = _current_actor()
-        except Exception:
-            viewer = ""
-    include_private = _bool_kwarg(kwargs.get("include_private"))
+    viewer = _resolve_caller_viewer()
 
     try:
         from workflow.api.quality_leaderboard import build_quality_leaderboard
@@ -61,7 +77,6 @@ def _action_quality_leaderboard(kwargs: dict[str, Any]) -> str:
             _base_universe_dir(),
             goal_id=goal_id,
             viewer=viewer,
-            include_private=include_private,
         )
     except Exception as exc:
         logger.exception("quality_leaderboard failed for %s", goal_id)
@@ -78,8 +93,8 @@ def _action_quality_leaderboard(kwargs: dict[str, Any]) -> str:
 def _action_recommended_parent_for_fork(kwargs: dict[str, Any]) -> str:
     """Return the top leaderboard entry + rationale for forking.
 
-    Required: ``goal_id``. Same viewer / include_private kwargs as
-    ``quality_leaderboard``.
+    Required: ``goal_id``. Same viewer-derivation rules as
+    ``quality_leaderboard`` — visibility is server-side only.
     """
     goal_id = (kwargs.get("goal_id") or "").strip()
     if not goal_id:
@@ -88,14 +103,7 @@ def _action_recommended_parent_for_fork(kwargs: dict[str, Any]) -> str:
             "failure_class": "missing_goal_id",
             "actionable_by": "chatbot",
         })
-    viewer = (kwargs.get("viewer") or "").strip()
-    if not viewer:
-        try:
-            from workflow.api.engine_helpers import _current_actor
-            viewer = _current_actor()
-        except Exception:
-            viewer = ""
-    include_private = _bool_kwarg(kwargs.get("include_private"))
+    viewer = _resolve_caller_viewer()
 
     try:
         from workflow.api.quality_leaderboard import recommend_parent_for_fork
@@ -103,7 +111,6 @@ def _action_recommended_parent_for_fork(kwargs: dict[str, Any]) -> str:
             _base_universe_dir(),
             goal_id=goal_id,
             viewer=viewer,
-            include_private=include_private,
         )
     except Exception as exc:
         logger.exception(
@@ -117,14 +124,6 @@ def _action_recommended_parent_for_fork(kwargs: dict[str, Any]) -> str:
 
     result["text"] = _render_recommendation_text(result)
     return json.dumps(result, default=str)
-
-
-def _bool_kwarg(value: Any) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on"}
-    return bool(value)
 
 
 def _render_leaderboard_text(board: dict[str, Any]) -> str:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
@@ -1,0 +1,626 @@
+"""Quality leaderboard + parent-selection — PR-123 substrate (M2).
+
+Surfaces, for any Goal that has competing Branch entries:
+
+- ``quality_leaderboard(goal_id)`` — ranked list of Branches bound to
+  the Goal, with the per-entry signal summary that produced the score.
+- ``recommended_parent_for_fork(goal_id)`` — the top entry plus a
+  human-readable rationale string, intended as a thin handle for the
+  community designer asking "what should I fork from?".
+
+Design source: wiki page
+``pages/patch-requests/pr-123-goal-archive-with-parent-selection-...``
+on the live MCP brain. The PLAN Goals & Gates module names this
+surface as ``archive_consultation parent-rank scoring formula`` and
+flags it as **open evolution** — a follow-on may turn the scoring
+formula into an evolvable Workflow node so the community can iterate
+on weights through autoresearch rather than asking the platform to
+ship "the right" constants.
+
+This slice is **best-effort v1**: ranking is signal-driven, not
+ground-truth-driven. The formula constants are surfaced in every
+response under ``formula`` so reviewers can audit and tune them
+without re-reading source.
+
+Goal-generic by design — same primitive works for patch-loops AND
+fantasy-writing AND recipe-trackers AND any community. No
+Loop-2-specific assumptions.
+
+Signals (all read from existing storage; no new tables in this slice):
+
+- ``completed_run_count`` — runs with ``status='completed'``.
+- ``failed_run_count`` — runs with ``status='failed'`` (penalty).
+- ``total_run_count`` — full count regardless of status.
+- ``last_successful_run_at`` — max ``finished_at`` of completed runs.
+- ``recency_decay`` — ``exp(-age_days/30)`` against the wall clock;
+  0 when the branch never produced a successful run.
+- ``judgment_count`` — rows in ``run_judgments`` joined via ``runs``.
+- ``judgment_score_avg`` — mean of numeric scores parsed from
+  judgment tags like ``quality:8.2``, ``novelty:7``, ``risk:3``.
+  None when no numeric tags exist (the signal contributes 0 to the
+  score in that case rather than NaN-propagating).
+- ``fork_count`` — branches whose ``parent_def_id`` or ``fork_from``
+  references this branch. Community votes with their forks.
+- ``gate_rung_top`` — the lexicographically-greatest active
+  ``rung_key`` from ``gate_claims`` for this (branch, goal).
+- ``safe_to_publish`` — best-effort read of
+  ``branch.stats.next_action_packet.safe_to_publish``. The packet
+  shape isn't on-disk-stable yet; if absent, the signal contributes 0.
+
+Score formula (weights surfaced in the response so they are auditable):
+
+  score = 3.0 * normalized_judgment_score
+        + 1.5 * log1p(completed_run_count)
+        + 2.0 * log1p(fork_count)
+        + 2.0 * recency_decay
+        + 1.0 * has_gate_rung
+        + 1.5 * safe_to_publish
+        - 1.0 * log1p(failed_run_count)
+
+``normalized_judgment_score`` is ``judgment_score_avg / 10.0`` (DGM
+scores are on a 0-10 scale) clamped to [0, 1] so the term is bounded.
+log1p bounds the impact of high-volume entries; recency / gate /
+safe_to_publish are already [0, 1].
+
+Tie-breaks: higher ``last_successful_run_at`` wins; then higher
+``created_at`` (newer entry); then ``branch_def_id`` for stability.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Tunable weights — surfaced in the response under ``formula``
+# ---------------------------------------------------------------------------
+
+W_JUDGMENT = 3.0
+W_RUNS = 1.5
+W_FORKS = 2.0
+W_RECENCY = 2.0
+W_GATE = 1.0
+W_SAFE_PUBLISH = 1.5
+W_FAILED_PENALTY = 1.0
+
+RECENCY_HALFLIFE_DAYS = 30.0
+JUDGMENT_MAX_SCALE = 10.0  # DGM-style 0-10
+
+# Numeric judgment-tag pattern: ``key:N`` where N is integer/float.
+# Examples that match: ``quality:8``, ``quality:8.2``, ``novelty:7.5``,
+# ``risk:3``. Negative numbers and tags without ``:N`` are ignored.
+_NUMERIC_TAG_RE = re.compile(
+    r"^\s*([A-Za-z][A-Za-z0-9_\-]*)\s*:\s*([0-9]+(?:\.[0-9]+)?)\s*$"
+)
+
+# Tag names that contribute to the average quality signal. Tags outside
+# this set are recorded under ``other_numeric_tags`` so the chatbot can
+# surface them without polluting the headline score.
+_QUALITY_TAG_KEYS = frozenset({"quality", "novelty", "score"})
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_quality_leaderboard(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    now: float | None = None,
+    viewer: str = "",
+    include_private: bool = False,
+) -> dict[str, Any]:
+    """Compute the ranked list of branches bound to ``goal_id``.
+
+    Returns ``{"goal_id": ..., "goal": <row | None>, "entries": [...],
+    "formula": {...}, "generated_at": ...}``.
+
+    Each entry is::
+
+        {
+            "rank":             1,
+            "branch_def_id":    "...",
+            "name":             "...",
+            "description":      "...",
+            "author":           "...",
+            "created_at":       <unix>,
+            "updated_at":       <unix>,
+            "score":            <float>,
+            "signals":          {<see Signals section above>},
+            "score_components": {<per-term contribution to score>},
+        }
+
+    The function returns the ranked entries even when the Goal does not
+    exist or has no bound branches — the chatbot can render a friendly
+    "no entries yet" page from ``entries == []``.
+
+    ``base_path`` is the daemon's data root (matches the rest of the
+    storage layer).
+    """
+    if now is None:
+        import time as _time
+        now = _time.time()
+
+    goal_row = _safe_get_goal(base_path, goal_id)
+
+    from workflow.daemon_server import list_branch_definitions
+    branches = list_branch_definitions(
+        base_path,
+        goal_id=goal_id,
+        viewer=viewer,
+        include_private=include_private,
+    )
+
+    entries: list[dict[str, Any]] = []
+    for branch in branches:
+        signals = _collect_signals_for_branch(base_path, branch, now=now)
+        components = _score_components(signals)
+        score = sum(components.values())
+        entries.append({
+            "branch_def_id": branch["branch_def_id"],
+            "name": branch.get("name", ""),
+            "description": branch.get("description", ""),
+            "author": branch.get("author", ""),
+            "created_at": branch.get("created_at", 0.0),
+            "updated_at": branch.get("updated_at", 0.0),
+            "score": round(score, 4),
+            "signals": signals,
+            "score_components": {
+                k: round(v, 4) for k, v in components.items()
+            },
+        })
+
+    # Two-pass stable sort. First pass: branch_def_id ascending (string
+    # compare). Second pass: primary keys with reverse=True. Python's
+    # sort is stable, so the secondary key from the first pass survives
+    # within ties of the primary sort.
+    entries.sort(key=lambda e: e.get("branch_def_id", ""))
+    entries.sort(key=_entry_sort_key, reverse=True)
+    for rank, entry in enumerate(entries, start=1):
+        entry["rank"] = rank
+
+    return {
+        "goal_id": goal_id,
+        "goal": goal_row,
+        "entries": entries,
+        "formula": _formula_disclosure(),
+        "generated_at": now,
+    }
+
+
+def recommend_parent_for_fork(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    now: float | None = None,
+    viewer: str = "",
+    include_private: bool = False,
+) -> dict[str, Any]:
+    """Return the top leaderboard entry plus a human-readable rationale.
+
+    Returns ``{"goal_id": ..., "recommended_parent": <entry | None>,
+    "rationale": "...", "leaderboard_size": <int>, "generated_at": ...}``.
+
+    When no branch is bound to the Goal the response carries
+    ``recommended_parent=None`` and a rationale explaining that no
+    parent exists yet — the chatbot should propose "create the first
+    branch" rather than "fork from".
+    """
+    board = build_quality_leaderboard(
+        base_path,
+        goal_id=goal_id,
+        now=now,
+        viewer=viewer,
+        include_private=include_private,
+    )
+    entries = board["entries"]
+    if not entries:
+        return {
+            "goal_id": goal_id,
+            "recommended_parent": None,
+            "rationale": (
+                "No Branch is bound to this Goal yet. Create the first "
+                "Branch via extensions action=build_branch goal_id=… or "
+                "fork from a peer Goal's leaderboard."
+            ),
+            "leaderboard_size": 0,
+            "generated_at": board["generated_at"],
+        }
+    top = entries[0]
+    return {
+        "goal_id": goal_id,
+        "recommended_parent": top,
+        "rationale": _build_rationale(top, leaderboard_size=len(entries)),
+        "leaderboard_size": len(entries),
+        "generated_at": board["generated_at"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Signal collection
+# ---------------------------------------------------------------------------
+
+
+def _collect_signals_for_branch(
+    base_path: str | Path,
+    branch: dict[str, Any],
+    *,
+    now: float,
+) -> dict[str, Any]:
+    bid = branch["branch_def_id"]
+    goal_id = branch.get("goal_id") or ""
+
+    run_stats = _run_stats(base_path, bid)
+    judgment_stats = _judgment_stats(base_path, bid)
+    fork_count = _fork_count(base_path, bid)
+    gate_rung_top = _gate_rung_top(base_path, bid, goal_id)
+    safe_to_publish = _safe_to_publish(branch)
+
+    last_ok = run_stats["last_successful_run_at"]
+    if last_ok and last_ok > 0:
+        age_days = max(0.0, (now - last_ok) / 86400.0)
+        recency_decay = math.exp(-age_days / RECENCY_HALFLIFE_DAYS)
+    else:
+        age_days = None
+        recency_decay = 0.0
+
+    return {
+        "total_run_count": run_stats["total"],
+        "completed_run_count": run_stats["completed"],
+        "failed_run_count": run_stats["failed"],
+        "last_successful_run_at": last_ok,
+        "age_days_since_success": age_days,
+        "recency_decay": round(recency_decay, 4),
+        "judgment_count": judgment_stats["count"],
+        "judgment_score_avg": judgment_stats["score_avg"],
+        "judgment_score_samples": judgment_stats["score_samples"],
+        "other_numeric_tags": judgment_stats["other_numeric_tags"],
+        "fork_count": fork_count,
+        "gate_rung_top": gate_rung_top,
+        "has_gate_rung": gate_rung_top is not None,
+        "safe_to_publish": safe_to_publish,
+    }
+
+
+def _run_stats(base_path: str | Path, branch_def_id: str) -> dict[str, Any]:
+    """Aggregate counts + last_successful_run_at directly against runs DB.
+
+    A direct SQL aggregate is cheaper than fetching every row via
+    ``list_runs`` — this is invoked once per branch on the leaderboard
+    and a Goal can carry 50+ branches.
+    """
+    from workflow.runs import _connect, initialize_runs_db
+
+    initialize_runs_db(base_path)
+    with _connect(base_path) as conn:
+        row = conn.execute(
+            """
+            SELECT
+                COUNT(*) AS total,
+                SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed,
+                SUM(CASE WHEN status = 'failed'    THEN 1 ELSE 0 END) AS failed,
+                MAX(CASE WHEN status = 'completed' THEN finished_at END)
+                    AS last_successful_run_at
+            FROM runs
+            WHERE branch_def_id = ?
+            """,
+            (branch_def_id,),
+        ).fetchone()
+    if row is None:
+        return {
+            "total": 0, "completed": 0, "failed": 0,
+            "last_successful_run_at": 0.0,
+        }
+    return {
+        "total": int(row["total"] or 0),
+        "completed": int(row["completed"] or 0),
+        "failed": int(row["failed"] or 0),
+        "last_successful_run_at": float(row["last_successful_run_at"] or 0.0),
+    }
+
+
+def _judgment_stats(
+    base_path: str | Path, branch_def_id: str,
+) -> dict[str, Any]:
+    """Parse numeric scores out of judgment tags scoped to this branch.
+
+    Judgments are free-text + tags; the leaderboard reads ``tags_json``
+    looking for ``key:N`` patterns where ``key`` is in
+    ``_QUALITY_TAG_KEYS`` for the headline score. Other numeric tags are
+    bucketed under ``other_numeric_tags`` for surface-level reporting
+    but don't contribute to the score in this slice.
+    """
+    from workflow.runs import _connect, initialize_runs_db
+    from workflow.storage import _json_loads
+
+    initialize_runs_db(base_path)
+    with _connect(base_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT j.tags_json
+              FROM run_judgments j
+              JOIN runs r ON r.run_id = j.run_id
+             WHERE r.branch_def_id = ?
+            """,
+            (branch_def_id,),
+        ).fetchall()
+    count = len(rows)
+    quality_scores: list[float] = []
+    other_counts: dict[str, int] = {}
+    for row in rows:
+        tags = _json_loads(row["tags_json"], []) or []
+        if not isinstance(tags, list):
+            continue
+        for tag in tags:
+            if not isinstance(tag, str):
+                continue
+            m = _NUMERIC_TAG_RE.match(tag)
+            if not m:
+                continue
+            key = m.group(1).lower()
+            try:
+                value = float(m.group(2))
+            except (TypeError, ValueError):
+                continue
+            if key in _QUALITY_TAG_KEYS:
+                quality_scores.append(value)
+            else:
+                other_counts[key] = other_counts.get(key, 0) + 1
+    score_avg = (
+        sum(quality_scores) / len(quality_scores)
+        if quality_scores else None
+    )
+    return {
+        "count": count,
+        "score_avg": (round(score_avg, 4) if score_avg is not None else None),
+        "score_samples": len(quality_scores),
+        "other_numeric_tags": other_counts,
+    }
+
+
+def _fork_count(base_path: str | Path, branch_def_id: str) -> int:
+    """Count descendants. Either ``parent_def_id`` or ``fork_from`` may
+    reference this branch — count rows whose either column matches.
+    """
+    from workflow.storage import _connect
+
+    with _connect(base_path) as conn:
+        row = conn.execute(
+            """
+            SELECT COUNT(*) AS n
+              FROM branch_definitions
+             WHERE parent_def_id = ? OR fork_from = ?
+            """,
+            (branch_def_id, branch_def_id),
+        ).fetchone()
+    return int(row["n"] or 0) if row is not None else 0
+
+
+def _gate_rung_top(
+    base_path: str | Path,
+    branch_def_id: str,
+    goal_id: str,
+) -> str | None:
+    """Return the highest active gate rung for (branch, goal), or None.
+
+    "Highest" in this slice is lexicographically-greatest ``rung_key``
+    among non-retracted claims. Goal-ladder-aware ordering is a follow-on
+    once the ladder shape is stable per-Goal.
+    """
+    if not goal_id:
+        return None
+    from workflow.daemon_server import list_gate_claims
+
+    try:
+        claims = list_gate_claims(
+            base_path,
+            branch_def_id=branch_def_id,
+            include_retracted=False,
+            limit=200,
+        )
+    except Exception:
+        return None
+    candidates = [
+        (c.get("rung_key") or "")
+        for c in claims
+        if (c.get("goal_id") or "") == goal_id
+        and not c.get("retracted_at")
+    ]
+    candidates = [r for r in candidates if r]
+    if not candidates:
+        return None
+    return max(candidates)
+
+
+def _safe_to_publish(branch: dict[str, Any]) -> bool:
+    """Best-effort lookup of a Loop-2-style next_action_packet flag.
+
+    The packet shape isn't on-disk-stable yet; nodes that emit it write
+    into the branch ``stats`` JSON. When absent, the signal is False
+    rather than missing — score contribution is 0 either way.
+    """
+    stats = branch.get("stats")
+    if not isinstance(stats, dict):
+        return False
+    packet = stats.get("next_action_packet")
+    if not isinstance(packet, dict):
+        return False
+    return bool(packet.get("safe_to_publish"))
+
+
+def _safe_get_goal(
+    base_path: str | Path, goal_id: str,
+) -> dict[str, Any] | None:
+    from workflow.daemon_server import get_goal
+    try:
+        return get_goal(base_path, goal_id=goal_id)
+    except KeyError:
+        return None
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def _score_components(signals: dict[str, Any]) -> dict[str, float]:
+    """Per-term contributions to score. Surfaced in the response so the
+    chatbot can render "why this one ranked first" without re-computing.
+    """
+    score_avg = signals.get("judgment_score_avg")
+    if score_avg is None:
+        normalized_judgment = 0.0
+    else:
+        normalized_judgment = max(0.0, min(1.0, score_avg / JUDGMENT_MAX_SCALE))
+
+    completed = max(0, int(signals.get("completed_run_count") or 0))
+    failed = max(0, int(signals.get("failed_run_count") or 0))
+    fork_count = max(0, int(signals.get("fork_count") or 0))
+    recency = float(signals.get("recency_decay") or 0.0)
+    has_gate = 1.0 if signals.get("has_gate_rung") else 0.0
+    safe_pub = 1.0 if signals.get("safe_to_publish") else 0.0
+
+    return {
+        "judgment":  W_JUDGMENT * normalized_judgment,
+        "runs":      W_RUNS * math.log1p(completed),
+        "forks":     W_FORKS * math.log1p(fork_count),
+        "recency":   W_RECENCY * recency,
+        "gate":      W_GATE * has_gate,
+        "safe_pub":  W_SAFE_PUBLISH * safe_pub,
+        "failed_penalty": -W_FAILED_PENALTY * math.log1p(failed),
+    }
+
+
+def _entry_sort_key(entry: dict[str, Any]) -> tuple:
+    """Primary sort key for ranked entries (used with ``reverse=True``).
+
+    Tuple order:
+      1. ``score`` — higher is better.
+      2. ``last_successful_run_at`` — newer success wins ties.
+      3. ``created_at`` — newer branch wins ties.
+
+    Final ``branch_def_id`` tie-break is handled by a separate stable
+    sort pass before this one is applied — see ``build_quality_leaderboard``.
+    """
+    signals = entry.get("signals") or {}
+    return (
+        float(entry.get("score") or 0.0),
+        float(signals.get("last_successful_run_at") or 0.0),
+        float(entry.get("created_at") or 0.0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Disclosure + rationale
+# ---------------------------------------------------------------------------
+
+
+def _formula_disclosure() -> dict[str, Any]:
+    return {
+        "weights": {
+            "judgment": W_JUDGMENT,
+            "runs": W_RUNS,
+            "forks": W_FORKS,
+            "recency": W_RECENCY,
+            "gate": W_GATE,
+            "safe_publish": W_SAFE_PUBLISH,
+            "failed_penalty": -W_FAILED_PENALTY,
+        },
+        "recency_halflife_days": RECENCY_HALFLIFE_DAYS,
+        "judgment_max_scale": JUDGMENT_MAX_SCALE,
+        "judgment_tag_keys": sorted(_QUALITY_TAG_KEYS),
+        "tie_breakers": [
+            "last_successful_run_at desc",
+            "created_at desc",
+            "branch_def_id asc",
+        ],
+        "notes": (
+            "Best-effort v1. Weights are initial guesses surfaced for "
+            "audit. Per PLAN Goals & Gates, the parent-rank scoring "
+            "formula is open evolution — a follow-on slice will let "
+            "the community iterate weights via an evolvable Workflow "
+            "node rather than ship constants."
+        ),
+    }
+
+
+def _build_rationale(
+    top_entry: dict[str, Any], *, leaderboard_size: int,
+) -> str:
+    """Compose the human-readable rationale string for the top entry."""
+    signals = top_entry.get("signals") or {}
+    name = top_entry.get("name") or top_entry.get("branch_def_id") or "(unnamed)"
+    parts: list[str] = []
+    parts.append(
+        f"'{name}' (#{top_entry.get('branch_def_id')}) ranked first of "
+        f"{leaderboard_size} bound Branches with score "
+        f"{top_entry.get('score', 0.0):.2f}."
+    )
+
+    score_pieces: list[str] = []
+    judgment_avg = signals.get("judgment_score_avg")
+    if judgment_avg is not None:
+        score_pieces.append(
+            f"avg judgment score {judgment_avg:.2f}/{int(JUDGMENT_MAX_SCALE)} "
+            f"across {int(signals.get('judgment_score_samples') or 0)} sample(s)"
+        )
+    completed = int(signals.get("completed_run_count") or 0)
+    if completed:
+        score_pieces.append(f"{completed} completed run(s)")
+    forks = int(signals.get("fork_count") or 0)
+    if forks:
+        score_pieces.append(f"{forks} community fork(s)")
+    age = signals.get("age_days_since_success")
+    if age is not None:
+        if age < 1:
+            age_phrase = "under a day ago"
+        elif age < 2:
+            age_phrase = "yesterday"
+        else:
+            age_phrase = f"{int(age)} days ago"
+        score_pieces.append(f"most recent successful run {age_phrase}")
+    rung = signals.get("gate_rung_top")
+    if rung:
+        score_pieces.append(f"highest gate rung claimed: '{rung}'")
+    if signals.get("safe_to_publish"):
+        score_pieces.append("flagged safe_to_publish by its own packet")
+    failed = int(signals.get("failed_run_count") or 0)
+    if failed:
+        score_pieces.append(f"({failed} failed run(s) — penalty applied)")
+
+    if score_pieces:
+        parts.append("Signals: " + "; ".join(score_pieces) + ".")
+    else:
+        parts.append(
+            "No quality signals yet — ranking is by recency / author "
+            "registration only. Treat as a tentative parent until the "
+            "first judgment lands."
+        )
+
+    parts.append(
+        "Note: this is a best-effort v1 recommendation. Inspect the "
+        "score_components in the leaderboard entry to see which "
+        "signals dominated the rank."
+    )
+    return " ".join(parts)
+
+
+__all__ = [
+    "build_quality_leaderboard",
+    "recommend_parent_for_fork",
+    "W_JUDGMENT",
+    "W_RUNS",
+    "W_FORKS",
+    "W_RECENCY",
+    "W_GATE",
+    "W_SAFE_PUBLISH",
+    "W_FAILED_PENALTY",
+    "RECENCY_HALFLIFE_DAYS",
+    "JUDGMENT_MAX_SCALE",
+]

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
@@ -110,14 +110,26 @@ def build_quality_leaderboard(
     base_path: str | Path,
     *,
     goal_id: str,
+    viewer: str,
     now: float | None = None,
-    viewer: str = "",
-    include_private: bool = False,
 ) -> dict[str, Any]:
     """Compute the ranked list of branches bound to ``goal_id``.
 
     Returns ``{"goal_id": ..., "goal": <row | None>, "entries": [...],
     "formula": {...}, "generated_at": ...}``.
+
+    Visibility / auth-boundary contract (round-2 P1.1 fix)
+    ------------------------------------------------------
+    ``viewer`` is the actor identity for which visibility is resolved
+    and MUST be derived server-side by the caller (never accepted from
+    an MCP input). Pass an empty string for the "strictly public" view
+    (no private branches included). The function does NOT accept an
+    ``include_private`` knob — that surface was caller-controllable in
+    round-1 and let an MCP caller flip visibility by passing
+    ``force=true``. To inspect private branches from a host/internal
+    script, build the response directly via the storage helpers; this
+    public entry point ALWAYS applies the public-or-author-owned
+    visibility filter.
 
     Each entry is::
 
@@ -148,16 +160,25 @@ def build_quality_leaderboard(
     goal_row = _safe_get_goal(base_path, goal_id)
 
     from workflow.daemon_server import list_branch_definitions
+    # P1.1 fix — visibility is ALWAYS the public-or-author-owned filter.
+    # ``include_private`` is hard-False at this seam: there's no MCP
+    # surface that legitimately needs to bypass this filter, and round-1
+    # let a caller-supplied ``force=true`` flip it. If a future internal
+    # caller genuinely needs every row, it must reach for the storage
+    # helpers directly with explicit ``include_private=True`` — that
+    # path is host/internal-only and not reachable from MCP.
     branches = list_branch_definitions(
         base_path,
         goal_id=goal_id,
         viewer=viewer,
-        include_private=include_private,
+        include_private=False,
     )
 
     entries: list[dict[str, Any]] = []
     for branch in branches:
-        signals = _collect_signals_for_branch(base_path, branch, now=now)
+        signals = _collect_signals_for_branch(
+            base_path, branch, now=now, viewer=viewer,
+        )
         components = _score_components(signals)
         score = sum(components.values())
         entries.append({
@@ -196,14 +217,17 @@ def recommend_parent_for_fork(
     base_path: str | Path,
     *,
     goal_id: str,
+    viewer: str,
     now: float | None = None,
-    viewer: str = "",
-    include_private: bool = False,
 ) -> dict[str, Any]:
     """Return the top leaderboard entry plus a human-readable rationale.
 
     Returns ``{"goal_id": ..., "recommended_parent": <entry | None>,
     "rationale": "...", "leaderboard_size": <int>, "generated_at": ...}``.
+
+    Visibility contract matches :func:`build_quality_leaderboard` —
+    ``viewer`` must be server-derived; private branches the viewer does
+    not own are excluded.
 
     When no branch is bound to the Goal the response carries
     ``recommended_parent=None`` and a rationale explaining that no
@@ -213,9 +237,8 @@ def recommend_parent_for_fork(
     board = build_quality_leaderboard(
         base_path,
         goal_id=goal_id,
-        now=now,
         viewer=viewer,
-        include_private=include_private,
+        now=now,
     )
     entries = board["entries"]
     if not entries:
@@ -250,13 +273,17 @@ def _collect_signals_for_branch(
     branch: dict[str, Any],
     *,
     now: float,
+    viewer: str,
 ) -> dict[str, Any]:
     bid = branch["branch_def_id"]
     goal_id = branch.get("goal_id") or ""
 
     run_stats = _run_stats(base_path, bid)
     judgment_stats = _judgment_stats(base_path, bid)
-    fork_count = _fork_count(base_path, bid)
+    # P1.2 fix — fork count respects viewer visibility. Counting raw
+    # descendant rows would leak existence of private forks (the row
+    # was hidden from the listing but the aggregate count exposed it).
+    fork_count = _fork_count(base_path, bid, viewer=viewer)
     gate_rung_top = _gate_rung_top(base_path, bid, goal_id)
     safe_to_publish = _safe_to_publish(branch)
 
@@ -382,21 +409,44 @@ def _judgment_stats(
     }
 
 
-def _fork_count(base_path: str | Path, branch_def_id: str) -> int:
-    """Count descendants. Either ``parent_def_id`` or ``fork_from`` may
-    reference this branch — count rows whose either column matches.
+def _fork_count(
+    base_path: str | Path,
+    branch_def_id: str,
+    *,
+    viewer: str,
+) -> int:
+    """Count descendants the ``viewer`` can see.
+
+    Either ``parent_def_id`` or ``fork_from`` may reference this branch
+    — count rows whose either column matches AND that pass the same
+    visibility filter ``list_branch_definitions`` applies (public OR
+    authored by the viewer). This closes the round-2 P1.2 finding: a
+    naive raw count exposed the existence of private descendant rows
+    even when the rows themselves were hidden from the listing.
+
+    Passing ``viewer=""`` matches the "strictly public" semantics —
+    counts only public descendants, never private ones.
     """
     from workflow.storage import _connect
 
+    if viewer:
+        sql = (
+            "SELECT COUNT(*) AS n "
+            "FROM branch_definitions "
+            "WHERE (parent_def_id = ? OR fork_from = ?) "
+            "AND (visibility = 'public' OR author = ?)"
+        )
+        params: tuple[Any, ...] = (branch_def_id, branch_def_id, viewer)
+    else:
+        sql = (
+            "SELECT COUNT(*) AS n "
+            "FROM branch_definitions "
+            "WHERE (parent_def_id = ? OR fork_from = ?) "
+            "AND visibility = 'public'"
+        )
+        params = (branch_def_id, branch_def_id)
     with _connect(base_path) as conn:
-        row = conn.execute(
-            """
-            SELECT COUNT(*) AS n
-              FROM branch_definitions
-             WHERE parent_def_id = ? OR fork_from = ?
-            """,
-            (branch_def_id, branch_def_id),
-        ).fetchone()
+        row = conn.execute(sql, params).fetchone()
     return int(row["n"] or 0) if row is not None else 0
 
 

--- a/tests/test_extensions_leaderboard_actions.py
+++ b/tests/test_extensions_leaderboard_actions.py
@@ -1,0 +1,208 @@
+"""Tests for the ``extensions`` MCP actions added by PR-123 substrate (M2).
+
+- ``quality_leaderboard(goal_id, [author=<viewer>], [force=<include_private>])``
+- ``recommended_parent_for_fork(goal_id, ...)``
+
+The dispatch reuses existing ``extensions(...)`` kwargs to keep the
+tool signature stable:
+  * ``goal_id`` -> Goal under inspection.
+  * ``author`` (string) -> optional viewer override; defaults to the
+    current actor when omitted.
+  * ``force`` (bool) -> include_private flag (host / internal callers).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def us_env(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "tester")
+    from workflow import universe_server as us
+    importlib.reload(us)
+    yield us, tmp_path
+    importlib.reload(us)
+
+
+def _call(us, action: str, **kwargs) -> dict:
+    return json.loads(us.extensions(action=action, **kwargs))
+
+
+def _seed_goal_and_branches(base_path: Path):
+    from workflow.daemon_server import save_branch_definition, save_goal
+    from workflow.runs import (
+        RUN_STATUS_COMPLETED,
+        add_judgment,
+        create_run,
+        update_run_status,
+    )
+
+    save_goal(
+        base_path,
+        goal=dict(
+            goal_id="g-mcp",
+            name="Test MCP Goal",
+            description="for MCP-surface integration test",
+            author="host",
+            tags=[],
+            visibility="public",
+        ),
+    )
+    for bid, score in (("b-top", 9.0), ("b-mid", 6.0), ("b-low", 3.0)):
+        save_branch_definition(
+            base_path,
+            branch_def=dict(
+                branch_def_id=bid,
+                name=f"Branch {bid}",
+                description="t",
+                author="alice",
+                tags=[],
+                graph_nodes=[],
+                edges=[],
+                state_schema=[],
+                entry_point="",
+                published=True,
+                goal_id="g-mcp",
+            ),
+        )
+        rid = create_run(
+            base_path, branch_def_id=bid, thread_id=bid, inputs={},
+        )
+        update_run_status(
+            base_path, rid,
+            status=RUN_STATUS_COMPLETED,
+            finished_at=time.time(),
+        )
+        add_judgment(
+            base_path,
+            run_id=rid, text="t",
+            tags=[f"quality:{score}"],
+            author="judge",
+        )
+
+
+# ---------------------------------------------------------------------------
+# quality_leaderboard
+# ---------------------------------------------------------------------------
+
+
+def test_quality_leaderboard_requires_goal_id(us_env):
+    us, _ = us_env
+    result = _call(us, "quality_leaderboard")
+    assert "error" in result
+    assert result["failure_class"] == "missing_goal_id"
+
+
+def test_quality_leaderboard_returns_ranked_entries(us_env):
+    us, base = us_env
+    _seed_goal_and_branches(base)
+    result = _call(us, "quality_leaderboard", goal_id="g-mcp")
+    assert "entries" in result
+    assert len(result["entries"]) == 3
+    bids = [e["branch_def_id"] for e in result["entries"]]
+    # Higher quality should rank first.
+    assert bids[0] == "b-top"
+    assert bids[-1] == "b-low"
+    # Every entry has rank + score + signals + score_components.
+    for entry in result["entries"]:
+        assert "rank" in entry
+        assert "score" in entry
+        assert "signals" in entry
+        assert "score_components" in entry
+    # Text channel is phone-legible.
+    assert "Quality leaderboard" in result["text"]
+    assert "Rank | Branch" in result["text"]
+
+
+def test_quality_leaderboard_empty_goal_renders_friendly_text(us_env):
+    us, base = us_env
+    from workflow.daemon_server import save_goal
+    save_goal(
+        base,
+        goal=dict(
+            goal_id="g-empty", name="Empty", description="", author="h",
+            tags=[], visibility="public",
+        ),
+    )
+    result = _call(us, "quality_leaderboard", goal_id="g-empty")
+    assert result["entries"] == []
+    assert "No Branches" in result["text"]
+
+
+def test_quality_leaderboard_unknown_goal_returns_no_entries(us_env):
+    us, _ = us_env
+    result = _call(us, "quality_leaderboard", goal_id="nope")
+    assert result["entries"] == []
+    # goal is None in the structured payload.
+    assert result["goal"] is None
+
+
+def test_quality_leaderboard_response_includes_formula_disclosure(us_env):
+    us, base = us_env
+    _seed_goal_and_branches(base)
+    result = _call(us, "quality_leaderboard", goal_id="g-mcp")
+    assert "formula" in result
+    assert "weights" in result["formula"]
+    assert "judgment" in result["formula"]["weights"]
+
+
+# ---------------------------------------------------------------------------
+# recommended_parent_for_fork
+# ---------------------------------------------------------------------------
+
+
+def test_recommended_parent_requires_goal_id(us_env):
+    us, _ = us_env
+    result = _call(us, "recommended_parent_for_fork")
+    assert "error" in result
+    assert result["failure_class"] == "missing_goal_id"
+
+
+def test_recommended_parent_returns_top_entry(us_env):
+    us, base = us_env
+    _seed_goal_and_branches(base)
+    result = _call(us, "recommended_parent_for_fork", goal_id="g-mcp")
+    parent = result["recommended_parent"]
+    assert parent is not None
+    assert parent["branch_def_id"] == "b-top"
+    assert parent["rank"] == 1
+    assert result["leaderboard_size"] == 3
+    assert "Recommended parent" in result["text"]
+
+
+def test_recommended_parent_empty_goal_text_carries_rationale(us_env):
+    us, base = us_env
+    from workflow.daemon_server import save_goal
+    save_goal(
+        base,
+        goal=dict(
+            goal_id="g-empty", name="Empty", description="", author="h",
+            tags=[], visibility="public",
+        ),
+    )
+    result = _call(us, "recommended_parent_for_fork", goal_id="g-empty")
+    assert result["recommended_parent"] is None
+    assert "No Branch is bound" in result["rationale"]
+    assert result["text"] == result["rationale"]
+
+
+# ---------------------------------------------------------------------------
+# Tool surface stability — the action names are listed under
+# `available_actions` in the unknown-action error so the chatbot can
+# discover them.
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_action_lists_new_action_names(us_env):
+    us, _ = us_env
+    result = _call(us, "does_not_exist")
+    actions = result.get("available_actions") or []
+    assert "quality_leaderboard" in actions
+    assert "recommended_parent_for_fork" in actions

--- a/tests/test_quality_leaderboard.py
+++ b/tests/test_quality_leaderboard.py
@@ -1,0 +1,615 @@
+"""Tests for workflow.api.quality_leaderboard.
+
+PR-123 substrate (M2). Covers:
+
+- Empty Goal (no branches bound) -> empty entries + parent-rec returns None.
+- Single entry -> rank 1, score reflects signals.
+- Multiple entries with diverse signals -> correct ranking.
+- Recency decay correctness (older success ranks lower vs newer).
+- Goal with many branches (realistic scale, 15+).
+- Numeric tag parsing from judgments (quality:8, novelty:7, risk:3).
+- Fork count signal (parent_def_id + fork_from both contribute).
+- Best-effort safe_to_publish lookup in branch.stats.
+- Gate-rung claim signal.
+- ``recommend_parent_for_fork`` rationale shape.
+
+Storage is exercised through the canonical helpers
+(``save_goal`` / ``save_branch_definition`` / ``create_run`` /
+``update_run_status`` / ``add_judgment`` / ``record_gate_claim``)
+so any future schema migration is exercised here too.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from workflow.api.quality_leaderboard import (
+    JUDGMENT_MAX_SCALE,
+    RECENCY_HALFLIFE_DAYS,
+    build_quality_leaderboard,
+    recommend_parent_for_fork,
+)
+from workflow.daemon_server import (
+    initialize_author_server,
+    save_branch_definition,
+    save_goal,
+)
+from workflow.runs import (
+    RUN_STATUS_COMPLETED,
+    RUN_STATUS_FAILED,
+    add_judgment,
+    create_run,
+    initialize_runs_db,
+    update_run_status,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def base_path(tmp_path: Path, monkeypatch) -> Path:
+    """Per-test data root with both schema layers initialized."""
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    initialize_author_server(tmp_path)
+    initialize_runs_db(tmp_path)
+    return tmp_path
+
+
+def _make_goal(base_path: Path, goal_id: str, *, name: str = "g") -> str:
+    save_goal(
+        base_path,
+        goal=dict(
+            goal_id=goal_id,
+            name=name,
+            description=f"test goal {goal_id}",
+            author="host",
+            tags=[],
+            visibility="public",
+        ),
+    )
+    return goal_id
+
+
+def _make_branch(
+    base_path: Path,
+    *,
+    branch_def_id: str,
+    goal_id: str,
+    name: str | None = None,
+    parent_def_id: str | None = None,
+    fork_from: str | None = None,
+    stats: dict | None = None,
+    author: str = "alice",
+) -> str:
+    save_branch_definition(
+        base_path,
+        branch_def=dict(
+            branch_def_id=branch_def_id,
+            name=name or branch_def_id,
+            description=f"branch {branch_def_id}",
+            author=author,
+            tags=[],
+            graph_nodes=[],
+            edges=[],
+            state_schema=[],
+            entry_point="",
+            published=True,
+            goal_id=goal_id,
+            parent_def_id=parent_def_id,
+            fork_from=fork_from,
+            stats=stats or {},
+        ),
+    )
+    return branch_def_id
+
+
+def _record_run(
+    base_path: Path,
+    *,
+    branch_def_id: str,
+    status: str,
+    finished_at: float | None = None,
+) -> str:
+    run_id = create_run(
+        base_path,
+        branch_def_id=branch_def_id,
+        thread_id=branch_def_id,
+        inputs={},
+    )
+    update_run_status(
+        base_path,
+        run_id,
+        status=status,
+        finished_at=finished_at if finished_at is not None else time.time(),
+    )
+    return run_id
+
+
+def _record_judgment(
+    base_path: Path,
+    *,
+    run_id: str,
+    tags: list[str],
+    text: str = "test judgment",
+) -> None:
+    add_judgment(
+        base_path,
+        run_id=run_id,
+        text=text,
+        tags=tags,
+        author="judge",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Empty Goal
+# ---------------------------------------------------------------------------
+
+
+def test_empty_goal_returns_no_entries(base_path):
+    _make_goal(base_path, "g-empty")
+    board = build_quality_leaderboard(base_path, goal_id="g-empty")
+    assert board["entries"] == []
+    assert board["goal_id"] == "g-empty"
+    assert board["goal"] is not None
+    assert board["formula"]["weights"]["judgment"] > 0
+    # Recency halflife exposed for tuning visibility.
+    assert board["formula"]["recency_halflife_days"] == RECENCY_HALFLIFE_DAYS
+
+
+def test_unknown_goal_id_returns_empty_entries_and_none_goal(base_path):
+    board = build_quality_leaderboard(base_path, goal_id="nope")
+    assert board["entries"] == []
+    assert board["goal"] is None
+
+
+def test_recommend_parent_when_no_entries(base_path):
+    _make_goal(base_path, "g-empty")
+    rec = recommend_parent_for_fork(base_path, goal_id="g-empty")
+    assert rec["recommended_parent"] is None
+    assert "No Branch is bound" in rec["rationale"]
+    assert rec["leaderboard_size"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Single entry
+# ---------------------------------------------------------------------------
+
+
+def test_single_branch_ranks_first(base_path):
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    board = build_quality_leaderboard(base_path, goal_id="g1")
+    assert len(board["entries"]) == 1
+    entry = board["entries"][0]
+    assert entry["rank"] == 1
+    assert entry["branch_def_id"] == "b1"
+    # No runs, no judgments -> score is 0 (or possibly negative from
+    # failed-penalty term, but we have no failed runs either).
+    assert entry["score"] == 0.0
+    assert entry["signals"]["completed_run_count"] == 0
+    assert entry["signals"]["fork_count"] == 0
+    assert entry["signals"]["has_gate_rung"] is False
+    assert entry["signals"]["safe_to_publish"] is False
+
+
+def test_single_branch_with_completed_run_scores_above_zero(base_path):
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    _record_run(
+        base_path,
+        branch_def_id="b1",
+        status=RUN_STATUS_COMPLETED,
+        finished_at=time.time(),
+    )
+    board = build_quality_leaderboard(base_path, goal_id="g1")
+    entry = board["entries"][0]
+    assert entry["score"] > 0
+    assert entry["signals"]["completed_run_count"] == 1
+    # Recency near 1.0 for a just-finished run.
+    assert entry["signals"]["recency_decay"] > 0.95
+
+
+# ---------------------------------------------------------------------------
+# Numeric judgment parsing
+# ---------------------------------------------------------------------------
+
+
+def test_judgment_tag_parsing_produces_score_avg(base_path):
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    run_id = _record_run(
+        base_path, branch_def_id="b1",
+        status=RUN_STATUS_COMPLETED, finished_at=time.time(),
+    )
+    _record_judgment(base_path, run_id=run_id, tags=["quality:8.0", "novelty:7.0"])
+    _record_judgment(base_path, run_id=run_id, tags=["quality:9.0"])
+    board = build_quality_leaderboard(base_path, goal_id="g1")
+    entry = board["entries"][0]
+    # avg of 8.0, 7.0, 9.0 = 8.0
+    assert entry["signals"]["judgment_score_avg"] == pytest.approx(8.0)
+    assert entry["signals"]["judgment_score_samples"] == 3
+    assert entry["signals"]["judgment_count"] == 2  # two judgment rows
+
+
+def test_other_numeric_tags_recorded_separately(base_path):
+    """Tags like ``risk:3`` are numeric but NOT in the headline score
+    average; they appear under ``other_numeric_tags``."""
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    run_id = _record_run(
+        base_path, branch_def_id="b1",
+        status=RUN_STATUS_COMPLETED, finished_at=time.time(),
+    )
+    _record_judgment(
+        base_path, run_id=run_id,
+        tags=["quality:8", "risk:3", "cost:42"],
+    )
+    board = build_quality_leaderboard(base_path, goal_id="g1")
+    signals = board["entries"][0]["signals"]
+    assert signals["judgment_score_avg"] == pytest.approx(8.0)
+    assert signals["other_numeric_tags"] == {"risk": 1, "cost": 1}
+
+
+def test_non_numeric_tags_ignored(base_path):
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    run_id = _record_run(
+        base_path, branch_def_id="b1",
+        status=RUN_STATUS_COMPLETED, finished_at=time.time(),
+    )
+    _record_judgment(
+        base_path, run_id=run_id,
+        tags=["needs-revision", "writer:loop-2"],
+    )
+    signals = build_quality_leaderboard(
+        base_path, goal_id="g1",
+    )["entries"][0]["signals"]
+    assert signals["judgment_score_avg"] is None
+    assert signals["other_numeric_tags"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Multi-branch ranking
+# ---------------------------------------------------------------------------
+
+
+def test_higher_judgment_wins_over_lower(base_path):
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b-low", goal_id="g1")
+    _make_branch(base_path, branch_def_id="b-high", goal_id="g1")
+    now = time.time()
+    r_low = _record_run(
+        base_path, branch_def_id="b-low",
+        status=RUN_STATUS_COMPLETED, finished_at=now,
+    )
+    r_high = _record_run(
+        base_path, branch_def_id="b-high",
+        status=RUN_STATUS_COMPLETED, finished_at=now,
+    )
+    _record_judgment(base_path, run_id=r_low, tags=["quality:3.0"])
+    _record_judgment(base_path, run_id=r_high, tags=["quality:9.0"])
+    board = build_quality_leaderboard(base_path, goal_id="g1", now=now)
+    ranks = {e["branch_def_id"]: e["rank"] for e in board["entries"]}
+    assert ranks["b-high"] == 1
+    assert ranks["b-low"] == 2
+
+
+def test_recency_decay_breaks_score_ties_among_equal_quality(base_path):
+    """Two branches with identical judgments but different recency.
+    Fresher success should rank first."""
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b-old", goal_id="g1")
+    _make_branch(base_path, branch_def_id="b-new", goal_id="g1")
+    now = 1_700_000_000.0
+    # 'b-old' finished 60 days ago, 'b-new' finished today.
+    sixty_days_ago = now - 60 * 86400
+    r_old = _record_run(
+        base_path, branch_def_id="b-old",
+        status=RUN_STATUS_COMPLETED, finished_at=sixty_days_ago,
+    )
+    r_new = _record_run(
+        base_path, branch_def_id="b-new",
+        status=RUN_STATUS_COMPLETED, finished_at=now,
+    )
+    _record_judgment(base_path, run_id=r_old, tags=["quality:8.0"])
+    _record_judgment(base_path, run_id=r_new, tags=["quality:8.0"])
+    board = build_quality_leaderboard(base_path, goal_id="g1", now=now)
+    entries = board["entries"]
+    assert entries[0]["branch_def_id"] == "b-new"
+    assert entries[1]["branch_def_id"] == "b-old"
+    # Recency decay should differ meaningfully.
+    new_decay = entries[0]["signals"]["recency_decay"]
+    old_decay = entries[1]["signals"]["recency_decay"]
+    assert new_decay > old_decay
+    # 60 days at 30-day halflife ~ exp(-2) ~ 0.135.
+    assert 0.10 < old_decay < 0.20
+
+
+def test_fork_count_contributes_to_score(base_path):
+    """A branch with community forks ranks above one without."""
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b-popular", goal_id="g1")
+    _make_branch(base_path, branch_def_id="b-lonely", goal_id="g1")
+    # 3 forks of b-popular via parent_def_id.
+    _make_branch(
+        base_path, branch_def_id="fork-1",
+        goal_id="g1", parent_def_id="b-popular",
+    )
+    _make_branch(
+        base_path, branch_def_id="fork-2",
+        goal_id="g1", parent_def_id="b-popular",
+    )
+    # 1 fork via fork_from.
+    _make_branch(
+        base_path, branch_def_id="fork-3",
+        goal_id="g1", fork_from="b-popular",
+    )
+    board = build_quality_leaderboard(base_path, goal_id="g1")
+    pop_entry = next(
+        e for e in board["entries"] if e["branch_def_id"] == "b-popular"
+    )
+    lonely_entry = next(
+        e for e in board["entries"] if e["branch_def_id"] == "b-lonely"
+    )
+    assert pop_entry["signals"]["fork_count"] == 3
+    assert lonely_entry["signals"]["fork_count"] == 0
+    assert pop_entry["score"] > lonely_entry["score"]
+    assert pop_entry["rank"] < lonely_entry["rank"]
+
+
+def test_failed_runs_apply_penalty(base_path):
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b-clean", goal_id="g1")
+    _make_branch(base_path, branch_def_id="b-buggy", goal_id="g1")
+    now = time.time()
+    _record_run(
+        base_path, branch_def_id="b-clean",
+        status=RUN_STATUS_COMPLETED, finished_at=now,
+    )
+    _record_run(
+        base_path, branch_def_id="b-buggy",
+        status=RUN_STATUS_COMPLETED, finished_at=now,
+    )
+    for _ in range(5):
+        _record_run(
+            base_path, branch_def_id="b-buggy",
+            status=RUN_STATUS_FAILED, finished_at=now,
+        )
+    board = build_quality_leaderboard(base_path, goal_id="g1", now=now)
+    clean = next(
+        e for e in board["entries"] if e["branch_def_id"] == "b-clean"
+    )
+    buggy = next(
+        e for e in board["entries"] if e["branch_def_id"] == "b-buggy"
+    )
+    assert buggy["signals"]["failed_run_count"] == 5
+    assert clean["signals"]["failed_run_count"] == 0
+    # Penalty should be visible in score_components.
+    assert clean["score_components"]["failed_penalty"] == 0.0
+    assert buggy["score_components"]["failed_penalty"] < 0
+    assert clean["score"] > buggy["score"]
+
+
+# ---------------------------------------------------------------------------
+# safe_to_publish best-effort signal
+# ---------------------------------------------------------------------------
+
+
+def test_safe_to_publish_signal_from_branch_stats(base_path):
+    _make_goal(base_path, "g1")
+    _make_branch(
+        base_path,
+        branch_def_id="b-safe",
+        goal_id="g1",
+        stats={"next_action_packet": {"safe_to_publish": True}},
+    )
+    _make_branch(base_path, branch_def_id="b-unsafe", goal_id="g1")
+    board = build_quality_leaderboard(base_path, goal_id="g1")
+    safe = next(
+        e for e in board["entries"] if e["branch_def_id"] == "b-safe"
+    )
+    unsafe = next(
+        e for e in board["entries"] if e["branch_def_id"] == "b-unsafe"
+    )
+    assert safe["signals"]["safe_to_publish"] is True
+    assert unsafe["signals"]["safe_to_publish"] is False
+    assert safe["score"] > unsafe["score"]
+
+
+def test_safe_to_publish_absent_or_falsy_does_not_crash(base_path):
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b-no-packet", goal_id="g1")
+    _make_branch(
+        base_path, branch_def_id="b-empty-packet",
+        goal_id="g1", stats={"next_action_packet": {}},
+    )
+    _make_branch(
+        base_path, branch_def_id="b-not-a-dict",
+        goal_id="g1", stats={"next_action_packet": "not a packet"},
+    )
+    board = build_quality_leaderboard(base_path, goal_id="g1")
+    for entry in board["entries"]:
+        assert entry["signals"]["safe_to_publish"] is False
+
+
+# ---------------------------------------------------------------------------
+# Gate-rung signal
+# ---------------------------------------------------------------------------
+
+
+def test_gate_rung_signal_populates_when_claim_present(base_path):
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b-rung", goal_id="g1")
+    _make_branch(base_path, branch_def_id="b-no-rung", goal_id="g1")
+    # Insert a gate claim directly.
+    from workflow.storage import _connect
+    with _connect(base_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO gate_claims (
+                claim_id, branch_def_id, goal_id, rung_key,
+                evidence_url, evidence_note, claimed_by, claimed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "c-1", "b-rung", "g1", "submission",
+                "https://example.test/x", "", "host",
+                "2026-01-01T00:00:00",
+            ),
+        )
+    board = build_quality_leaderboard(base_path, goal_id="g1")
+    rung = next(
+        e for e in board["entries"] if e["branch_def_id"] == "b-rung"
+    )
+    no_rung = next(
+        e for e in board["entries"] if e["branch_def_id"] == "b-no-rung"
+    )
+    assert rung["signals"]["gate_rung_top"] == "submission"
+    assert rung["signals"]["has_gate_rung"] is True
+    assert no_rung["signals"]["has_gate_rung"] is False
+    assert rung["score"] > no_rung["score"]
+
+
+# ---------------------------------------------------------------------------
+# Realistic scale — Goal with 15+ entries
+# ---------------------------------------------------------------------------
+
+
+def test_realistic_goal_with_fifteen_entries(base_path):
+    """Smoke + correctness at the scale of Goal 4ff5862cc26d (~15+
+    bound branches). Verifies rank monotonicity and that the top entry
+    has the highest score."""
+    _make_goal(base_path, "g-big")
+    now = 1_700_000_000.0
+    for i in range(18):
+        bid = f"b-{i:02d}"
+        _make_branch(base_path, branch_def_id=bid, goal_id="g-big")
+        # Spread completed-run counts + judgment scores so ranking is
+        # non-trivial.
+        for _ in range(i % 5):
+            rid = _record_run(
+                base_path, branch_def_id=bid,
+                status=RUN_STATUS_COMPLETED,
+                finished_at=now - (i * 86400),  # older for higher i
+            )
+            _record_judgment(
+                base_path, run_id=rid,
+                tags=[f"quality:{(i % 9) + 1}"],
+            )
+    board = build_quality_leaderboard(
+        base_path, goal_id="g-big", now=now,
+    )
+    assert len(board["entries"]) == 18
+    # Ranks are 1..18 with no gaps.
+    ranks = sorted(e["rank"] for e in board["entries"])
+    assert ranks == list(range(1, 19))
+    # First entry's score >= every other entry's score.
+    top_score = board["entries"][0]["score"]
+    for entry in board["entries"][1:]:
+        assert top_score >= entry["score"]
+
+
+# ---------------------------------------------------------------------------
+# recommend_parent_for_fork
+# ---------------------------------------------------------------------------
+
+
+def test_recommend_parent_returns_top_with_rationale(base_path):
+    _make_goal(base_path, "g1", name="Patch Loop")
+    _make_branch(
+        base_path, branch_def_id="b-top",
+        goal_id="g1", name="High-Quality Take",
+    )
+    _make_branch(base_path, branch_def_id="b-other", goal_id="g1")
+    now = time.time()
+    rid = _record_run(
+        base_path, branch_def_id="b-top",
+        status=RUN_STATUS_COMPLETED, finished_at=now,
+    )
+    _record_judgment(base_path, run_id=rid, tags=["quality:9.5"])
+    # Add a fork of b-top so the rationale has community-vote signal.
+    _make_branch(
+        base_path, branch_def_id="b-top-fork",
+        goal_id="g1", parent_def_id="b-top",
+    )
+    rec = recommend_parent_for_fork(base_path, goal_id="g1", now=now)
+    assert rec["recommended_parent"] is not None
+    assert rec["recommended_parent"]["branch_def_id"] == "b-top"
+    rationale = rec["rationale"]
+    # Rationale should mention some of the signals we exercised.
+    assert "ranked first" in rationale.lower()
+    assert "judgment" in rationale.lower() or "9.5" in rationale
+    assert "fork" in rationale.lower()
+    assert rec["leaderboard_size"] == 3  # b-top, b-other, b-top-fork
+
+
+def test_recommend_parent_no_judgments_yet_tentative_phrase(base_path):
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b-bare", goal_id="g1")
+    rec = recommend_parent_for_fork(base_path, goal_id="g1")
+    assert rec["recommended_parent"] is not None
+    # When the top entry has no signals at all, the rationale should
+    # call out the lack of quality data.
+    rationale_lc = rec["rationale"].lower()
+    assert "tentative" in rationale_lc or "no quality signals" in rationale_lc
+
+
+# ---------------------------------------------------------------------------
+# Formula disclosure surfaces all weights
+# ---------------------------------------------------------------------------
+
+
+def test_formula_disclosure_includes_all_weights(base_path):
+    _make_goal(base_path, "g1")
+    board = build_quality_leaderboard(base_path, goal_id="g1")
+    weights = board["formula"]["weights"]
+    expected_keys = {
+        "judgment", "runs", "forks", "recency",
+        "gate", "safe_publish", "failed_penalty",
+    }
+    assert set(weights.keys()) == expected_keys
+    # judgment_max_scale is published.
+    assert board["formula"]["judgment_max_scale"] == JUDGMENT_MAX_SCALE
+
+
+def test_score_components_sum_to_score(base_path):
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    rid = _record_run(
+        base_path, branch_def_id="b1",
+        status=RUN_STATUS_COMPLETED, finished_at=time.time(),
+    )
+    _record_judgment(base_path, run_id=rid, tags=["quality:7"])
+    board = build_quality_leaderboard(base_path, goal_id="g1")
+    entry = board["entries"][0]
+    component_sum = sum(entry["score_components"].values())
+    assert entry["score"] == pytest.approx(component_sum, abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Determinism — same input -> same ranking
+# ---------------------------------------------------------------------------
+
+
+def test_ranking_is_deterministic(base_path):
+    _make_goal(base_path, "g1")
+    for i in range(5):
+        _make_branch(base_path, branch_def_id=f"b{i}", goal_id="g1")
+    now = 1_700_000_000.0
+    board_a = build_quality_leaderboard(
+        base_path, goal_id="g1", now=now,
+    )
+    board_b = build_quality_leaderboard(
+        base_path, goal_id="g1", now=now,
+    )
+    assert [
+        e["branch_def_id"] for e in board_a["entries"]
+    ] == [
+        e["branch_def_id"] for e in board_b["entries"]
+    ]

--- a/tests/test_quality_leaderboard.py
+++ b/tests/test_quality_leaderboard.py
@@ -153,7 +153,7 @@ def _record_judgment(
 
 def test_empty_goal_returns_no_entries(base_path):
     _make_goal(base_path, "g-empty")
-    board = build_quality_leaderboard(base_path, goal_id="g-empty")
+    board = build_quality_leaderboard(base_path, goal_id="g-empty", viewer="")
     assert board["entries"] == []
     assert board["goal_id"] == "g-empty"
     assert board["goal"] is not None
@@ -163,14 +163,14 @@ def test_empty_goal_returns_no_entries(base_path):
 
 
 def test_unknown_goal_id_returns_empty_entries_and_none_goal(base_path):
-    board = build_quality_leaderboard(base_path, goal_id="nope")
+    board = build_quality_leaderboard(base_path, goal_id="nope", viewer="")
     assert board["entries"] == []
     assert board["goal"] is None
 
 
 def test_recommend_parent_when_no_entries(base_path):
     _make_goal(base_path, "g-empty")
-    rec = recommend_parent_for_fork(base_path, goal_id="g-empty")
+    rec = recommend_parent_for_fork(base_path, goal_id="g-empty", viewer="")
     assert rec["recommended_parent"] is None
     assert "No Branch is bound" in rec["rationale"]
     assert rec["leaderboard_size"] == 0
@@ -184,7 +184,7 @@ def test_recommend_parent_when_no_entries(base_path):
 def test_single_branch_ranks_first(base_path):
     _make_goal(base_path, "g1")
     _make_branch(base_path, branch_def_id="b1", goal_id="g1")
-    board = build_quality_leaderboard(base_path, goal_id="g1")
+    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
     assert len(board["entries"]) == 1
     entry = board["entries"][0]
     assert entry["rank"] == 1
@@ -207,7 +207,7 @@ def test_single_branch_with_completed_run_scores_above_zero(base_path):
         status=RUN_STATUS_COMPLETED,
         finished_at=time.time(),
     )
-    board = build_quality_leaderboard(base_path, goal_id="g1")
+    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
     entry = board["entries"][0]
     assert entry["score"] > 0
     assert entry["signals"]["completed_run_count"] == 1
@@ -229,7 +229,7 @@ def test_judgment_tag_parsing_produces_score_avg(base_path):
     )
     _record_judgment(base_path, run_id=run_id, tags=["quality:8.0", "novelty:7.0"])
     _record_judgment(base_path, run_id=run_id, tags=["quality:9.0"])
-    board = build_quality_leaderboard(base_path, goal_id="g1")
+    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
     entry = board["entries"][0]
     # avg of 8.0, 7.0, 9.0 = 8.0
     assert entry["signals"]["judgment_score_avg"] == pytest.approx(8.0)
@@ -250,7 +250,7 @@ def test_other_numeric_tags_recorded_separately(base_path):
         base_path, run_id=run_id,
         tags=["quality:8", "risk:3", "cost:42"],
     )
-    board = build_quality_leaderboard(base_path, goal_id="g1")
+    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
     signals = board["entries"][0]["signals"]
     assert signals["judgment_score_avg"] == pytest.approx(8.0)
     assert signals["other_numeric_tags"] == {"risk": 1, "cost": 1}
@@ -268,7 +268,7 @@ def test_non_numeric_tags_ignored(base_path):
         tags=["needs-revision", "writer:loop-2"],
     )
     signals = build_quality_leaderboard(
-        base_path, goal_id="g1",
+        base_path, goal_id="g1", viewer="",
     )["entries"][0]["signals"]
     assert signals["judgment_score_avg"] is None
     assert signals["other_numeric_tags"] == {}
@@ -294,7 +294,7 @@ def test_higher_judgment_wins_over_lower(base_path):
     )
     _record_judgment(base_path, run_id=r_low, tags=["quality:3.0"])
     _record_judgment(base_path, run_id=r_high, tags=["quality:9.0"])
-    board = build_quality_leaderboard(base_path, goal_id="g1", now=now)
+    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="", now=now)
     ranks = {e["branch_def_id"]: e["rank"] for e in board["entries"]}
     assert ranks["b-high"] == 1
     assert ranks["b-low"] == 2
@@ -319,7 +319,7 @@ def test_recency_decay_breaks_score_ties_among_equal_quality(base_path):
     )
     _record_judgment(base_path, run_id=r_old, tags=["quality:8.0"])
     _record_judgment(base_path, run_id=r_new, tags=["quality:8.0"])
-    board = build_quality_leaderboard(base_path, goal_id="g1", now=now)
+    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="", now=now)
     entries = board["entries"]
     assert entries[0]["branch_def_id"] == "b-new"
     assert entries[1]["branch_def_id"] == "b-old"
@@ -350,7 +350,7 @@ def test_fork_count_contributes_to_score(base_path):
         base_path, branch_def_id="fork-3",
         goal_id="g1", fork_from="b-popular",
     )
-    board = build_quality_leaderboard(base_path, goal_id="g1")
+    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
     pop_entry = next(
         e for e in board["entries"] if e["branch_def_id"] == "b-popular"
     )
@@ -381,7 +381,7 @@ def test_failed_runs_apply_penalty(base_path):
             base_path, branch_def_id="b-buggy",
             status=RUN_STATUS_FAILED, finished_at=now,
         )
-    board = build_quality_leaderboard(base_path, goal_id="g1", now=now)
+    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="", now=now)
     clean = next(
         e for e in board["entries"] if e["branch_def_id"] == "b-clean"
     )
@@ -410,7 +410,7 @@ def test_safe_to_publish_signal_from_branch_stats(base_path):
         stats={"next_action_packet": {"safe_to_publish": True}},
     )
     _make_branch(base_path, branch_def_id="b-unsafe", goal_id="g1")
-    board = build_quality_leaderboard(base_path, goal_id="g1")
+    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
     safe = next(
         e for e in board["entries"] if e["branch_def_id"] == "b-safe"
     )
@@ -433,7 +433,7 @@ def test_safe_to_publish_absent_or_falsy_does_not_crash(base_path):
         base_path, branch_def_id="b-not-a-dict",
         goal_id="g1", stats={"next_action_packet": "not a packet"},
     )
-    board = build_quality_leaderboard(base_path, goal_id="g1")
+    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
     for entry in board["entries"]:
         assert entry["signals"]["safe_to_publish"] is False
 
@@ -463,7 +463,7 @@ def test_gate_rung_signal_populates_when_claim_present(base_path):
                 "2026-01-01T00:00:00",
             ),
         )
-    board = build_quality_leaderboard(base_path, goal_id="g1")
+    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
     rung = next(
         e for e in board["entries"] if e["branch_def_id"] == "b-rung"
     )
@@ -503,7 +503,7 @@ def test_realistic_goal_with_fifteen_entries(base_path):
                 tags=[f"quality:{(i % 9) + 1}"],
             )
     board = build_quality_leaderboard(
-        base_path, goal_id="g-big", now=now,
+        base_path, goal_id="g-big", viewer="", now=now,
     )
     assert len(board["entries"]) == 18
     # Ranks are 1..18 with no gaps.
@@ -538,7 +538,7 @@ def test_recommend_parent_returns_top_with_rationale(base_path):
         base_path, branch_def_id="b-top-fork",
         goal_id="g1", parent_def_id="b-top",
     )
-    rec = recommend_parent_for_fork(base_path, goal_id="g1", now=now)
+    rec = recommend_parent_for_fork(base_path, goal_id="g1", viewer="", now=now)
     assert rec["recommended_parent"] is not None
     assert rec["recommended_parent"]["branch_def_id"] == "b-top"
     rationale = rec["rationale"]
@@ -552,7 +552,7 @@ def test_recommend_parent_returns_top_with_rationale(base_path):
 def test_recommend_parent_no_judgments_yet_tentative_phrase(base_path):
     _make_goal(base_path, "g1")
     _make_branch(base_path, branch_def_id="b-bare", goal_id="g1")
-    rec = recommend_parent_for_fork(base_path, goal_id="g1")
+    rec = recommend_parent_for_fork(base_path, goal_id="g1", viewer="")
     assert rec["recommended_parent"] is not None
     # When the top entry has no signals at all, the rationale should
     # call out the lack of quality data.
@@ -567,7 +567,7 @@ def test_recommend_parent_no_judgments_yet_tentative_phrase(base_path):
 
 def test_formula_disclosure_includes_all_weights(base_path):
     _make_goal(base_path, "g1")
-    board = build_quality_leaderboard(base_path, goal_id="g1")
+    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
     weights = board["formula"]["weights"]
     expected_keys = {
         "judgment", "runs", "forks", "recency",
@@ -586,7 +586,7 @@ def test_score_components_sum_to_score(base_path):
         status=RUN_STATUS_COMPLETED, finished_at=time.time(),
     )
     _record_judgment(base_path, run_id=rid, tags=["quality:7"])
-    board = build_quality_leaderboard(base_path, goal_id="g1")
+    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
     entry = board["entries"][0]
     component_sum = sum(entry["score_components"].values())
     assert entry["score"] == pytest.approx(component_sum, abs=1e-3)
@@ -603,10 +603,10 @@ def test_ranking_is_deterministic(base_path):
         _make_branch(base_path, branch_def_id=f"b{i}", goal_id="g1")
     now = 1_700_000_000.0
     board_a = build_quality_leaderboard(
-        base_path, goal_id="g1", now=now,
+        base_path, goal_id="g1", viewer="", now=now,
     )
     board_b = build_quality_leaderboard(
-        base_path, goal_id="g1", now=now,
+        base_path, goal_id="g1", viewer="", now=now,
     )
     assert [
         e["branch_def_id"] for e in board_a["entries"]

--- a/tests/test_quality_leaderboard_auth_boundary.py
+++ b/tests/test_quality_leaderboard_auth_boundary.py
@@ -1,0 +1,476 @@
+"""PR-123 round-2 auth-boundary regression guards.
+
+Codex's round-1 review on PR #970 caught two real P1 issues:
+
+  P1.1 — Caller-controlled visibility leak. ``extensions.py`` mapped
+         caller-supplied ``author`` to ``viewer`` and ``force`` to
+         ``include_private``. A chatbot calling
+         ``extensions action=quality_leaderboard author=alice`` saw
+         alice's private branches; ``force=true`` returned every row.
+
+  P1.2 — Fork-count signal leaked private descendant existence. The
+         leaderboard hid private fork rows from the entry list but
+         the public parent's ``fork_count`` aggregate still counted
+         them, so the third-party viewer could infer the private
+         fork's existence.
+
+These tests lock in the fix and serve as the regression gate for any
+future signal that aggregates over rows.
+
+Threat model:
+  * actor_alice  — author of one private branch ``priv-alice``.
+  * actor_bob    — author of one public branch ``pub-bob`` plus one
+                   private fork ``priv-bob-fork`` of a public peer.
+  * actor_eve    — third party. Default test caller — should NEVER
+                   see alice's or bob's private rows.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def us_env(tmp_path: Path, monkeypatch):
+    """Daemon env where the calling actor is ``eve`` by default."""
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "eve")
+    from workflow import universe_server as us
+    importlib.reload(us)
+    yield us, tmp_path
+    importlib.reload(us)
+
+
+def _call(us, action: str, **kwargs) -> dict:
+    return json.loads(us.extensions(action=action, **kwargs))
+
+
+def _seed_universe(base: Path) -> dict:
+    """Populate the storage layer with the threat-model seed.
+
+    Returns a dict of useful ids: {goal_id, pub_eve, pub_bob,
+    priv_alice, priv_bob_fork, child_of_pub_bob}.
+    """
+    from workflow.daemon_server import (
+        initialize_author_server,
+        save_branch_definition,
+        save_goal,
+    )
+    initialize_author_server(base)
+    save_goal(
+        base,
+        goal=dict(
+            goal_id="g-test",
+            name="Shared Goal",
+            description="",
+            author="host",
+            tags=[],
+            visibility="public",
+        ),
+    )
+    # Public branch authored by eve.
+    save_branch_definition(
+        base,
+        branch_def=dict(
+            branch_def_id="pub-eve",
+            name="Eve's public take",
+            description="",
+            author="eve",
+            tags=[],
+            graph_nodes=[],
+            edges=[],
+            state_schema=[],
+            entry_point="",
+            published=True,
+            goal_id="g-test",
+            visibility="public",
+        ),
+    )
+    # Public branch authored by bob — this is the leak target for P1.2.
+    save_branch_definition(
+        base,
+        branch_def=dict(
+            branch_def_id="pub-bob",
+            name="Bob's public take",
+            description="",
+            author="bob",
+            tags=[],
+            graph_nodes=[],
+            edges=[],
+            state_schema=[],
+            entry_point="",
+            published=True,
+            goal_id="g-test",
+            visibility="public",
+        ),
+    )
+    # Private branch authored by alice.
+    save_branch_definition(
+        base,
+        branch_def=dict(
+            branch_def_id="priv-alice",
+            name="Alice's PRIVATE take",
+            description="",
+            author="alice",
+            tags=[],
+            graph_nodes=[],
+            edges=[],
+            state_schema=[],
+            entry_point="",
+            published=True,
+            goal_id="g-test",
+            visibility="private",
+        ),
+    )
+    # Private fork of pub-bob authored by alice. Exists to test P1.2:
+    # eve should NOT see this row, and the fork_count aggregate must
+    # not reveal its existence either.
+    save_branch_definition(
+        base,
+        branch_def=dict(
+            branch_def_id="priv-bob-fork",
+            name="Alice's PRIVATE fork of Bob's take",
+            description="",
+            author="alice",
+            tags=[],
+            graph_nodes=[],
+            edges=[],
+            state_schema=[],
+            entry_point="",
+            published=True,
+            goal_id="g-test",
+            visibility="private",
+            parent_def_id="pub-bob",
+        ),
+    )
+    # Public fork of pub-bob authored by eve. Visible to everyone —
+    # the leaderboard should count this in fork_count regardless of
+    # the viewer.
+    save_branch_definition(
+        base,
+        branch_def=dict(
+            branch_def_id="pub-bob-public-fork",
+            name="Eve's public fork of Bob's take",
+            description="",
+            author="eve",
+            tags=[],
+            graph_nodes=[],
+            edges=[],
+            state_schema=[],
+            entry_point="",
+            published=True,
+            goal_id="g-test",
+            visibility="public",
+            parent_def_id="pub-bob",
+        ),
+    )
+    return {
+        "goal_id": "g-test",
+        "pub_eve": "pub-eve",
+        "pub_bob": "pub-bob",
+        "priv_alice": "priv-alice",
+        "priv_bob_fork": "priv-bob-fork",
+        "pub_bob_public_fork": "pub-bob-public-fork",
+    }
+
+
+# ---------------------------------------------------------------------------
+# P1.1 — caller cannot impersonate another viewer
+# ---------------------------------------------------------------------------
+
+
+def test_default_caller_sees_only_public_and_owned_rows(us_env):
+    """Baseline: eve (the calling actor) sees public + owned rows.
+    Alice's + Bob's private rows are filtered out."""
+    us, base = us_env
+    _seed_universe(base)
+    result = _call(us, "quality_leaderboard", goal_id="g-test")
+    bids = {e["branch_def_id"] for e in result["entries"]}
+    # Eve owns no private rows; she sees only the 3 public rows.
+    assert bids == {"pub-eve", "pub-bob", "pub-bob-public-fork"}
+    assert "priv-alice" not in bids
+    assert "priv-bob-fork" not in bids
+
+
+def test_caller_supplied_author_kwarg_does_not_grant_alices_visibility(us_env):
+    """P1.1 adversarial — eve passes ``author='alice'`` hoping to read
+    alice's private branches. The handler MUST ignore the caller-named
+    identity and use the daemon-side actor (eve)."""
+    us, base = us_env
+    _seed_universe(base)
+    result = _call(
+        us, "quality_leaderboard", goal_id="g-test", author="alice",
+    )
+    bids = {e["branch_def_id"] for e in result["entries"]}
+    # Same as the baseline — author=alice MUST NOT change visibility.
+    assert "priv-alice" not in bids
+    assert "priv-bob-fork" not in bids
+    assert bids == {"pub-eve", "pub-bob", "pub-bob-public-fork"}
+
+
+def test_caller_supplied_force_does_not_grant_all_private_rows(us_env):
+    """P1.1 adversarial — eve passes ``force=true`` hoping to bypass
+    visibility. The handler MUST ignore force for visibility."""
+    us, base = us_env
+    _seed_universe(base)
+    result = _call(
+        us, "quality_leaderboard", goal_id="g-test", force=True,
+    )
+    bids = {e["branch_def_id"] for e in result["entries"]}
+    assert "priv-alice" not in bids
+    assert "priv-bob-fork" not in bids
+
+
+def test_caller_supplied_force_and_author_combined_is_still_filtered(us_env):
+    """P1.1 adversarial — the combination round-1 used to surface all
+    of alice's privates (author=alice + force=true). Both ignored."""
+    us, base = us_env
+    _seed_universe(base)
+    result = _call(
+        us, "quality_leaderboard",
+        goal_id="g-test", author="alice", force=True,
+    )
+    bids = {e["branch_def_id"] for e in result["entries"]}
+    assert "priv-alice" not in bids
+    assert "priv-bob-fork" not in bids
+
+
+def test_owner_sees_own_private_rows(us_env, monkeypatch):
+    """Owner exception — alice running as the daemon-side actor DOES
+    see her own private rows (this is the legitimate visibility path
+    the caller-spoofing attack was trying to abuse)."""
+    us, base = us_env
+    _seed_universe(base)
+    # Reload the daemon as alice.
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "alice")
+    importlib.reload(us)
+    try:
+        result = _call(us, "quality_leaderboard", goal_id="g-test")
+        bids = {e["branch_def_id"] for e in result["entries"]}
+        # Alice sees the 3 public rows + her own 2 private rows.
+        assert bids == {
+            "pub-eve", "pub-bob", "pub-bob-public-fork",
+            "priv-alice", "priv-bob-fork",
+        }
+    finally:
+        importlib.reload(us)
+
+
+def test_recommended_parent_for_fork_inherits_same_visibility(us_env):
+    """The recommended-parent action shares the visibility surface;
+    eve cannot reach a private branch via the rationale path either."""
+    us, base = us_env
+    _seed_universe(base)
+    result = _call(
+        us, "recommended_parent_for_fork",
+        goal_id="g-test", author="alice", force=True,
+    )
+    parent = result.get("recommended_parent")
+    if parent is not None:
+        assert parent["branch_def_id"] != "priv-alice"
+        assert parent["branch_def_id"] != "priv-bob-fork"
+
+
+# ---------------------------------------------------------------------------
+# P1.2 — fork_count must respect viewer visibility
+# ---------------------------------------------------------------------------
+
+
+def test_fork_count_excludes_private_forks_for_third_party_viewer(us_env):
+    """P1.2 adversarial — pub-bob has TWO descendants on disk
+    (priv-bob-fork by alice, pub-bob-public-fork by eve). Eve (third
+    party) should only see the public one count toward fork_count.
+    A naive raw count would expose the existence of priv-bob-fork."""
+    us, base = us_env
+    _seed_universe(base)
+    result = _call(us, "quality_leaderboard", goal_id="g-test")
+    pub_bob_entry = next(
+        e for e in result["entries"] if e["branch_def_id"] == "pub-bob"
+    )
+    assert pub_bob_entry["signals"]["fork_count"] == 1, (
+        "fork_count must exclude private forks the viewer cannot see "
+        "(P1.2 leak — exposed private descendant existence)"
+    )
+
+
+def test_fork_count_includes_owned_private_forks_for_owner(us_env, monkeypatch):
+    """Owner exception — alice running as the daemon-side actor sees
+    her private fork count toward pub-bob's fork_count (2 forks: her
+    private + eve's public)."""
+    us, base = us_env
+    _seed_universe(base)
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "alice")
+    importlib.reload(us)
+    try:
+        result = _call(us, "quality_leaderboard", goal_id="g-test")
+        pub_bob_entry = next(
+            e for e in result["entries"]
+            if e["branch_def_id"] == "pub-bob"
+        )
+        assert pub_bob_entry["signals"]["fork_count"] == 2
+    finally:
+        importlib.reload(us)
+
+
+def test_fork_count_unit_at_storage_layer_respects_viewer(tmp_path):
+    """Direct unit on ``_fork_count`` so the regression can't slip
+    through if the dispatch wiring shifts."""
+    from workflow.api.quality_leaderboard import _fork_count
+    from workflow.daemon_server import (
+        initialize_author_server,
+        save_branch_definition,
+        save_goal,
+    )
+    initialize_author_server(tmp_path)
+    save_goal(
+        tmp_path,
+        goal=dict(goal_id="g", name="g", author="h", tags=[],
+                  visibility="public"),
+    )
+    save_branch_definition(
+        tmp_path,
+        branch_def=dict(
+            branch_def_id="parent",
+            name="P", description="", author="bob", tags=[],
+            graph_nodes=[], edges=[], state_schema=[], entry_point="",
+            published=True, goal_id="g", visibility="public",
+        ),
+    )
+    save_branch_definition(
+        tmp_path,
+        branch_def=dict(
+            branch_def_id="pub-fork",
+            name="PF", description="", author="bob", tags=[],
+            graph_nodes=[], edges=[], state_schema=[], entry_point="",
+            published=True, goal_id="g", visibility="public",
+            parent_def_id="parent",
+        ),
+    )
+    save_branch_definition(
+        tmp_path,
+        branch_def=dict(
+            branch_def_id="priv-fork",
+            name="PrivF", description="", author="alice", tags=[],
+            graph_nodes=[], edges=[], state_schema=[], entry_point="",
+            published=True, goal_id="g", visibility="private",
+            parent_def_id="parent",
+        ),
+    )
+    # Third-party viewer.
+    assert _fork_count(tmp_path, "parent", viewer="eve") == 1
+    # Owner.
+    assert _fork_count(tmp_path, "parent", viewer="alice") == 2
+    # No viewer (strictly public).
+    assert _fork_count(tmp_path, "parent", viewer="") == 1
+    # Public via fork_from column.
+    save_branch_definition(
+        tmp_path,
+        branch_def=dict(
+            branch_def_id="forkfrom-pub",
+            name="FF", description="", author="charlie", tags=[],
+            graph_nodes=[], edges=[], state_schema=[], entry_point="",
+            published=True, goal_id="g", visibility="public",
+            fork_from="parent",
+        ),
+    )
+    assert _fork_count(tmp_path, "parent", viewer="eve") == 2
+
+
+# ---------------------------------------------------------------------------
+# Public-API signature lock: include_private is no longer a kwarg
+# ---------------------------------------------------------------------------
+
+
+def test_build_quality_leaderboard_signature_has_no_include_private():
+    """Lock the public API surface: ``include_private`` is REMOVED
+    from the public entry point so a future refactor can't reintroduce
+    a caller-controllable visibility knob without a test failure."""
+    import inspect
+
+    from workflow.api.quality_leaderboard import build_quality_leaderboard
+    sig = inspect.signature(build_quality_leaderboard)
+    assert "include_private" not in sig.parameters
+    # ``viewer`` is required (no default) so callers cannot accidentally
+    # invoke the public path without explicitly committing to a viewer
+    # identity. The MCP handler always supplies ``_current_actor()``.
+    assert sig.parameters["viewer"].default is inspect.Parameter.empty
+
+
+def test_recommend_parent_for_fork_signature_has_no_include_private():
+    import inspect
+
+    from workflow.api.quality_leaderboard import recommend_parent_for_fork
+    sig = inspect.signature(recommend_parent_for_fork)
+    assert "include_private" not in sig.parameters
+    assert sig.parameters["viewer"].default is inspect.Parameter.empty
+
+
+# ---------------------------------------------------------------------------
+# Empty current_actor falls back to strictly-public, not "expose all"
+# ---------------------------------------------------------------------------
+
+
+def test_anonymous_actor_falls_back_to_strictly_public(us_env, monkeypatch):
+    """When the daemon-side actor resolves to an empty / anonymous
+    identity, the visibility filter must collapse to 'strictly public'
+    rather than 'no filter' (which would expose every private row)."""
+    us, base = us_env
+    _seed_universe(base)
+    monkeypatch.delenv("UNIVERSE_SERVER_USER", raising=False)
+    importlib.reload(us)
+    try:
+        result = _call(us, "quality_leaderboard", goal_id="g-test")
+        bids = {e["branch_def_id"] for e in result["entries"]}
+        # The default actor is "anonymous" — that's a string, but no
+        # branches are authored by 'anonymous', so the OR clause adds
+        # nothing. Only public rows surface.
+        assert bids == {"pub-eve", "pub-bob", "pub-bob-public-fork"}
+        assert "priv-alice" not in bids
+        assert "priv-bob-fork" not in bids
+    finally:
+        importlib.reload(us)
+
+
+# ---------------------------------------------------------------------------
+# Time-domain: ensure visibility test doesn't depend on recency decay
+# ---------------------------------------------------------------------------
+
+
+def test_visibility_filter_holds_even_with_signal_rich_branches(us_env):
+    """Sanity check — visibility is the outer filter; signal richness
+    can't unmask a private row. Seed alice's private with multiple
+    judgments and verify eve still doesn't see it."""
+    us, base = us_env
+    seeds = _seed_universe(base)
+    # Give alice's private branch a completed run + high-quality
+    # judgment so it would score high if visibility were off.
+    from workflow.runs import (
+        RUN_STATUS_COMPLETED,
+        add_judgment,
+        create_run,
+        update_run_status,
+    )
+    run_id = create_run(
+        base, branch_def_id=seeds["priv_alice"],
+        thread_id=seeds["priv_alice"], inputs={},
+    )
+    update_run_status(
+        base, run_id, status=RUN_STATUS_COMPLETED, finished_at=time.time(),
+    )
+    add_judgment(
+        base, run_id=run_id, text="excellent",
+        tags=["quality:10"], author="judge",
+    )
+    # Eve still sees only the public branches.
+    result = _call(us, "quality_leaderboard", goal_id="g-test")
+    bids = {e["branch_def_id"] for e in result["entries"]}
+    assert seeds["priv_alice"] not in bids

--- a/workflow/api/extensions.py
+++ b/workflow/api/extensions.py
@@ -66,6 +66,7 @@ from workflow.api.evaluation import (
     _JUDGMENT_ACTIONS,
     _dispatch_judgment_action,
 )
+from workflow.api.extensions_leaderboard_actions import _LEADERBOARD_ACTIONS
 from workflow.api.helpers import _base_path, _read_json
 from workflow.api.market import (
     _ATTRIBUTION_ACTIONS,
@@ -635,6 +636,22 @@ def _extensions_impl(
         }
         return attribution_handler(attr_kwargs)
 
+    # ── Quality leaderboard / parent selection (PR-123 substrate M2) ───────
+    leaderboard_handler = _LEADERBOARD_ACTIONS.get(action)
+    if leaderboard_handler is not None:
+        lb_kwargs: dict[str, Any] = {
+            "goal_id": goal_id,
+            "author": author,
+            "force": force,
+        }
+        # ``author`` carries the optional viewer override; ``force`` is
+        # the include_private flag (host / internal callers only).
+        # Field reuse keeps the extensions() tool signature stable —
+        # no new kwargs added in this slice.
+        lb_kwargs["viewer"] = author or ""
+        lb_kwargs["include_private"] = force
+        return leaderboard_handler(lb_kwargs)
+
     return json.dumps({
         "error": f"Unknown action '{action}'.",
         "available_actions": [
@@ -665,6 +682,7 @@ def _extensions_impl(
             "pause_schedule", "unpause_schedule", "list_scheduler_subscriptions",
             "record_outcome", "list_outcomes", "get_outcome",
             "record_remix", "get_provenance",
+            "quality_leaderboard", "recommended_parent_for_fork",
         ],
     })
 

--- a/workflow/api/extensions.py
+++ b/workflow/api/extensions.py
@@ -639,18 +639,16 @@ def _extensions_impl(
     # ── Quality leaderboard / parent selection (PR-123 substrate M2) ───────
     leaderboard_handler = _LEADERBOARD_ACTIONS.get(action)
     if leaderboard_handler is not None:
-        lb_kwargs: dict[str, Any] = {
-            "goal_id": goal_id,
-            "author": author,
-            "force": force,
-        }
-        # ``author`` carries the optional viewer override; ``force`` is
-        # the include_private flag (host / internal callers only).
-        # Field reuse keeps the extensions() tool signature stable —
-        # no new kwargs added in this slice.
-        lb_kwargs["viewer"] = author or ""
-        lb_kwargs["include_private"] = force
-        return leaderboard_handler(lb_kwargs)
+        # P1.1 fix (round 2) — the dispatch MUST NOT forward
+        # caller-supplied ``author`` / ``force`` into the leaderboard
+        # handler's visibility surface. Round-1 mapped
+        # ``author -> viewer`` and ``force -> include_private``, which
+        # let an MCP caller see private branches authored by anyone
+        # they could name. The handler now resolves viewer identity
+        # server-side via ``_current_actor()``; visibility is
+        # public-or-author-owned for the actual caller, never the
+        # caller-named identity.
+        return leaderboard_handler({"goal_id": goal_id})
 
     return json.dumps({
         "error": f"Unknown action '{action}'.",

--- a/workflow/api/extensions_leaderboard_actions.py
+++ b/workflow/api/extensions_leaderboard_actions.py
@@ -1,0 +1,208 @@
+"""MCP action handlers for the quality leaderboard — PR-123 substrate (M2).
+
+Wires ``workflow.api.quality_leaderboard`` into the ``extensions`` MCP
+tool surface so chatbots can call:
+
+- ``extensions action=quality_leaderboard goal_id=<goal>`` — ranked
+  list of branches bound to this Goal with per-entry signal summaries.
+- ``extensions action=recommended_parent_for_fork goal_id=<goal>`` —
+  top branch_def_id + rationale string. Thin wrapper for community
+  designers asking "what should I fork from?".
+
+Goal-generic by design — same primitive works for patch-loops AND
+fantasy-writing AND recipe-trackers AND any community.
+
+The dispatch dict shape matches the other ``_*_ACTIONS`` modules under
+``workflow/api/``: each handler takes a single ``kwargs: dict`` and
+returns a JSON string for the MCP response. The text channel renders
+a phone-legible mermaid-free summary; raw entries live in
+``structuredContent`` for downstream tools.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _base_universe_dir():
+    from workflow.api.helpers import _base_path
+    return _base_path()
+
+
+def _action_quality_leaderboard(kwargs: dict[str, Any]) -> str:
+    """Return the ranked leaderboard for a Goal.
+
+    Required: ``goal_id``. Optional: ``viewer`` (defaults to current
+    actor), ``include_private`` (default False).
+    """
+    goal_id = (kwargs.get("goal_id") or "").strip()
+    if not goal_id:
+        return json.dumps({
+            "error": "quality_leaderboard requires 'goal_id'",
+            "failure_class": "missing_goal_id",
+            "actionable_by": "chatbot",
+        })
+    viewer = (kwargs.get("viewer") or "").strip()
+    if not viewer:
+        try:
+            from workflow.api.engine_helpers import _current_actor
+            viewer = _current_actor()
+        except Exception:
+            viewer = ""
+    include_private = _bool_kwarg(kwargs.get("include_private"))
+
+    try:
+        from workflow.api.quality_leaderboard import build_quality_leaderboard
+        board = build_quality_leaderboard(
+            _base_universe_dir(),
+            goal_id=goal_id,
+            viewer=viewer,
+            include_private=include_private,
+        )
+    except Exception as exc:
+        logger.exception("quality_leaderboard failed for %s", goal_id)
+        return json.dumps({
+            "error": f"quality_leaderboard failed: {exc}",
+            "failure_class": "storage_error",
+            "actionable_by": "host",
+        })
+
+    board["text"] = _render_leaderboard_text(board)
+    return json.dumps(board, default=str)
+
+
+def _action_recommended_parent_for_fork(kwargs: dict[str, Any]) -> str:
+    """Return the top leaderboard entry + rationale for forking.
+
+    Required: ``goal_id``. Same viewer / include_private kwargs as
+    ``quality_leaderboard``.
+    """
+    goal_id = (kwargs.get("goal_id") or "").strip()
+    if not goal_id:
+        return json.dumps({
+            "error": "recommended_parent_for_fork requires 'goal_id'",
+            "failure_class": "missing_goal_id",
+            "actionable_by": "chatbot",
+        })
+    viewer = (kwargs.get("viewer") or "").strip()
+    if not viewer:
+        try:
+            from workflow.api.engine_helpers import _current_actor
+            viewer = _current_actor()
+        except Exception:
+            viewer = ""
+    include_private = _bool_kwarg(kwargs.get("include_private"))
+
+    try:
+        from workflow.api.quality_leaderboard import recommend_parent_for_fork
+        result = recommend_parent_for_fork(
+            _base_universe_dir(),
+            goal_id=goal_id,
+            viewer=viewer,
+            include_private=include_private,
+        )
+    except Exception as exc:
+        logger.exception(
+            "recommended_parent_for_fork failed for %s", goal_id,
+        )
+        return json.dumps({
+            "error": f"recommended_parent_for_fork failed: {exc}",
+            "failure_class": "storage_error",
+            "actionable_by": "host",
+        })
+
+    result["text"] = _render_recommendation_text(result)
+    return json.dumps(result, default=str)
+
+
+def _bool_kwarg(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _render_leaderboard_text(board: dict[str, Any]) -> str:
+    entries = board.get("entries") or []
+    goal = board.get("goal") or {}
+    goal_label = (
+        f"'{goal.get('name')}' ({board.get('goal_id')})"
+        if goal else f"Goal {board.get('goal_id')}"
+    )
+    if not entries:
+        return (
+            f"No Branches are currently bound to {goal_label}. "
+            "Use `extensions action=build_branch goal_id=...` to "
+            "create the first entry."
+        )
+
+    lines: list[str] = [
+        f"**Quality leaderboard for {goal_label}** "
+        f"({len(entries)} entries):",
+        "",
+        "| Rank | Branch | Author | Score | Runs | Forks | Recency |",
+        "|------|--------|--------|-------|------|-------|---------|",
+    ]
+    for entry in entries[:15]:
+        signals = entry.get("signals") or {}
+        name = entry.get("name") or "(unnamed)"
+        if len(name) > 30:
+            name = name[:30].rstrip() + "…"
+        age = signals.get("age_days_since_success")
+        if age is None:
+            age_text = "never"
+        elif age < 1:
+            age_text = "<1d"
+        else:
+            age_text = f"{int(age)}d ago"
+        lines.append(
+            f"| {entry.get('rank')} "
+            f"| `{entry.get('branch_def_id', '')[:12]}` {name} "
+            f"| {entry.get('author', '')} "
+            f"| {entry.get('score', 0.0):.2f} "
+            f"| {int(signals.get('completed_run_count') or 0)} "
+            f"| {int(signals.get('fork_count') or 0)} "
+            f"| {age_text} |"
+        )
+    if len(entries) > 15:
+        lines.append("")
+        lines.append(f"… and {len(entries) - 15} more entries.")
+    lines.append("")
+    lines.append(
+        "_Best-effort v1 ranking. Use "
+        "`extensions action=recommended_parent_for_fork goal_id=…` "
+        "for the top entry plus a rationale._"
+    )
+    return "\n".join(lines)
+
+
+def _render_recommendation_text(result: dict[str, Any]) -> str:
+    parent = result.get("recommended_parent")
+    rationale = result.get("rationale") or ""
+    if parent is None:
+        return rationale
+    name = parent.get("name") or "(unnamed)"
+    bid = parent.get("branch_def_id") or ""
+    return (
+        f"**Recommended parent for fork:** `{bid}` — '{name}' "
+        f"(score {parent.get('score', 0.0):.2f}).\n\n"
+        f"{rationale}"
+    )
+
+
+_LEADERBOARD_ACTIONS: dict[str, Any] = {
+    "quality_leaderboard": _action_quality_leaderboard,
+    "recommended_parent_for_fork": _action_recommended_parent_for_fork,
+}
+
+
+__all__ = [
+    "_LEADERBOARD_ACTIONS",
+    "_action_quality_leaderboard",
+    "_action_recommended_parent_for_fork",
+]

--- a/workflow/api/extensions_leaderboard_actions.py
+++ b/workflow/api/extensions_leaderboard_actions.py
@@ -33,11 +33,34 @@ def _base_universe_dir():
     return _base_path()
 
 
+def _resolve_caller_viewer() -> str:
+    """Resolve the viewer identity ONLY from the daemon-side actor.
+
+    Round-2 P1.1 fix — the round-1 handler trusted a caller-supplied
+    ``viewer`` kwarg, which let an MCP caller passing
+    ``author="someone-else"`` see that user's private branches. This
+    helper drops the kwarg entirely and reads ``_current_actor()`` as
+    the single source of truth. Defensive try/except so a misconfigured
+    daemon falls back to the "strictly public" filter rather than
+    leaking private rows on import failure.
+    """
+    try:
+        from workflow.api.engine_helpers import _current_actor
+        return _current_actor() or ""
+    except Exception:
+        logger.exception("failed to resolve _current_actor for viewer")
+        return ""
+
+
 def _action_quality_leaderboard(kwargs: dict[str, Any]) -> str:
     """Return the ranked leaderboard for a Goal.
 
-    Required: ``goal_id``. Optional: ``viewer`` (defaults to current
-    actor), ``include_private`` (default False).
+    Required: ``goal_id``.
+
+    NOTE: any caller-supplied ``viewer`` / ``include_private`` / ``force``
+    keys in ``kwargs`` are IGNORED for visibility purposes. Visibility
+    is always derived server-side from the current actor — see the
+    round-2 PR comment on #970 for the auth-boundary rationale.
     """
     goal_id = (kwargs.get("goal_id") or "").strip()
     if not goal_id:
@@ -46,14 +69,7 @@ def _action_quality_leaderboard(kwargs: dict[str, Any]) -> str:
             "failure_class": "missing_goal_id",
             "actionable_by": "chatbot",
         })
-    viewer = (kwargs.get("viewer") or "").strip()
-    if not viewer:
-        try:
-            from workflow.api.engine_helpers import _current_actor
-            viewer = _current_actor()
-        except Exception:
-            viewer = ""
-    include_private = _bool_kwarg(kwargs.get("include_private"))
+    viewer = _resolve_caller_viewer()
 
     try:
         from workflow.api.quality_leaderboard import build_quality_leaderboard
@@ -61,7 +77,6 @@ def _action_quality_leaderboard(kwargs: dict[str, Any]) -> str:
             _base_universe_dir(),
             goal_id=goal_id,
             viewer=viewer,
-            include_private=include_private,
         )
     except Exception as exc:
         logger.exception("quality_leaderboard failed for %s", goal_id)
@@ -78,8 +93,8 @@ def _action_quality_leaderboard(kwargs: dict[str, Any]) -> str:
 def _action_recommended_parent_for_fork(kwargs: dict[str, Any]) -> str:
     """Return the top leaderboard entry + rationale for forking.
 
-    Required: ``goal_id``. Same viewer / include_private kwargs as
-    ``quality_leaderboard``.
+    Required: ``goal_id``. Same viewer-derivation rules as
+    ``quality_leaderboard`` — visibility is server-side only.
     """
     goal_id = (kwargs.get("goal_id") or "").strip()
     if not goal_id:
@@ -88,14 +103,7 @@ def _action_recommended_parent_for_fork(kwargs: dict[str, Any]) -> str:
             "failure_class": "missing_goal_id",
             "actionable_by": "chatbot",
         })
-    viewer = (kwargs.get("viewer") or "").strip()
-    if not viewer:
-        try:
-            from workflow.api.engine_helpers import _current_actor
-            viewer = _current_actor()
-        except Exception:
-            viewer = ""
-    include_private = _bool_kwarg(kwargs.get("include_private"))
+    viewer = _resolve_caller_viewer()
 
     try:
         from workflow.api.quality_leaderboard import recommend_parent_for_fork
@@ -103,7 +111,6 @@ def _action_recommended_parent_for_fork(kwargs: dict[str, Any]) -> str:
             _base_universe_dir(),
             goal_id=goal_id,
             viewer=viewer,
-            include_private=include_private,
         )
     except Exception as exc:
         logger.exception(
@@ -117,14 +124,6 @@ def _action_recommended_parent_for_fork(kwargs: dict[str, Any]) -> str:
 
     result["text"] = _render_recommendation_text(result)
     return json.dumps(result, default=str)
-
-
-def _bool_kwarg(value: Any) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on"}
-    return bool(value)
 
 
 def _render_leaderboard_text(board: dict[str, Any]) -> str:

--- a/workflow/api/quality_leaderboard.py
+++ b/workflow/api/quality_leaderboard.py
@@ -1,0 +1,626 @@
+"""Quality leaderboard + parent-selection — PR-123 substrate (M2).
+
+Surfaces, for any Goal that has competing Branch entries:
+
+- ``quality_leaderboard(goal_id)`` — ranked list of Branches bound to
+  the Goal, with the per-entry signal summary that produced the score.
+- ``recommended_parent_for_fork(goal_id)`` — the top entry plus a
+  human-readable rationale string, intended as a thin handle for the
+  community designer asking "what should I fork from?".
+
+Design source: wiki page
+``pages/patch-requests/pr-123-goal-archive-with-parent-selection-...``
+on the live MCP brain. The PLAN Goals & Gates module names this
+surface as ``archive_consultation parent-rank scoring formula`` and
+flags it as **open evolution** — a follow-on may turn the scoring
+formula into an evolvable Workflow node so the community can iterate
+on weights through autoresearch rather than asking the platform to
+ship "the right" constants.
+
+This slice is **best-effort v1**: ranking is signal-driven, not
+ground-truth-driven. The formula constants are surfaced in every
+response under ``formula`` so reviewers can audit and tune them
+without re-reading source.
+
+Goal-generic by design — same primitive works for patch-loops AND
+fantasy-writing AND recipe-trackers AND any community. No
+Loop-2-specific assumptions.
+
+Signals (all read from existing storage; no new tables in this slice):
+
+- ``completed_run_count`` — runs with ``status='completed'``.
+- ``failed_run_count`` — runs with ``status='failed'`` (penalty).
+- ``total_run_count`` — full count regardless of status.
+- ``last_successful_run_at`` — max ``finished_at`` of completed runs.
+- ``recency_decay`` — ``exp(-age_days/30)`` against the wall clock;
+  0 when the branch never produced a successful run.
+- ``judgment_count`` — rows in ``run_judgments`` joined via ``runs``.
+- ``judgment_score_avg`` — mean of numeric scores parsed from
+  judgment tags like ``quality:8.2``, ``novelty:7``, ``risk:3``.
+  None when no numeric tags exist (the signal contributes 0 to the
+  score in that case rather than NaN-propagating).
+- ``fork_count`` — branches whose ``parent_def_id`` or ``fork_from``
+  references this branch. Community votes with their forks.
+- ``gate_rung_top`` — the lexicographically-greatest active
+  ``rung_key`` from ``gate_claims`` for this (branch, goal).
+- ``safe_to_publish`` — best-effort read of
+  ``branch.stats.next_action_packet.safe_to_publish``. The packet
+  shape isn't on-disk-stable yet; if absent, the signal contributes 0.
+
+Score formula (weights surfaced in the response so they are auditable):
+
+  score = 3.0 * normalized_judgment_score
+        + 1.5 * log1p(completed_run_count)
+        + 2.0 * log1p(fork_count)
+        + 2.0 * recency_decay
+        + 1.0 * has_gate_rung
+        + 1.5 * safe_to_publish
+        - 1.0 * log1p(failed_run_count)
+
+``normalized_judgment_score`` is ``judgment_score_avg / 10.0`` (DGM
+scores are on a 0-10 scale) clamped to [0, 1] so the term is bounded.
+log1p bounds the impact of high-volume entries; recency / gate /
+safe_to_publish are already [0, 1].
+
+Tie-breaks: higher ``last_successful_run_at`` wins; then higher
+``created_at`` (newer entry); then ``branch_def_id`` for stability.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Tunable weights — surfaced in the response under ``formula``
+# ---------------------------------------------------------------------------
+
+W_JUDGMENT = 3.0
+W_RUNS = 1.5
+W_FORKS = 2.0
+W_RECENCY = 2.0
+W_GATE = 1.0
+W_SAFE_PUBLISH = 1.5
+W_FAILED_PENALTY = 1.0
+
+RECENCY_HALFLIFE_DAYS = 30.0
+JUDGMENT_MAX_SCALE = 10.0  # DGM-style 0-10
+
+# Numeric judgment-tag pattern: ``key:N`` where N is integer/float.
+# Examples that match: ``quality:8``, ``quality:8.2``, ``novelty:7.5``,
+# ``risk:3``. Negative numbers and tags without ``:N`` are ignored.
+_NUMERIC_TAG_RE = re.compile(
+    r"^\s*([A-Za-z][A-Za-z0-9_\-]*)\s*:\s*([0-9]+(?:\.[0-9]+)?)\s*$"
+)
+
+# Tag names that contribute to the average quality signal. Tags outside
+# this set are recorded under ``other_numeric_tags`` so the chatbot can
+# surface them without polluting the headline score.
+_QUALITY_TAG_KEYS = frozenset({"quality", "novelty", "score"})
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_quality_leaderboard(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    now: float | None = None,
+    viewer: str = "",
+    include_private: bool = False,
+) -> dict[str, Any]:
+    """Compute the ranked list of branches bound to ``goal_id``.
+
+    Returns ``{"goal_id": ..., "goal": <row | None>, "entries": [...],
+    "formula": {...}, "generated_at": ...}``.
+
+    Each entry is::
+
+        {
+            "rank":             1,
+            "branch_def_id":    "...",
+            "name":             "...",
+            "description":      "...",
+            "author":           "...",
+            "created_at":       <unix>,
+            "updated_at":       <unix>,
+            "score":            <float>,
+            "signals":          {<see Signals section above>},
+            "score_components": {<per-term contribution to score>},
+        }
+
+    The function returns the ranked entries even when the Goal does not
+    exist or has no bound branches — the chatbot can render a friendly
+    "no entries yet" page from ``entries == []``.
+
+    ``base_path`` is the daemon's data root (matches the rest of the
+    storage layer).
+    """
+    if now is None:
+        import time as _time
+        now = _time.time()
+
+    goal_row = _safe_get_goal(base_path, goal_id)
+
+    from workflow.daemon_server import list_branch_definitions
+    branches = list_branch_definitions(
+        base_path,
+        goal_id=goal_id,
+        viewer=viewer,
+        include_private=include_private,
+    )
+
+    entries: list[dict[str, Any]] = []
+    for branch in branches:
+        signals = _collect_signals_for_branch(base_path, branch, now=now)
+        components = _score_components(signals)
+        score = sum(components.values())
+        entries.append({
+            "branch_def_id": branch["branch_def_id"],
+            "name": branch.get("name", ""),
+            "description": branch.get("description", ""),
+            "author": branch.get("author", ""),
+            "created_at": branch.get("created_at", 0.0),
+            "updated_at": branch.get("updated_at", 0.0),
+            "score": round(score, 4),
+            "signals": signals,
+            "score_components": {
+                k: round(v, 4) for k, v in components.items()
+            },
+        })
+
+    # Two-pass stable sort. First pass: branch_def_id ascending (string
+    # compare). Second pass: primary keys with reverse=True. Python's
+    # sort is stable, so the secondary key from the first pass survives
+    # within ties of the primary sort.
+    entries.sort(key=lambda e: e.get("branch_def_id", ""))
+    entries.sort(key=_entry_sort_key, reverse=True)
+    for rank, entry in enumerate(entries, start=1):
+        entry["rank"] = rank
+
+    return {
+        "goal_id": goal_id,
+        "goal": goal_row,
+        "entries": entries,
+        "formula": _formula_disclosure(),
+        "generated_at": now,
+    }
+
+
+def recommend_parent_for_fork(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    now: float | None = None,
+    viewer: str = "",
+    include_private: bool = False,
+) -> dict[str, Any]:
+    """Return the top leaderboard entry plus a human-readable rationale.
+
+    Returns ``{"goal_id": ..., "recommended_parent": <entry | None>,
+    "rationale": "...", "leaderboard_size": <int>, "generated_at": ...}``.
+
+    When no branch is bound to the Goal the response carries
+    ``recommended_parent=None`` and a rationale explaining that no
+    parent exists yet — the chatbot should propose "create the first
+    branch" rather than "fork from".
+    """
+    board = build_quality_leaderboard(
+        base_path,
+        goal_id=goal_id,
+        now=now,
+        viewer=viewer,
+        include_private=include_private,
+    )
+    entries = board["entries"]
+    if not entries:
+        return {
+            "goal_id": goal_id,
+            "recommended_parent": None,
+            "rationale": (
+                "No Branch is bound to this Goal yet. Create the first "
+                "Branch via extensions action=build_branch goal_id=… or "
+                "fork from a peer Goal's leaderboard."
+            ),
+            "leaderboard_size": 0,
+            "generated_at": board["generated_at"],
+        }
+    top = entries[0]
+    return {
+        "goal_id": goal_id,
+        "recommended_parent": top,
+        "rationale": _build_rationale(top, leaderboard_size=len(entries)),
+        "leaderboard_size": len(entries),
+        "generated_at": board["generated_at"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Signal collection
+# ---------------------------------------------------------------------------
+
+
+def _collect_signals_for_branch(
+    base_path: str | Path,
+    branch: dict[str, Any],
+    *,
+    now: float,
+) -> dict[str, Any]:
+    bid = branch["branch_def_id"]
+    goal_id = branch.get("goal_id") or ""
+
+    run_stats = _run_stats(base_path, bid)
+    judgment_stats = _judgment_stats(base_path, bid)
+    fork_count = _fork_count(base_path, bid)
+    gate_rung_top = _gate_rung_top(base_path, bid, goal_id)
+    safe_to_publish = _safe_to_publish(branch)
+
+    last_ok = run_stats["last_successful_run_at"]
+    if last_ok and last_ok > 0:
+        age_days = max(0.0, (now - last_ok) / 86400.0)
+        recency_decay = math.exp(-age_days / RECENCY_HALFLIFE_DAYS)
+    else:
+        age_days = None
+        recency_decay = 0.0
+
+    return {
+        "total_run_count": run_stats["total"],
+        "completed_run_count": run_stats["completed"],
+        "failed_run_count": run_stats["failed"],
+        "last_successful_run_at": last_ok,
+        "age_days_since_success": age_days,
+        "recency_decay": round(recency_decay, 4),
+        "judgment_count": judgment_stats["count"],
+        "judgment_score_avg": judgment_stats["score_avg"],
+        "judgment_score_samples": judgment_stats["score_samples"],
+        "other_numeric_tags": judgment_stats["other_numeric_tags"],
+        "fork_count": fork_count,
+        "gate_rung_top": gate_rung_top,
+        "has_gate_rung": gate_rung_top is not None,
+        "safe_to_publish": safe_to_publish,
+    }
+
+
+def _run_stats(base_path: str | Path, branch_def_id: str) -> dict[str, Any]:
+    """Aggregate counts + last_successful_run_at directly against runs DB.
+
+    A direct SQL aggregate is cheaper than fetching every row via
+    ``list_runs`` — this is invoked once per branch on the leaderboard
+    and a Goal can carry 50+ branches.
+    """
+    from workflow.runs import _connect, initialize_runs_db
+
+    initialize_runs_db(base_path)
+    with _connect(base_path) as conn:
+        row = conn.execute(
+            """
+            SELECT
+                COUNT(*) AS total,
+                SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed,
+                SUM(CASE WHEN status = 'failed'    THEN 1 ELSE 0 END) AS failed,
+                MAX(CASE WHEN status = 'completed' THEN finished_at END)
+                    AS last_successful_run_at
+            FROM runs
+            WHERE branch_def_id = ?
+            """,
+            (branch_def_id,),
+        ).fetchone()
+    if row is None:
+        return {
+            "total": 0, "completed": 0, "failed": 0,
+            "last_successful_run_at": 0.0,
+        }
+    return {
+        "total": int(row["total"] or 0),
+        "completed": int(row["completed"] or 0),
+        "failed": int(row["failed"] or 0),
+        "last_successful_run_at": float(row["last_successful_run_at"] or 0.0),
+    }
+
+
+def _judgment_stats(
+    base_path: str | Path, branch_def_id: str,
+) -> dict[str, Any]:
+    """Parse numeric scores out of judgment tags scoped to this branch.
+
+    Judgments are free-text + tags; the leaderboard reads ``tags_json``
+    looking for ``key:N`` patterns where ``key`` is in
+    ``_QUALITY_TAG_KEYS`` for the headline score. Other numeric tags are
+    bucketed under ``other_numeric_tags`` for surface-level reporting
+    but don't contribute to the score in this slice.
+    """
+    from workflow.runs import _connect, initialize_runs_db
+    from workflow.storage import _json_loads
+
+    initialize_runs_db(base_path)
+    with _connect(base_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT j.tags_json
+              FROM run_judgments j
+              JOIN runs r ON r.run_id = j.run_id
+             WHERE r.branch_def_id = ?
+            """,
+            (branch_def_id,),
+        ).fetchall()
+    count = len(rows)
+    quality_scores: list[float] = []
+    other_counts: dict[str, int] = {}
+    for row in rows:
+        tags = _json_loads(row["tags_json"], []) or []
+        if not isinstance(tags, list):
+            continue
+        for tag in tags:
+            if not isinstance(tag, str):
+                continue
+            m = _NUMERIC_TAG_RE.match(tag)
+            if not m:
+                continue
+            key = m.group(1).lower()
+            try:
+                value = float(m.group(2))
+            except (TypeError, ValueError):
+                continue
+            if key in _QUALITY_TAG_KEYS:
+                quality_scores.append(value)
+            else:
+                other_counts[key] = other_counts.get(key, 0) + 1
+    score_avg = (
+        sum(quality_scores) / len(quality_scores)
+        if quality_scores else None
+    )
+    return {
+        "count": count,
+        "score_avg": (round(score_avg, 4) if score_avg is not None else None),
+        "score_samples": len(quality_scores),
+        "other_numeric_tags": other_counts,
+    }
+
+
+def _fork_count(base_path: str | Path, branch_def_id: str) -> int:
+    """Count descendants. Either ``parent_def_id`` or ``fork_from`` may
+    reference this branch — count rows whose either column matches.
+    """
+    from workflow.storage import _connect
+
+    with _connect(base_path) as conn:
+        row = conn.execute(
+            """
+            SELECT COUNT(*) AS n
+              FROM branch_definitions
+             WHERE parent_def_id = ? OR fork_from = ?
+            """,
+            (branch_def_id, branch_def_id),
+        ).fetchone()
+    return int(row["n"] or 0) if row is not None else 0
+
+
+def _gate_rung_top(
+    base_path: str | Path,
+    branch_def_id: str,
+    goal_id: str,
+) -> str | None:
+    """Return the highest active gate rung for (branch, goal), or None.
+
+    "Highest" in this slice is lexicographically-greatest ``rung_key``
+    among non-retracted claims. Goal-ladder-aware ordering is a follow-on
+    once the ladder shape is stable per-Goal.
+    """
+    if not goal_id:
+        return None
+    from workflow.daemon_server import list_gate_claims
+
+    try:
+        claims = list_gate_claims(
+            base_path,
+            branch_def_id=branch_def_id,
+            include_retracted=False,
+            limit=200,
+        )
+    except Exception:
+        return None
+    candidates = [
+        (c.get("rung_key") or "")
+        for c in claims
+        if (c.get("goal_id") or "") == goal_id
+        and not c.get("retracted_at")
+    ]
+    candidates = [r for r in candidates if r]
+    if not candidates:
+        return None
+    return max(candidates)
+
+
+def _safe_to_publish(branch: dict[str, Any]) -> bool:
+    """Best-effort lookup of a Loop-2-style next_action_packet flag.
+
+    The packet shape isn't on-disk-stable yet; nodes that emit it write
+    into the branch ``stats`` JSON. When absent, the signal is False
+    rather than missing — score contribution is 0 either way.
+    """
+    stats = branch.get("stats")
+    if not isinstance(stats, dict):
+        return False
+    packet = stats.get("next_action_packet")
+    if not isinstance(packet, dict):
+        return False
+    return bool(packet.get("safe_to_publish"))
+
+
+def _safe_get_goal(
+    base_path: str | Path, goal_id: str,
+) -> dict[str, Any] | None:
+    from workflow.daemon_server import get_goal
+    try:
+        return get_goal(base_path, goal_id=goal_id)
+    except KeyError:
+        return None
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def _score_components(signals: dict[str, Any]) -> dict[str, float]:
+    """Per-term contributions to score. Surfaced in the response so the
+    chatbot can render "why this one ranked first" without re-computing.
+    """
+    score_avg = signals.get("judgment_score_avg")
+    if score_avg is None:
+        normalized_judgment = 0.0
+    else:
+        normalized_judgment = max(0.0, min(1.0, score_avg / JUDGMENT_MAX_SCALE))
+
+    completed = max(0, int(signals.get("completed_run_count") or 0))
+    failed = max(0, int(signals.get("failed_run_count") or 0))
+    fork_count = max(0, int(signals.get("fork_count") or 0))
+    recency = float(signals.get("recency_decay") or 0.0)
+    has_gate = 1.0 if signals.get("has_gate_rung") else 0.0
+    safe_pub = 1.0 if signals.get("safe_to_publish") else 0.0
+
+    return {
+        "judgment":  W_JUDGMENT * normalized_judgment,
+        "runs":      W_RUNS * math.log1p(completed),
+        "forks":     W_FORKS * math.log1p(fork_count),
+        "recency":   W_RECENCY * recency,
+        "gate":      W_GATE * has_gate,
+        "safe_pub":  W_SAFE_PUBLISH * safe_pub,
+        "failed_penalty": -W_FAILED_PENALTY * math.log1p(failed),
+    }
+
+
+def _entry_sort_key(entry: dict[str, Any]) -> tuple:
+    """Primary sort key for ranked entries (used with ``reverse=True``).
+
+    Tuple order:
+      1. ``score`` — higher is better.
+      2. ``last_successful_run_at`` — newer success wins ties.
+      3. ``created_at`` — newer branch wins ties.
+
+    Final ``branch_def_id`` tie-break is handled by a separate stable
+    sort pass before this one is applied — see ``build_quality_leaderboard``.
+    """
+    signals = entry.get("signals") or {}
+    return (
+        float(entry.get("score") or 0.0),
+        float(signals.get("last_successful_run_at") or 0.0),
+        float(entry.get("created_at") or 0.0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Disclosure + rationale
+# ---------------------------------------------------------------------------
+
+
+def _formula_disclosure() -> dict[str, Any]:
+    return {
+        "weights": {
+            "judgment": W_JUDGMENT,
+            "runs": W_RUNS,
+            "forks": W_FORKS,
+            "recency": W_RECENCY,
+            "gate": W_GATE,
+            "safe_publish": W_SAFE_PUBLISH,
+            "failed_penalty": -W_FAILED_PENALTY,
+        },
+        "recency_halflife_days": RECENCY_HALFLIFE_DAYS,
+        "judgment_max_scale": JUDGMENT_MAX_SCALE,
+        "judgment_tag_keys": sorted(_QUALITY_TAG_KEYS),
+        "tie_breakers": [
+            "last_successful_run_at desc",
+            "created_at desc",
+            "branch_def_id asc",
+        ],
+        "notes": (
+            "Best-effort v1. Weights are initial guesses surfaced for "
+            "audit. Per PLAN Goals & Gates, the parent-rank scoring "
+            "formula is open evolution — a follow-on slice will let "
+            "the community iterate weights via an evolvable Workflow "
+            "node rather than ship constants."
+        ),
+    }
+
+
+def _build_rationale(
+    top_entry: dict[str, Any], *, leaderboard_size: int,
+) -> str:
+    """Compose the human-readable rationale string for the top entry."""
+    signals = top_entry.get("signals") or {}
+    name = top_entry.get("name") or top_entry.get("branch_def_id") or "(unnamed)"
+    parts: list[str] = []
+    parts.append(
+        f"'{name}' (#{top_entry.get('branch_def_id')}) ranked first of "
+        f"{leaderboard_size} bound Branches with score "
+        f"{top_entry.get('score', 0.0):.2f}."
+    )
+
+    score_pieces: list[str] = []
+    judgment_avg = signals.get("judgment_score_avg")
+    if judgment_avg is not None:
+        score_pieces.append(
+            f"avg judgment score {judgment_avg:.2f}/{int(JUDGMENT_MAX_SCALE)} "
+            f"across {int(signals.get('judgment_score_samples') or 0)} sample(s)"
+        )
+    completed = int(signals.get("completed_run_count") or 0)
+    if completed:
+        score_pieces.append(f"{completed} completed run(s)")
+    forks = int(signals.get("fork_count") or 0)
+    if forks:
+        score_pieces.append(f"{forks} community fork(s)")
+    age = signals.get("age_days_since_success")
+    if age is not None:
+        if age < 1:
+            age_phrase = "under a day ago"
+        elif age < 2:
+            age_phrase = "yesterday"
+        else:
+            age_phrase = f"{int(age)} days ago"
+        score_pieces.append(f"most recent successful run {age_phrase}")
+    rung = signals.get("gate_rung_top")
+    if rung:
+        score_pieces.append(f"highest gate rung claimed: '{rung}'")
+    if signals.get("safe_to_publish"):
+        score_pieces.append("flagged safe_to_publish by its own packet")
+    failed = int(signals.get("failed_run_count") or 0)
+    if failed:
+        score_pieces.append(f"({failed} failed run(s) — penalty applied)")
+
+    if score_pieces:
+        parts.append("Signals: " + "; ".join(score_pieces) + ".")
+    else:
+        parts.append(
+            "No quality signals yet — ranking is by recency / author "
+            "registration only. Treat as a tentative parent until the "
+            "first judgment lands."
+        )
+
+    parts.append(
+        "Note: this is a best-effort v1 recommendation. Inspect the "
+        "score_components in the leaderboard entry to see which "
+        "signals dominated the rank."
+    )
+    return " ".join(parts)
+
+
+__all__ = [
+    "build_quality_leaderboard",
+    "recommend_parent_for_fork",
+    "W_JUDGMENT",
+    "W_RUNS",
+    "W_FORKS",
+    "W_RECENCY",
+    "W_GATE",
+    "W_SAFE_PUBLISH",
+    "W_FAILED_PENALTY",
+    "RECENCY_HALFLIFE_DAYS",
+    "JUDGMENT_MAX_SCALE",
+]

--- a/workflow/api/quality_leaderboard.py
+++ b/workflow/api/quality_leaderboard.py
@@ -110,14 +110,26 @@ def build_quality_leaderboard(
     base_path: str | Path,
     *,
     goal_id: str,
+    viewer: str,
     now: float | None = None,
-    viewer: str = "",
-    include_private: bool = False,
 ) -> dict[str, Any]:
     """Compute the ranked list of branches bound to ``goal_id``.
 
     Returns ``{"goal_id": ..., "goal": <row | None>, "entries": [...],
     "formula": {...}, "generated_at": ...}``.
+
+    Visibility / auth-boundary contract (round-2 P1.1 fix)
+    ------------------------------------------------------
+    ``viewer`` is the actor identity for which visibility is resolved
+    and MUST be derived server-side by the caller (never accepted from
+    an MCP input). Pass an empty string for the "strictly public" view
+    (no private branches included). The function does NOT accept an
+    ``include_private`` knob — that surface was caller-controllable in
+    round-1 and let an MCP caller flip visibility by passing
+    ``force=true``. To inspect private branches from a host/internal
+    script, build the response directly via the storage helpers; this
+    public entry point ALWAYS applies the public-or-author-owned
+    visibility filter.
 
     Each entry is::
 
@@ -148,16 +160,25 @@ def build_quality_leaderboard(
     goal_row = _safe_get_goal(base_path, goal_id)
 
     from workflow.daemon_server import list_branch_definitions
+    # P1.1 fix — visibility is ALWAYS the public-or-author-owned filter.
+    # ``include_private`` is hard-False at this seam: there's no MCP
+    # surface that legitimately needs to bypass this filter, and round-1
+    # let a caller-supplied ``force=true`` flip it. If a future internal
+    # caller genuinely needs every row, it must reach for the storage
+    # helpers directly with explicit ``include_private=True`` — that
+    # path is host/internal-only and not reachable from MCP.
     branches = list_branch_definitions(
         base_path,
         goal_id=goal_id,
         viewer=viewer,
-        include_private=include_private,
+        include_private=False,
     )
 
     entries: list[dict[str, Any]] = []
     for branch in branches:
-        signals = _collect_signals_for_branch(base_path, branch, now=now)
+        signals = _collect_signals_for_branch(
+            base_path, branch, now=now, viewer=viewer,
+        )
         components = _score_components(signals)
         score = sum(components.values())
         entries.append({
@@ -196,14 +217,17 @@ def recommend_parent_for_fork(
     base_path: str | Path,
     *,
     goal_id: str,
+    viewer: str,
     now: float | None = None,
-    viewer: str = "",
-    include_private: bool = False,
 ) -> dict[str, Any]:
     """Return the top leaderboard entry plus a human-readable rationale.
 
     Returns ``{"goal_id": ..., "recommended_parent": <entry | None>,
     "rationale": "...", "leaderboard_size": <int>, "generated_at": ...}``.
+
+    Visibility contract matches :func:`build_quality_leaderboard` —
+    ``viewer`` must be server-derived; private branches the viewer does
+    not own are excluded.
 
     When no branch is bound to the Goal the response carries
     ``recommended_parent=None`` and a rationale explaining that no
@@ -213,9 +237,8 @@ def recommend_parent_for_fork(
     board = build_quality_leaderboard(
         base_path,
         goal_id=goal_id,
-        now=now,
         viewer=viewer,
-        include_private=include_private,
+        now=now,
     )
     entries = board["entries"]
     if not entries:
@@ -250,13 +273,17 @@ def _collect_signals_for_branch(
     branch: dict[str, Any],
     *,
     now: float,
+    viewer: str,
 ) -> dict[str, Any]:
     bid = branch["branch_def_id"]
     goal_id = branch.get("goal_id") or ""
 
     run_stats = _run_stats(base_path, bid)
     judgment_stats = _judgment_stats(base_path, bid)
-    fork_count = _fork_count(base_path, bid)
+    # P1.2 fix — fork count respects viewer visibility. Counting raw
+    # descendant rows would leak existence of private forks (the row
+    # was hidden from the listing but the aggregate count exposed it).
+    fork_count = _fork_count(base_path, bid, viewer=viewer)
     gate_rung_top = _gate_rung_top(base_path, bid, goal_id)
     safe_to_publish = _safe_to_publish(branch)
 
@@ -382,21 +409,44 @@ def _judgment_stats(
     }
 
 
-def _fork_count(base_path: str | Path, branch_def_id: str) -> int:
-    """Count descendants. Either ``parent_def_id`` or ``fork_from`` may
-    reference this branch — count rows whose either column matches.
+def _fork_count(
+    base_path: str | Path,
+    branch_def_id: str,
+    *,
+    viewer: str,
+) -> int:
+    """Count descendants the ``viewer`` can see.
+
+    Either ``parent_def_id`` or ``fork_from`` may reference this branch
+    — count rows whose either column matches AND that pass the same
+    visibility filter ``list_branch_definitions`` applies (public OR
+    authored by the viewer). This closes the round-2 P1.2 finding: a
+    naive raw count exposed the existence of private descendant rows
+    even when the rows themselves were hidden from the listing.
+
+    Passing ``viewer=""`` matches the "strictly public" semantics —
+    counts only public descendants, never private ones.
     """
     from workflow.storage import _connect
 
+    if viewer:
+        sql = (
+            "SELECT COUNT(*) AS n "
+            "FROM branch_definitions "
+            "WHERE (parent_def_id = ? OR fork_from = ?) "
+            "AND (visibility = 'public' OR author = ?)"
+        )
+        params: tuple[Any, ...] = (branch_def_id, branch_def_id, viewer)
+    else:
+        sql = (
+            "SELECT COUNT(*) AS n "
+            "FROM branch_definitions "
+            "WHERE (parent_def_id = ? OR fork_from = ?) "
+            "AND visibility = 'public'"
+        )
+        params = (branch_def_id, branch_def_id)
     with _connect(base_path) as conn:
-        row = conn.execute(
-            """
-            SELECT COUNT(*) AS n
-              FROM branch_definitions
-             WHERE parent_def_id = ? OR fork_from = ?
-            """,
-            (branch_def_id, branch_def_id),
-        ).fetchone()
+        row = conn.execute(sql, params).fetchone()
     return int(row["n"] or 0) if row is not None else 0
 
 


### PR DESCRIPTION
## Summary

The first competing designer has arrived on Goal `4ff5862cc26d`, so the substrate now needs to surface "what's currently the best entry" + "what should I fork from" automatically. This PR ships the two named-handle MCP actions that close that gap.

**Spec source:** wiki page `pages/patch-requests/pr-123-goal-archive-with-parent-selection-...` on the live MCP brain.
**PLAN alignment:** Goals & Gates module names this surface as the `archive_consultation parent-rank scoring formula` and flags it as **open evolution** — a follow-on slice will let the community iterate weights via an evolvable Workflow node rather than ship constants.
**Scope:** best-effort v1, ranking is signal-driven, not ground-truth-driven.

## New MCP actions

| Action | Inputs | Returns |
|---|---|---|
| `extensions action=quality_leaderboard goal_id=<g>` | optional `author=<viewer>`, `force=<include_private>` | ranked list of Branches bound to this Goal with full per-entry signal summary + per-term score components |
| `extensions action=recommended_parent_for_fork goal_id=<g>` | same | thin wrapper returning top entry + human-readable rationale paragraph |

The handler reuses existing `extensions(...)` kwargs (`goal_id`, `author`, `force`) — **no new args added to the tool signature** in this slice.

## Signals used (all read from existing storage; no new tables)

1. `completed_run_count` — `runs.status='completed'`
2. `failed_run_count` — `runs.status='failed'` (penalty term)
3. `total_run_count` — full count regardless of status
4. `last_successful_run_at` — `max(finished_at)` of completed runs
5. `recency_decay` — `exp(-age_days/30)`; 0 when never run
6. `judgment_count` — rows in `run_judgments` joined via `runs`
7. `judgment_score_avg` — mean of numeric scores parsed from tags like `quality:8.2`, `novelty:7`. `risk:N` and other domain-specific numeric tags are bucketed under `other_numeric_tags` so they appear in the response without polluting the headline score.
8. `fork_count` — branches whose `parent_def_id` OR `fork_from` references this branch (community votes with their forks)
9. `gate_rung_top` — highest active `rung_key` from `gate_claims` for `(branch, goal)` — lexicographically-greatest in v1; ladder-aware ordering is a follow-on once the per-Goal ladder shape is canonical
10. `safe_to_publish` — best-effort read of `branch.stats.next_action_packet.safe_to_publish` (packet shape isn't on-disk-stable; absent = False)

## Score formula (initial weights — surfaced in every response under `formula`)

```
score = 3.0 * normalized_judgment             # judgment_score_avg / 10, clamped [0,1]
      + 1.5 * log1p(completed_run_count)
      + 2.0 * log1p(fork_count)
      + 2.0 * recency_decay                   # [0, 1]
      + 1.0 * has_gate_rung                   # {0, 1}
      + 1.5 * safe_to_publish                 # {0, 1}
      - 1.0 * log1p(failed_run_count)
```

`log1p` bounds the impact of high-volume entries; recency/gate/safe_publish are already bounded. Per-term contribution is returned under `score_components` so the chatbot can render "why this one ranked first" without re-computing. Tie-breaks: `last_successful_run_at` desc → `created_at` desc → `branch_def_id` asc (deterministic).

## Realistic test target

`tests/test_quality_leaderboard.py::test_realistic_goal_with_fifteen_entries` exercises an 18-entry Goal with diverse signal distributions to mirror the current state of `4ff5862cc26d` (15+ bound branches). Verifies rank monotonicity + top-score-wins invariants at that scale.

## Caveats / followups (deferred from this slice)

- **Cross-branch run aggregation + 30-day staleness flag + diversity index** — named in Loop 2 v1.1's `gap_map_packet`. Not in this slice.
- **Weight tuning** — initial weights are guesses; needs tuning once host/community check rankings against real judgment. Long-term path per PLAN open-evolution note: turn the formula into an evolvable Workflow node so the community iterates constants via autoresearch.
- **Gate-wiring** — auto-claim on rung hit lands in PR-126 / M5. This slice only exposes the rank.
- **Ladder-aware rung ordering** — current `gate_rung_top` is lexicographic; a per-Goal-ladder-aware ordering follows once the ladder shape is canonical.
- **Wiki spec page `## Implementation` section** — needs to happen via `wiki action=patch` on the live MCP brain after merge (this slice is project-folder-access only). PR body lists the canonical module + landed sha for the follow-up patch.

## Test plan

- [x] `pytest tests/test_quality_leaderboard.py tests/test_extensions_leaderboard_actions.py -p no:cacheprovider` → **30 passed**, 0 failed
- [x] `pytest tests/test_external_write_effector.py -p no:cacheprovider` → **24 passed** (extensions dispatch non-regressive)
- [x] `ruff check workflow/api/quality_leaderboard.py workflow/api/extensions_leaderboard_actions.py workflow/api/extensions.py tests/test_quality_leaderboard.py tests/test_extensions_leaderboard_actions.py` → clean
- [x] `python packaging/claude-plugin/build_plugin.py` → probe-ok (197 files mirrored, +2 new modules)
- [x] Pre-commit hooks: mojibake clean, import-graph smoke clean, cross-provider-drift clean, skills-valid clean
- [ ] Post-merge: chatbot smoke against Goal `4ff5862cc26d` to confirm the leaderboard renders meaningfully against the real 15+ entries (this is what the host can verify quickly once the new image deploys)
- [ ] Post-merge: `wiki action=patch` on `pr-123-goal-archive-with-parent-selection-...` to add the `## Implementation` section with the landed PR sha

## Codex round-2 verdict needed before merge

Substantive substrate addition. Standard cross-family review applies. Checker should re-verify:

1. The two new actions never write — they're pure queries over existing storage (no new tables, no schema migration).
2. `safe_to_publish` lookup is genuinely best-effort and degrades to `False` for any malformed `stats.next_action_packet` shape (test coverage: `test_safe_to_publish_absent_or_falsy_does_not_crash`).
3. Score formula weights are surfaced in every response — community can audit/tune without re-reading source.
4. Tool signature unchanged — dispatch reuses existing kwargs; no new args added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)