### PR TITLE
Fix update_node model policy persistence

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -1347,7 +1347,7 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
     if err:
         return err
     llm_policy, err = _coerce_llm_policy_update(
-        raw.get("llm_policy"), "llm_policy",
+        raw.get("llm_policy"), f"node '{nid}' llm_policy",
     )
     if err:
         return err
@@ -1508,8 +1508,8 @@ def _coerce_llm_policy_update(
     if raw is None:
         return None, ""
     if isinstance(raw, dict):
-        return raw, ""
-    if isinstance(raw, str):
+        policy = raw
+    elif isinstance(raw, str):
         value = raw.strip()
         if not value or value == "null":
             return None, ""
@@ -1520,8 +1520,18 @@ def _coerce_llm_policy_update(
         if decoded is None:
             return None, ""
         if isinstance(decoded, dict):
-            return decoded, ""
-    return None, f"{field} must be a JSON object or null."
+            policy = decoded
+        else:
+            return None, f"{field} must be a JSON object or null."
+    else:
+        return None, f"{field} must be a JSON object or null."
+
+    from workflow.branches import _validate_llm_policy_shape
+
+    errors = _validate_llm_policy_shape(policy, context=field)
+    if errors:
+        return None, "; ".join(errors)
+    return policy, ""
 
 
 def _staged_branch_from_spec(
@@ -1865,7 +1875,7 @@ def _apply_patch_op(branch: Any, op: dict[str, Any]) -> str:
                     n.model_hint = model_hint
                 if "llm_policy" in op:
                     llm_policy, err = _coerce_llm_policy_update(
-                        op["llm_policy"], "llm_policy",
+                        op["llm_policy"], f"node '{nid}' llm_policy",
                     )
                     if err:
                         return err
@@ -2397,21 +2407,10 @@ def _ext_branch_update_node(kwargs: dict[str, Any]) -> str:
             target_node.model_hint = model_hint
         if "llm_policy" in updates:
             llm_policy, err = _coerce_llm_policy_update(
-                updates["llm_policy"], "llm_policy",
+                updates["llm_policy"], f"node '{nid}' llm_policy",
             )
             if err:
                 return json.dumps({"status": "rejected", "error": err})
-            if llm_policy is not None:
-                from workflow.branches import _validate_llm_policy_shape
-
-                errors = _validate_llm_policy_shape(
-                    llm_policy, context=f"node '{nid}' llm_policy",
-                )
-                if errors:
-                    return json.dumps({
-                        "status": "rejected",
-                        "error": "; ".join(errors),
-                    })
             target_node.llm_policy = llm_policy
         if "input_keys" in updates:
             keys, err = _coerce_node_keys(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -1341,6 +1341,16 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
     out_keys, err = _coerce_node_keys(raw.get("output_keys"), "output_keys")
     if err:
         return err
+    model_hint, err = _coerce_model_hint_update(
+        raw.get("model_hint", ""), "model_hint",
+    )
+    if err:
+        return err
+    llm_policy, err = _coerce_llm_policy_update(
+        raw.get("llm_policy"), "llm_policy",
+    )
+    if err:
+        return err
     # BUG-045: thread the three sub-branch / sibling-run spec fields. The
     # compiler reads them (workflow/graph_compiler.py:_build_invoke_branch /
     # invoke_branch_version / await_run callables) and NodeDefinition
@@ -1381,6 +1391,8 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
             strict_input_isolation=strict_input_isolation,
             source_code=source_code,
             prompt_template=prompt_template,
+            model_hint=model_hint,
+            llm_policy=llm_policy,
             author=raw.get("author") or _current_actor(),
             approved=bool(raw.get("approved", False)),
             invoke_branch_spec=invoke_branch_arg,
@@ -1480,6 +1492,36 @@ def _apply_state_field_spec(branch: Any, raw: dict[str, Any]) -> str:
             f"coerced to '{ftype}'."
         )
     return ""
+
+
+def _coerce_model_hint_update(raw: Any, field: str) -> tuple[str, str]:
+    if raw is None:
+        return "", ""
+    if not isinstance(raw, str):
+        return "", f"{field} must be a string."
+    return raw, ""
+
+
+def _coerce_llm_policy_update(
+    raw: Any, field: str,
+) -> tuple[dict[str, Any] | None, str]:
+    if raw is None:
+        return None, ""
+    if isinstance(raw, dict):
+        return raw, ""
+    if isinstance(raw, str):
+        value = raw.strip()
+        if not value or value == "null":
+            return None, ""
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError as exc:
+            return None, f"{field} is not valid JSON: {exc}"
+        if decoded is None:
+            return None, ""
+        if isinstance(decoded, dict):
+            return decoded, ""
+    return None, f"{field} must be a JSON object or null."
 
 
 def _staged_branch_from_spec(
@@ -1814,6 +1856,20 @@ def _apply_patch_op(branch: Any, op: dict[str, Any]) -> str:
                     n.prompt_template = op["prompt_template"]
                 if "source_code" in op:
                     n.source_code = op["source_code"]
+                if "model_hint" in op:
+                    model_hint, err = _coerce_model_hint_update(
+                        op["model_hint"], "model_hint",
+                    )
+                    if err:
+                        return err
+                    n.model_hint = model_hint
+                if "llm_policy" in op:
+                    llm_policy, err = _coerce_llm_policy_update(
+                        op["llm_policy"], "llm_policy",
+                    )
+                    if err:
+                        return err
+                    n.llm_policy = llm_policy
                 if "input_keys" in op:
                     keys, err = _coerce_node_keys(
                         op["input_keys"], "input_keys",
@@ -2222,10 +2278,12 @@ def _ext_branch_update_node(kwargs: dict[str, Any]) -> str:
         # Pull supported fields from the top-level kwargs.
         for field in (
             "display_name", "description", "phase",
-            "prompt_template", "source_code",
+            "prompt_template", "source_code", "model_hint",
         ):
             if kwargs.get(field):
                 updates[field] = kwargs[field]
+        if "llm_policy" in kwargs and kwargs.get("llm_policy") is not None:
+            updates["llm_policy"] = kwargs["llm_policy"]
         if kwargs.get("input_keys"):
             updates["input_keys"] = kwargs["input_keys"]
         if kwargs.get("output_keys"):
@@ -2267,7 +2325,8 @@ def _ext_branch_update_node(kwargs: dict[str, Any]) -> str:
             "error": (
                 "No fields to update. Pass one or more of "
                 "display_name / description / phase / prompt_template / "
-                "source_code / input_keys / output_keys, or a "
+                "source_code / model_hint / llm_policy / input_keys / "
+                "output_keys, or a "
                 "changes_json object."
             ),
         })
@@ -2329,6 +2388,31 @@ def _ext_branch_update_node(kwargs: dict[str, Any]) -> str:
             target_node.source_code = updates["source_code"]
             if target_node.source_code:
                 target_node.prompt_template = ""
+        if "model_hint" in updates:
+            model_hint, err = _coerce_model_hint_update(
+                updates["model_hint"], "model_hint",
+            )
+            if err:
+                return json.dumps({"status": "rejected", "error": err})
+            target_node.model_hint = model_hint
+        if "llm_policy" in updates:
+            llm_policy, err = _coerce_llm_policy_update(
+                updates["llm_policy"], "llm_policy",
+            )
+            if err:
+                return json.dumps({"status": "rejected", "error": err})
+            if llm_policy is not None:
+                from workflow.branches import _validate_llm_policy_shape
+
+                errors = _validate_llm_policy_shape(
+                    llm_policy, context=f"node '{nid}' llm_policy",
+                )
+                if errors:
+                    return json.dumps({
+                        "status": "rejected",
+                        "error": "; ".join(errors),
+                    })
+            target_node.llm_policy = llm_policy
         if "input_keys" in updates:
             keys, err = _coerce_node_keys(
                 updates["input_keys"], "input_keys",

--- a/tests/test_patch_branch_node_keys.py
+++ b/tests/test_patch_branch_node_keys.py
@@ -266,7 +266,7 @@ class TestPatchBranchUpdateNodeKeys:
         assert node["model_hint"] == "checker"
         assert node["llm_policy"] == policy
 
-    def test_update_node_rejects_invalid_llm_policy(self, ext_env):
+    def test_update_node_patch_op_rejects_invalid_llm_policy(self, ext_env):
         us, _ = ext_env
         bid = _build(us)
 
@@ -379,6 +379,42 @@ class TestAddNodeSpecKeys:
         node = _node(_load(us, base, res["branch_def_id"]), "capture")
         assert node["model_hint"] == "writer"
         assert node["llm_policy"] == policy
+
+    def test_build_branch_rejects_invalid_llm_policy(self, ext_env):
+        us, _ = ext_env
+        spec = {
+            "name": "b",
+            "entry_point": "capture",
+            "node_defs": [{
+                "node_id": "capture",
+                "display_name": "Capture",
+                "prompt_template": "cap: {x}",
+                "input_keys": ["x"],
+                "llm_policy": {"preferred": {}},
+            }],
+            "edges": [
+                {"from": "START", "to": "capture"},
+                {"from": "capture", "to": "END"},
+            ],
+            "state_schema": [{"name": "x", "type": "str"}],
+        }
+
+        res = _call(us, "extensions", "build_branch",
+                    spec_json=json.dumps(spec))
+
+        assert res["status"] == "rejected", res
+        assert "provider" in json.dumps(res)
+
+    def test_add_node_rejects_invalid_llm_policy(self, ext_env):
+        us, _ = ext_env
+        bid = _build(us)
+        ops = self._add_scribe_ops(input_keys=["x"], output_keys=["draft"])
+        ops[0]["llm_policy"] = {"preferred": {}}
+
+        res = _patch(us, bid, ops)
+
+        assert res.get("status") == "rejected", res
+        assert "provider" in json.dumps(res)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_patch_branch_node_keys.py
+++ b/tests/test_patch_branch_node_keys.py
@@ -249,6 +249,36 @@ class TestPatchBranchUpdateNodeKeys:
         }])
         assert res.get("status") == "rejected", res
 
+    def test_update_node_model_hint_and_llm_policy_round_trip(self, ext_env):
+        us, base = ext_env
+        bid = _build(us)
+        policy = {"preferred": {"provider": "codex", "model": "gpt-5.5"}}
+
+        res = _patch(us, bid, [{
+            "op": "update_node",
+            "node_id": "capture",
+            "model_hint": "checker",
+            "llm_policy": policy,
+        }])
+
+        assert res.get("status") != "rejected", res
+        node = _node(_load(us, base, bid), "capture")
+        assert node["model_hint"] == "checker"
+        assert node["llm_policy"] == policy
+
+    def test_update_node_rejects_invalid_llm_policy(self, ext_env):
+        us, _ = ext_env
+        bid = _build(us)
+
+        res = _patch(us, bid, [{
+            "op": "update_node",
+            "node_id": "capture",
+            "llm_policy": {"preferred": {}},
+        }])
+
+        assert res.get("status") == "rejected", res
+        assert "provider" in json.dumps(res)
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # build_branch / patch_branch add_node — same coercion path via _apply_node_spec.
@@ -320,6 +350,35 @@ class TestAddNodeSpecKeys:
         res = _call(us, "extensions", "build_branch",
                     spec_json=json.dumps(spec))
         assert res["status"] == "rejected", res
+
+    def test_build_branch_persists_model_hint_and_llm_policy(self, ext_env):
+        us, base = ext_env
+        policy = {"preferred": {"provider": "codex", "model": "gpt-5.5"}}
+        spec = {
+            "name": "b",
+            "entry_point": "capture",
+            "node_defs": [{
+                "node_id": "capture",
+                "display_name": "Capture",
+                "prompt_template": "cap: {x}",
+                "input_keys": ["x"],
+                "model_hint": "writer",
+                "llm_policy": policy,
+            }],
+            "edges": [
+                {"from": "START", "to": "capture"},
+                {"from": "capture", "to": "END"},
+            ],
+            "state_schema": [{"name": "x", "type": "str"}],
+        }
+
+        res = _call(us, "extensions", "build_branch",
+                    spec_json=json.dumps(spec))
+
+        assert res["status"] == "built", res
+        node = _node(_load(us, base, res["branch_def_id"]), "capture")
+        assert node["model_hint"] == "writer"
+        assert node["llm_policy"] == policy
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -431,3 +490,37 @@ class TestUpdateNodeKwargs:
             changes_json=json.dumps({"input_keys": [1, 2]}),
         )
         assert res.get("status") == "rejected", res
