### PR TITLE
[auto-change] WIKI-PATCH: Branch nodes have no runtime MCP affordance — tools_allowed declared but never consumed; community-build pattern can read leaderboard from chatbot but not from inside graph nodes

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -1341,6 +1341,11 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
     out_keys, err = _coerce_node_keys(raw.get("output_keys"), "output_keys")
     if err:
         return err
+    tools_allowed, err = _coerce_node_keys(
+        raw.get("tools_allowed"), "tools_allowed",
+    )
+    if err:
+        return err
     # BUG-045: thread the three sub-branch / sibling-run spec fields. The
     # compiler reads them (workflow/graph_compiler.py:_build_invoke_branch /
     # invoke_branch_version / await_run callables) and NodeDefinition
@@ -1378,6 +1383,7 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
             phase=phase,
             input_keys=in_keys,
             output_keys=out_keys,
+            tools_allowed=tools_allowed,
             strict_input_isolation=strict_input_isolation,
             source_code=source_code,
             prompt_template=prompt_template,
@@ -1828,6 +1834,13 @@ def _apply_patch_op(branch: Any, op: dict[str, Any]) -> str:
                     if err:
                         return err
                     n.output_keys = keys
+                if "tools_allowed" in op:
+                    tools_allowed, err = _coerce_node_keys(
+                        op["tools_allowed"], "tools_allowed",
+                    )
+                    if err:
+                        return err
+                    n.tools_allowed = tools_allowed
                 return ""
         return f"update_node: node '{nid}' not found"
     if name == "add_skill":

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branches.py
@@ -419,7 +419,12 @@ class NodeDefinition:
         # character-by-character, silently corrupting sandbox/state
         # handling. Per Hard Rule #8, we'd rather fail to load than
         # accept malformed data.
-        for field_name in ("input_keys", "output_keys", "effects"):
+        for field_name in (
+            "input_keys",
+            "output_keys",
+            "tools_allowed",
+            "effects",
+        ):
             value = getattr(self, field_name)
             if not isinstance(value, list):
                 raise NodeDefinitionValidationError(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
@@ -1169,6 +1169,92 @@ def _validate_source_code(node: NodeDefinition) -> None:
             )
 
 
