### PR TITLE
Fix parent selector timestamp parsing

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
@@ -70,6 +70,7 @@ from __future__ import annotations
 
 import math
 import re
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -346,7 +347,9 @@ def _run_stats(base_path: str | Path, branch_def_id: str) -> dict[str, Any]:
         "total": int(row["total"] or 0),
         "completed": int(row["completed"] or 0),
         "failed": int(row["failed"] or 0),
-        "last_successful_run_at": float(row["last_successful_run_at"] or 0.0),
+        "last_successful_run_at": _timestamp_to_epoch(
+            row["last_successful_run_at"],
+        ),
     }
 
 
@@ -561,9 +564,39 @@ def _entry_sort_key(entry: dict[str, Any]) -> tuple:
     signals = entry.get("signals") or {}
     return (
         float(entry.get("score") or 0.0),
-        float(signals.get("last_successful_run_at") or 0.0),
-        float(entry.get("created_at") or 0.0),
+        _timestamp_to_epoch(signals.get("last_successful_run_at")),
+        _timestamp_to_epoch(entry.get("created_at")),
     )
+
+
+def _timestamp_to_epoch(raw: Any) -> float:
+    """Return epoch seconds for numeric or ISO timestamps.
+
+    Branch metadata has historically stored ``created_at`` as both Unix
+    seconds and ISO strings. Leaderboard sort keys must tolerate both
+    because one malformed legacy value should not make parent selection
+    fail for the whole Goal.
+    """
+    if raw is None:
+        return 0.0
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    if isinstance(raw, str):
+        value = raw.strip()
+        if not value:
+            return 0.0
+        try:
+            return float(value)
+        except ValueError:
+            pass
+        try:
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return 0.0
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    return 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
@@ -580,23 +580,29 @@ def _timestamp_to_epoch(raw: Any) -> float:
     if raw is None:
         return 0.0
     if isinstance(raw, (int, float)):
-        return float(raw)
+        return _finite_epoch_or_zero(float(raw))
     if isinstance(raw, str):
         value = raw.strip()
         if not value:
             return 0.0
         try:
-            return float(value)
+            return _finite_epoch_or_zero(float(value))
         except ValueError:
             pass
+        if value.endswith("Z"):
+            value = f"{value[:-1]}+00:00"
         try:
-            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            dt = datetime.fromisoformat(value)
         except ValueError:
             return 0.0
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
-        return dt.timestamp()
+        return _finite_epoch_or_zero(dt.timestamp())
     return 0.0
+
+
+def _finite_epoch_or_zero(value: float) -> float:
+    return value if math.isfinite(value) else 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_extensions_leaderboard_actions.py
+++ b/tests/test_extensions_leaderboard_actions.py
@@ -193,6 +193,46 @@ def test_recommended_parent_empty_goal_text_carries_rationale(us_env):
     assert result["text"] == result["rationale"]
 
 
+def test_recommended_parent_tolerates_iso_created_at(us_env):
+    us, base = us_env
+    from workflow.daemon_server import save_branch_definition, save_goal
+
+    save_goal(
+        base,
+        goal=dict(
+            goal_id="g-iso", name="ISO", description="", author="h",
+            tags=[], visibility="public",
+        ),
+    )
+    for bid, created_at in (
+        ("b-old", "2026-05-15T05:53:29.558425+00:00"),
+        ("b-new", "2026-05-16T05:53:29.558425+00:00"),
+    ):
+        save_branch_definition(
+            base,
+            branch_def=dict(
+                branch_def_id=bid,
+                name=f"Branch {bid}",
+                description="t",
+                author="alice",
+                tags=[],
+                graph_nodes=[],
+                edges=[],
+                state_schema=[],
+                entry_point="",
+                published=True,
+                goal_id="g-iso",
+                created_at=created_at,
+                updated_at=created_at,
+            ),
+        )
+
+    result = _call(us, "recommended_parent_for_fork", goal_id="g-iso")
+
+    assert "error" not in result
+    assert result["recommended_parent"]["branch_def_id"] == "b-new"
+
+
 # ---------------------------------------------------------------------------
 # Tool surface stability — the action names are listed under
 # `available_actions` in the unknown-action error so the chatbot can

--- a/tests/test_quality_leaderboard.py
+++ b/tests/test_quality_leaderboard.py
@@ -29,6 +29,7 @@ import pytest
 from workflow.api.quality_leaderboard import (
     JUDGMENT_MAX_SCALE,
     RECENCY_HALFLIFE_DAYS,
+    _timestamp_to_epoch,
     build_quality_leaderboard,
     recommend_parent_for_fork,
 )
@@ -128,6 +129,19 @@ def _record_run(
         finished_at=finished_at if finished_at is not None else time.time(),
     )
     return run_id