+
+    def test_update_node_model_hint_and_llm_policy_changes_json(self, ext_env):
+        us, base = ext_env
+        bid = _build(us)
+        policy = {"preferred": {"provider": "codex", "model": "gpt-5.5"}}
+
+        res = _call(
+            us, "extensions", "update_node",
+            branch_def_id=bid,
+            node_id="capture",
+            changes_json=json.dumps({
+                "model_hint": "checker",
+                "llm_policy": policy,
+            }),
+        )
+
+        assert res.get("status") == "updated", res
+        node = _node(_load(us, base, bid), "capture")
+        assert node["model_hint"] == "checker"
+        assert node["llm_policy"] == policy
+
+    def test_update_node_changes_json_rejects_invalid_llm_policy(self, ext_env):
+        us, _ = ext_env
+        bid = _build(us)
+
+        res = _call(
+            us, "extensions", "update_node",
+            branch_def_id=bid,
+            node_id="capture",
+            changes_json=json.dumps({"llm_policy": {"preferred": {}}}),
+        )
+
+        assert res.get("status") == "rejected", res
+        assert "provider" in res.get("error", "")

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -1347,7 +1347,7 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
     if err:
         return err
     llm_policy, err = _coerce_llm_policy_update(
-        raw.get("llm_policy"), "llm_policy",
+        raw.get("llm_policy"), f"node '{nid}' llm_policy",
     )
     if err:
         return err