+_NODE_MCP_ACTION_ALIASES: dict[str, tuple[str, str]] = {
+    "goals.leaderboard": ("goals", "leaderboard"),
+    "goal_leaderboard": ("goals", "leaderboard"),
+    "quality_leaderboard": ("goals", "leaderboard"),
+    "goals.archive_consultation": ("goals", "archive_consultation"),
+    "goal_archive_consultation": ("goals", "archive_consultation"),
+    "gates.leaderboard": ("gates", "leaderboard"),
+    "gates_leaderboard": ("gates", "leaderboard"),
+    "gates.get_ladder": ("gates", "get_ladder"),
+}
+
+
+def _build_node_mcp_invoker(
+    node: NodeDefinition,
+    *,
+    event_sink: Callable[..., None] | None,
+) -> Callable[..., dict[str, Any]]:
+    allowed = set(node.tools_allowed or [])
+
+    def _invoke_mcp_action(action_name: str, **kwargs: Any) -> dict[str, Any]:
+        requested = str(action_name or "").strip()
+        if not requested:
+            raise CompilerError(
+                f"Node '{node.node_id}' invoke_mcp_action requires action_name."
+            )
+        resolved = _NODE_MCP_ACTION_ALIASES.get(requested)
+        if resolved is None:
+            raise CompilerError(
+                f"Node '{node.node_id}' requested unsupported MCP action "
+                f"'{requested}'. Supported actions: "
+                f"{sorted(_NODE_MCP_ACTION_ALIASES)}"
+            )
+        canonical = ".".join(resolved)
+        if requested not in allowed and canonical not in allowed:
+            raise CompilerError(
+                f"Node '{node.node_id}' is not allowed to call MCP action "
+                f"'{requested}'. Declare it in tools_allowed first."
+            )
+
+        if event_sink is not None:
+            try:
+                event_sink(
+                    node_id=node.node_id,
+                    phase="mcp_action",
+                    action_name=requested,
+                    canonical_action=canonical,
+                )
+            except Exception as exc:
+                if _is_cancel_exception(exc):
+                    raise
+                logger.exception(
+                    "event_sink raised for node MCP action in %s",
+                    node.node_id,
+                )
+
+        tool_name, action = resolved
+        if tool_name == "goals":
+            from workflow.api.market import goals
+
+            raw = goals(action=action, **kwargs)
+        elif tool_name == "gates":
+            from workflow.api.market import gates
+
+            raw = gates(action=action, **kwargs)
+        else:  # pragma: no cover - mapping above owns the dispatch domain.
+            raise CompilerError(
+                f"Node '{node.node_id}' requested unsupported MCP tool "
+                f"'{tool_name}'."
+            )
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise CompilerError(
+                f"Node '{node.node_id}' MCP action '{requested}' returned "
+                f"invalid JSON: {exc}"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise CompilerError(
+                f"Node '{node.node_id}' MCP action '{requested}' returned "
+                f"{type(parsed).__name__}, expected object."
+            )
+        return parsed
+
+    return _invoke_mcp_action
+
+
 def _build_source_code_node(
     node: NodeDefinition,
     *,
@@ -1184,10 +1270,18 @@ def _build_source_code_node(
     _validate_source_code(node)
     src = node.source_code
     timeout_s = float(node.timeout_seconds or 300.0)
+    invoke_mcp_action = _build_node_mcp_invoker(node, event_sink=event_sink)
 
     local_scope: dict[str, Any] = {}
     try:
-        exec(src, {"__builtins__": __builtins__}, local_scope)  # noqa: S102
+        exec(  # noqa: S102
+            src,
+            {
+                "__builtins__": __builtins__,
+                "invoke_mcp_action": invoke_mcp_action,
+            },
+            local_scope,
+        )
     except Exception as exc:
         raise CompilerError(
             f"Node '{node.node_id}' source_code failed to load: {exc}"

--- a/tests/test_branch_runner.py
+++ b/tests/test_branch_runner.py
@@ -142,6 +142,110 @@ def test_compiler_accepts_approved_source_code():
     assert result["out"] == 6
 
 
+def test_source_code_node_can_call_allowed_mcp_action(monkeypatch):
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    import workflow.api.market as market
+    from workflow.graph_compiler import compile_branch
+
+    calls: list[tuple[str, dict]] = []
+
+    def fake_goals(*, action: str, **kwargs):
+        calls.append((action, kwargs))
+        return json.dumps({
+            "status": "ok",
+            "entries": [{"branch_def_id": "b1"}],
+        })
+
+    monkeypatch.setattr(market, "goals", fake_goals)
+
+    b = BranchDefinition(name="test", entry_point="only")
+    b.node_defs = [NodeDefinition(
+        node_id="only",
+        display_name="Only",
+        source_code=(
+            "def run(state):\n"
+            "    board = invoke_mcp_action("
+            "'goals.leaderboard', goal_id=state['goal_id'], metric='run_count')\n"
+            "    return {'leaderboard_count': len(board['entries'])}\n"
+        ),
+        input_keys=["goal_id"],
+        output_keys=["leaderboard_count"],
+        tools_allowed=["goals.leaderboard"],
+        approved=True,
+    )]
+    b.graph_nodes = [GraphNodeRef(id="only", node_def_id="only")]
+    b.edges = [
+        EdgeDefinition(from_node="START", to_node="only"),
+        EdgeDefinition(from_node="only", to_node="END"),
+    ]
+    b.state_schema = [
+        {"name": "goal_id", "type": "str"},
+        {"name": "leaderboard_count", "type": "int"},
+    ]
+    compiled = compile_branch(b)
+    app = compiled.graph.compile(checkpointer=InMemorySaver())
+    result = app.invoke(
+        {"goal_id": "g1"}, config={"configurable": {"thread_id": "mcp-ok"}},
+    )
+
+    assert result["leaderboard_count"] == 1
+    assert calls == [("leaderboard", {"goal_id": "g1", "metric": "run_count"})]
+
+
+def test_source_code_node_rejects_mcp_action_not_in_tools_allowed(monkeypatch):
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    import workflow.api.market as market
+    from workflow.graph_compiler import CompilerError, compile_branch
+
+    def fake_goals(*, action: str, **kwargs):
+        raise AssertionError("disallowed MCP action should not dispatch")
+
+    monkeypatch.setattr(market, "goals", fake_goals)
+
+    b = BranchDefinition(name="test", entry_point="only")
+    b.node_defs = [NodeDefinition(
+        node_id="only",
+        display_name="Only",
+        source_code=(
+            "def run(state):\n"
+            "    invoke_mcp_action('goals.leaderboard', goal_id='g1')\n"
+            "    return {'out': 'unreachable'}\n"
+        ),
+        output_keys=["out"],
+        tools_allowed=[],
+        approved=True,
+    )]
+    b.graph_nodes = [GraphNodeRef(id="only", node_def_id="only")]
+    b.edges = [
+        EdgeDefinition(from_node="START", to_node="only"),
+        EdgeDefinition(from_node="only", to_node="END"),
+    ]
+    b.state_schema = [{"name": "out", "type": "str"}]
+    compiled = compile_branch(b)
+    app = compiled.graph.compile(checkpointer=InMemorySaver())
+
+    with pytest.raises(CompilerError) as exc_info:
+        app.invoke({}, config={"configurable": {"thread_id": "mcp-denied"}})
+    assert "not allowed" in str(exc_info.value)
+
+
+def test_branch_spec_preserves_tools_allowed():
+    from workflow.api.branches import _apply_node_spec
+
+    branch = BranchDefinition(name="test")
+    err = _apply_node_spec(branch, {
+        "node_id": "only",
+        "display_name": "Only",
+        "source_code": "def run(state): return {}",
+        "tools_allowed": ["goals.leaderboard"],
+    })
+
+    assert err == ""
+    assert branch.node_defs[0].tools_allowed == ["goals.leaderboard"]
+
+
 def test_compiler_synthesized_typeddict_reducer_append():
     """state_schema with reducer=append should accumulate across nodes."""
     from langgraph.checkpoint.memory import InMemorySaver

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -196,6 +196,15 @@ class TestNodeDefinition:
         })
         assert n.node_id == "x"
 
+    def test_tools_allowed_rejects_non_list_shape(self):
+        with pytest.raises(NodeDefinitionValidationError) as exc_info:
+            NodeDefinition(
+                node_id="x",
+                display_name="X",
+                tools_allowed="goals.leaderboard",  # type: ignore[arg-type]
+            )
+        assert exc_info.value.field == "tools_allowed"
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # GraphNodeRef

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -1341,6 +1341,11 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
     out_keys, err = _coerce_node_keys(raw.get("output_keys"), "output_keys")
     if err:
         return err
+    tools_allowed, err = _coerce_node_keys(
+        raw.get("tools_allowed"), "tools_allowed",
+    )
+    if err:
+        return err
     # BUG-045: thread the three sub-branch / sibling-run spec fields. The
     # compiler reads them (workflow/graph_compiler.py:_build_invoke_branch /
     # invoke_branch_version / await_run callables) and NodeDefinition
@@ -1378,6 +1383,7 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
             phase=phase,
             input_keys=in_keys,
             output_keys=out_keys,
+            tools_allowed=tools_allowed,
             strict_input_isolation=strict_input_isolation,
             source_code=source_code,
             prompt_template=prompt_template,
@@ -1828,6 +1834,13 @@ def _apply_patch_op(branch: Any, op: dict[str, Any]) -> str:
                     if err:
                         return err
                     n.output_keys = keys
+                if "tools_allowed" in op:
+                    tools_allowed, err = _coerce_node_keys(
+                        op["tools_allowed"], "tools_allowed",
+                    )
+                    if err:
+                        return err
+                    n.tools_allowed = tools_allowed
                 return ""
         return f"update_node: node '{nid}' not found"
     if name == "add_skill":

--- a/workflow/branches.py
+++ b/workflow/branches.py
@@ -419,7 +419,12 @@ class NodeDefinition:
         # character-by-character, silently corrupting sandbox/state
         # handling. Per Hard Rule #8, we'd rather fail to load than
         # accept malformed data.
-        for field_name in ("input_keys", "output_keys", "effects"):
+        for field_name in (
+            "input_keys",
+            "output_keys",
+            "tools_allowed",
+            "effects",
+        ):
             value = getattr(self, field_name)
             if not isinstance(value, list):
                 raise NodeDefinitionValidationError(

--- a/workflow/graph_compiler.py
+++ b/workflow/graph_compiler.py
@@ -1169,6 +1169,92 @@ def _validate_source_code(node: NodeDefinition) -> None:
             )
 
 
+_NODE_MCP_ACTION_ALIASES: dict[str, tuple[str, str]] = {
+    "goals.leaderboard": ("goals", "leaderboard"),
+    "goal_leaderboard": ("goals", "leaderboard"),
+    "quality_leaderboard": ("goals", "leaderboard"),
+    "goals.archive_consultation": ("goals", "archive_consultation"),
+    "goal_archive_consultation": ("goals", "archive_consultation"),
+    "gates.leaderboard": ("gates", "leaderboard"),
+    "gates_leaderboard": ("gates", "leaderboard"),
+    "gates.get_ladder": ("gates", "get_ladder"),
+}
+
+
+def _build_node_mcp_invoker(
+    node: NodeDefinition,
+    *,
+    event_sink: Callable[..., None] | None,
+) -> Callable[..., dict[str, Any]]:
+    allowed = set(node.tools_allowed or [])
+
+    def _invoke_mcp_action(action_name: str, **kwargs: Any) -> dict[str, Any]:
+        requested = str(action_name or "").strip()
+        if not requested:
+            raise CompilerError(
+                f"Node '{node.node_id}' invoke_mcp_action requires action_name."
+            )
+        resolved = _NODE_MCP_ACTION_ALIASES.get(requested)
+        if resolved is None:
+            raise CompilerError(
+                f"Node '{node.node_id}' requested unsupported MCP action "
+                f"'{requested}'. Supported actions: "
+                f"{sorted(_NODE_MCP_ACTION_ALIASES)}"
+            )
+        canonical = ".".join(resolved)
+        if requested not in allowed and canonical not in allowed:
+            raise CompilerError(
+                f"Node '{node.node_id}' is not allowed to call MCP action "
+                f"'{requested}'. Declare it in tools_allowed first."
+            )
+
+        if event_sink is not None:
+            try:
+                event_sink(
+                    node_id=node.node_id,
+                    phase="mcp_action",
+                    action_name=requested,
+                    canonical_action=canonical,
+                )
+            except Exception as exc:
+                if _is_cancel_exception(exc):
+                    raise
+                logger.exception(
+                    "event_sink raised for node MCP action in %s",
+                    node.node_id,
+                )
+
+        tool_name, action = resolved
+        if tool_name == "goals":
+            from workflow.api.market import goals
+
+            raw = goals(action=action, **kwargs)
+        elif tool_name == "gates":
+            from workflow.api.market import gates
+
+            raw = gates(action=action, **kwargs)
+        else:  # pragma: no cover - mapping above owns the dispatch domain.
+            raise CompilerError(
+                f"Node '{node.node_id}' requested unsupported MCP tool "
+                f"'{tool_name}'."
+            )
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise CompilerError(
+                f"Node '{node.node_id}' MCP action '{requested}' returned "
+                f"invalid JSON: {exc}"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise CompilerError(
+                f"Node '{node.node_id}' MCP action '{requested}' returned "
+                f"{type(parsed).__name__}, expected object."
+            )
+        return parsed
+
+    return _invoke_mcp_action
+
+
 def _build_source_code_node(
     node: NodeDefinition,
     *,
@@ -1184,10 +1270,18 @@ def _build_source_code_node(
     _validate_source_code(node)
     src = node.source_code
     timeout_s = float(node.timeout_seconds or 300.0)
+    invoke_mcp_action = _build_node_mcp_invoker(node, event_sink=event_sink)
 
     local_scope: dict[str, Any] = {}
     try:
-        exec(src, {"__builtins__": __builtins__}, local_scope)  # noqa: S102
+        exec(  # noqa: S102
+            src,
+            {
+                "__builtins__": __builtins__,
+                "invoke_mcp_action": invoke_mcp_action,
+            },
+            local_scope,
+        )
     except Exception as exc:
         raise CompilerError(
             f"Node '{node.node_id}' source_code failed to load: {exc}"


### PR DESCRIPTION
Fixes #974

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-136-branch-nodes-have-no-runtime-mcp-affordance-tools-allowed-de.md`
- GitHub issue: #974
- Branch task: `auto-change/issue-974`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.