+
+
+def test_timestamp_to_epoch_tolerates_numeric_iso_z_and_bad_values():
+    plus_utc = _timestamp_to_epoch("2026-05-15T05:53:29+00:00")
+
+    assert _timestamp_to_epoch("2026-05-15T05:53:29Z") == pytest.approx(plus_utc)
+    assert _timestamp_to_epoch("2026-05-15T05:53:29") == pytest.approx(plus_utc)
+    assert _timestamp_to_epoch(str(int(plus_utc))) == pytest.approx(
+        float(int(plus_utc)),
+    )
+    assert _timestamp_to_epoch("not-a-date") == 0.0
+    assert _timestamp_to_epoch("nan") == 0.0
+    assert _timestamp_to_epoch(float("inf")) == 0.0
 
 
 def _record_judgment(

--- a/workflow/api/quality_leaderboard.py
+++ b/workflow/api/quality_leaderboard.py
@@ -70,6 +70,7 @@ from __future__ import annotations
 
 import math
 import re
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -346,7 +347,9 @@ def _run_stats(base_path: str | Path, branch_def_id: str) -> dict[str, Any]:
         "total": int(row["total"] or 0),
         "completed": int(row["completed"] or 0),
         "failed": int(row["failed"] or 0),
-        "last_successful_run_at": float(row["last_successful_run_at"] or 0.0),
+        "last_successful_run_at": _timestamp_to_epoch(
+            row["last_successful_run_at"],
+        ),
     }
 
 
@@ -561,9 +564,39 @@ def _entry_sort_key(entry: dict[str, Any]) -> tuple:
     signals = entry.get("signals") or {}
     return (
         float(entry.get("score") or 0.0),
-        float(signals.get("last_successful_run_at") or 0.0),
-        float(entry.get("created_at") or 0.0),
+        _timestamp_to_epoch(signals.get("last_successful_run_at")),
+        _timestamp_to_epoch(entry.get("created_at")),
     )
+
+
+def _timestamp_to_epoch(raw: Any) -> float:
+    """Return epoch seconds for numeric or ISO timestamps.
+
+    Branch metadata has historically stored ``created_at`` as both Unix
+    seconds and ISO strings. Leaderboard sort keys must tolerate both
+    because one malformed legacy value should not make parent selection
+    fail for the whole Goal.
+    """
+    if raw is None:
+        return 0.0
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    if isinstance(raw, str):
+        value = raw.strip()
+        if not value:
+            return 0.0
+        try:
+            return float(value)
+        except ValueError:
+            pass
+        try:
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return 0.0
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    return 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/workflow/api/quality_leaderboard.py
+++ b/workflow/api/quality_leaderboard.py
@@ -580,23 +580,29 @@ def _timestamp_to_epoch(raw: Any) -> float:
     if raw is None:
         return 0.0
     if isinstance(raw, (int, float)):
-        return float(raw)
+        return _finite_epoch_or_zero(float(raw))
     if isinstance(raw, str):
         value = raw.strip()
         if not value:
             return 0.0
         try:
-            return float(value)
+            return _finite_epoch_or_zero(float(value))
         except ValueError:
             pass
+        if value.endswith("Z"):
+            value = f"{value[:-1]}+00:00"
         try:
-            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            dt = datetime.fromisoformat(value)
         except ValueError:
             return 0.0
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
-        return dt.timestamp()
+        return _finite_epoch_or_zero(dt.timestamp())
     return 0.0
+
+
+def _finite_epoch_or_zero(value: float) -> float:
+    return value if math.isfinite(value) else 0.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Make quality-leaderboard sort keys tolerate both Unix-second and ISO timestamp values.
- Apply the same timestamp coercion to `last_successful_run_at` so legacy run metadata cannot crash parent selection.
- Mirror the packaged plugin runtime copy.
- Add a regression test for `recommended_parent_for_fork` with ISO `created_at` branch metadata.

Fixes BUG-101.

## Root cause

`recommended_parent_for_fork` calls the quality leaderboard, which sorts entries through `_entry_sort_key`. That sort key coerced `entry["created_at"]` with `float(...)`. Some branch rows store ISO timestamps like `2026-05-15T05:53:29.558425+00:00`, so the selector failed before returning a canonical parent recommendation.

## Why this matters

The M6 cutover plan depends on substrate-selected canonical Loop 2 handlers via `recommended_parent_for_fork goal_id=4ff5862cc26d`. If one legacy timestamp can crash selection for the whole Goal, Loop 1 retirement cannot safely rely on leaderboard-driven canonical selection.

## Validation

- `python -m pytest tests/test_extensions_leaderboard_actions.py -q` => 10 passed
- `python -m pytest tests/test_extensions_leaderboard_actions.py tests/test_quality_leaderboard.py -q` => 31 passed
- `python -m pytest tests/test_extensions_leaderboard_actions.py tests/test_quality_leaderboard.py tests/test_quality_leaderboard_auth_boundary.py tests/test_gate_event_leaderboard.py -q` => 57 passed
- `git diff --check` clean