@@ -1508,8 +1508,8 @@ def _coerce_llm_policy_update(
     if raw is None:
         return None, ""
     if isinstance(raw, dict):
-        return raw, ""
-    if isinstance(raw, str):
+        policy = raw
+    elif isinstance(raw, str):
         value = raw.strip()
         if not value or value == "null":
             return None, ""
@@ -1520,8 +1520,18 @@ def _coerce_llm_policy_update(
         if decoded is None:
             return None, ""
         if isinstance(decoded, dict):
-            return decoded, ""
-    return None, f"{field} must be a JSON object or null."
+            policy = decoded
+        else:
+            return None, f"{field} must be a JSON object or null."
+    else:
+        return None, f"{field} must be a JSON object or null."
+
+    from workflow.branches import _validate_llm_policy_shape
+
+    errors = _validate_llm_policy_shape(policy, context=field)
+    if errors:
+        return None, "; ".join(errors)
+    return policy, ""
 
 
 def _staged_branch_from_spec(
@@ -1865,7 +1875,7 @@ def _apply_patch_op(branch: Any, op: dict[str, Any]) -> str:
                     n.model_hint = model_hint
                 if "llm_policy" in op:
                     llm_policy, err = _coerce_llm_policy_update(
-                        op["llm_policy"], "llm_policy",
+                        op["llm_policy"], f"node '{nid}' llm_policy",
                     )
                     if err:
                         return err
@@ -2397,21 +2407,10 @@ def _ext_branch_update_node(kwargs: dict[str, Any]) -> str:
             target_node.model_hint = model_hint
         if "llm_policy" in updates:
             llm_policy, err = _coerce_llm_policy_update(
-                updates["llm_policy"], "llm_policy",
+                updates["llm_policy"], f"node '{nid}' llm_policy",
             )
             if err:
                 return json.dumps({"status": "rejected", "error": err})
-            if llm_policy is not None:
-                from workflow.branches import _validate_llm_policy_shape
-
-                errors = _validate_llm_policy_shape(
-                    llm_policy, context=f"node '{nid}' llm_policy",
-                )
-                if errors:
-                    return json.dumps({
-                        "status": "rejected",
-                        "error": "; ".join(errors),
-                    })
             target_node.llm_policy = llm_policy
         if "input_keys" in updates:
             keys, err = _coerce_node_keys(

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -1341,6 +1341,16 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
     out_keys, err = _coerce_node_keys(raw.get("output_keys"), "output_keys")
     if err:
         return err
+    model_hint, err = _coerce_model_hint_update(
+        raw.get("model_hint", ""), "model_hint",
+    )
+    if err:
+        return err
+    llm_policy, err = _coerce_llm_policy_update(
+        raw.get("llm_policy"), "llm_policy",
+    )
+    if err:
+        return err
     # BUG-045: thread the three sub-branch / sibling-run spec fields. The
     # compiler reads them (workflow/graph_compiler.py:_build_invoke_branch /
     # invoke_branch_version / await_run callables) and NodeDefinition
@@ -1381,6 +1391,8 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
             strict_input_isolation=strict_input_isolation,
             source_code=source_code,
             prompt_template=prompt_template,
+            model_hint=model_hint,
+            llm_policy=llm_policy,
             author=raw.get("author") or _current_actor(),
             approved=bool(raw.get("approved", False)),
             invoke_branch_spec=invoke_branch_arg,
@@ -1480,6 +1492,36 @@ def _apply_state_field_spec(branch: Any, raw: dict[str, Any]) -> str:
             f"coerced to '{ftype}'."
         )
     return ""
+
+
+def _coerce_model_hint_update(raw: Any, field: str) -> tuple[str, str]:
+    if raw is None:
+        return "", ""
+    if not isinstance(raw, str):
+        return "", f"{field} must be a string."
+    return raw, ""
+
+
+def _coerce_llm_policy_update(
+    raw: Any, field: str,
+) -> tuple[dict[str, Any] | None, str]:
+    if raw is None:
+        return None, ""
+    if isinstance(raw, dict):
+        return raw, ""
+    if isinstance(raw, str):
+        value = raw.strip()
+        if not value or value == "null":
+            return None, ""
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError as exc:
+            return None, f"{field} is not valid JSON: {exc}"
+        if decoded is None:
+            return None, ""
+        if isinstance(decoded, dict):
+            return decoded, ""
+    return None, f"{field} must be a JSON object or null."
 
 
 def _staged_branch_from_spec(
@@ -1814,6 +1856,20 @@ def _apply_patch_op(branch: Any, op: dict[str, Any]) -> str:
                     n.prompt_template = op["prompt_template"]
                 if "source_code" in op:
                     n.source_code = op["source_code"]
+                if "model_hint" in op:
+                    model_hint, err = _coerce_model_hint_update(
+                        op["model_hint"], "model_hint",
+                    )
+                    if err:
+                        return err
+                    n.model_hint = model_hint
+                if "llm_policy" in op:
+                    llm_policy, err = _coerce_llm_policy_update(
+                        op["llm_policy"], "llm_policy",
+                    )
+                    if err:
+                        return err
+                    n.llm_policy = llm_policy
                 if "input_keys" in op:
                     keys, err = _coerce_node_keys(
                         op["input_keys"], "input_keys",
@@ -2222,10 +2278,12 @@ def _ext_branch_update_node(kwargs: dict[str, Any]) -> str:
         # Pull supported fields from the top-level kwargs.
         for field in (
             "display_name", "description", "phase",
-            "prompt_template", "source_code",
+            "prompt_template", "source_code", "model_hint",
         ):
             if kwargs.get(field):
                 updates[field] = kwargs[field]
+        if "llm_policy" in kwargs and kwargs.get("llm_policy") is not None:
+            updates["llm_policy"] = kwargs["llm_policy"]
         if kwargs.get("input_keys"):
             updates["input_keys"] = kwargs["input_keys"]
         if kwargs.get("output_keys"):
@@ -2267,7 +2325,8 @@ def _ext_branch_update_node(kwargs: dict[str, Any]) -> str:
             "error": (
                 "No fields to update. Pass one or more of "
                 "display_name / description / phase / prompt_template / "
-                "source_code / input_keys / output_keys, or a "
+                "source_code / model_hint / llm_policy / input_keys / "
+                "output_keys, or a "
                 "changes_json object."
             ),
         })
@@ -2329,6 +2388,31 @@ def _ext_branch_update_node(kwargs: dict[str, Any]) -> str:
             target_node.source_code = updates["source_code"]
             if target_node.source_code:
                 target_node.prompt_template = ""
+        if "model_hint" in updates:
+            model_hint, err = _coerce_model_hint_update(
+                updates["model_hint"], "model_hint",
+            )
+            if err:
+                return json.dumps({"status": "rejected", "error": err})
+            target_node.model_hint = model_hint
+        if "llm_policy" in updates:
+            llm_policy, err = _coerce_llm_policy_update(
+                updates["llm_policy"], "llm_policy",
+            )
+            if err:
+                return json.dumps({"status": "rejected", "error": err})
+            if llm_policy is not None:
+                from workflow.branches import _validate_llm_policy_shape
+
+                errors = _validate_llm_policy_shape(
+                    llm_policy, context=f"node '{nid}' llm_policy",
+                )
+                if errors:
+                    return json.dumps({
+                        "status": "rejected",
+                        "error": "; ".join(errors),
+                    })
+            target_node.llm_policy = llm_policy
         if "input_keys" in updates:
             keys, err = _coerce_node_keys(
                 updates["input_keys"], "input_keys",


### PR DESCRIPTION
## Summary

- Thread `model_hint` and `llm_policy` through branch node authoring so `build_branch` / `add_node` no longer drop them.
- Make `patch_branch` `update_node` persist `model_hint` and `llm_policy`, with invalid policy shapes rejected by branch validation.
- Make standalone `update_node` accept the same fields through `changes_json`, including JSON-string policy decoding for kwargs-style callers.
- Keep the packaged plugin runtime copy in parity with `workflow/api/branches.py`.

Fixes #972.

## Why this matters

Eli's GPT-5.5 loop experiments hit this directly: a branch can state a model policy in prose, but the substrate ignored the metadata mutation path. This patch makes the metadata authoring path testable instead of advisory-only.

## Validation

- `python -m pytest tests/test_patch_branch_node_keys.py -q`
- `python -m pytest tests/test_composite_branch_actions.py tests/test_llm_policy_override.py -q`
- `python -m pytest tests/test_patch_branch_node_keys.py tests/test_composite_branch_actions.py tests/test_llm_policy_override.py -q`
- `git diff --check`

## Evidence limits

This PR creates real patch-to-PR evidence, not merge evidence. It should not be counted above learned_failure/pass-prep until review, checks, merge, and follow-up observation are recorded with canonical keys.