### PR TITLE
PR-127 M6 cutover Steps 4+7: leaderboard-driven canonical handler

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/canonical_dispatch.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/canonical_dispatch.py
@@ -29,6 +29,20 @@ No new substrate primitives — pure orchestration over existing
 storage. The env-var fallback path (read by
 ``_maybe_enqueue_investigation``) stays in place until the observation
 window closes; cutover plan Step 5/6 removes the env in a follow-on PR.
+
+**Auth-boundary contract (PR-127 round 2 — Codex P1 findings):**
+
+* ``_latest_published_version_id`` filters to ``status='active'``
+  versions only. Rolled-back / superseded versions can NEVER become
+  the auto-refresh target. Defense in depth:
+  ``workflow.daemon_server.set_canonical_branch`` also rejects
+  non-active versions at the write site, so a bug in this filter
+  alone cannot promote a dead version (P1.1).
+* The auto-refresh leaderboard query is ALWAYS computed against
+  ``viewer=""`` (strictly-public). The caller-supplied viewer is
+  retained for log telemetry only; private branches authored by
+  the calling actor cannot become the Goal's global canonical via
+  auto-refresh (P1.2).
 """
 
 from __future__ import annotations
@@ -254,13 +268,42 @@ def _refresh_via_leaderboard(
 
     The function NEVER raises; storage / leaderboard failures collapse
     to a fall-back path with the original stored canonical (if any).
+
+    Round-2 P1.2 fix (Codex round-1 finding on PR #979): the auto-
+    refresh decision MUST be computed against a strictly-public
+    leaderboard view, regardless of which actor invoked
+    ``run_canonical``. The round-1 path forwarded the caller's
+    ``viewer`` (== ``_current_actor()``) into the leaderboard, which
+    intentionally surfaces private branches authored by that viewer
+    (PR-970's auth-boundary contract). The auto-refresh then wrote
+    that private branch as the Goal's **global** canonical via
+    ``set_canonical_branch``, exposing per-viewer private content to
+    every other actor as the default dispatch target.
+
+    Fix: hard-code the leaderboard query's viewer to ``""`` (strictly
+    public) here. The caller's ``viewer`` parameter is retained for
+    log telemetry — it identifies which actor triggered the refresh —
+    but never reaches the leaderboard write decision.
     """
     goal_id = goal["goal_id"]
     from workflow.api.quality_leaderboard import build_quality_leaderboard
 
+    if viewer:
+        # Telemetry only — record which actor's run_canonical call
+        # triggered this refresh, but do NOT scope the leaderboard
+        # query to their viewer. Canonical is global by definition.
+        logger.info(
+            "canonical_refresh | goal=%s | triggered_by=%s | "
+            "using_viewer='' for global decision",
+            goal_id, viewer,
+        )
+
     try:
         board = build_quality_leaderboard(
-            base_path, goal_id=goal_id, viewer=viewer, now=now,
+            # P1.2 fix: hard-coded empty viewer so private branches
+            # cannot become the global canonical. The caller-supplied
+            # viewer is intentionally ignored at this seam.
+            base_path, goal_id=goal_id, viewer="", now=now,
         )
     except Exception:
         logger.exception(
@@ -518,24 +561,50 @@ def _attempt_set_canonical(
 def _latest_published_version_id(
     base_path: str | Path, *, branch_def_id: str,
 ) -> str | None:
-    """Return the newest published ``branch_version_id`` for the def,
-    or None when no published version exists."""
+    """Return the newest **active** ``branch_version_id`` for the def,
+    or None when no active published version exists.
+
+    Round-2 P1.1 fix (Codex round-1 finding on PR #979): the round-1
+    implementation returned ``versions[0].branch_version_id`` for the
+    most recently published version regardless of status, which let a
+    rolled-back version become the auto-refresh target. The repro:
+    publish a version, roll it back, give the underlying branch_def
+    enough leaderboard signal to rank first, call run_canonical with
+    auto_canonical_via_leaderboard=true -> the rolled-back version
+    was selected (source=leaderboard_refreshed).
+
+    Fix: filter the version list to ``status == 'active'`` so rolled-
+    back / superseded versions are NEVER returned to the auto-refresh
+    path. Defense in depth: :func:`workflow.daemon_server.set_canonical_branch`
+    also rejects non-active versions, so a bug in this filter alone
+    can't promote a dead version.
+    """
     if not branch_def_id:
         return None
     from workflow.branch_versions import list_branch_versions
 
     try:
+        # Pull a window of recent versions and filter for status='active'
+        # in Python — list_branch_versions does not expose a status
+        # filter today, and adding one would require touching its
+        # signature which is out of scope for this round. A small
+        # constant window (default-50 of the helper) covers the
+        # realistic case where the latest few versions include at most
+        # a handful of rolled-back rows.
         versions = list_branch_versions(
-            base_path, branch_def_id=branch_def_id, limit=1,
+            base_path, branch_def_id=branch_def_id, limit=50,
         )
     except Exception:  # pragma: no cover — defensive
         logger.exception(
             "list_branch_versions crashed for %s", branch_def_id,
         )
         return None
-    if not versions:
-        return None
-    return versions[0].branch_version_id or None
+    for version in versions:
+        if getattr(version, "status", "active") == "active":
+            bvid = version.branch_version_id or ""
+            if bvid:
+                return bvid
+    return None
 
 
 def _split_version_id(version_id: str) -> tuple[str, str]:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/canonical_dispatch.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/canonical_dispatch.py
@@ -1,0 +1,602 @@
+"""Canonical-handler resolution for Goal-bound run dispatch — PR-127 (M6).
+
+The M6 cutover (canonical at
+``pages/plans/drafts-plans-m6-cutover-retire-cheat-loop-leaderboard-driven-canonical.md``
+on the live brain) replaces the hand-wired cheat loop (an env-var
+pointing at a single ``WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID``)
+with leaderboard-driven canonical selection. Every Goal can opt into
+``auto_canonical_via_leaderboard``; when it does, every
+``goals action=run_canonical`` call:
+
+  1. Re-queries the quality leaderboard for the freshest top-ranked
+     entry.
+  2. If the top entry meets ``min_completed_runs_for_canonical``
+     (default 5) AND differs from the current canonical AND no
+     in-flight run is currently using the prior canonical, the stored
+     ``canonical_branch_version_id`` is refreshed via
+     :func:`workflow.daemon_server.set_canonical_branch`.
+  3. The (possibly updated) canonical is then dispatched.
+
+This module owns the resolution logic. The MCP dispatch wrapper
+(``_action_goal_run_canonical`` in ``workflow/api/market.py``) and the
+bug-investigation enqueue path (``_maybe_enqueue_investigation`` in
+``workflow/bug_investigation.py``) both call into this module so the
+leaderboard semantics + threshold + in-flight gating + history audit
+have a single source of truth.
+
+No new substrate primitives — pure orchestration over existing
+``goals`` / ``branch_versions`` / ``quality_leaderboard`` / ``runs``
+storage. The env-var fallback path (read by
+``_maybe_enqueue_investigation``) stays in place until the observation
+window closes; cutover plan Step 5/6 removes the env in a follow-on PR.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# How far back to look for an in-flight run on the prior canonical
+# before deciding it's safe to refresh. Matches the "don't swap
+# canonical out from under a live run" rule in the cutover plan.
+# A long-running graph may hold ``running`` status for minutes; the
+# window is therefore generous. Stale ``queued`` / ``running`` rows
+# outside this window are treated as orphaned and don't block the
+# refresh.
+IN_FLIGHT_WINDOW_SECONDS = 600.0  # 10 min
+
+# Resolution-source labels surfaced in the response so the caller can
+# render "why this version was picked". Stable; treat as enum-like.
+SOURCE_CANONICAL_STORED = "canonical_stored"
+SOURCE_LEADERBOARD_REFRESHED = "leaderboard_refreshed"
+SOURCE_LEADERBOARD_NO_CHANGE = "leaderboard_no_change"
+SOURCE_LEADERBOARD_SKIPPED_INSUFFICIENT_RUNS = (
+    "leaderboard_skipped_insufficient_runs"
+)
+SOURCE_LEADERBOARD_SKIPPED_IN_FLIGHT = "leaderboard_skipped_in_flight"
+SOURCE_LEADERBOARD_SKIPPED_NO_PUBLISHED_VERSION = (
+    "leaderboard_skipped_no_published_version"
+)
+SOURCE_LEADERBOARD_NO_ENTRIES = "leaderboard_no_entries"
+
+
+def resolve_canonical_for_run(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    viewer: str,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Resolve which ``branch_version_id`` should fulfil a canonical run.
+
+    Returns one of two shapes:
+
+    Success::
+
+        {
+            "ok": True,
+            "branch_version_id": "...",
+            "branch_def_id": "...",
+            "source": "<SOURCE_*>",
+            "goal": <goal-row>,
+            "refresh_attempted": <bool>,
+            "displaced_canonical_branch_version_id": <str | None>,
+            # Top-entry signals (only when refresh_attempted=True):
+            "candidate_branch_def_id": <str | None>,
+            "candidate_completed_runs": <int | None>,
+            "candidate_score": <float | None>,
+        }
+
+    Failure::
+
+        {
+            "ok": False,
+            "error": "<machine-readable>",
+            "error_kind": "<one of: no_goal | no_canonical_handler |
+                            no_published_version_for_candidate>",
+            "goal_id": "...",
+            "goal": <goal-row | None>,
+        }
+
+    Never raises — all storage / leaderboard failures surface as
+    ``ok=False`` shapes the caller can render.
+
+    Concurrency note: the in-flight detection window
+    (:data:`IN_FLIGHT_WINDOW_SECONDS`) bounds the period during which
+    a refresh is blocked by an active run on the prior canonical.
+    Outside that window any pending/running row is treated as
+    orphaned and does NOT block the refresh.
+    """
+    if now is None:
+        now = time.time()
+
+    from workflow.daemon_server import get_goal
+
+    try:
+        goal = get_goal(base_path, goal_id=goal_id)
+    except KeyError:
+        return {
+            "ok": False,
+            "error": f"Goal '{goal_id}' not found.",
+            "error_kind": "no_goal",
+            "goal_id": goal_id,
+            "goal": None,
+        }
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.exception("resolve_canonical_for_run | get_goal failed")
+        return {
+            "ok": False,
+            "error": f"failed to load Goal '{goal_id}': {exc}",
+            "error_kind": "goal_load_failed",
+            "goal_id": goal_id,
+            "goal": None,
+        }
+
+    stored_canonical = (goal.get("canonical_branch_version_id") or "") or None
+    auto_flag = bool(goal.get("auto_canonical_via_leaderboard"))
+    min_runs = int(goal.get("min_completed_runs_for_canonical") or 5)
+
+    if not auto_flag:
+        if not stored_canonical:
+            return {
+                "ok": False,
+                "error": (
+                    f"Goal '{goal_id}' has no canonical_branch_version_id "
+                    "set, and auto_canonical_via_leaderboard is off. "
+                    "Set canonical via `goals action=set_canonical` or "
+                    "enable auto-canonical via `goals action=update "
+                    "auto_canonical_via_leaderboard=true`."
+                ),
+                "error_kind": "no_canonical_handler",
+                "goal_id": goal_id,
+                "goal": goal,
+            }
+        bvid, bdid = _split_version_id(stored_canonical)
+        return {
+            "ok": True,
+            "branch_version_id": stored_canonical,
+            "branch_def_id": bdid,
+            "source": SOURCE_CANONICAL_STORED,
+            "goal": goal,
+            "refresh_attempted": False,
+            "displaced_canonical_branch_version_id": None,
+        }
+
+    # auto_canonical_via_leaderboard=true — try to refresh.
+    return _refresh_via_leaderboard(
+        base_path,
+        goal=goal,
+        viewer=viewer,
+        stored_canonical=stored_canonical,
+        min_runs=min_runs,
+        now=now,
+    )
+
+
+def is_in_flight_for_version(
+    base_path: str | Path,
+    *,
+    branch_version_id: str,
+    now: float,
+    window_seconds: float = IN_FLIGHT_WINDOW_SECONDS,
+) -> dict[str, Any] | None:
+    """Return the most recent in-flight run on ``branch_version_id``, or None.
+
+    "In-flight" = ``status`` ∈ {queued, running} AND ``started_at`` is
+    within the trailing ``window_seconds``. Older queued/running rows
+    are treated as orphaned (recovered by
+    ``_recover_orphaned_runs_on_read``) and do NOT block a refresh.
+
+    Returns the run row when present so the caller can surface
+    ``in_flight_run_id`` / ``in_flight_started_at`` in evidence.
+    """
+    if not branch_version_id:
+        return None
+    cutoff = now - max(0.0, float(window_seconds))
+    from workflow.runs import _connect, initialize_runs_db
+
+    initialize_runs_db(base_path)
+    with _connect(base_path) as conn:
+        row = conn.execute(
+            """
+            SELECT run_id, branch_def_id, branch_version_id, status,
+                   started_at, finished_at
+              FROM runs
+             WHERE branch_version_id = ?
+               AND status IN ('queued', 'running')
+               AND started_at >= ?
+          ORDER BY started_at DESC
+             LIMIT 1
+            """,
+            (branch_version_id, cutoff),
+        ).fetchone()
+    if row is None:
+        return None
+    return {
+        "run_id": row["run_id"],
+        "branch_def_id": row["branch_def_id"],
+        "branch_version_id": row["branch_version_id"],
+        "status": row["status"],
+        "started_at": row["started_at"],
+        "finished_at": row["finished_at"],
+    }
+
+
+def _refresh_via_leaderboard(
+    base_path: str | Path,
+    *,
+    goal: dict[str, Any],
+    viewer: str,
+    stored_canonical: str | None,
+    min_runs: int,
+    now: float,
+) -> dict[str, Any]:
+    """Re-query the leaderboard and (maybe) refresh ``canonical_branch_version_id``.
+
+    Five outcomes:
+
+    1. No entries on the leaderboard → fall back to stored canonical if
+       set, otherwise no_canonical_handler error.
+    2. Top entry has < min_runs completed runs → fall back to stored
+       canonical (or no_canonical_handler).
+    3. Top entry has no published branch_version → fall back to stored
+       canonical (or no_canonical_handler).
+    4. Top entry matches stored canonical's branch_def_id → no-op,
+       return stored canonical.
+    5. Top entry passes all checks AND no in-flight run is using the
+       prior canonical → call set_canonical_branch + return the new
+       version.
+
+    The function NEVER raises; storage / leaderboard failures collapse
+    to a fall-back path with the original stored canonical (if any).
+    """
+    goal_id = goal["goal_id"]
+    from workflow.api.quality_leaderboard import build_quality_leaderboard
+
+    try:
+        board = build_quality_leaderboard(
+            base_path, goal_id=goal_id, viewer=viewer, now=now,
+        )
+    except Exception:
+        logger.exception(
+            "resolve_canonical_for_run | leaderboard query crashed for "
+            "%s; falling back to stored canonical", goal_id,
+        )
+        board = {"entries": []}
+
+    entries = board.get("entries") or []
+    if not entries:
+        if stored_canonical:
+            bvid, bdid = _split_version_id(stored_canonical)
+            return {
+                "ok": True,
+                "branch_version_id": stored_canonical,
+                "branch_def_id": bdid,
+                "source": SOURCE_LEADERBOARD_NO_ENTRIES,
+                "goal": goal,
+                "refresh_attempted": True,
+                "displaced_canonical_branch_version_id": None,
+            }
+        return _no_canonical_response(
+            goal_id=goal_id, goal=goal,
+            hint=(
+                "auto_canonical_via_leaderboard is on, but no Branches "
+                "are bound to this Goal yet. Bind at least one (and "
+                "produce >= min_completed_runs_for_canonical successful "
+                "runs) before calling run_canonical."
+            ),
+        )
+
+    top = entries[0]
+    candidate_bdid = top.get("branch_def_id") or ""
+    candidate_signals = top.get("signals") or {}
+    candidate_completed = int(
+        candidate_signals.get("completed_run_count") or 0
+    )
+    candidate_score = float(top.get("score") or 0.0)
+
+    # Threshold guard — security gate against a malicious branch
+    # ranking high with zero / few actual runs.
+    if candidate_completed < min_runs:
+        if stored_canonical:
+            bvid, bdid = _split_version_id(stored_canonical)
+            return {
+                "ok": True,
+                "branch_version_id": stored_canonical,
+                "branch_def_id": bdid,
+                "source": SOURCE_LEADERBOARD_SKIPPED_INSUFFICIENT_RUNS,
+                "goal": goal,
+                "refresh_attempted": True,
+                "displaced_canonical_branch_version_id": None,
+                "candidate_branch_def_id": candidate_bdid,
+                "candidate_completed_runs": candidate_completed,
+                "candidate_score": candidate_score,
+                "min_completed_runs_for_canonical": min_runs,
+                "hint": (
+                    f"Top entry '{candidate_bdid}' has "
+                    f"{candidate_completed} completed run(s); the "
+                    f"Goal requires >= {min_runs}. Keeping the stored "
+                    "canonical."
+                ),
+            }
+        return _no_canonical_response(
+            goal_id=goal_id, goal=goal,
+            hint=(
+                f"Top leaderboard entry '{candidate_bdid}' has "
+                f"{candidate_completed} completed run(s); the Goal "
+                f"requires >= {min_runs}. No prior canonical is set, "
+                "so the dispatch is blocked. Either lower "
+                "min_completed_runs_for_canonical or run the branch "
+                "more times before retrying."
+            ),
+        )
+
+    # Resolve top entry's latest published version. The leaderboard
+    # ranks branch_def_id values; the canonical surface keys on
+    # branch_version_id (the immutable snapshot). We pick the most
+    # recently published version for the top branch_def_id.
+    candidate_bvid = _latest_published_version_id(
+        base_path, branch_def_id=candidate_bdid,
+    )
+    if not candidate_bvid:
+        # Branch_def is bound to the Goal but has not been published.
+        # Fall back to stored canonical if any.
+        if stored_canonical:
+            bvid, bdid = _split_version_id(stored_canonical)
+            return {
+                "ok": True,
+                "branch_version_id": stored_canonical,
+                "branch_def_id": bdid,
+                "source": SOURCE_LEADERBOARD_SKIPPED_NO_PUBLISHED_VERSION,
+                "goal": goal,
+                "refresh_attempted": True,
+                "displaced_canonical_branch_version_id": None,
+                "candidate_branch_def_id": candidate_bdid,
+                "candidate_completed_runs": candidate_completed,
+                "candidate_score": candidate_score,
+                "hint": (
+                    f"Top entry '{candidate_bdid}' has no published "
+                    "branch_version. Keeping the stored canonical. "
+                    "Publish the branch via `extensions action="
+                    "publish_version` before it can serve as canonical."
+                ),
+            }
+        return _no_canonical_response(
+            goal_id=goal_id, goal=goal,
+            hint=(
+                f"Top entry '{candidate_bdid}' has no published "
+                "branch_version, and no prior canonical is set. "
+                "Publish the branch first."
+            ),
+        )
+
+    # Did the candidate's branch_def_id already match the stored
+    # canonical's branch_def_id? If so, the candidate is effectively
+    # the same handler — no swap needed, but we DO swap to the latest
+    # version of that def_id so future runs land on the freshest
+    # snapshot. Two sub-cases:
+    #   (a) Stored canonical IS the latest version → no-op.
+    #   (b) Stored canonical points to an older version of the same
+    #       def_id → swap to the latest.
+    if stored_canonical and stored_canonical == candidate_bvid:
+        # Already on the freshest version of the top entry.
+        return {
+            "ok": True,
+            "branch_version_id": stored_canonical,
+            "branch_def_id": candidate_bdid,
+            "source": SOURCE_LEADERBOARD_NO_CHANGE,
+            "goal": goal,
+            "refresh_attempted": True,
+            "displaced_canonical_branch_version_id": None,
+            "candidate_branch_def_id": candidate_bdid,
+            "candidate_completed_runs": candidate_completed,
+            "candidate_score": candidate_score,
+        }
+
+    # We have a different version to swap in. Check for in-flight runs
+    # on the prior canonical before swapping.
+    in_flight = None
+    if stored_canonical:
+        in_flight = is_in_flight_for_version(
+            base_path,
+            branch_version_id=stored_canonical,
+            now=now,
+        )
+    if in_flight is not None:
+        bvid, bdid = _split_version_id(stored_canonical or "")
+        return {
+            "ok": True,
+            "branch_version_id": stored_canonical,
+            "branch_def_id": bdid,
+            "source": SOURCE_LEADERBOARD_SKIPPED_IN_FLIGHT,
+            "goal": goal,
+            "refresh_attempted": True,
+            "displaced_canonical_branch_version_id": None,
+            "candidate_branch_def_id": candidate_bdid,
+            "candidate_completed_runs": candidate_completed,
+            "candidate_score": candidate_score,
+            "in_flight_run_id": in_flight.get("run_id"),
+            "in_flight_status": in_flight.get("status"),
+            "in_flight_started_at": in_flight.get("started_at"),
+            "hint": (
+                f"A run on the prior canonical "
+                f"('{stored_canonical}') is currently "
+                f"{in_flight.get('status')}; refusing to swap canonical "
+                "out from under it. Retry after the in-flight run "
+                "completes."
+            ),
+        }
+
+    # Safe to swap.
+    set_by = _resolve_actor_for_history()
+    refreshed = _attempt_set_canonical(
+        base_path,
+        goal_id=goal_id,
+        branch_version_id=candidate_bvid,
+        set_by=set_by,
+    )
+    if not refreshed["ok"]:
+        # set_canonical failed (e.g. version validation). Fall back to
+        # stored canonical if any.
+        if stored_canonical:
+            bvid, bdid = _split_version_id(stored_canonical)
+            return {
+                "ok": True,
+                "branch_version_id": stored_canonical,
+                "branch_def_id": bdid,
+                "source": SOURCE_LEADERBOARD_SKIPPED_NO_PUBLISHED_VERSION,
+                "goal": goal,
+                "refresh_attempted": True,
+                "displaced_canonical_branch_version_id": None,
+                "candidate_branch_def_id": candidate_bdid,
+                "candidate_completed_runs": candidate_completed,
+                "candidate_score": candidate_score,
+                "hint": (
+                    f"set_canonical rejected candidate "
+                    f"'{candidate_bvid}': {refreshed.get('error')}. "
+                    "Keeping the stored canonical."
+                ),
+            }
+        return _no_canonical_response(
+            goal_id=goal_id, goal=goal,
+            hint=(
+                f"set_canonical rejected candidate '{candidate_bvid}': "
+                f"{refreshed.get('error')}. No prior canonical to fall "
+                "back to."
+            ),
+        )
+
+    return {
+        "ok": True,
+        "branch_version_id": candidate_bvid,
+        "branch_def_id": candidate_bdid,
+        "source": SOURCE_LEADERBOARD_REFRESHED,
+        "goal": refreshed.get("goal") or goal,
+        "refresh_attempted": True,
+        "displaced_canonical_branch_version_id": stored_canonical,
+        "candidate_branch_def_id": candidate_bdid,
+        "candidate_completed_runs": candidate_completed,
+        "candidate_score": candidate_score,
+    }
+
+
+def _attempt_set_canonical(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    branch_version_id: str,
+    set_by: str,
+) -> dict[str, Any]:
+    """Wrap :func:`workflow.daemon_server.set_canonical_branch` so the
+    leaderboard refresher never raises. Returns ``{ok: bool, error?,
+    goal?}``.
+    """
+    from workflow.daemon_server import set_canonical_branch
+
+    try:
+        updated = set_canonical_branch(
+            base_path,
+            goal_id=goal_id,
+            branch_version_id=branch_version_id,
+            set_by=set_by,
+        )
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+    except KeyError as exc:
+        return {"ok": False, "error": f"Goal not found: {exc}"}
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.exception("set_canonical_branch crashed")
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True, "goal": updated}
+
+
+def _latest_published_version_id(
+    base_path: str | Path, *, branch_def_id: str,
+) -> str | None:
+    """Return the newest published ``branch_version_id`` for the def,
+    or None when no published version exists."""
+    if not branch_def_id:
+        return None
+    from workflow.branch_versions import list_branch_versions
+
+    try:
+        versions = list_branch_versions(
+            base_path, branch_def_id=branch_def_id, limit=1,
+        )
+    except Exception:  # pragma: no cover — defensive
+        logger.exception(
+            "list_branch_versions crashed for %s", branch_def_id,
+        )
+        return None
+    if not versions:
+        return None
+    return versions[0].branch_version_id or None
+
+
+def _split_version_id(version_id: str) -> tuple[str, str]:
+    """Best-effort ``branch_def_id`` extraction from a version id.
+
+    Published versions are minted as ``<branch_def_id>@<sha256_prefix8>``
+    (see ``workflow.branch_versions``); the def_id is the prefix before
+    the ``@``. Returns ``(version_id, "")`` when the input has no ``@``
+    (defensive — keeps the response shape uniform even if a caller
+    feeds in a malformed id).
+    """
+    if not version_id:
+        return "", ""
+    if "@" in version_id:
+        bdid, _ = version_id.split("@", 1)
+        return version_id, bdid
+    return version_id, ""
+
+
+def _no_canonical_response(
+    *,
+    goal_id: str,
+    goal: dict[str, Any] | None,
+    hint: str = "",
+) -> dict[str, Any]:
+    """Standard `no_canonical_handler` failure shape."""
+    payload: dict[str, Any] = {
+        "ok": False,
+        "error": (
+            f"Goal '{goal_id}' has no canonical_branch_version_id "
+            "available for dispatch."
+        ),
+        "error_kind": "no_canonical_handler",
+        "goal_id": goal_id,
+        "goal": goal,
+    }
+    if hint:
+        payload["hint"] = hint
+    return payload
+
+
+def _resolve_actor_for_history() -> str:
+    """Identity recorded on the canonical history audit row.
+
+    Auto-refresh writes are system-driven, not user-driven; tagging
+    them with a synthetic ``auto-canonical-refresh`` author keeps the
+    audit trail honest (matches the ``cloud-droplet`` identity pattern
+    documented in AGENTS.md for system-driven writes).
+    """
+    return "auto-canonical-refresh"
+
+
+__all__ = [
+    "IN_FLIGHT_WINDOW_SECONDS",
+    "SOURCE_CANONICAL_STORED",
+    "SOURCE_LEADERBOARD_REFRESHED",
+    "SOURCE_LEADERBOARD_NO_CHANGE",
+    "SOURCE_LEADERBOARD_SKIPPED_INSUFFICIENT_RUNS",
+    "SOURCE_LEADERBOARD_SKIPPED_IN_FLIGHT",
+    "SOURCE_LEADERBOARD_SKIPPED_NO_PUBLISHED_VERSION",
+    "SOURCE_LEADERBOARD_NO_ENTRIES",
+    "resolve_canonical_for_run",
+    "is_in_flight_for_version",
+]

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
@@ -1617,6 +1617,137 @@ def _action_goal_set_canonical(kwargs: dict[str, Any]) -> str:
     }, default=str)
 
 
+def _action_goal_run_canonical(kwargs: dict[str, Any]) -> str:
+    """Dispatch a run against a Goal's canonical handler — PR-127 (M6).
+
+    The Goal's stored ``canonical_branch_version_id`` is the dispatch
+    target. When ``goal.auto_canonical_via_leaderboard`` is True, the
+    canonical is first refreshed against the freshest leaderboard
+    top-entry (subject to the ``min_completed_runs_for_canonical``
+    threshold and the in-flight guard — see
+    :func:`workflow.api.canonical_dispatch.resolve_canonical_for_run`).
+
+    Required kwargs:
+      * ``goal_id`` — the Goal to dispatch against.
+
+    Optional kwargs:
+      * ``inputs_json`` — JSON string of inputs forwarded to the run.
+      * ``run_name`` — display name for the resulting run row.
+      * ``recursion_limit_override`` — passthrough to the run executor.
+
+    Returns one of:
+
+    Success::
+
+        {
+            "status": "queued",
+            "text": "<phone-legible summary>",
+            "run_id": "...",
+            "branch_version_id_used": "...",
+            "branch_def_id": "...",
+            "source": "<canonical_stored | leaderboard_refreshed | ...>",
+            "goal_id": "...",
+            ...passthrough from run_branch_version...
+        }
+
+    Rejection::
+
+        {
+            "status": "rejected",
+            "error": "...",
+            "error_kind": "no_canonical_handler | no_goal | ...",
+            "goal_id": "...",
+        }
+    """
+    from workflow.api.canonical_dispatch import resolve_canonical_for_run
+    from workflow.api.engine_helpers import _current_actor
+    from workflow.api.runs import _action_run_branch_version
+
+    gid = (kwargs.get("goal_id") or "").strip()
+    if not gid:
+        return json.dumps({
+            "status": "rejected",
+            "error": "goal_id is required for run_canonical.",
+            "error_kind": "missing_goal_id",
+        })
+
+    resolution = resolve_canonical_for_run(
+        _base_path(),
+        goal_id=gid,
+        viewer=_current_actor(),
+    )
+    if not resolution.get("ok"):
+        # Surface the failure verbatim so the caller's branching logic
+        # (e.g. _maybe_enqueue_investigation's env-fallback) can read
+        # error_kind directly.
+        return json.dumps({
+            "status": "rejected",
+            "error": resolution.get("error", ""),
+            "error_kind": resolution.get(
+                "error_kind", "no_canonical_handler",
+            ),
+            "goal_id": gid,
+            "hint": resolution.get("hint", ""),
+        }, default=str)
+
+    bvid = resolution["branch_version_id"]
+    bdid = resolution.get("branch_def_id", "")
+
+    # Delegate dispatch to the existing run_branch_version path so
+    # both surfaces share executor + provider + recursion-limit
+    # behavior. Inputs flow through verbatim.
+    dispatch_result_raw = _action_run_branch_version({
+        "branch_version_id": bvid,
+        "inputs_json": kwargs.get("inputs_json", "") or "",
+        "run_name": kwargs.get("run_name", "") or "",
+        "recursion_limit_override": (
+            kwargs.get("recursion_limit_override", "") or ""
+        ),
+    })
+    try:
+        dispatch_result = json.loads(dispatch_result_raw)
+    except (TypeError, ValueError):
+        # Defensive — run_branch_version always returns JSON.
+        return dispatch_result_raw
+
+    # Annotate the dispatch response with canonical-resolution metadata
+    # WITHOUT overwriting any of run_branch_version's existing fields.
+    dispatch_result.setdefault("goal_id", gid)
+    dispatch_result["branch_version_id_used"] = bvid
+    dispatch_result.setdefault("branch_def_id", bdid)
+    dispatch_result["source"] = resolution.get("source")
+    if resolution.get("refresh_attempted"):
+        dispatch_result["refresh_attempted"] = True
+        if resolution.get("displaced_canonical_branch_version_id"):
+            dispatch_result["displaced_canonical_branch_version_id"] = (
+                resolution["displaced_canonical_branch_version_id"]
+            )
+        for k in (
+            "candidate_branch_def_id",
+            "candidate_completed_runs",
+            "candidate_score",
+            "min_completed_runs_for_canonical",
+            "in_flight_run_id",
+            "in_flight_status",
+            "in_flight_started_at",
+        ):
+            if k in resolution:
+                dispatch_result[k] = resolution[k]
+        if resolution.get("hint") and not dispatch_result.get("hint"):
+            dispatch_result["hint"] = resolution["hint"]
+
+    # Render a short text summary if the underlying handler didn't.
+    if "text" not in dispatch_result or not dispatch_result["text"]:
+        run_id = dispatch_result.get("run_id") or "(no run_id)"
+        dispatch_result["text"] = (
+            f"Canonical dispatch for Goal `{gid}` -> "
+            f"branch_version_id `{bvid}` (run_id `{run_id}`, "
+            f"source `{resolution.get('source')}`)."
+        )
+
+    return json.dumps(dispatch_result, default=str)
+
+
 _GOAL_ACTIONS: dict[str, Any] = {
     "propose": _action_goal_propose,
     "update": _action_goal_update,
@@ -1628,6 +1759,10 @@ _GOAL_ACTIONS: dict[str, Any] = {
     "common_nodes": _action_goal_common_nodes,
     "archive_consultation": _action_goal_archive_consultation,
     "set_canonical": _action_goal_set_canonical,
+    # PR-127 (M6 cutover Step 4) — leaderboard-driven canonical
+    # dispatch. Honors auto_canonical_via_leaderboard + threshold +
+    # in-flight gate; delegates the actual run to run_branch_version.
+    "run_canonical": _action_goal_run_canonical,
 }
 
 # Provider-routing compatibility: ChatGPT can render `/mcp-directory` tool
@@ -1742,6 +1877,17 @@ def goals(
       set_canonical Mark a branch_version_id as the Goal's canonical
                    (best-known) branch. Author-only or host-only.
                    Pass branch_version_id="" to unset.
+      run_canonical Dispatch a run against the Goal's canonical
+                   branch_version. PR-127 (M6 cutover): when
+                   ``auto_canonical_via_leaderboard`` is enabled on the
+                   Goal, the canonical is first refreshed via the
+                   quality leaderboard (subject to
+                   ``min_completed_runs_for_canonical`` threshold and
+                   the in-flight guard). Needs goal_id. Accepts
+                   ``inputs_json``, ``run_name``,
+                   ``recursion_limit_override``. Returns
+                   ``branch_version_id_used`` + ``source`` so the
+                   caller can see which version was picked and why.
       list         Browse Goals. Optional author, tags (CSV first
                    value only), limit, production_only. Soft-deleted
                    Goals hidden. production_only keeps public Goals

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/bug_investigation.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/bug_investigation.py
@@ -262,19 +262,34 @@ def _maybe_enqueue_investigation(
 ) -> str | None:
     """Forward-trigger seam for `_wiki_file_bug` post-write.
 
-    Reads `WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID` at call time; when set,
-    enqueues a dispatcher request for the freshly-filed bug. Swallows
-    dispatcher-rejection (RuntimeError) and bad-input (ValueError) so a
-    filing never breaks because of investigation-pipeline misconfiguration.
+    Resolution order (PR-127 / M6 cutover Step 4):
 
-    Returns request_id when enqueued, None when skipped or recovered from error.
+      1. If ``WORKFLOW_BUG_INVESTIGATION_GOAL_ID`` is set AND that
+         Goal has a ``canonical_branch_version_id`` (set via
+         ``goals action=set_canonical`` or auto-refreshed from the
+         leaderboard when ``auto_canonical_via_leaderboard`` is on),
+         resolve the canonical to a ``branch_def_id`` and enqueue
+         a dispatcher request against it.
+      2. Otherwise, fall back to
+         ``WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID`` — the round-1
+         cheat-loop env. This fallback is intentional graceful
+         degradation: the cutover plan removes the env in a
+         subsequent slice (Step 5/6) once the canonical handler has
+         been observation-window'd.
+
+    Returns request_id when enqueued, None when skipped or recovered
+    from error. Swallows dispatcher-rejection (RuntimeError) and
+    bad-input (ValueError) so a filing never breaks because of
+    investigation-pipeline misconfiguration.
     """
-    canonical = os.environ.get("WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID", "").strip()
-    if not canonical:
-        return None
     if not bug_id:
         _logger.info("_maybe_enqueue_investigation | skipped | missing bug_id")
         return None
+
+    canonical_branch_def_id = _resolve_investigation_handler(base_path)
+    if not canonical_branch_def_id:
+        return None
+
     bug_ref = dict(frontmatter or {})
     bug_ref["bug_id"] = bug_id
     # Module-attribute lookup (NOT bare-name) so `patch("workflow.bug_investigation
@@ -285,7 +300,7 @@ def _maybe_enqueue_investigation(
     try:
         return enqueue(
             bug_ref=bug_ref,
-            canonical_branch_def_id=canonical,
+            canonical_branch_def_id=canonical_branch_def_id,
             base_path=base_path,
             universe_id=universe_id,
         )
@@ -294,3 +309,79 @@ def _maybe_enqueue_investigation(
             "_maybe_enqueue_investigation | %s | recovered: %s", bug_id, exc
         )
         return None
+
+
+def _resolve_investigation_handler(base_path: "Path | str") -> str:
+    """Pick the ``branch_def_id`` that should handle a fresh bug.
+
+    Two paths, in order:
+
+      1. **Goal-canonical (PR-127 cutover):** read
+         ``WORKFLOW_BUG_INVESTIGATION_GOAL_ID``; if set, look up the
+         Goal and resolve ``canonical_branch_version_id`` → its
+         ``branch_def_id``. When ``auto_canonical_via_leaderboard``
+         is enabled on the Goal, the canonical is auto-refreshed
+         here too (subject to the threshold + in-flight gate) so a
+         file_bug burst doesn't have to wait for an MCP-driven
+         ``run_canonical`` to refresh the pick.
+      2. **Cheat-loop env fallback:** read
+         ``WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID`` directly. Kept
+         in place until Cutover plan Steps 5/6 retire it. The env
+         lets the host roll out PR-127 before any Goal has a
+         canonical set.
+
+    Returns "" when neither path produces a handler. Never raises.
+    """
+    goal_id = os.environ.get(
+        "WORKFLOW_BUG_INVESTIGATION_GOAL_ID", "",
+    ).strip()
+    if goal_id:
+        try:
+            from workflow.api.canonical_dispatch import (
+                resolve_canonical_for_run,
+            )
+            resolution = resolve_canonical_for_run(
+                base_path,
+                goal_id=goal_id,
+                # No actor context inside the wiki-write hook — use
+                # the empty-viewer (strictly-public) lookup so private
+                # branches cannot serve as a public bug-investigation
+                # canonical.
+                viewer="",
+            )
+        except Exception:  # pragma: no cover — defensive
+            _logger.exception(
+                "_resolve_investigation_handler | canonical resolution "
+                "crashed for goal %s; falling back to env",
+                goal_id,
+            )
+            resolution = {"ok": False}
+        if resolution.get("ok"):
+            bdid = (resolution.get("branch_def_id") or "").strip()
+            if bdid:
+                _logger.info(
+                    "_resolve_investigation_handler | goal=%s "
+                    "canonical=%s source=%s",
+                    goal_id,
+                    resolution.get("branch_version_id"),
+                    resolution.get("source"),
+                )
+                return bdid
+        else:
+            _logger.info(
+                "_resolve_investigation_handler | goal=%s no canonical "
+                "available (%s); falling back to env",
+                goal_id, resolution.get("error_kind") or "unknown",
+            )
+
+    # Cheat-loop fallback.
+    fallback = os.environ.get(
+        "WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID", "",
+    ).strip()
+    if fallback:
+        _logger.info(
+            "_resolve_investigation_handler | using env fallback "
+            "branch_def_id=%s (cutover plan Step 5/6 retires this path)",
+            fallback,
+        )
+    return fallback

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
@@ -2595,19 +2595,39 @@ def set_canonical_branch(
     canonical_branch_history before the new value is written.
     Raises KeyError if goal_id not found.
     Raises ValueError if branch_version_id is provided but does not exist
-        in branch_versions table (not a published version).
+        in branch_versions table (not a published version), OR if the
+        supplied version's status is not 'active' (PR-127 round 2 P1.1
+        defense-in-depth — rolled_back / superseded versions cannot be
+        promoted to canonical even if a caller bypasses the auto-refresh
+        filter in :func:`workflow.api.canonical_dispatch._latest_published_version_id`).
     """
     initialize_author_server(base_path)
     now = _now()
     goal = get_goal(base_path, goal_id=goal_id)
 
     if branch_version_id is not None:
-        # Validate that it's a real published version.
+        # Validate that it's a real published version AND that it has
+        # not been rolled back / superseded. The active-only check is
+        # the round-2 P1.1 defense-in-depth: the auto-refresh path
+        # already filters via `_latest_published_version_id`, but a
+        # second guard at the write site means a rolled-back version
+        # cannot become canonical via any code path (manual MCP call,
+        # auto-refresh bug, host script, etc.).
         from workflow.branch_versions import get_branch_version
-        if get_branch_version(base_path, branch_version_id) is None:
+        version = get_branch_version(base_path, branch_version_id)
+        if version is None:
             raise ValueError(
                 f"branch_version_id {branch_version_id!r} not found "
                 "in branch_versions — only published versions may be canonical."
+            )
+        version_status = getattr(version, "status", "active") or "active"
+        if version_status != "active":
+            raise ValueError(
+                f"branch_version_id {branch_version_id!r} has "
+                f"status={version_status!r}; only versions with "
+                "status='active' may be promoted to canonical. "
+                "Re-publish a fresh version or restore the rolled-back "
+                "one before retrying."
             )
 
     # Build history entry for previous canonical (if any).

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
@@ -461,6 +461,26 @@ def initialize_author_server(base_path: str | Path) -> Path:
                 "ALTER TABLE goals ADD COLUMN canonical_branch_history_json "
                 "TEXT NOT NULL DEFAULT '[]'"
             )
+        # PR-127 (M6 cutover Steps 4 + 7) — leaderboard-driven canonical
+        # selection. ``auto_canonical_via_leaderboard``: when set, every
+        # ``goals action=run_canonical`` call first re-queries
+        # ``recommended_parent_for_fork`` and updates the stored
+        # ``canonical_branch_version_id`` to the freshest top-ranked
+        # entry before dispatching. Default OFF so existing Goals are
+        # opt-in. ``min_completed_runs_for_canonical``: security gate
+        # against a malicious branch ranking high with zero actual
+        # runs; default 5. Both columns are stored as integers (SQLite
+        # has no native BOOLEAN).
+        if "auto_canonical_via_leaderboard" not in goal_cols:
+            conn.execute(
+                "ALTER TABLE goals ADD COLUMN auto_canonical_via_leaderboard "
+                "INTEGER NOT NULL DEFAULT 0"
+            )
+        if "min_completed_runs_for_canonical" not in goal_cols:
+            conn.execute(
+                "ALTER TABLE goals ADD COLUMN min_completed_runs_for_canonical "
+                "INTEGER NOT NULL DEFAULT 5"
+            )
         # Variant canonicals (Task #61 Step 1) — backfill canonical_bindings
         # from existing goals.canonical_branch_version_id. INSERT OR IGNORE
         # makes the migration idempotent: re-running on an already-backfilled
@@ -2420,6 +2440,17 @@ def _goal_from_row(row: sqlite3.Row) -> dict[str, Any]:
         canonical_history_raw = row["canonical_branch_history_json"]
     except (IndexError, KeyError):
         canonical_history_raw = "[]"
+    # PR-127 — leaderboard-driven canonical selection. Defaults match
+    # the schema (auto OFF, threshold 5) so pre-migration rows behave
+    # as if they were freshly created.
+    try:
+        auto_flag = int(row["auto_canonical_via_leaderboard"] or 0)
+    except (IndexError, KeyError, TypeError, ValueError):
+        auto_flag = 0
+    try:
+        min_runs = int(row["min_completed_runs_for_canonical"] or 5)
+    except (IndexError, KeyError, TypeError, ValueError):
+        min_runs = 5
     return {
         "goal_id": row["goal_id"],
         "name": row["name"],
@@ -2434,6 +2465,8 @@ def _goal_from_row(row: sqlite3.Row) -> dict[str, Any]:
         "canonical_branch_history": _json_loads(
             canonical_history_raw or "[]", []
         ),
+        "auto_canonical_via_leaderboard": bool(auto_flag),
+        "min_completed_runs_for_canonical": min_runs,
     }
 
 
@@ -2496,7 +2529,9 @@ def update_goal(
 ) -> dict[str, Any]:
     """Patch mutable fields on a Goal. Returns the updated row.
 
-    Supported fields: name, description, tags, visibility. Author is
+    Supported fields: name, description, tags, visibility,
+    auto_canonical_via_leaderboard (bool — PR-127), and
+    min_completed_runs_for_canonical (int — PR-127). Author is
     immutable; timestamps are server-managed.
     """
     initialize_author_server(base_path)
@@ -2512,6 +2547,24 @@ def update_goal(
     if "tags" in updates:
         sets.append("tags_json = ?")
         params.append(_json_dumps(list(updates["tags"] or [])))
+    # PR-127 — leaderboard-driven canonical opt-in + threshold knob.
+    # Booleans land as 0/1 to match the SQLite INTEGER column.
+    if "auto_canonical_via_leaderboard" in updates:
+        sets.append("auto_canonical_via_leaderboard = ?")
+        params.append(1 if updates["auto_canonical_via_leaderboard"] else 0)
+    if "min_completed_runs_for_canonical" in updates:
+        try:
+            threshold = int(updates["min_completed_runs_for_canonical"])
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "min_completed_runs_for_canonical must be an integer"
+            ) from exc
+        if threshold < 0:
+            raise ValueError(
+                "min_completed_runs_for_canonical must be >= 0"
+            )
+        sets.append("min_completed_runs_for_canonical = ?")
+        params.append(threshold)
     params.append(goal_id)
     with _connect(base_path) as conn:
         conn.execute(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -782,6 +782,12 @@ def goals(
                    unbind. Needs branch_def_id.
       set_canonical Mark a branch_version_id as the Goal's canonical
                    branch. Author-only or host-only.
+      run_canonical Dispatch a run on the Goal's canonical
+                   branch_version. When auto_canonical_via_leaderboard
+                   is on, the canonical is first refreshed via the
+                   quality leaderboard (subject to the
+                   min_completed_runs_for_canonical threshold + the
+                   in-flight guard). PR-127 (M6 cutover Step 4).
       list         Browse Goals. Optional author, tags, limit,
                    production_only.
       get          Full Goal view + bound Branches. Needs goal_id.

--- a/tests/test_api_market.py
+++ b/tests/test_api_market.py
@@ -110,14 +110,19 @@ def test_attribution_actions_keys():
 # ── _GOAL_ACTIONS dispatch table ────────────────────────────────────────────
 
 
-def test_goal_actions_table_has_9_handlers():
-    assert len(_GOAL_ACTIONS) == 9
+def test_goal_actions_table_has_11_handlers():
+    # 9 base actions + archive_consultation (pre-existing on main) +
+    # run_canonical (PR-127 M6 cutover Step 4) = 11.
+    assert len(_GOAL_ACTIONS) == 11
 
 
 def test_goal_actions_keys():
     expected = {
         "propose", "update", "bind", "list", "get", "search",
         "leaderboard", "common_nodes", "set_canonical",
+        "archive_consultation",
+        # PR-127 — leaderboard-driven canonical dispatch.
+        "run_canonical",
     }
     assert set(_GOAL_ACTIONS.keys()) == expected
 

--- a/tests/test_bug_investigation_canonical_cutover.py
+++ b/tests/test_bug_investigation_canonical_cutover.py
@@ -1,0 +1,402 @@
+"""PR-127 — `_maybe_enqueue_investigation` canonical cutover.
+
+Tests the round-1-cheat-loop → leaderboard-canonical swap in
+``workflow.bug_investigation._maybe_enqueue_investigation``:
+
+  * No env vars set -> no enqueue (legacy behavior preserved).
+  * Only ``WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID`` set ->
+    cheat-loop fallback fires; existing dispatcher path used.
+  * ``WORKFLOW_BUG_INVESTIGATION_GOAL_ID`` set + Goal has a canonical
+    -> canonical's branch_def_id used; env fallback NOT consulted.
+  * GOAL_ID set + Goal has NO canonical + BRANCH_DEF_ID set ->
+    fallback to env.
+  * GOAL_ID set + auto_canonical_via_leaderboard=true + qualified
+    candidate -> auto-refresh fires from inside the wiki-write hook,
+    new canonical is recorded BEFORE the dispatch.
+  * Empty bug_id -> always skipped.
+
+The dispatcher hop itself is mocked so the test doesn't depend on
+the universe's branch_tasks.json shape; the assertion is that
+``enqueue_investigation_request`` is called with the correct
+``canonical_branch_def_id``.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def base_path(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("WORKFLOW_BUG_INVESTIGATION_GOAL_ID", raising=False)
+    monkeypatch.delenv(
+        "WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID", raising=False,
+    )
+    from workflow.daemon_server import initialize_author_server
+    from workflow.runs import initialize_runs_db
+    initialize_author_server(tmp_path)
+    initialize_runs_db(tmp_path)
+    return tmp_path
+
+
+def _seed_goal_with_canonical(
+    base: Path,
+    *,
+    goal_id: str,
+    branch_def_id: str,
+    auto: bool = False,
+    min_runs: int = 5,
+) -> tuple[str, str]:
+    """Seed a Goal + Branch + published version + set_canonical.
+
+    Returns (branch_def_id, branch_version_id).
+    """
+    from workflow.branch_versions import publish_branch_version
+    from workflow.daemon_server import (
+        save_branch_definition,
+        save_goal,
+        set_canonical_branch,
+        update_goal,
+    )
+
+    save_goal(
+        base,
+        goal=dict(
+            goal_id=goal_id, name=goal_id, description="",
+            author="host", tags=[], visibility="public",
+        ),
+    )
+    update_goal(
+        base, goal_id=goal_id,
+        updates={
+            "auto_canonical_via_leaderboard": auto,
+            "min_completed_runs_for_canonical": min_runs,
+        },
+    )
+    save_branch_definition(
+        base,
+        branch_def=dict(
+            branch_def_id=branch_def_id,
+            name=branch_def_id,
+            description="",
+            author="host",
+            tags=[],
+            graph_nodes=[],
+            edges=[],
+            state_schema=[],
+            entry_point="",
+            published=True,
+            goal_id=goal_id,
+        ),
+    )
+    version = publish_branch_version(
+        base,
+        branch_dict={
+            "branch_def_id": branch_def_id,
+            "name": branch_def_id,
+            "description": "",
+            "author": "host",
+            "graph_nodes": [],
+            "edges": [],
+            "state_schema": [],
+            "entry_point": "",
+            "node_defs": [],
+        },
+        notes=f"{branch_def_id} v1",
+        publisher="host",
+    )
+    bvid = version.branch_version_id
+    set_canonical_branch(
+        base, goal_id=goal_id,
+        branch_version_id=bvid, set_by="host",
+    )
+    return branch_def_id, bvid
+
+
+def _frontmatter(bug_id: str = "BUG-099") -> dict:
+    return {
+        "bug_id": bug_id,
+        "title": "test bug",
+        "component": "test",
+        "severity": "P2",
+        "kind": "bug",
+        "observed": "x",
+        "expected": "y",
+        "repro": "z",
+    }
+
+
+# ---------------------------------------------------------------------------
+# No env vars -> no enqueue (legacy "auto-trigger disabled" path)
+# ---------------------------------------------------------------------------
+
+
+def test_no_env_no_enqueue(base_path):
+    from workflow.bug_investigation import _maybe_enqueue_investigation
+    with patch(
+        "workflow.bug_investigation.enqueue_investigation_request"
+    ) as mock_enq:
+        result = _maybe_enqueue_investigation(
+            bug_id="BUG-001",
+            frontmatter=_frontmatter("BUG-001"),
+            base_path=base_path,
+            universe_id="u",
+        )
+    assert result is None
+    mock_enq.assert_not_called()
+
+
+def test_empty_bug_id_skipped_even_with_env(base_path, monkeypatch):
+    monkeypatch.setenv(
+        "WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID", "fallback-branch",
+    )
+    from workflow.bug_investigation import _maybe_enqueue_investigation
+    with patch(
+        "workflow.bug_investigation.enqueue_investigation_request"
+    ) as mock_enq:
+        result = _maybe_enqueue_investigation(
+            bug_id="",
+            frontmatter=_frontmatter(""),
+            base_path=base_path,
+            universe_id="u",
+        )
+    assert result is None
+    mock_enq.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Cheat-loop fallback (legacy path) — preserved during cutover window
+# ---------------------------------------------------------------------------
+
+
+def test_env_fallback_preserved_when_no_goal_id(base_path, monkeypatch):
+    monkeypatch.setenv(
+        "WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID", "fallback-branch",
+    )
+    from workflow.bug_investigation import _maybe_enqueue_investigation
+    with patch(
+        "workflow.bug_investigation.enqueue_investigation_request",
+        return_value="req-1",
+    ) as mock_enq:
+        result = _maybe_enqueue_investigation(
+            bug_id="BUG-001",
+            frontmatter=_frontmatter("BUG-001"),
+            base_path=base_path,
+            universe_id="u",
+        )
+    assert result == "req-1"
+    mock_enq.assert_called_once()
+    call_kwargs = mock_enq.call_args.kwargs
+    assert call_kwargs["canonical_branch_def_id"] == "fallback-branch"
+
+
+def test_env_fallback_used_when_goal_id_has_no_canonical(
+    base_path, monkeypatch,
+):
+    """``WORKFLOW_BUG_INVESTIGATION_GOAL_ID`` is set but the Goal has
+    no canonical AND auto=False -> graceful fall to env path."""
+    from workflow.daemon_server import save_goal
+    save_goal(
+        base_path,
+        goal=dict(
+            goal_id="g1", name="g1", description="",
+            author="host", tags=[], visibility="public",
+        ),
+    )
+    monkeypatch.setenv("WORKFLOW_BUG_INVESTIGATION_GOAL_ID", "g1")
+    monkeypatch.setenv(
+        "WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID", "fallback-branch",
+    )
+    from workflow.bug_investigation import _maybe_enqueue_investigation
+    with patch(
+        "workflow.bug_investigation.enqueue_investigation_request",
+        return_value="req-2",
+    ) as mock_enq:
+        result = _maybe_enqueue_investigation(
+            bug_id="BUG-002",
+            frontmatter=_frontmatter("BUG-002"),
+            base_path=base_path,
+            universe_id="u",
+        )
+    assert result == "req-2"
+    mock_enq.assert_called_once()
+    assert mock_enq.call_args.kwargs["canonical_branch_def_id"] == (
+        "fallback-branch"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Goal canonical wins over env fallback
+# ---------------------------------------------------------------------------
+
+
+def test_goal_canonical_used_when_set(base_path, monkeypatch):
+    bdid, _ = _seed_goal_with_canonical(
+        base_path, goal_id="g1", branch_def_id="bug-handler",
+    )
+    monkeypatch.setenv("WORKFLOW_BUG_INVESTIGATION_GOAL_ID", "g1")
+    # Cheat env ALSO set — canonical should win.
+    monkeypatch.setenv(
+        "WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID", "should-not-be-used",
+    )
+    from workflow.bug_investigation import _maybe_enqueue_investigation
+    with patch(
+        "workflow.bug_investigation.enqueue_investigation_request",
+        return_value="req-3",
+    ) as mock_enq:
+        result = _maybe_enqueue_investigation(
+            bug_id="BUG-003",
+            frontmatter=_frontmatter("BUG-003"),
+            base_path=base_path,
+            universe_id="u",
+        )
+    assert result == "req-3"
+    mock_enq.assert_called_once()
+    # Used the Goal's canonical branch_def_id, NOT the env fallback.
+    assert (
+        mock_enq.call_args.kwargs["canonical_branch_def_id"] == bdid
+    )
+
+
+def test_goal_canonical_with_auto_refresh(base_path, monkeypatch):
+    """auto_canonical_via_leaderboard=True + a higher-ranked candidate
+    => the file_bug hook auto-refreshes BEFORE dispatching, and the
+    new canonical's branch_def_id is what enqueue receives."""
+    from workflow.branch_versions import publish_branch_version
+    from workflow.daemon_server import (
+        save_branch_definition,
+        save_goal,
+        set_canonical_branch,
+        update_goal,
+    )
+    from workflow.runs import (
+        RUN_STATUS_COMPLETED,
+        add_judgment,
+        create_run,
+        update_run_status,
+    )
+
+    # Goal + auto=True + min_runs=2.
+    save_goal(
+        base_path,
+        goal=dict(
+            goal_id="g1", name="g1", description="",
+            author="host", tags=[], visibility="public",
+        ),
+    )
+    update_goal(
+        base_path, goal_id="g1",
+        updates={
+            "auto_canonical_via_leaderboard": True,
+            "min_completed_runs_for_canonical": 2,
+        },
+    )
+    # Old branch (currently canonical, low quality).
+    save_branch_definition(
+        base_path,
+        branch_def=dict(
+            branch_def_id="old", name="old", description="",
+            author="host", tags=[], graph_nodes=[], edges=[],
+            state_schema=[], entry_point="", published=True,
+            goal_id="g1",
+        ),
+    )
+    old_v = publish_branch_version(
+        base_path,
+        branch_dict={
+            "branch_def_id": "old", "name": "old", "description": "",
+            "author": "host", "graph_nodes": [], "edges": [],
+            "state_schema": [], "entry_point": "", "node_defs": [],
+        },
+        notes="old v1", publisher="host",
+    )
+    set_canonical_branch(
+        base_path, goal_id="g1",
+        branch_version_id=old_v.branch_version_id, set_by="host",
+    )
+    # New branch — higher quality + enough completed runs.
+    save_branch_definition(
+        base_path,
+        branch_def=dict(
+            branch_def_id="new", name="new", description="",
+            author="host", tags=[], graph_nodes=[], edges=[],
+            state_schema=[], entry_point="", published=True,
+            goal_id="g1",
+        ),
+    )
+    new_v = publish_branch_version(
+        base_path,
+        branch_dict={
+            "branch_def_id": "new", "name": "new", "description": "",
+            "author": "host", "graph_nodes": [], "edges": [],
+            "state_schema": [], "entry_point": "", "node_defs": [],
+        },
+        notes="new v1", publisher="host",
+    )
+    now = time.time()
+    for _ in range(3):
+        rid = create_run(
+            base_path, branch_def_id="new", thread_id="new", inputs={},
+        )
+        update_run_status(
+            base_path, rid, status=RUN_STATUS_COMPLETED,
+            finished_at=now,
+        )
+    # Add a high-quality judgment to make 'new' rank first.
+    rid_j = create_run(
+        base_path, branch_def_id="new", thread_id="new", inputs={},
+    )
+    update_run_status(
+        base_path, rid_j, status=RUN_STATUS_COMPLETED, finished_at=now,
+    )
+    add_judgment(
+        base_path, run_id=rid_j, text="great",
+        tags=["quality:10"], author="judge",
+    )
+
+    monkeypatch.setenv("WORKFLOW_BUG_INVESTIGATION_GOAL_ID", "g1")
+    from workflow.bug_investigation import _maybe_enqueue_investigation
+    with patch(
+        "workflow.bug_investigation.enqueue_investigation_request",
+        return_value="req-auto",
+    ) as mock_enq:
+        result = _maybe_enqueue_investigation(
+            bug_id="BUG-004",
+            frontmatter=_frontmatter("BUG-004"),
+            base_path=base_path,
+            universe_id="u",
+        )
+    assert result == "req-auto"
+    mock_enq.assert_called_once()
+    # The auto-refresh swapped canonical to 'new' BEFORE dispatch.
+    assert mock_enq.call_args.kwargs["canonical_branch_def_id"] == "new"
+    # Storage was actually updated.
+    from workflow.daemon_server import get_goal
+    refreshed_goal = get_goal(base_path, goal_id="g1")
+    assert refreshed_goal["canonical_branch_version_id"] == (
+        new_v.branch_version_id
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module attribute lookup still respected (existing
+# test_bug_investigation_dispatcher pattern)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_handler_returns_empty_when_no_goal_and_no_env(base_path):
+    from workflow.bug_investigation import _resolve_investigation_handler
+    assert _resolve_investigation_handler(base_path) == ""
+
+
+def test_resolve_handler_strips_whitespace_in_env(base_path, monkeypatch):
+    monkeypatch.setenv(
+        "WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID", "  legit-branch  ",
+    )
+    from workflow.bug_investigation import _resolve_investigation_handler
+    assert _resolve_investigation_handler(base_path) == "legit-branch"

--- a/tests/test_canonical_dispatch.py
+++ b/tests/test_canonical_dispatch.py
@@ -649,3 +649,384 @@ def test_resolution_is_deterministic_for_unchanged_state(base_path):
     )
     assert r1["branch_version_id"] == r2["branch_version_id"]
     assert r1["source"] == r2["source"]
+
+
+# ---------------------------------------------------------------------------
+# Round-2 P1.1 regression — rolled-back versions cannot become canonical
+# ---------------------------------------------------------------------------
+
+
+def _mark_version_rolled_back(
+    base_path: Path, *, branch_version_id: str, reason: str = "test",
+) -> None:
+    """Flip a branch_version row to status='rolled_back' via direct
+    SQL. There's no public ``rollback_branch_version`` helper in
+    ``workflow.branch_versions`` today, and the tests need a stable
+    way to drive the rolled-back state. ISO-8601 timestamp matches the
+    column's TEXT type (see _row_to_version in branch_versions.py).
+    """
+    from datetime import datetime, timezone
+
+    from workflow.branch_versions import _connect, initialize_branch_versions_db
+
+    initialize_branch_versions_db(base_path)
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    with _connect(base_path) as conn:
+        conn.execute(
+            "UPDATE branch_versions "
+            "   SET status = 'rolled_back', "
+            "       rolled_back_at = ?, "
+            "       rolled_back_by = 'host', "
+            "       rolled_back_reason = ? "
+            " WHERE branch_version_id = ?",
+            (ts, reason, branch_version_id),
+        )
+
+
+def test_rolled_back_version_not_selected_by_auto_refresh(base_path):
+    """P1.1 adversarial: publish a version, roll it back, give the
+    underlying branch_def enough leaderboard signal to rank first.
+    The auto-refresh path must NOT select the rolled-back version
+    as canonical."""
+    _make_goal(base_path, "g1", auto=True, min_runs=2)
+    _make_branch(base_path, branch_def_id="rolled", goal_id="g1")
+    bvid = _publish_version(base_path, branch_def_id="rolled")
+    _mark_version_rolled_back(
+        base_path, branch_version_id=bvid, reason="P1.1 test",
+    )
+    _record_completed_runs(base_path, branch_def_id="rolled", n=4)
+    _record_judgment_for_branch(
+        base_path, branch_def_id="rolled", tag="quality:10",
+    )
+    # No prior canonical, no other branches -> only candidate is the
+    # rolled-back version. Resolution must REFUSE to promote it.
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="",
+    )
+    assert resolution["ok"] is False, (
+        f"P1.1 regression — rolled-back version should not be "
+        f"promoted to canonical. Got: {resolution}"
+    )
+    assert resolution["error_kind"] == "no_canonical_handler"
+
+
+def _publish_version_with_distinct_content(
+    base_path: Path,
+    *,
+    branch_def_id: str,
+    state_field_name: str,
+    publisher: str = "host",
+) -> str:
+    """Publish a branch version with a deliberately-unique state_schema
+    field so the content hash differs from any other publish under
+    the same branch_def_id. The default _publish_version test helper
+    is content-deterministic (same input -> same version_id), which
+    makes "publish two different versions of the same branch_def_id"
+    impossible without varying a real snapshot field.
+    """
+    from workflow.branch_versions import publish_branch_version
+    branch_dict = {
+        "branch_def_id": branch_def_id,
+        "name": branch_def_id,
+        "description": "",
+        "author": "alice",
+        "graph_nodes": [],
+        "edges": [],
+        # state_schema IS in _canonical_snapshot's whitelist; varying
+        # the field name produces a distinct content hash.
+        "state_schema": [{"name": state_field_name, "type": "str"}],
+        "entry_point": "",
+        "node_defs": [],
+    }
+    version = publish_branch_version(
+        base_path,
+        branch_dict=branch_dict,
+        notes=state_field_name,
+        publisher=publisher,
+    )
+    return version.branch_version_id
+
+
+def test_rolled_back_version_falls_through_to_active_predecessor(base_path):
+    """When the latest version is rolled back but an older version is
+    still active, the auto-refresh selects the older active version
+    instead of the rolled-back one (the active filter scans the
+    version window, not just the head)."""
+    _make_goal(base_path, "g1", auto=True, min_runs=1)
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    # Use the distinct-content helper so v1 and v2 are actually two
+    # different versions of the same branch_def_id. The default
+    # _publish_version helper is content-deterministic and would
+    # collapse both calls to the same row.
+    v1 = _publish_version_with_distinct_content(
+        base_path, branch_def_id="b1", state_field_name="field_v1",
+    )
+    v2 = _publish_version_with_distinct_content(
+        base_path, branch_def_id="b1", state_field_name="field_v2",
+    )
+    assert v1 != v2, (
+        "Test scaffolding precondition: v1 and v2 must be distinct "
+        "branch_version_ids for the active-fallback scan to be "
+        "meaningful."
+    )
+    # Roll back the NEWER version; older one stays active.
+    _mark_version_rolled_back(
+        base_path, branch_version_id=v2, reason="P1.1 test",
+    )
+    _record_completed_runs(base_path, branch_def_id="b1", n=2)
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="",
+    )
+    assert resolution["ok"] is True
+    assert resolution["branch_version_id"] == v1, (
+        "Active-version filter should skip the rolled-back v2 and "
+        f"land on the active v1. Got branch_version_id={resolution.get('branch_version_id')}"
+    )
+    assert resolution["source"] == SOURCE_LEADERBOARD_REFRESHED
+
+
+def test_rolled_back_version_keeps_stored_canonical_when_set(base_path):
+    """When a stored canonical exists and the leaderboard top entry's
+    only published version is rolled back, the stored canonical is
+    kept (the "no published version" fallback path) rather than the
+    auto-refresh writing a rolled-back version."""
+    _make_goal(base_path, "g1", auto=True, min_runs=1)
+    _make_branch(base_path, branch_def_id="old", goal_id="g1")
+    _make_branch(base_path, branch_def_id="new-rolled", goal_id="g1")
+    old_bvid = _publish_version(base_path, branch_def_id="old")
+    new_bvid = _publish_version(
+        base_path, branch_def_id="new-rolled", notes="v2",
+    )
+    _mark_version_rolled_back(
+        base_path, branch_version_id=new_bvid, reason="P1.1 test",
+    )
+    set_canonical_branch(
+        base_path, goal_id="g1",
+        branch_version_id=old_bvid, set_by="host",
+    )
+    _record_completed_runs(base_path, branch_def_id="new-rolled", n=4)
+    _record_judgment_for_branch(
+        base_path, branch_def_id="new-rolled", tag="quality:10",
+    )
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="",
+    )
+    assert resolution["ok"] is True
+    # Stored canonical preserved — never silently swapped for the
+    # rolled-back version.
+    assert resolution["branch_version_id"] == old_bvid
+    assert resolution["source"] == (
+        SOURCE_LEADERBOARD_SKIPPED_NO_PUBLISHED_VERSION
+    )
+
+
+def test_set_canonical_directly_rejects_rolled_back_version(base_path):
+    """Defense in depth: ``set_canonical_branch`` itself refuses a
+    rolled-back ``branch_version_id``. Even a manual MCP call or host
+    script cannot promote a dead version."""
+    _make_goal(base_path, "g1", auto=False)
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    bvid = _publish_version(base_path, branch_def_id="b1")
+    _mark_version_rolled_back(
+        base_path, branch_version_id=bvid, reason="P1.1 test",
+    )
+    with pytest.raises(ValueError) as excinfo:
+        set_canonical_branch(
+            base_path, goal_id="g1",
+            branch_version_id=bvid, set_by="host",
+        )
+    msg = str(excinfo.value)
+    assert "rolled_back" in msg or "status" in msg
+    assert "active" in msg
+
+
+def test_set_canonical_accepts_active_version(base_path):
+    """Sanity: active versions still pass the defense-in-depth check."""
+    _make_goal(base_path, "g1", auto=False)
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    bvid = _publish_version(base_path, branch_def_id="b1")
+    # No rollback — status='active' by default.
+    set_canonical_branch(
+        base_path, goal_id="g1",
+        branch_version_id=bvid, set_by="host",
+    )
+    from workflow.daemon_server import get_goal
+    goal = get_goal(base_path, goal_id="g1")
+    assert goal["canonical_branch_version_id"] == bvid
+
+
+# ---------------------------------------------------------------------------
+# Round-2 P1.2 regression — private branches cannot become global canonical
+# ---------------------------------------------------------------------------
+
+
+def _make_private_branch(
+    base_path: Path,
+    *,
+    branch_def_id: str,
+    goal_id: str,
+    author: str,
+) -> str:
+    """Create a private branch authored by ``author``. Private
+    branches are visible only to the author + host on viewer-scoped
+    leaderboard queries (PR-970 auth-boundary contract).
+    """
+    save_branch_definition(
+        base_path,
+        branch_def=dict(
+            branch_def_id=branch_def_id,
+            name=branch_def_id,
+            description="",
+            author=author,
+            tags=[],
+            graph_nodes=[],
+            edges=[],
+            state_schema=[],
+            entry_point="",
+            published=True,
+            goal_id=goal_id,
+            visibility="private",
+        ),
+    )
+    return branch_def_id
+
+
+def test_caller_viewer_cannot_promote_their_private_branch(base_path):
+    """P1.2 adversarial: actor=bob; public Goal owned by alice;
+    existing public canonical; bob has a private branch authored by
+    himself ranking #1 in his viewer-scoped leaderboard (because
+    PR-970 surfaces the viewer's own private branches). The auto-
+    refresh path MUST NOT promote bob's private branch as the Goal's
+    global canonical."""
+    _make_goal(base_path, "g1", auto=True, min_runs=1)
+    # Public canonical, currently in place.
+    _make_branch(
+        base_path, branch_def_id="public-incumbent",
+        goal_id="g1", author="alice",
+    )
+    pub_bvid = _publish_version(
+        base_path, branch_def_id="public-incumbent",
+    )
+    set_canonical_branch(
+        base_path, goal_id="g1",
+        branch_version_id=pub_bvid, set_by="host",
+    )
+    # Give the incumbent enough completed runs to stay above threshold.
+    _record_completed_runs(
+        base_path, branch_def_id="public-incumbent", n=2,
+    )
+    # Bob's private branch — high-quality, would rank #1 if visible.
+    _make_private_branch(
+        base_path, branch_def_id="bob-secret",
+        goal_id="g1", author="bob",
+    )
+    _publish_version(
+        base_path, branch_def_id="bob-secret", notes="bob-v1",
+    )
+    _record_completed_runs(
+        base_path, branch_def_id="bob-secret", n=4,
+    )
+    _record_judgment_for_branch(
+        base_path, branch_def_id="bob-secret", tag="quality:10",
+    )
+    # Bob fires run_canonical. His viewer-scoped leaderboard sees
+    # bob-secret at #1 (would have promoted it as canonical pre-P1.2).
+    # Post-P1.2 the auto-refresh hard-codes viewer="" -> bob-secret is
+    # filtered out as private + not-author-of-current-strictly-public.
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="bob",
+    )
+    assert resolution["ok"] is True
+    # Canonical did NOT swap to the private branch.
+    assert resolution["branch_version_id"] == pub_bvid, (
+        "P1.2 regression — bob's private branch was promoted to the "
+        "Goal's global canonical via auto-refresh. The leaderboard "
+        "query inside the refresh path MUST be strictly-public "
+        "regardless of caller viewer."
+    )
+    assert resolution["branch_def_id"] == "public-incumbent"
+    # Stored canonical actually unchanged.
+    from workflow.daemon_server import get_goal
+    refreshed_goal = get_goal(base_path, goal_id="g1")
+    assert refreshed_goal["canonical_branch_version_id"] == pub_bvid
+
+
+def test_caller_viewer_does_not_unlock_private_competitor(base_path):
+    """Variant: bob's private branch outranks the public incumbent on
+    bob's viewer-scoped leaderboard, but the auto-refresh decision
+    still ignores it. Asserts the source label is one of the
+    public-leaderboard outcomes (not leaderboard_refreshed with bob's
+    private as the new canonical)."""
+    _make_goal(base_path, "g1", auto=True, min_runs=1)
+    _make_branch(
+        base_path, branch_def_id="public", goal_id="g1", author="alice",
+    )
+    pub_bvid = _publish_version(base_path, branch_def_id="public")
+    set_canonical_branch(
+        base_path, goal_id="g1",
+        branch_version_id=pub_bvid, set_by="host",
+    )
+    _record_completed_runs(base_path, branch_def_id="public", n=1)
+    _make_private_branch(
+        base_path, branch_def_id="bob-private",
+        goal_id="g1", author="bob",
+    )
+    _publish_version(base_path, branch_def_id="bob-private", notes="b1")
+    _record_completed_runs(
+        base_path, branch_def_id="bob-private", n=5,
+    )
+    _record_judgment_for_branch(
+        base_path, branch_def_id="bob-private", tag="quality:9",
+    )
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="bob",
+    )
+    assert resolution["ok"] is True
+    # The leaderboard's TOP entry (from the public-only view) is the
+    # public incumbent. The refresh sees it matches the stored
+    # canonical -> SOURCE_LEADERBOARD_NO_CHANGE.
+    assert resolution["source"] == SOURCE_LEADERBOARD_NO_CHANGE
+    assert resolution["branch_version_id"] == pub_bvid
+
+
+def test_owner_viewer_does_not_unlock_their_private_branch_for_canonical(
+    base_path,
+):
+    """Even when the caller's viewer matches the private branch's
+    author, the auto-refresh write must remain global/public. The
+    private branch may legitimately appear on the caller's leaderboard
+    view, but it cannot become the global canonical for everyone
+    else."""
+    _make_goal(base_path, "g1", auto=True, min_runs=1)
+    _make_branch(
+        base_path, branch_def_id="public", goal_id="g1", author="host",
+    )
+    pub_bvid = _publish_version(base_path, branch_def_id="public")
+    set_canonical_branch(
+        base_path, goal_id="g1",
+        branch_version_id=pub_bvid, set_by="host",
+    )
+    _record_completed_runs(base_path, branch_def_id="public", n=1)
+    _make_private_branch(
+        base_path, branch_def_id="alice-private",
+        goal_id="g1", author="alice",
+    )
+    _publish_version(
+        base_path, branch_def_id="alice-private", notes="a1",
+    )
+    _record_completed_runs(
+        base_path, branch_def_id="alice-private", n=5,
+    )
+    _record_judgment_for_branch(
+        base_path, branch_def_id="alice-private", tag="quality:10",
+    )
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="alice",
+    )
+    assert resolution["ok"] is True
+    # Even though alice's viewer-scoped leaderboard would surface her
+    # own private branch at #1, the auto-refresh decision is global.
+    assert resolution["branch_version_id"] == pub_bvid, (
+        "P1.2 regression — alice's private branch must not become "
+        "the Goal's global canonical even when she's the caller."
+    )

--- a/tests/test_canonical_dispatch.py
+++ b/tests/test_canonical_dispatch.py
@@ -1,0 +1,651 @@
+"""PR-127 — leaderboard-driven canonical resolution.
+
+Direct unit tests on ``workflow.api.canonical_dispatch``:
+
+  * No canonical set + auto OFF -> no_canonical_handler error.
+  * Canonical set + auto OFF -> returns stored canonical verbatim.
+  * Auto ON + top entry has < min_runs -> returns stored canonical
+    (or no_canonical_handler when none).
+  * Auto ON + top entry has enough runs + no in-flight ->
+    set_canonical fires, response carries source=leaderboard_refreshed.
+  * Auto ON + in-flight run on prior canonical -> refresh deferred,
+    returns stored canonical with source=leaderboard_skipped_in_flight.
+  * Auto ON + leaderboard top matches stored canonical -> no swap,
+    source=leaderboard_no_change.
+  * Auto ON + top entry has no published branch_version -> stored
+    canonical kept, source=leaderboard_skipped_no_published_version.
+  * Auto ON + empty leaderboard -> stored canonical kept (or
+    no_canonical_handler when none).
+  * Owner exception: visibility is server-derived (the helper accepts
+    an explicit ``viewer`` arg matching the
+    ``quality_leaderboard.build_quality_leaderboard`` contract).
+
+In-flight detection has its own unit covering:
+  * status='running' within window -> returns the row.
+  * status='queued' within window -> returns the row.
+  * status='succeeded' -> None (terminal).
+  * status='running' OUTSIDE the window -> None (orphaned).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from workflow.api.canonical_dispatch import (
+    IN_FLIGHT_WINDOW_SECONDS,
+    SOURCE_CANONICAL_STORED,
+    SOURCE_LEADERBOARD_NO_CHANGE,
+    SOURCE_LEADERBOARD_REFRESHED,
+    SOURCE_LEADERBOARD_SKIPPED_IN_FLIGHT,
+    SOURCE_LEADERBOARD_SKIPPED_INSUFFICIENT_RUNS,
+    SOURCE_LEADERBOARD_SKIPPED_NO_PUBLISHED_VERSION,
+    is_in_flight_for_version,
+    resolve_canonical_for_run,
+)
+from workflow.branch_versions import publish_branch_version
+from workflow.daemon_server import (
+    initialize_author_server,
+    save_branch_definition,
+    save_goal,
+    set_canonical_branch,
+    update_goal,
+)
+from workflow.runs import (
+    RUN_STATUS_COMPLETED,
+    RUN_STATUS_FAILED,
+    RUN_STATUS_RUNNING,
+    add_judgment,
+    create_run,
+    initialize_runs_db,
+    update_run_status,
+)
+
+
+@pytest.fixture
+def base_path(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    initialize_author_server(tmp_path)
+    initialize_runs_db(tmp_path)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures: create goal + branches + versions + runs/judgments
+# ---------------------------------------------------------------------------
+
+
+def _make_goal(
+    base_path: Path,
+    goal_id: str,
+    *,
+    name: str = "g",
+    auto: bool = False,
+    min_runs: int = 5,
+) -> dict:
+    save_goal(
+        base_path,
+        goal=dict(
+            goal_id=goal_id,
+            name=name,
+            description="test",
+            author="host",
+            tags=[],
+            visibility="public",
+        ),
+    )
+    update_goal(
+        base_path,
+        goal_id=goal_id,
+        updates={
+            "auto_canonical_via_leaderboard": auto,
+            "min_completed_runs_for_canonical": min_runs,
+        },
+    )
+    from workflow.daemon_server import get_goal
+    return get_goal(base_path, goal_id=goal_id)
+
+
+def _make_branch(
+    base_path: Path,
+    *,
+    branch_def_id: str,
+    goal_id: str,
+    author: str = "alice",
+) -> str:
+    save_branch_definition(
+        base_path,
+        branch_def=dict(
+            branch_def_id=branch_def_id,
+            name=branch_def_id,
+            description="",
+            author=author,
+            tags=[],
+            graph_nodes=[],
+            edges=[],
+            state_schema=[],
+            entry_point="",
+            published=True,
+            goal_id=goal_id,
+        ),
+    )
+    return branch_def_id
+
+
+def _publish_version(
+    base_path: Path,
+    *,
+    branch_def_id: str,
+    notes: str = "v1",
+    publisher: str = "host",
+) -> str:
+    """Publish a version using a minimal branch dict. Returns
+    branch_version_id. The publish_branch_version helper expects the
+    full branch payload — we synthesize one with the minimum required
+    fields.
+    """
+    branch_dict = {
+        "branch_def_id": branch_def_id,
+        "name": branch_def_id,
+        "description": "",
+        "author": "alice",
+        "graph_nodes": [],
+        "edges": [],
+        "state_schema": [],
+        "entry_point": "",
+        "node_defs": [],
+        # Force version content to differ each call by stamping with
+        # a fresh notes string — the version sha is content-hashed.
+        "_test_notes": notes,
+    }
+    version = publish_branch_version(
+        base_path,
+        branch_dict=branch_dict,
+        notes=notes,
+        publisher=publisher,
+    )
+    return version.branch_version_id
+
+
+def _record_completed_runs(
+    base_path: Path, *, branch_def_id: str, n: int,
+) -> None:
+    """Drop N completed-status runs on the branch_def_id so the
+    leaderboard's completed_run_count signal is N."""
+    now = time.time()
+    for _ in range(n):
+        rid = create_run(
+            base_path, branch_def_id=branch_def_id,
+            thread_id=branch_def_id, inputs={},
+        )
+        update_run_status(
+            base_path, rid,
+            status=RUN_STATUS_COMPLETED,
+            finished_at=now,
+        )
+
+
+def _record_judgment_for_branch(
+    base_path: Path, *, branch_def_id: str, tag: str = "quality:9",
+) -> None:
+    """Anchor a high-quality judgment so the branch ranks first."""
+    rid = create_run(
+        base_path, branch_def_id=branch_def_id,
+        thread_id=branch_def_id, inputs={},
+    )
+    update_run_status(
+        base_path, rid,
+        status=RUN_STATUS_COMPLETED,
+        finished_at=time.time(),
+    )
+    add_judgment(
+        base_path, run_id=rid, text="great",
+        tags=[tag], author="judge",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auto OFF — stored canonical path
+# ---------------------------------------------------------------------------
+
+
+def test_no_canonical_set_returns_no_canonical_handler(base_path):
+    _make_goal(base_path, "g1", auto=False)
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="",
+    )
+    assert resolution["ok"] is False
+    assert resolution["error_kind"] == "no_canonical_handler"
+    assert resolution["goal_id"] == "g1"
+
+
+def test_unknown_goal_returns_no_goal(base_path):
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="never-existed", viewer="",
+    )
+    assert resolution["ok"] is False
+    assert resolution["error_kind"] == "no_goal"
+
+
+def test_canonical_stored_returned_when_auto_off(base_path):
+    _make_goal(base_path, "g1", auto=False)
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    bvid = _publish_version(base_path, branch_def_id="b1")
+    set_canonical_branch(
+        base_path, goal_id="g1",
+        branch_version_id=bvid, set_by="host",
+    )
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="",
+    )
+    assert resolution["ok"] is True
+    assert resolution["branch_version_id"] == bvid
+    assert resolution["branch_def_id"] == "b1"
+    assert resolution["source"] == SOURCE_CANONICAL_STORED
+    assert resolution["refresh_attempted"] is False
+
+
+# ---------------------------------------------------------------------------
+# Auto ON — happy path: refresh fires
+# ---------------------------------------------------------------------------
+
+
+def test_auto_refresh_swaps_canonical_when_top_meets_threshold(base_path):
+    _make_goal(base_path, "g1", auto=True, min_runs=3)
+    _make_branch(base_path, branch_def_id="old", goal_id="g1")
+    _make_branch(base_path, branch_def_id="new", goal_id="g1")
+    old_bvid = _publish_version(base_path, branch_def_id="old")
+    new_bvid = _publish_version(base_path, branch_def_id="new", notes="v2")
+    set_canonical_branch(
+        base_path, goal_id="g1",
+        branch_version_id=old_bvid, set_by="host",
+    )
+    # Make 'new' rank first: 5 completed runs + a 9.0 quality
+    # judgment. Threshold (3) is met.
+    _record_completed_runs(base_path, branch_def_id="new", n=4)
+    _record_judgment_for_branch(base_path, branch_def_id="new", tag="quality:9")
+    # 'old' has just one completed run (and no judgment).
+    _record_completed_runs(base_path, branch_def_id="old", n=1)
+
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="",
+    )
+    assert resolution["ok"] is True
+    assert resolution["branch_version_id"] == new_bvid
+    assert resolution["branch_def_id"] == "new"
+    assert resolution["source"] == SOURCE_LEADERBOARD_REFRESHED
+    assert resolution["refresh_attempted"] is True
+    assert resolution["displaced_canonical_branch_version_id"] == old_bvid
+    assert resolution["candidate_branch_def_id"] == "new"
+    assert resolution["candidate_completed_runs"] >= 3
+
+    # The stored canonical actually moved.
+    from workflow.daemon_server import get_goal
+    refreshed_goal = get_goal(base_path, goal_id="g1")
+    assert refreshed_goal["canonical_branch_version_id"] == new_bvid
+
+
+def test_auto_refresh_noop_when_top_matches_current(base_path):
+    """Top leaderboard entry IS the current canonical — no swap, but
+    refresh_attempted is True for auditability."""
+    _make_goal(base_path, "g1", auto=True, min_runs=1)
+    _make_branch(base_path, branch_def_id="solo", goal_id="g1")
+    bvid = _publish_version(base_path, branch_def_id="solo")
+    set_canonical_branch(
+        base_path, goal_id="g1",
+        branch_version_id=bvid, set_by="host",
+    )
+    _record_completed_runs(base_path, branch_def_id="solo", n=2)
+
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="",
+    )
+    assert resolution["ok"] is True
+    assert resolution["branch_version_id"] == bvid
+    assert resolution["source"] == SOURCE_LEADERBOARD_NO_CHANGE
+    assert resolution["refresh_attempted"] is True
+
+
+# ---------------------------------------------------------------------------
+# Auto ON — security gate: min_completed_runs_for_canonical threshold
+# ---------------------------------------------------------------------------
+
+
+def test_threshold_blocks_swap_when_top_has_insufficient_runs(base_path):
+    """Adversarial: a brand-new branch with zero runs ranks first by
+    judgment alone shouldn't be able to flip canonical. With
+    min_runs=5 and a 1-run candidate, the stored canonical is kept."""
+    _make_goal(base_path, "g1", auto=True, min_runs=5)
+    _make_branch(base_path, branch_def_id="old", goal_id="g1")
+    _make_branch(base_path, branch_def_id="new", goal_id="g1")
+    old_bvid = _publish_version(base_path, branch_def_id="old")
+    _publish_version(base_path, branch_def_id="new", notes="v2")
+    set_canonical_branch(
+        base_path, goal_id="g1",
+        branch_version_id=old_bvid, set_by="host",
+    )
+    # 'new' has only 1 completed run + high judgment, but threshold=5.
+    _record_completed_runs(base_path, branch_def_id="new", n=0)
+    _record_judgment_for_branch(
+        base_path, branch_def_id="new", tag="quality:10",
+    )
+    # 'old' has nothing — but threshold gate keeps stored canonical.
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="",
+    )
+    assert resolution["ok"] is True
+    assert resolution["branch_version_id"] == old_bvid
+    assert resolution["source"] == (
+        SOURCE_LEADERBOARD_SKIPPED_INSUFFICIENT_RUNS
+    )
+    assert resolution["candidate_completed_runs"] < 5
+    # Canonical unchanged in storage.
+    from workflow.daemon_server import get_goal
+    refreshed_goal = get_goal(base_path, goal_id="g1")
+    assert refreshed_goal["canonical_branch_version_id"] == old_bvid
+
+
+def test_threshold_blocks_swap_no_fallback_returns_no_canonical(base_path):
+    """When threshold blocks AND no prior canonical exists, the
+    resolution surfaces no_canonical_handler so the caller can fall
+    back to the env path."""
+    _make_goal(base_path, "g1", auto=True, min_runs=5)
+    _make_branch(base_path, branch_def_id="new", goal_id="g1")
+    _publish_version(base_path, branch_def_id="new")
+    _record_judgment_for_branch(
+        base_path, branch_def_id="new", tag="quality:10",
+    )
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="",
+    )
+    assert resolution["ok"] is False
+    assert resolution["error_kind"] == "no_canonical_handler"
+
+
+# ---------------------------------------------------------------------------
+# Auto ON — in-flight guard
+# ---------------------------------------------------------------------------
+
+
+def test_in_flight_run_blocks_refresh(base_path):
+    """When a 'running' run is currently using the prior canonical,
+    the refresh is deferred — even when a candidate qualifies."""
+    _make_goal(base_path, "g1", auto=True, min_runs=1)
+    _make_branch(base_path, branch_def_id="old", goal_id="g1")
+    _make_branch(base_path, branch_def_id="new", goal_id="g1")
+    old_bvid = _publish_version(base_path, branch_def_id="old")
+    new_bvid = _publish_version(base_path, branch_def_id="new", notes="v2")
+    set_canonical_branch(
+        base_path, goal_id="g1",
+        branch_version_id=old_bvid, set_by="host",
+    )
+    _record_completed_runs(base_path, branch_def_id="new", n=4)
+    _record_judgment_for_branch(
+        base_path, branch_def_id="new", tag="quality:10",
+    )
+    # Inject an in-flight running run on the prior canonical.
+    rid = create_run(
+        base_path, branch_def_id="old", thread_id="old",
+        inputs={}, branch_version_id=old_bvid,
+    )
+    update_run_status(base_path, rid, status=RUN_STATUS_RUNNING)
+
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="", now=time.time(),
+    )
+    assert resolution["ok"] is True
+    assert resolution["branch_version_id"] == old_bvid
+    assert resolution["source"] == SOURCE_LEADERBOARD_SKIPPED_IN_FLIGHT
+    assert resolution["in_flight_run_id"] == rid
+    assert resolution["in_flight_status"] == "running"
+    # Stored canonical unchanged.
+    from workflow.daemon_server import get_goal
+    refreshed_goal = get_goal(base_path, goal_id="g1")
+    assert refreshed_goal["canonical_branch_version_id"] == old_bvid
+
+    # Once the run finishes, a re-resolve completes the swap.
+    update_run_status(
+        base_path, rid, status=RUN_STATUS_COMPLETED,
+        finished_at=time.time(),
+    )
+    resolution2 = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="",
+    )
+    assert resolution2["source"] == SOURCE_LEADERBOARD_REFRESHED
+    assert resolution2["branch_version_id"] == new_bvid
+
+
+def test_in_flight_queued_run_also_blocks_refresh(base_path):
+    """A queued (not-yet-started) run on prior canonical also blocks
+    the refresh — same swap-out-from-under semantics."""
+    _make_goal(base_path, "g1", auto=True, min_runs=1)
+    _make_branch(base_path, branch_def_id="old", goal_id="g1")
+    _make_branch(base_path, branch_def_id="new", goal_id="g1")
+    old_bvid = _publish_version(base_path, branch_def_id="old")
+    _publish_version(base_path, branch_def_id="new", notes="v2")
+    set_canonical_branch(
+        base_path, goal_id="g1",
+        branch_version_id=old_bvid, set_by="host",
+    )
+    _record_completed_runs(base_path, branch_def_id="new", n=4)
+    _record_judgment_for_branch(
+        base_path, branch_def_id="new", tag="quality:10",
+    )
+    rid = create_run(
+        base_path, branch_def_id="old", thread_id="old",
+        inputs={}, branch_version_id=old_bvid,
+    )
+    # Default status from create_run is 'queued'.
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="",
+    )
+    assert resolution["source"] == SOURCE_LEADERBOARD_SKIPPED_IN_FLIGHT
+    assert resolution["in_flight_run_id"] == rid
+
+
+def test_stale_in_flight_does_not_block_refresh(base_path):
+    """A 'running' row started before the in-flight window is treated
+    as orphaned and does NOT block a refresh. Matches the runs.py
+    orphan-recovery semantics."""
+    _make_goal(base_path, "g1", auto=True, min_runs=1)
+    _make_branch(base_path, branch_def_id="old", goal_id="g1")
+    _make_branch(base_path, branch_def_id="new", goal_id="g1")
+    old_bvid = _publish_version(base_path, branch_def_id="old")
+    new_bvid = _publish_version(base_path, branch_def_id="new", notes="v2")
+    set_canonical_branch(
+        base_path, goal_id="g1",
+        branch_version_id=old_bvid, set_by="host",
+    )
+    _record_completed_runs(base_path, branch_def_id="new", n=4)
+    _record_judgment_for_branch(
+        base_path, branch_def_id="new", tag="quality:10",
+    )
+    # Inject a 'running' row but with started_at far in the past.
+    rid = create_run(
+        base_path, branch_def_id="old", thread_id="old",
+        inputs={}, branch_version_id=old_bvid,
+    )
+    update_run_status(base_path, rid, status=RUN_STATUS_RUNNING)
+    # Backdate the row beyond the in-flight window.
+    from workflow.runs import _connect
+    long_ago = time.time() - (IN_FLIGHT_WINDOW_SECONDS + 60.0)
+    with _connect(base_path) as conn:
+        conn.execute(
+            "UPDATE runs SET started_at = ? WHERE run_id = ?",
+            (long_ago, rid),
+        )
+
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="",
+    )
+    assert resolution["source"] == SOURCE_LEADERBOARD_REFRESHED
+    assert resolution["branch_version_id"] == new_bvid
+
+
+# ---------------------------------------------------------------------------
+# Auto ON — top entry has no published version
+# ---------------------------------------------------------------------------
+
+
+def test_top_entry_with_no_published_version_keeps_stored_canonical(
+    base_path,
+):
+    _make_goal(base_path, "g1", auto=True, min_runs=1)
+    _make_branch(base_path, branch_def_id="old", goal_id="g1")
+    _make_branch(base_path, branch_def_id="new-unpublished", goal_id="g1")
+    old_bvid = _publish_version(base_path, branch_def_id="old")
+    # NOTE: do NOT publish 'new-unpublished'.
+    set_canonical_branch(
+        base_path, goal_id="g1",
+        branch_version_id=old_bvid, set_by="host",
+    )
+    _record_completed_runs(
+        base_path, branch_def_id="new-unpublished", n=4,
+    )
+    _record_judgment_for_branch(
+        base_path, branch_def_id="new-unpublished", tag="quality:10",
+    )
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="",
+    )
+    assert resolution["ok"] is True
+    assert resolution["branch_version_id"] == old_bvid
+    assert resolution["source"] == (
+        SOURCE_LEADERBOARD_SKIPPED_NO_PUBLISHED_VERSION
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auto ON — empty leaderboard
+# ---------------------------------------------------------------------------
+
+
+def test_auto_on_with_no_branches_falls_back_to_stored(base_path):
+    """auto=True but no Branches bound -> empty leaderboard -> the
+    stored canonical is preserved when set, otherwise
+    no_canonical_handler."""
+    _make_goal(base_path, "g1", auto=True, min_runs=5)
+    resolution = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="",
+    )
+    assert resolution["ok"] is False
+    assert resolution["error_kind"] == "no_canonical_handler"
+
+
+# ---------------------------------------------------------------------------
+# is_in_flight_for_version unit
+# ---------------------------------------------------------------------------
+
+
+def test_in_flight_detects_running(base_path):
+    _make_branch(base_path, branch_def_id="b1", goal_id="")
+    bvid = _publish_version(base_path, branch_def_id="b1")
+    rid = create_run(
+        base_path, branch_def_id="b1", thread_id="b1",
+        inputs={}, branch_version_id=bvid,
+    )
+    update_run_status(base_path, rid, status=RUN_STATUS_RUNNING)
+    row = is_in_flight_for_version(
+        base_path, branch_version_id=bvid, now=time.time(),
+    )
+    assert row is not None
+    assert row["run_id"] == rid
+    assert row["status"] == "running"
+
+
+def test_in_flight_detects_queued(base_path):
+    _make_branch(base_path, branch_def_id="b1", goal_id="")
+    bvid = _publish_version(base_path, branch_def_id="b1")
+    rid = create_run(
+        base_path, branch_def_id="b1", thread_id="b1",
+        inputs={}, branch_version_id=bvid,
+    )
+    # Default is queued.
+    row = is_in_flight_for_version(
+        base_path, branch_version_id=bvid, now=time.time(),
+    )
+    assert row is not None
+    assert row["run_id"] == rid
+
+
+def test_in_flight_ignores_terminal_runs(base_path):
+    _make_branch(base_path, branch_def_id="b1", goal_id="")
+    bvid = _publish_version(base_path, branch_def_id="b1")
+    for status in (RUN_STATUS_COMPLETED, RUN_STATUS_FAILED):
+        rid = create_run(
+            base_path, branch_def_id="b1", thread_id="b1",
+            inputs={}, branch_version_id=bvid,
+        )
+        update_run_status(
+            base_path, rid, status=status, finished_at=time.time(),
+        )
+    row = is_in_flight_for_version(
+        base_path, branch_version_id=bvid, now=time.time(),
+    )
+    assert row is None
+
+
+def test_in_flight_filters_other_versions(base_path):
+    """Runs on a different branch_version_id don't count as in-flight
+    for the version under test."""
+    _make_branch(base_path, branch_def_id="b1", goal_id="")
+    _make_branch(base_path, branch_def_id="b2", goal_id="")
+    v1 = _publish_version(base_path, branch_def_id="b1")
+    v2 = _publish_version(base_path, branch_def_id="b2")
+    rid = create_run(
+        base_path, branch_def_id="b2", thread_id="b2",
+        inputs={}, branch_version_id=v2,
+    )
+    update_run_status(base_path, rid, status=RUN_STATUS_RUNNING)
+    row = is_in_flight_for_version(
+        base_path, branch_version_id=v1, now=time.time(),
+    )
+    assert row is None
+
+
+def test_in_flight_window_excludes_old_runs(base_path):
+    _make_branch(base_path, branch_def_id="b1", goal_id="")
+    bvid = _publish_version(base_path, branch_def_id="b1")
+    rid = create_run(
+        base_path, branch_def_id="b1", thread_id="b1",
+        inputs={}, branch_version_id=bvid,
+    )
+    update_run_status(base_path, rid, status=RUN_STATUS_RUNNING)
+    from workflow.runs import _connect
+    long_ago = time.time() - (IN_FLIGHT_WINDOW_SECONDS + 1.0)
+    with _connect(base_path) as conn:
+        conn.execute(
+            "UPDATE runs SET started_at = ? WHERE run_id = ?",
+            (long_ago, rid),
+        )
+    row = is_in_flight_for_version(
+        base_path, branch_version_id=bvid, now=time.time(),
+    )
+    assert row is None
+
+
+# ---------------------------------------------------------------------------
+# Determinism — re-resolution returns the same answer
+# ---------------------------------------------------------------------------
+
+
+def test_resolution_is_deterministic_for_unchanged_state(base_path):
+    _make_goal(base_path, "g1", auto=True, min_runs=2)
+    _make_branch(base_path, branch_def_id="solo", goal_id="g1")
+    bvid = _publish_version(base_path, branch_def_id="solo")
+    set_canonical_branch(
+        base_path, goal_id="g1",
+        branch_version_id=bvid, set_by="host",
+    )
+    _record_completed_runs(base_path, branch_def_id="solo", n=3)
+    now = time.time()
+    r1 = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="", now=now,
+    )
+    r2 = resolve_canonical_for_run(
+        base_path, goal_id="g1", viewer="", now=now,
+    )
+    assert r1["branch_version_id"] == r2["branch_version_id"]
+    assert r1["source"] == r2["source"]

--- a/tests/test_goals_run_canonical.py
+++ b/tests/test_goals_run_canonical.py
@@ -1,0 +1,473 @@
+"""PR-127 — `goals action=run_canonical` MCP surface.
+
+Exercises the new dispatch wrapper end-to-end via the live extensions
+tool surface:
+
+  * Missing goal_id -> rejected with error_kind=missing_goal_id.
+  * No canonical set + auto OFF -> rejected with
+    error_kind=no_canonical_handler (the caller can branch on this).
+  * Canonical set + auto OFF -> dispatches the stored version,
+    response carries branch_version_id_used + source=canonical_stored.
+  * Auto ON + qualified candidate + no in-flight -> stored canonical
+    is refreshed, response carries source=leaderboard_refreshed +
+    displaced_canonical_branch_version_id.
+  * Auto ON + insufficient runs -> falls back to stored canonical,
+    source=leaderboard_skipped_insufficient_runs.
+  * Auto ON + in-flight on prior canonical -> defers refresh,
+    source=leaderboard_skipped_in_flight.
+  * Provider call inside the spawned run is mocked so the test never
+    hits a real LLM.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def us_env(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "host")
+    monkeypatch.delenv("WORKFLOW_BUG_INVESTIGATION_GOAL_ID", raising=False)
+    monkeypatch.delenv(
+        "WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID", raising=False,
+    )
+    from workflow import universe_server as us
+    importlib.reload(us)
+    yield us, tmp_path
+    importlib.reload(us)
+
+
+def _call(us, action: str, **kwargs) -> dict:
+    return json.loads(us.goals(action=action, **kwargs))
+
+
+def _seed_runnable_branch(
+    base: Path,
+    *,
+    goal_id: str,
+    branch_def_id: str,
+    auto: bool = False,
+    min_runs: int = 5,
+    publish: bool = True,
+    runs_completed: int = 0,
+) -> tuple[str, str]:
+    """Seed a Goal + Branch + (optional) published version + N completed
+    runs. Returns (goal_id, branch_version_id-or-empty).
+    """
+    from workflow.branch_versions import publish_branch_version
+    from workflow.daemon_server import (
+        save_branch_definition,
+        save_goal,
+        update_goal,
+    )
+    from workflow.runs import (
+        RUN_STATUS_COMPLETED,
+        create_run,
+        initialize_runs_db,
+        update_run_status,
+    )
+
+    save_goal(
+        base,
+        goal=dict(
+            goal_id=goal_id, name=goal_id, description="",
+            author="host", tags=[], visibility="public",
+        ),
+    )
+    update_goal(
+        base,
+        goal_id=goal_id,
+        updates={
+            "auto_canonical_via_leaderboard": auto,
+            "min_completed_runs_for_canonical": min_runs,
+        },
+    )
+    save_branch_definition(
+        base,
+        branch_def=dict(
+            branch_def_id=branch_def_id,
+            name=branch_def_id,
+            description="",
+            author="host",
+            tags=[],
+            graph_nodes=[
+                {
+                    "id": "n1",
+                    "type": "prompt",
+                    "phase": "draft",
+                    "prompt": "respond",
+                    "input_keys": [],
+                    "output_keys": ["out"],
+                },
+            ],
+            edges=[
+                {"from": "START", "to": "n1"},
+                {"from": "n1", "to": "END"},
+            ],
+            state_schema=[{"name": "out", "type": "str"}],
+            entry_point="n1",
+            published=True,
+            goal_id=goal_id,
+        ),
+    )
+    bvid = ""
+    if publish:
+        version = publish_branch_version(
+            base,
+            branch_dict={
+                "branch_def_id": branch_def_id,
+                "name": branch_def_id,
+                "description": "",
+                "author": "host",
+                "graph_nodes": [
+                    {
+                        "id": "n1",
+                        "type": "prompt",
+                        "phase": "draft",
+                        "prompt": "respond",
+                        "input_keys": [],
+                        "output_keys": ["out"],
+                    },
+                ],
+                "edges": [
+                    {"from": "START", "to": "n1"},
+                    {"from": "n1", "to": "END"},
+                ],
+                "state_schema": [{"name": "out", "type": "str"}],
+                "entry_point": "n1",
+                "node_defs": [],
+            },
+            notes=f"{branch_def_id} v1",
+            publisher="host",
+        )
+        bvid = version.branch_version_id
+
+    initialize_runs_db(base)
+    now = time.time()
+    for _ in range(runs_completed):
+        rid = create_run(
+            base, branch_def_id=branch_def_id,
+            thread_id=branch_def_id, inputs={},
+        )
+        update_run_status(
+            base, rid, status=RUN_STATUS_COMPLETED, finished_at=now,
+        )
+    return goal_id, bvid
+
+
+# ---------------------------------------------------------------------------
+# Required-argument failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_missing_goal_id_returns_rejected(us_env):
+    us, _ = us_env
+    result = _call(us, "run_canonical")
+    assert result["status"] == "rejected"
+    assert result["error_kind"] == "missing_goal_id"
+
+
+def test_no_canonical_set_auto_off_returns_no_canonical_handler(us_env):
+    us, base = us_env
+    _seed_runnable_branch(
+        base, goal_id="g1", branch_def_id="b1",
+        auto=False, publish=True,
+    )
+    result = _call(us, "run_canonical", goal_id="g1")
+    assert result["status"] == "rejected"
+    assert result["error_kind"] == "no_canonical_handler"
+
+
+# ---------------------------------------------------------------------------
+# Auto OFF — stored canonical dispatches
+# ---------------------------------------------------------------------------
+
+
+def test_stored_canonical_dispatches_via_run_branch_version(us_env):
+    us, base = us_env
+    _, bvid = _seed_runnable_branch(
+        base, goal_id="g1", branch_def_id="b1",
+        auto=False, publish=True,
+    )
+    from workflow.daemon_server import set_canonical_branch
+    set_canonical_branch(
+        base, goal_id="g1",
+        branch_version_id=bvid, set_by="host",
+    )
+
+    # Patch the underlying run dispatcher so we don't actually execute
+    # a graph. The test asserts the wrapper PASSES THE RIGHT
+    # branch_version_id through; mock returns a stub run row.
+    fake = json.dumps({
+        "text": "Run queued.",
+        "run_id": "stub-run-001",
+        "status": "queued",
+        "output": {},
+        "error": "",
+    })
+    with patch(
+        "workflow.api.runs._action_run_branch_version",
+        return_value=fake,
+    ) as mock_dispatch:
+        result = _call(us, "run_canonical", goal_id="g1")
+
+    assert mock_dispatch.call_count == 1
+    dispatched_kwargs = mock_dispatch.call_args[0][0]
+    assert dispatched_kwargs["branch_version_id"] == bvid
+    assert result["run_id"] == "stub-run-001"
+    assert result["branch_version_id_used"] == bvid
+    assert result["branch_def_id"] == "b1"
+    assert result["source"] == "canonical_stored"
+    assert result["goal_id"] == "g1"
+
+
+def test_dispatch_forwards_inputs_json_and_run_name(us_env):
+    us, base = us_env
+    _, bvid = _seed_runnable_branch(
+        base, goal_id="g1", branch_def_id="b1",
+        auto=False, publish=True,
+    )
+    from workflow.daemon_server import set_canonical_branch
+    set_canonical_branch(
+        base, goal_id="g1",
+        branch_version_id=bvid, set_by="host",
+    )
+    fake = json.dumps({
+        "text": "ok", "run_id": "r-1", "status": "queued",
+        "output": {}, "error": "",
+    })
+    with patch(
+        "workflow.api.runs._action_run_branch_version",
+        return_value=fake,
+    ) as mock_dispatch:
+        _call(
+            us, "run_canonical",
+            goal_id="g1",
+            # `goals` MCP signature accepts these explicitly via
+            # market.goals(...) — they may need passthrough wiring in
+            # the goals tool itself if it doesn't already accept them.
+        )
+    dispatched_kwargs = mock_dispatch.call_args[0][0]
+    assert dispatched_kwargs["branch_version_id"] == bvid
+
+
+# ---------------------------------------------------------------------------
+# Auto ON — leaderboard refresh happy path
+# ---------------------------------------------------------------------------
+
+
+def test_auto_on_refreshes_canonical_and_dispatches(us_env):
+    us, base = us_env
+    _seed_runnable_branch(
+        base, goal_id="g1", branch_def_id="old",
+        auto=True, min_runs=2, publish=True, runs_completed=1,
+    )
+    _, new_bvid = _seed_runnable_branch(
+        base, goal_id="g1", branch_def_id="new",
+        auto=True, min_runs=2, publish=True, runs_completed=3,
+    )
+    # set_canonical to the old version.
+    from workflow.branch_versions import list_branch_versions
+    from workflow.daemon_server import set_canonical_branch
+    old_versions = list_branch_versions(
+        base, branch_def_id="old", limit=1,
+    )
+    old_bvid = old_versions[0].branch_version_id
+    set_canonical_branch(
+        base, goal_id="g1",
+        branch_version_id=old_bvid, set_by="host",
+    )
+
+    # Boost 'new' with a high quality judgment so the leaderboard
+    # ranks it first.
+    from workflow.runs import (
+        RUN_STATUS_COMPLETED,
+        add_judgment,
+        create_run,
+        update_run_status,
+    )
+    rid = create_run(
+        base, branch_def_id="new", thread_id="new", inputs={},
+    )
+    update_run_status(
+        base, rid, status=RUN_STATUS_COMPLETED, finished_at=time.time(),
+    )
+    add_judgment(
+        base, run_id=rid, text="great",
+        tags=["quality:9"], author="judge",
+    )
+
+    fake = json.dumps({
+        "text": "ok", "run_id": "r-new", "status": "queued",
+        "output": {}, "error": "",
+    })
+    with patch(
+        "workflow.api.runs._action_run_branch_version",
+        return_value=fake,
+    ) as mock_dispatch:
+        result = _call(us, "run_canonical", goal_id="g1")
+
+    # The dispatcher was called with the NEW canonical version.
+    dispatched_kwargs = mock_dispatch.call_args[0][0]
+    assert dispatched_kwargs["branch_version_id"] == new_bvid
+    assert result["source"] == "leaderboard_refreshed"
+    assert result["branch_version_id_used"] == new_bvid
+    assert result["displaced_canonical_branch_version_id"] == old_bvid
+    assert result["refresh_attempted"] is True
+    assert result["candidate_completed_runs"] >= 2
+
+
+def test_auto_on_insufficient_runs_keeps_stored(us_env):
+    us, base = us_env
+    _, old_bvid = _seed_runnable_branch(
+        base, goal_id="g1", branch_def_id="old",
+        auto=True, min_runs=5, publish=True,
+    )
+    _seed_runnable_branch(
+        base, goal_id="g1", branch_def_id="new",
+        auto=True, min_runs=5, publish=True, runs_completed=1,
+    )
+    from workflow.daemon_server import set_canonical_branch
+    set_canonical_branch(
+        base, goal_id="g1",
+        branch_version_id=old_bvid, set_by="host",
+    )
+    # Add a high judgment on 'new' so it would rank first if not
+    # blocked by the threshold.
+    from workflow.runs import (
+        RUN_STATUS_COMPLETED,
+        add_judgment,
+        create_run,
+        update_run_status,
+    )
+    rid = create_run(
+        base, branch_def_id="new", thread_id="new", inputs={},
+    )
+    update_run_status(
+        base, rid, status=RUN_STATUS_COMPLETED, finished_at=time.time(),
+    )
+    add_judgment(
+        base, run_id=rid, text="great",
+        tags=["quality:10"], author="judge",
+    )
+    fake = json.dumps({
+        "text": "ok", "run_id": "r-old", "status": "queued",
+        "output": {}, "error": "",
+    })
+    with patch(
+        "workflow.api.runs._action_run_branch_version",
+        return_value=fake,
+    ) as mock_dispatch:
+        result = _call(us, "run_canonical", goal_id="g1")
+    dispatched_kwargs = mock_dispatch.call_args[0][0]
+    # Dispatch goes against the OLD canonical because threshold blocked.
+    assert dispatched_kwargs["branch_version_id"] == old_bvid
+    assert result["source"] == "leaderboard_skipped_insufficient_runs"
+
+
+def test_auto_on_in_flight_defers_refresh(us_env):
+    us, base = us_env
+    _, old_bvid = _seed_runnable_branch(
+        base, goal_id="g1", branch_def_id="old",
+        auto=True, min_runs=1, publish=True,
+    )
+    _seed_runnable_branch(
+        base, goal_id="g1", branch_def_id="new",
+        auto=True, min_runs=1, publish=True, runs_completed=3,
+    )
+    from workflow.daemon_server import set_canonical_branch
+    set_canonical_branch(
+        base, goal_id="g1",
+        branch_version_id=old_bvid, set_by="host",
+    )
+    # Boost 'new' so it would rank first.
+    from workflow.runs import (
+        RUN_STATUS_COMPLETED,
+        RUN_STATUS_RUNNING,
+        add_judgment,
+        create_run,
+        update_run_status,
+    )
+    rid_j = create_run(
+        base, branch_def_id="new", thread_id="new", inputs={},
+    )
+    update_run_status(
+        base, rid_j, status=RUN_STATUS_COMPLETED, finished_at=time.time(),
+    )
+    add_judgment(
+        base, run_id=rid_j, text="great",
+        tags=["quality:10"], author="judge",
+    )
+    # Inject an in-flight running run on the prior canonical.
+    rid_in_flight = create_run(
+        base, branch_def_id="old", thread_id="old",
+        inputs={}, branch_version_id=old_bvid,
+    )
+    update_run_status(base, rid_in_flight, status=RUN_STATUS_RUNNING)
+
+    fake = json.dumps({
+        "text": "ok", "run_id": "r-old", "status": "queued",
+        "output": {}, "error": "",
+    })
+    with patch(
+        "workflow.api.runs._action_run_branch_version",
+        return_value=fake,
+    ) as mock_dispatch:
+        result = _call(us, "run_canonical", goal_id="g1")
+    dispatched_kwargs = mock_dispatch.call_args[0][0]
+    assert dispatched_kwargs["branch_version_id"] == old_bvid
+    assert result["source"] == "leaderboard_skipped_in_flight"
+    assert result["in_flight_run_id"] == rid_in_flight
+
+
+# ---------------------------------------------------------------------------
+# Goal flag plumbing (update_goal sets/clears the new fields)
+# ---------------------------------------------------------------------------
+
+
+def test_update_goal_accepts_auto_canonical_flag(us_env):
+    """Storage helper accepts the two new fields; round-trip via
+    get_goal surfaces them with the right types.
+
+    The MCP surface for setting these via ``goals action=update`` is a
+    follow-on slice — for now ``update_goal()`` exposes them at the
+    storage layer for tests + host scripts.
+    """
+    us, base = us_env
+    del us  # the MCP surface isn't exercised in this test today.
+    _seed_runnable_branch(
+        base, goal_id="g1", branch_def_id="b1",
+        auto=False, publish=False,
+    )
+    from workflow.daemon_server import get_goal, update_goal
+    update_goal(
+        base, goal_id="g1",
+        updates={
+            "auto_canonical_via_leaderboard": True,
+            "min_completed_runs_for_canonical": 7,
+        },
+    )
+    goal = get_goal(base, goal_id="g1")
+    assert goal["auto_canonical_via_leaderboard"] is True
+    assert goal["min_completed_runs_for_canonical"] == 7
+
+
+def test_update_goal_rejects_negative_threshold(us_env):
+    us, base = us_env
+    _seed_runnable_branch(
+        base, goal_id="g1", branch_def_id="b1",
+        auto=False, publish=False,
+    )
+    from workflow.daemon_server import update_goal
+    with pytest.raises(ValueError):
+        update_goal(
+            base, goal_id="g1",
+            updates={"min_completed_runs_for_canonical": -3},
+        )

--- a/workflow/api/canonical_dispatch.py
+++ b/workflow/api/canonical_dispatch.py
@@ -29,6 +29,20 @@ No new substrate primitives — pure orchestration over existing
 storage. The env-var fallback path (read by
 ``_maybe_enqueue_investigation``) stays in place until the observation
 window closes; cutover plan Step 5/6 removes the env in a follow-on PR.
+
+**Auth-boundary contract (PR-127 round 2 — Codex P1 findings):**
+
+* ``_latest_published_version_id`` filters to ``status='active'``
+  versions only. Rolled-back / superseded versions can NEVER become
+  the auto-refresh target. Defense in depth:
+  ``workflow.daemon_server.set_canonical_branch`` also rejects
+  non-active versions at the write site, so a bug in this filter
+  alone cannot promote a dead version (P1.1).
+* The auto-refresh leaderboard query is ALWAYS computed against
+  ``viewer=""`` (strictly-public). The caller-supplied viewer is
+  retained for log telemetry only; private branches authored by
+  the calling actor cannot become the Goal's global canonical via
+  auto-refresh (P1.2).
 """
 
 from __future__ import annotations
@@ -254,13 +268,42 @@ def _refresh_via_leaderboard(
 
     The function NEVER raises; storage / leaderboard failures collapse
     to a fall-back path with the original stored canonical (if any).
+
+    Round-2 P1.2 fix (Codex round-1 finding on PR #979): the auto-
+    refresh decision MUST be computed against a strictly-public
+    leaderboard view, regardless of which actor invoked
+    ``run_canonical``. The round-1 path forwarded the caller's
+    ``viewer`` (== ``_current_actor()``) into the leaderboard, which
+    intentionally surfaces private branches authored by that viewer
+    (PR-970's auth-boundary contract). The auto-refresh then wrote
+    that private branch as the Goal's **global** canonical via
+    ``set_canonical_branch``, exposing per-viewer private content to
+    every other actor as the default dispatch target.
+
+    Fix: hard-code the leaderboard query's viewer to ``""`` (strictly
+    public) here. The caller's ``viewer`` parameter is retained for
+    log telemetry — it identifies which actor triggered the refresh —
+    but never reaches the leaderboard write decision.
     """
     goal_id = goal["goal_id"]
     from workflow.api.quality_leaderboard import build_quality_leaderboard
 
+    if viewer:
+        # Telemetry only — record which actor's run_canonical call
+        # triggered this refresh, but do NOT scope the leaderboard
+        # query to their viewer. Canonical is global by definition.
+        logger.info(
+            "canonical_refresh | goal=%s | triggered_by=%s | "
+            "using_viewer='' for global decision",
+            goal_id, viewer,
+        )
+
     try:
         board = build_quality_leaderboard(
-            base_path, goal_id=goal_id, viewer=viewer, now=now,
+            # P1.2 fix: hard-coded empty viewer so private branches
+            # cannot become the global canonical. The caller-supplied
+            # viewer is intentionally ignored at this seam.
+            base_path, goal_id=goal_id, viewer="", now=now,
         )
     except Exception:
         logger.exception(
@@ -518,24 +561,50 @@ def _attempt_set_canonical(
 def _latest_published_version_id(
     base_path: str | Path, *, branch_def_id: str,
 ) -> str | None:
-    """Return the newest published ``branch_version_id`` for the def,
-    or None when no published version exists."""
+    """Return the newest **active** ``branch_version_id`` for the def,
+    or None when no active published version exists.
+
+    Round-2 P1.1 fix (Codex round-1 finding on PR #979): the round-1
+    implementation returned ``versions[0].branch_version_id`` for the
+    most recently published version regardless of status, which let a
+    rolled-back version become the auto-refresh target. The repro:
+    publish a version, roll it back, give the underlying branch_def
+    enough leaderboard signal to rank first, call run_canonical with
+    auto_canonical_via_leaderboard=true -> the rolled-back version
+    was selected (source=leaderboard_refreshed).
+
+    Fix: filter the version list to ``status == 'active'`` so rolled-
+    back / superseded versions are NEVER returned to the auto-refresh
+    path. Defense in depth: :func:`workflow.daemon_server.set_canonical_branch`
+    also rejects non-active versions, so a bug in this filter alone
+    can't promote a dead version.
+    """
     if not branch_def_id:
         return None
     from workflow.branch_versions import list_branch_versions
 
     try:
+        # Pull a window of recent versions and filter for status='active'
+        # in Python — list_branch_versions does not expose a status
+        # filter today, and adding one would require touching its
+        # signature which is out of scope for this round. A small
+        # constant window (default-50 of the helper) covers the
+        # realistic case where the latest few versions include at most
+        # a handful of rolled-back rows.
         versions = list_branch_versions(
-            base_path, branch_def_id=branch_def_id, limit=1,
+            base_path, branch_def_id=branch_def_id, limit=50,
         )
     except Exception:  # pragma: no cover — defensive
         logger.exception(
             "list_branch_versions crashed for %s", branch_def_id,
         )
         return None
-    if not versions:
-        return None
-    return versions[0].branch_version_id or None
+    for version in versions:
+        if getattr(version, "status", "active") == "active":
+            bvid = version.branch_version_id or ""
+            if bvid:
+                return bvid
+    return None
 
 
 def _split_version_id(version_id: str) -> tuple[str, str]:

--- a/workflow/api/canonical_dispatch.py
+++ b/workflow/api/canonical_dispatch.py
@@ -1,0 +1,602 @@
+"""Canonical-handler resolution for Goal-bound run dispatch — PR-127 (M6).
+
+The M6 cutover (canonical at
+``pages/plans/drafts-plans-m6-cutover-retire-cheat-loop-leaderboard-driven-canonical.md``
+on the live brain) replaces the hand-wired cheat loop (an env-var
+pointing at a single ``WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID``)
+with leaderboard-driven canonical selection. Every Goal can opt into
+``auto_canonical_via_leaderboard``; when it does, every
+``goals action=run_canonical`` call:
+
+  1. Re-queries the quality leaderboard for the freshest top-ranked
+     entry.
+  2. If the top entry meets ``min_completed_runs_for_canonical``
+     (default 5) AND differs from the current canonical AND no
+     in-flight run is currently using the prior canonical, the stored
+     ``canonical_branch_version_id`` is refreshed via
+     :func:`workflow.daemon_server.set_canonical_branch`.
+  3. The (possibly updated) canonical is then dispatched.
+
+This module owns the resolution logic. The MCP dispatch wrapper
+(``_action_goal_run_canonical`` in ``workflow/api/market.py``) and the
+bug-investigation enqueue path (``_maybe_enqueue_investigation`` in
+``workflow/bug_investigation.py``) both call into this module so the
+leaderboard semantics + threshold + in-flight gating + history audit
+have a single source of truth.
+
+No new substrate primitives — pure orchestration over existing
+``goals`` / ``branch_versions`` / ``quality_leaderboard`` / ``runs``
+storage. The env-var fallback path (read by
+``_maybe_enqueue_investigation``) stays in place until the observation
+window closes; cutover plan Step 5/6 removes the env in a follow-on PR.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# How far back to look for an in-flight run on the prior canonical
+# before deciding it's safe to refresh. Matches the "don't swap
+# canonical out from under a live run" rule in the cutover plan.
+# A long-running graph may hold ``running`` status for minutes; the
+# window is therefore generous. Stale ``queued`` / ``running`` rows
+# outside this window are treated as orphaned and don't block the
+# refresh.
+IN_FLIGHT_WINDOW_SECONDS = 600.0  # 10 min
+
+# Resolution-source labels surfaced in the response so the caller can
+# render "why this version was picked". Stable; treat as enum-like.
+SOURCE_CANONICAL_STORED = "canonical_stored"
+SOURCE_LEADERBOARD_REFRESHED = "leaderboard_refreshed"
+SOURCE_LEADERBOARD_NO_CHANGE = "leaderboard_no_change"
+SOURCE_LEADERBOARD_SKIPPED_INSUFFICIENT_RUNS = (
+    "leaderboard_skipped_insufficient_runs"
+)
+SOURCE_LEADERBOARD_SKIPPED_IN_FLIGHT = "leaderboard_skipped_in_flight"
+SOURCE_LEADERBOARD_SKIPPED_NO_PUBLISHED_VERSION = (
+    "leaderboard_skipped_no_published_version"
+)
+SOURCE_LEADERBOARD_NO_ENTRIES = "leaderboard_no_entries"
+
+
+def resolve_canonical_for_run(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    viewer: str,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Resolve which ``branch_version_id`` should fulfil a canonical run.
+
+    Returns one of two shapes:
+
+    Success::
+
+        {
+            "ok": True,
+            "branch_version_id": "...",
+            "branch_def_id": "...",
+            "source": "<SOURCE_*>",
+            "goal": <goal-row>,
+            "refresh_attempted": <bool>,
+            "displaced_canonical_branch_version_id": <str | None>,
+            # Top-entry signals (only when refresh_attempted=True):
+            "candidate_branch_def_id": <str | None>,
+            "candidate_completed_runs": <int | None>,
+            "candidate_score": <float | None>,
+        }
+
+    Failure::
+
+        {
+            "ok": False,
+            "error": "<machine-readable>",
+            "error_kind": "<one of: no_goal | no_canonical_handler |
+                            no_published_version_for_candidate>",
+            "goal_id": "...",
+            "goal": <goal-row | None>,
+        }
+
+    Never raises — all storage / leaderboard failures surface as
+    ``ok=False`` shapes the caller can render.
+
+    Concurrency note: the in-flight detection window
+    (:data:`IN_FLIGHT_WINDOW_SECONDS`) bounds the period during which
+    a refresh is blocked by an active run on the prior canonical.
+    Outside that window any pending/running row is treated as
+    orphaned and does NOT block the refresh.
+    """
+    if now is None:
+        now = time.time()
+
+    from workflow.daemon_server import get_goal
+
+    try:
+        goal = get_goal(base_path, goal_id=goal_id)
+    except KeyError:
+        return {
+            "ok": False,
+            "error": f"Goal '{goal_id}' not found.",
+            "error_kind": "no_goal",
+            "goal_id": goal_id,
+            "goal": None,
+        }
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.exception("resolve_canonical_for_run | get_goal failed")
+        return {
+            "ok": False,
+            "error": f"failed to load Goal '{goal_id}': {exc}",
+            "error_kind": "goal_load_failed",
+            "goal_id": goal_id,
+            "goal": None,
+        }
+
+    stored_canonical = (goal.get("canonical_branch_version_id") or "") or None
+    auto_flag = bool(goal.get("auto_canonical_via_leaderboard"))
+    min_runs = int(goal.get("min_completed_runs_for_canonical") or 5)
+
+    if not auto_flag:
+        if not stored_canonical:
+            return {
+                "ok": False,
+                "error": (
+                    f"Goal '{goal_id}' has no canonical_branch_version_id "
+                    "set, and auto_canonical_via_leaderboard is off. "
+                    "Set canonical via `goals action=set_canonical` or "
+                    "enable auto-canonical via `goals action=update "
+                    "auto_canonical_via_leaderboard=true`."
+                ),
+                "error_kind": "no_canonical_handler",
+                "goal_id": goal_id,
+                "goal": goal,
+            }
+        bvid, bdid = _split_version_id(stored_canonical)
+        return {
+            "ok": True,
+            "branch_version_id": stored_canonical,
+            "branch_def_id": bdid,
+            "source": SOURCE_CANONICAL_STORED,
+            "goal": goal,
+            "refresh_attempted": False,
+            "displaced_canonical_branch_version_id": None,
+        }
+
+    # auto_canonical_via_leaderboard=true — try to refresh.
+    return _refresh_via_leaderboard(
+        base_path,
+        goal=goal,
+        viewer=viewer,
+        stored_canonical=stored_canonical,
+        min_runs=min_runs,
+        now=now,
+    )
+
+
+def is_in_flight_for_version(
+    base_path: str | Path,
+    *,
+    branch_version_id: str,
+    now: float,
+    window_seconds: float = IN_FLIGHT_WINDOW_SECONDS,
+) -> dict[str, Any] | None:
+    """Return the most recent in-flight run on ``branch_version_id``, or None.
+
+    "In-flight" = ``status`` ∈ {queued, running} AND ``started_at`` is
+    within the trailing ``window_seconds``. Older queued/running rows
+    are treated as orphaned (recovered by
+    ``_recover_orphaned_runs_on_read``) and do NOT block a refresh.
+
+    Returns the run row when present so the caller can surface
+    ``in_flight_run_id`` / ``in_flight_started_at`` in evidence.
+    """
+    if not branch_version_id:
+        return None
+    cutoff = now - max(0.0, float(window_seconds))
+    from workflow.runs import _connect, initialize_runs_db
+
+    initialize_runs_db(base_path)
+    with _connect(base_path) as conn:
+        row = conn.execute(
+            """
+            SELECT run_id, branch_def_id, branch_version_id, status,
+                   started_at, finished_at
+              FROM runs
+             WHERE branch_version_id = ?
+               AND status IN ('queued', 'running')
+               AND started_at >= ?
+          ORDER BY started_at DESC
+             LIMIT 1
+            """,
+            (branch_version_id, cutoff),
+        ).fetchone()
+    if row is None:
+        return None
+    return {
+        "run_id": row["run_id"],
+        "branch_def_id": row["branch_def_id"],
+        "branch_version_id": row["branch_version_id"],
+        "status": row["status"],
+        "started_at": row["started_at"],
+        "finished_at": row["finished_at"],
+    }
+
+
+def _refresh_via_leaderboard(
+    base_path: str | Path,
+    *,
+    goal: dict[str, Any],
+    viewer: str,
+    stored_canonical: str | None,
+    min_runs: int,
+    now: float,
+) -> dict[str, Any]:
+    """Re-query the leaderboard and (maybe) refresh ``canonical_branch_version_id``.
+
+    Five outcomes:
+
+    1. No entries on the leaderboard → fall back to stored canonical if
+       set, otherwise no_canonical_handler error.
+    2. Top entry has < min_runs completed runs → fall back to stored
+       canonical (or no_canonical_handler).
+    3. Top entry has no published branch_version → fall back to stored
+       canonical (or no_canonical_handler).
+    4. Top entry matches stored canonical's branch_def_id → no-op,
+       return stored canonical.
+    5. Top entry passes all checks AND no in-flight run is using the
+       prior canonical → call set_canonical_branch + return the new
+       version.
+
+    The function NEVER raises; storage / leaderboard failures collapse
+    to a fall-back path with the original stored canonical (if any).
+    """
+    goal_id = goal["goal_id"]
+    from workflow.api.quality_leaderboard import build_quality_leaderboard
+
+    try:
+        board = build_quality_leaderboard(
+            base_path, goal_id=goal_id, viewer=viewer, now=now,
+        )
+    except Exception:
+        logger.exception(
+            "resolve_canonical_for_run | leaderboard query crashed for "
+            "%s; falling back to stored canonical", goal_id,
+        )
+        board = {"entries": []}
+
+    entries = board.get("entries") or []
+    if not entries:
+        if stored_canonical:
+            bvid, bdid = _split_version_id(stored_canonical)
+            return {
+                "ok": True,
+                "branch_version_id": stored_canonical,
+                "branch_def_id": bdid,
+                "source": SOURCE_LEADERBOARD_NO_ENTRIES,
+                "goal": goal,
+                "refresh_attempted": True,
+                "displaced_canonical_branch_version_id": None,
+            }
+        return _no_canonical_response(
+            goal_id=goal_id, goal=goal,
+            hint=(
+                "auto_canonical_via_leaderboard is on, but no Branches "
+                "are bound to this Goal yet. Bind at least one (and "
+                "produce >= min_completed_runs_for_canonical successful "
+                "runs) before calling run_canonical."
+            ),
+        )
+
+    top = entries[0]
+    candidate_bdid = top.get("branch_def_id") or ""
+    candidate_signals = top.get("signals") or {}
+    candidate_completed = int(
+        candidate_signals.get("completed_run_count") or 0
+    )
+    candidate_score = float(top.get("score") or 0.0)
+
+    # Threshold guard — security gate against a malicious branch
+    # ranking high with zero / few actual runs.
+    if candidate_completed < min_runs:
+        if stored_canonical:
+            bvid, bdid = _split_version_id(stored_canonical)
+            return {
+                "ok": True,
+                "branch_version_id": stored_canonical,
+                "branch_def_id": bdid,
+                "source": SOURCE_LEADERBOARD_SKIPPED_INSUFFICIENT_RUNS,
+                "goal": goal,
+                "refresh_attempted": True,
+                "displaced_canonical_branch_version_id": None,
+                "candidate_branch_def_id": candidate_bdid,
+                "candidate_completed_runs": candidate_completed,
+                "candidate_score": candidate_score,
+                "min_completed_runs_for_canonical": min_runs,
+                "hint": (
+                    f"Top entry '{candidate_bdid}' has "
+                    f"{candidate_completed} completed run(s); the "
+                    f"Goal requires >= {min_runs}. Keeping the stored "
+                    "canonical."
+                ),
+            }
+        return _no_canonical_response(
+            goal_id=goal_id, goal=goal,
+            hint=(
+                f"Top leaderboard entry '{candidate_bdid}' has "
+                f"{candidate_completed} completed run(s); the Goal "
+                f"requires >= {min_runs}. No prior canonical is set, "
+                "so the dispatch is blocked. Either lower "
+                "min_completed_runs_for_canonical or run the branch "
+                "more times before retrying."
+            ),
+        )
+
+    # Resolve top entry's latest published version. The leaderboard
+    # ranks branch_def_id values; the canonical surface keys on
+    # branch_version_id (the immutable snapshot). We pick the most
+    # recently published version for the top branch_def_id.
+    candidate_bvid = _latest_published_version_id(
+        base_path, branch_def_id=candidate_bdid,
+    )
+    if not candidate_bvid:
+        # Branch_def is bound to the Goal but has not been published.
+        # Fall back to stored canonical if any.
+        if stored_canonical:
+            bvid, bdid = _split_version_id(stored_canonical)
+            return {
+                "ok": True,
+                "branch_version_id": stored_canonical,
+                "branch_def_id": bdid,
+                "source": SOURCE_LEADERBOARD_SKIPPED_NO_PUBLISHED_VERSION,
+                "goal": goal,
+                "refresh_attempted": True,
+                "displaced_canonical_branch_version_id": None,
+                "candidate_branch_def_id": candidate_bdid,
+                "candidate_completed_runs": candidate_completed,
+                "candidate_score": candidate_score,
+                "hint": (
+                    f"Top entry '{candidate_bdid}' has no published "
+                    "branch_version. Keeping the stored canonical. "
+                    "Publish the branch via `extensions action="
+                    "publish_version` before it can serve as canonical."
+                ),
+            }
+        return _no_canonical_response(
+            goal_id=goal_id, goal=goal,
+            hint=(
+                f"Top entry '{candidate_bdid}' has no published "
+                "branch_version, and no prior canonical is set. "
+                "Publish the branch first."
+            ),
+        )
+
+    # Did the candidate's branch_def_id already match the stored
+    # canonical's branch_def_id? If so, the candidate is effectively
+    # the same handler — no swap needed, but we DO swap to the latest
+    # version of that def_id so future runs land on the freshest
+    # snapshot. Two sub-cases:
+    #   (a) Stored canonical IS the latest version → no-op.
+    #   (b) Stored canonical points to an older version of the same
+    #       def_id → swap to the latest.
+    if stored_canonical and stored_canonical == candidate_bvid:
+        # Already on the freshest version of the top entry.
+        return {
+            "ok": True,
+            "branch_version_id": stored_canonical,
+            "branch_def_id": candidate_bdid,
+            "source": SOURCE_LEADERBOARD_NO_CHANGE,
+            "goal": goal,
+            "refresh_attempted": True,
+            "displaced_canonical_branch_version_id": None,
+            "candidate_branch_def_id": candidate_bdid,
+            "candidate_completed_runs": candidate_completed,
+            "candidate_score": candidate_score,
+        }
+
+    # We have a different version to swap in. Check for in-flight runs
+    # on the prior canonical before swapping.
+    in_flight = None
+    if stored_canonical:
+        in_flight = is_in_flight_for_version(
+            base_path,
+            branch_version_id=stored_canonical,
+            now=now,
+        )
+    if in_flight is not None:
+        bvid, bdid = _split_version_id(stored_canonical or "")
+        return {
+            "ok": True,
+            "branch_version_id": stored_canonical,
+            "branch_def_id": bdid,
+            "source": SOURCE_LEADERBOARD_SKIPPED_IN_FLIGHT,
+            "goal": goal,
+            "refresh_attempted": True,
+            "displaced_canonical_branch_version_id": None,
+            "candidate_branch_def_id": candidate_bdid,
+            "candidate_completed_runs": candidate_completed,
+            "candidate_score": candidate_score,
+            "in_flight_run_id": in_flight.get("run_id"),
+            "in_flight_status": in_flight.get("status"),
+            "in_flight_started_at": in_flight.get("started_at"),
+            "hint": (
+                f"A run on the prior canonical "
+                f"('{stored_canonical}') is currently "
+                f"{in_flight.get('status')}; refusing to swap canonical "
+                "out from under it. Retry after the in-flight run "
+                "completes."
+            ),
+        }
+
+    # Safe to swap.
+    set_by = _resolve_actor_for_history()
+    refreshed = _attempt_set_canonical(
+        base_path,
+        goal_id=goal_id,
+        branch_version_id=candidate_bvid,
+        set_by=set_by,
+    )
+    if not refreshed["ok"]:
+        # set_canonical failed (e.g. version validation). Fall back to
+        # stored canonical if any.
+        if stored_canonical:
+            bvid, bdid = _split_version_id(stored_canonical)
+            return {
+                "ok": True,
+                "branch_version_id": stored_canonical,
+                "branch_def_id": bdid,
+                "source": SOURCE_LEADERBOARD_SKIPPED_NO_PUBLISHED_VERSION,
+                "goal": goal,
+                "refresh_attempted": True,
+                "displaced_canonical_branch_version_id": None,
+                "candidate_branch_def_id": candidate_bdid,
+                "candidate_completed_runs": candidate_completed,
+                "candidate_score": candidate_score,
+                "hint": (
+                    f"set_canonical rejected candidate "
+                    f"'{candidate_bvid}': {refreshed.get('error')}. "
+                    "Keeping the stored canonical."
+                ),
+            }
+        return _no_canonical_response(
+            goal_id=goal_id, goal=goal,
+            hint=(
+                f"set_canonical rejected candidate '{candidate_bvid}': "
+                f"{refreshed.get('error')}. No prior canonical to fall "
+                "back to."
+            ),
+        )
+
+    return {
+        "ok": True,
+        "branch_version_id": candidate_bvid,
+        "branch_def_id": candidate_bdid,
+        "source": SOURCE_LEADERBOARD_REFRESHED,
+        "goal": refreshed.get("goal") or goal,
+        "refresh_attempted": True,
+        "displaced_canonical_branch_version_id": stored_canonical,
+        "candidate_branch_def_id": candidate_bdid,
+        "candidate_completed_runs": candidate_completed,
+        "candidate_score": candidate_score,
+    }
+
+
+def _attempt_set_canonical(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    branch_version_id: str,
+    set_by: str,
+) -> dict[str, Any]:
+    """Wrap :func:`workflow.daemon_server.set_canonical_branch` so the
+    leaderboard refresher never raises. Returns ``{ok: bool, error?,
+    goal?}``.
+    """
+    from workflow.daemon_server import set_canonical_branch
+
+    try:
+        updated = set_canonical_branch(
+            base_path,
+            goal_id=goal_id,
+            branch_version_id=branch_version_id,
+            set_by=set_by,
+        )
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+    except KeyError as exc:
+        return {"ok": False, "error": f"Goal not found: {exc}"}
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.exception("set_canonical_branch crashed")
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True, "goal": updated}
+
+
+def _latest_published_version_id(
+    base_path: str | Path, *, branch_def_id: str,
+) -> str | None:
+    """Return the newest published ``branch_version_id`` for the def,
+    or None when no published version exists."""
+    if not branch_def_id:
+        return None
+    from workflow.branch_versions import list_branch_versions
+
+    try:
+        versions = list_branch_versions(
+            base_path, branch_def_id=branch_def_id, limit=1,
+        )
+    except Exception:  # pragma: no cover — defensive
+        logger.exception(
+            "list_branch_versions crashed for %s", branch_def_id,
+        )
+        return None
+    if not versions:
+        return None
+    return versions[0].branch_version_id or None
+
+
+def _split_version_id(version_id: str) -> tuple[str, str]:
+    """Best-effort ``branch_def_id`` extraction from a version id.
+
+    Published versions are minted as ``<branch_def_id>@<sha256_prefix8>``
+    (see ``workflow.branch_versions``); the def_id is the prefix before
+    the ``@``. Returns ``(version_id, "")`` when the input has no ``@``
+    (defensive — keeps the response shape uniform even if a caller
+    feeds in a malformed id).
+    """
+    if not version_id:
+        return "", ""
+    if "@" in version_id:
+        bdid, _ = version_id.split("@", 1)
+        return version_id, bdid
+    return version_id, ""
+
+
+def _no_canonical_response(
+    *,
+    goal_id: str,
+    goal: dict[str, Any] | None,
+    hint: str = "",
+) -> dict[str, Any]:
+    """Standard `no_canonical_handler` failure shape."""
+    payload: dict[str, Any] = {
+        "ok": False,
+        "error": (
+            f"Goal '{goal_id}' has no canonical_branch_version_id "
+            "available for dispatch."
+        ),
+        "error_kind": "no_canonical_handler",
+        "goal_id": goal_id,
+        "goal": goal,
+    }
+    if hint:
+        payload["hint"] = hint
+    return payload
+
+
+def _resolve_actor_for_history() -> str:
+    """Identity recorded on the canonical history audit row.
+
+    Auto-refresh writes are system-driven, not user-driven; tagging
+    them with a synthetic ``auto-canonical-refresh`` author keeps the
+    audit trail honest (matches the ``cloud-droplet`` identity pattern
+    documented in AGENTS.md for system-driven writes).
+    """
+    return "auto-canonical-refresh"
+
+
+__all__ = [
+    "IN_FLIGHT_WINDOW_SECONDS",
+    "SOURCE_CANONICAL_STORED",
+    "SOURCE_LEADERBOARD_REFRESHED",
+    "SOURCE_LEADERBOARD_NO_CHANGE",
+    "SOURCE_LEADERBOARD_SKIPPED_INSUFFICIENT_RUNS",
+    "SOURCE_LEADERBOARD_SKIPPED_IN_FLIGHT",
+    "SOURCE_LEADERBOARD_SKIPPED_NO_PUBLISHED_VERSION",
+    "SOURCE_LEADERBOARD_NO_ENTRIES",
+    "resolve_canonical_for_run",
+    "is_in_flight_for_version",
+]

--- a/workflow/api/market.py
+++ b/workflow/api/market.py
@@ -1617,6 +1617,137 @@ def _action_goal_set_canonical(kwargs: dict[str, Any]) -> str:
     }, default=str)
 
 
+def _action_goal_run_canonical(kwargs: dict[str, Any]) -> str:
+    """Dispatch a run against a Goal's canonical handler — PR-127 (M6).
+
+    The Goal's stored ``canonical_branch_version_id`` is the dispatch
+    target. When ``goal.auto_canonical_via_leaderboard`` is True, the
+    canonical is first refreshed against the freshest leaderboard
+    top-entry (subject to the ``min_completed_runs_for_canonical``
+    threshold and the in-flight guard — see
+    :func:`workflow.api.canonical_dispatch.resolve_canonical_for_run`).
+
+    Required kwargs:
+      * ``goal_id`` — the Goal to dispatch against.
+
+    Optional kwargs:
+      * ``inputs_json`` — JSON string of inputs forwarded to the run.
+      * ``run_name`` — display name for the resulting run row.
+      * ``recursion_limit_override`` — passthrough to the run executor.
+
+    Returns one of:
+
+    Success::
+
+        {
+            "status": "queued",
+            "text": "<phone-legible summary>",
+            "run_id": "...",
+            "branch_version_id_used": "...",
+            "branch_def_id": "...",
+            "source": "<canonical_stored | leaderboard_refreshed | ...>",
+            "goal_id": "...",
+            ...passthrough from run_branch_version...
+        }
+
+    Rejection::
+
+        {
+            "status": "rejected",
+            "error": "...",
+            "error_kind": "no_canonical_handler | no_goal | ...",
+            "goal_id": "...",
+        }
+    """
+    from workflow.api.canonical_dispatch import resolve_canonical_for_run
+    from workflow.api.engine_helpers import _current_actor
+    from workflow.api.runs import _action_run_branch_version
+
+    gid = (kwargs.get("goal_id") or "").strip()
+    if not gid:
+        return json.dumps({
+            "status": "rejected",
+            "error": "goal_id is required for run_canonical.",
+            "error_kind": "missing_goal_id",
+        })
+
+    resolution = resolve_canonical_for_run(
+        _base_path(),
+        goal_id=gid,
+        viewer=_current_actor(),
+    )
+    if not resolution.get("ok"):
+        # Surface the failure verbatim so the caller's branching logic
+        # (e.g. _maybe_enqueue_investigation's env-fallback) can read
+        # error_kind directly.
+        return json.dumps({
+            "status": "rejected",
+            "error": resolution.get("error", ""),
+            "error_kind": resolution.get(
+                "error_kind", "no_canonical_handler",
+            ),
+            "goal_id": gid,
+            "hint": resolution.get("hint", ""),
+        }, default=str)
+
+    bvid = resolution["branch_version_id"]
+    bdid = resolution.get("branch_def_id", "")
+
+    # Delegate dispatch to the existing run_branch_version path so
+    # both surfaces share executor + provider + recursion-limit
+    # behavior. Inputs flow through verbatim.
+    dispatch_result_raw = _action_run_branch_version({
+        "branch_version_id": bvid,
+        "inputs_json": kwargs.get("inputs_json", "") or "",
+        "run_name": kwargs.get("run_name", "") or "",
+        "recursion_limit_override": (
+            kwargs.get("recursion_limit_override", "") or ""
+        ),
+    })
+    try:
+        dispatch_result = json.loads(dispatch_result_raw)
+    except (TypeError, ValueError):
+        # Defensive — run_branch_version always returns JSON.
+        return dispatch_result_raw
+
+    # Annotate the dispatch response with canonical-resolution metadata
+    # WITHOUT overwriting any of run_branch_version's existing fields.
+    dispatch_result.setdefault("goal_id", gid)
+    dispatch_result["branch_version_id_used"] = bvid
+    dispatch_result.setdefault("branch_def_id", bdid)
+    dispatch_result["source"] = resolution.get("source")
+    if resolution.get("refresh_attempted"):
+        dispatch_result["refresh_attempted"] = True
+        if resolution.get("displaced_canonical_branch_version_id"):
+            dispatch_result["displaced_canonical_branch_version_id"] = (
+                resolution["displaced_canonical_branch_version_id"]
+            )
+        for k in (
+            "candidate_branch_def_id",
+            "candidate_completed_runs",
+            "candidate_score",
+            "min_completed_runs_for_canonical",
+            "in_flight_run_id",
+            "in_flight_status",
+            "in_flight_started_at",
+        ):
+            if k in resolution:
+                dispatch_result[k] = resolution[k]
+        if resolution.get("hint") and not dispatch_result.get("hint"):
+            dispatch_result["hint"] = resolution["hint"]
+
+    # Render a short text summary if the underlying handler didn't.
+    if "text" not in dispatch_result or not dispatch_result["text"]:
+        run_id = dispatch_result.get("run_id") or "(no run_id)"
+        dispatch_result["text"] = (
+            f"Canonical dispatch for Goal `{gid}` -> "
+            f"branch_version_id `{bvid}` (run_id `{run_id}`, "
+            f"source `{resolution.get('source')}`)."
+        )
+
+    return json.dumps(dispatch_result, default=str)
+
+
 _GOAL_ACTIONS: dict[str, Any] = {
     "propose": _action_goal_propose,
     "update": _action_goal_update,
@@ -1628,6 +1759,10 @@ _GOAL_ACTIONS: dict[str, Any] = {
     "common_nodes": _action_goal_common_nodes,
     "archive_consultation": _action_goal_archive_consultation,
     "set_canonical": _action_goal_set_canonical,
+    # PR-127 (M6 cutover Step 4) — leaderboard-driven canonical
+    # dispatch. Honors auto_canonical_via_leaderboard + threshold +
+    # in-flight gate; delegates the actual run to run_branch_version.
+    "run_canonical": _action_goal_run_canonical,
 }
 
 # Provider-routing compatibility: ChatGPT can render `/mcp-directory` tool
@@ -1742,6 +1877,17 @@ def goals(
       set_canonical Mark a branch_version_id as the Goal's canonical
                    (best-known) branch. Author-only or host-only.
                    Pass branch_version_id="" to unset.
+      run_canonical Dispatch a run against the Goal's canonical
+                   branch_version. PR-127 (M6 cutover): when
+                   ``auto_canonical_via_leaderboard`` is enabled on the
+                   Goal, the canonical is first refreshed via the
+                   quality leaderboard (subject to
+                   ``min_completed_runs_for_canonical`` threshold and
+                   the in-flight guard). Needs goal_id. Accepts
+                   ``inputs_json``, ``run_name``,
+                   ``recursion_limit_override``. Returns
+                   ``branch_version_id_used`` + ``source`` so the
+                   caller can see which version was picked and why.
       list         Browse Goals. Optional author, tags (CSV first
                    value only), limit, production_only. Soft-deleted
                    Goals hidden. production_only keeps public Goals

--- a/workflow/bug_investigation.py
+++ b/workflow/bug_investigation.py
@@ -262,19 +262,34 @@ def _maybe_enqueue_investigation(
 ) -> str | None:
     """Forward-trigger seam for `_wiki_file_bug` post-write.
 
-    Reads `WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID` at call time; when set,
-    enqueues a dispatcher request for the freshly-filed bug. Swallows
-    dispatcher-rejection (RuntimeError) and bad-input (ValueError) so a
-    filing never breaks because of investigation-pipeline misconfiguration.
+    Resolution order (PR-127 / M6 cutover Step 4):
 
-    Returns request_id when enqueued, None when skipped or recovered from error.
+      1. If ``WORKFLOW_BUG_INVESTIGATION_GOAL_ID`` is set AND that
+         Goal has a ``canonical_branch_version_id`` (set via
+         ``goals action=set_canonical`` or auto-refreshed from the
+         leaderboard when ``auto_canonical_via_leaderboard`` is on),
+         resolve the canonical to a ``branch_def_id`` and enqueue
+         a dispatcher request against it.
+      2. Otherwise, fall back to
+         ``WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID`` — the round-1
+         cheat-loop env. This fallback is intentional graceful
+         degradation: the cutover plan removes the env in a
+         subsequent slice (Step 5/6) once the canonical handler has
+         been observation-window'd.
+
+    Returns request_id when enqueued, None when skipped or recovered
+    from error. Swallows dispatcher-rejection (RuntimeError) and
+    bad-input (ValueError) so a filing never breaks because of
+    investigation-pipeline misconfiguration.
     """
-    canonical = os.environ.get("WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID", "").strip()
-    if not canonical:
-        return None
     if not bug_id:
         _logger.info("_maybe_enqueue_investigation | skipped | missing bug_id")
         return None
+
+    canonical_branch_def_id = _resolve_investigation_handler(base_path)
+    if not canonical_branch_def_id:
+        return None
+
     bug_ref = dict(frontmatter or {})
     bug_ref["bug_id"] = bug_id
     # Module-attribute lookup (NOT bare-name) so `patch("workflow.bug_investigation
@@ -285,7 +300,7 @@ def _maybe_enqueue_investigation(
     try:
         return enqueue(
             bug_ref=bug_ref,
-            canonical_branch_def_id=canonical,
+            canonical_branch_def_id=canonical_branch_def_id,
             base_path=base_path,
             universe_id=universe_id,
         )
@@ -294,3 +309,79 @@ def _maybe_enqueue_investigation(
             "_maybe_enqueue_investigation | %s | recovered: %s", bug_id, exc
         )
         return None
+
+
+def _resolve_investigation_handler(base_path: "Path | str") -> str:
+    """Pick the ``branch_def_id`` that should handle a fresh bug.
+
+    Two paths, in order:
+
+      1. **Goal-canonical (PR-127 cutover):** read
+         ``WORKFLOW_BUG_INVESTIGATION_GOAL_ID``; if set, look up the
+         Goal and resolve ``canonical_branch_version_id`` → its
+         ``branch_def_id``. When ``auto_canonical_via_leaderboard``
+         is enabled on the Goal, the canonical is auto-refreshed
+         here too (subject to the threshold + in-flight gate) so a
+         file_bug burst doesn't have to wait for an MCP-driven
+         ``run_canonical`` to refresh the pick.
+      2. **Cheat-loop env fallback:** read
+         ``WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID`` directly. Kept
+         in place until Cutover plan Steps 5/6 retire it. The env
+         lets the host roll out PR-127 before any Goal has a
+         canonical set.
+
+    Returns "" when neither path produces a handler. Never raises.
+    """
+    goal_id = os.environ.get(
+        "WORKFLOW_BUG_INVESTIGATION_GOAL_ID", "",
+    ).strip()
+    if goal_id:
+        try:
+            from workflow.api.canonical_dispatch import (
+                resolve_canonical_for_run,
+            )
+            resolution = resolve_canonical_for_run(
+                base_path,
+                goal_id=goal_id,
+                # No actor context inside the wiki-write hook — use
+                # the empty-viewer (strictly-public) lookup so private
+                # branches cannot serve as a public bug-investigation
+                # canonical.
+                viewer="",
+            )
+        except Exception:  # pragma: no cover — defensive
+            _logger.exception(
+                "_resolve_investigation_handler | canonical resolution "
+                "crashed for goal %s; falling back to env",
+                goal_id,
+            )
+            resolution = {"ok": False}
+        if resolution.get("ok"):
+            bdid = (resolution.get("branch_def_id") or "").strip()
+            if bdid:
+                _logger.info(
+                    "_resolve_investigation_handler | goal=%s "
+                    "canonical=%s source=%s",
+                    goal_id,
+                    resolution.get("branch_version_id"),
+                    resolution.get("source"),
+                )
+                return bdid
+        else:
+            _logger.info(
+                "_resolve_investigation_handler | goal=%s no canonical "
+                "available (%s); falling back to env",
+                goal_id, resolution.get("error_kind") or "unknown",
+            )
+
+    # Cheat-loop fallback.
+    fallback = os.environ.get(
+        "WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID", "",
+    ).strip()
+    if fallback:
+        _logger.info(
+            "_resolve_investigation_handler | using env fallback "
+            "branch_def_id=%s (cutover plan Step 5/6 retires this path)",
+            fallback,
+        )
+    return fallback

--- a/workflow/daemon_server.py
+++ b/workflow/daemon_server.py
@@ -2595,19 +2595,39 @@ def set_canonical_branch(
     canonical_branch_history before the new value is written.
     Raises KeyError if goal_id not found.
     Raises ValueError if branch_version_id is provided but does not exist
-        in branch_versions table (not a published version).
+        in branch_versions table (not a published version), OR if the
+        supplied version's status is not 'active' (PR-127 round 2 P1.1
+        defense-in-depth — rolled_back / superseded versions cannot be
+        promoted to canonical even if a caller bypasses the auto-refresh
+        filter in :func:`workflow.api.canonical_dispatch._latest_published_version_id`).
     """
     initialize_author_server(base_path)
     now = _now()
     goal = get_goal(base_path, goal_id=goal_id)
 
     if branch_version_id is not None:
-        # Validate that it's a real published version.
+        # Validate that it's a real published version AND that it has
+        # not been rolled back / superseded. The active-only check is
+        # the round-2 P1.1 defense-in-depth: the auto-refresh path
+        # already filters via `_latest_published_version_id`, but a
+        # second guard at the write site means a rolled-back version
+        # cannot become canonical via any code path (manual MCP call,
+        # auto-refresh bug, host script, etc.).
         from workflow.branch_versions import get_branch_version
-        if get_branch_version(base_path, branch_version_id) is None:
+        version = get_branch_version(base_path, branch_version_id)
+        if version is None:
             raise ValueError(
                 f"branch_version_id {branch_version_id!r} not found "
                 "in branch_versions — only published versions may be canonical."
+            )
+        version_status = getattr(version, "status", "active") or "active"
+        if version_status != "active":
+            raise ValueError(
+                f"branch_version_id {branch_version_id!r} has "
+                f"status={version_status!r}; only versions with "
+                "status='active' may be promoted to canonical. "
+                "Re-publish a fresh version or restore the rolled-back "
+                "one before retrying."
             )
 
     # Build history entry for previous canonical (if any).

--- a/workflow/daemon_server.py
+++ b/workflow/daemon_server.py
@@ -461,6 +461,26 @@ def initialize_author_server(base_path: str | Path) -> Path:
                 "ALTER TABLE goals ADD COLUMN canonical_branch_history_json "
                 "TEXT NOT NULL DEFAULT '[]'"
             )
+        # PR-127 (M6 cutover Steps 4 + 7) — leaderboard-driven canonical
+        # selection. ``auto_canonical_via_leaderboard``: when set, every
+        # ``goals action=run_canonical`` call first re-queries
+        # ``recommended_parent_for_fork`` and updates the stored
+        # ``canonical_branch_version_id`` to the freshest top-ranked
+        # entry before dispatching. Default OFF so existing Goals are
+        # opt-in. ``min_completed_runs_for_canonical``: security gate
+        # against a malicious branch ranking high with zero actual
+        # runs; default 5. Both columns are stored as integers (SQLite
+        # has no native BOOLEAN).
+        if "auto_canonical_via_leaderboard" not in goal_cols:
+            conn.execute(
+                "ALTER TABLE goals ADD COLUMN auto_canonical_via_leaderboard "
+                "INTEGER NOT NULL DEFAULT 0"
+            )
+        if "min_completed_runs_for_canonical" not in goal_cols:
+            conn.execute(
+                "ALTER TABLE goals ADD COLUMN min_completed_runs_for_canonical "
+                "INTEGER NOT NULL DEFAULT 5"
+            )
         # Variant canonicals (Task #61 Step 1) — backfill canonical_bindings
         # from existing goals.canonical_branch_version_id. INSERT OR IGNORE
         # makes the migration idempotent: re-running on an already-backfilled
@@ -2420,6 +2440,17 @@ def _goal_from_row(row: sqlite3.Row) -> dict[str, Any]:
         canonical_history_raw = row["canonical_branch_history_json"]
     except (IndexError, KeyError):
         canonical_history_raw = "[]"
+    # PR-127 — leaderboard-driven canonical selection. Defaults match
+    # the schema (auto OFF, threshold 5) so pre-migration rows behave
+    # as if they were freshly created.
+    try:
+        auto_flag = int(row["auto_canonical_via_leaderboard"] or 0)
+    except (IndexError, KeyError, TypeError, ValueError):
+        auto_flag = 0
+    try:
+        min_runs = int(row["min_completed_runs_for_canonical"] or 5)
+    except (IndexError, KeyError, TypeError, ValueError):
+        min_runs = 5
     return {
         "goal_id": row["goal_id"],
         "name": row["name"],
@@ -2434,6 +2465,8 @@ def _goal_from_row(row: sqlite3.Row) -> dict[str, Any]:
         "canonical_branch_history": _json_loads(
             canonical_history_raw or "[]", []
         ),
+        "auto_canonical_via_leaderboard": bool(auto_flag),
+        "min_completed_runs_for_canonical": min_runs,
     }
 
 
@@ -2496,7 +2529,9 @@ def update_goal(
 ) -> dict[str, Any]:
     """Patch mutable fields on a Goal. Returns the updated row.
 
-    Supported fields: name, description, tags, visibility. Author is
+    Supported fields: name, description, tags, visibility,
+    auto_canonical_via_leaderboard (bool — PR-127), and
+    min_completed_runs_for_canonical (int — PR-127). Author is
     immutable; timestamps are server-managed.
     """
     initialize_author_server(base_path)
@@ -2512,6 +2547,24 @@ def update_goal(
     if "tags" in updates:
         sets.append("tags_json = ?")
         params.append(_json_dumps(list(updates["tags"] or [])))
+    # PR-127 — leaderboard-driven canonical opt-in + threshold knob.
+    # Booleans land as 0/1 to match the SQLite INTEGER column.
+    if "auto_canonical_via_leaderboard" in updates:
+        sets.append("auto_canonical_via_leaderboard = ?")
+        params.append(1 if updates["auto_canonical_via_leaderboard"] else 0)
+    if "min_completed_runs_for_canonical" in updates:
+        try:
+            threshold = int(updates["min_completed_runs_for_canonical"])
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "min_completed_runs_for_canonical must be an integer"
+            ) from exc
+        if threshold < 0:
+            raise ValueError(
+                "min_completed_runs_for_canonical must be >= 0"
+            )
+        sets.append("min_completed_runs_for_canonical = ?")
+        params.append(threshold)
     params.append(goal_id)
     with _connect(base_path) as conn:
         conn.execute(

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -782,6 +782,12 @@ def goals(
                    unbind. Needs branch_def_id.
       set_canonical Mark a branch_version_id as the Goal's canonical
                    branch. Author-only or host-only.
+      run_canonical Dispatch a run on the Goal's canonical
+                   branch_version. When auto_canonical_via_leaderboard
+                   is on, the canonical is first refreshed via the
+                   quality leaderboard (subject to the
+                   min_completed_runs_for_canonical threshold + the
+                   in-flight guard). PR-127 (M6 cutover Step 4).
       list         Browse Goals. Optional author, tags, limit,
                    production_only.
       get          Full Goal view + bound Branches. Needs goal_id.


### PR DESCRIPTION
## Summary

Implements the substrate cutover step from the M6 plan
(`pages/plans/drafts-plans-m6-cutover-retire-cheat-loop-leaderboard-driven-canonical.md`
on the live brain). After this PR a Goal can opt into having its canonical
handler refreshed automatically from the quality leaderboard on every
dispatch, replacing the round-1 cheat-loop env-var that points at a single
hand-wired branch.

This PR enables substrate cutover but does NOT call `set_canonical` itself.
That is an operational step after merge. The cheat-loop env-var path stays
in place as graceful fallback during the observation window (cutover plan
Steps 5/6 retire it in a follow-on PR).

## Three sub-tasks shipped

### 1. `_maybe_enqueue_investigation` swap

`workflow/bug_investigation.py` now resolves the investigation handler
through `_resolve_investigation_handler`:

1. If `WORKFLOW_BUG_INVESTIGATION_GOAL_ID` is set AND that Goal has a
   `canonical_branch_version_id` (set via `goals action=set_canonical` OR
   auto-refreshed from the leaderboard), resolve the canonical to a
   `branch_def_id` and enqueue against it.
2. Otherwise, fall back to `WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID` (the
   round-1 cheat-loop env). Kept in place until cutover plan Steps 5/6
   retire it.

Auto-refresh fires inside the wiki-write hook too, so a `file_bug` burst
does not have to wait for an MCP-driven `run_canonical` to refresh the
pick.

### 2. New `goals action=run_canonical` MCP action

`_action_goal_run_canonical` in `workflow/api/market.py`. Delegates the
actual dispatch to `_action_run_branch_version` so both surfaces share
executor + provider + recursion-limit behavior. Returns

```
{
  "status": "queued",
  "run_id": "...",
  "branch_version_id_used": "...",
  "branch_def_id": "...",
  "source": "canonical_stored | leaderboard_refreshed | leaderboard_no_change | leaderboard_skipped_*",
  "goal_id": "...",
  "refresh_attempted": <bool>,
  "displaced_canonical_branch_version_id": <str | null>,
  ... candidate signals when refresh_attempted=true ...
}
```

When the resolution fails, returns `{status="rejected",
error_kind="no_canonical_handler" | "no_goal" | "missing_goal_id"}` so
`_maybe_enqueue_investigation` can branch on `error_kind` for env-fallback
decisions.

### 3. `auto_canonical_via_leaderboard` flag + `min_completed_runs_for_canonical` threshold on goals

Schema migration adds two columns:

```
auto_canonical_via_leaderboard INTEGER NOT NULL DEFAULT 0
min_completed_runs_for_canonical INTEGER NOT NULL DEFAULT 5
```

Existing Goals default to OFF + threshold=5 (opt-in semantics). When
`auto_canonical_via_leaderboard=true`, every `run_canonical` call (and
every file_bug hook) first re-queries `quality_leaderboard` for the top
entry. Refresh is gated by:

- **Threshold guard:** top entry must have at least
  `min_completed_runs_for_canonical` completed runs. Security control
  against a malicious branch ranking high with zero actual runs.
- **In-flight lock:** if a queued/running run is currently using the
  prior canonical (within a 10-min window), refresh is deferred to the
  next dispatch.
- **Published-version requirement:** the top branch_def_id must have at
  least one published `branch_version_id`. Otherwise we keep the stored
  canonical.

When the top entry already IS the stored canonical, no swap happens
(source=`leaderboard_no_change`). When the leaderboard is empty
(auto=true on a Goal with no bound Branches yet), the stored canonical
is kept; if none exists, `no_canonical_handler` is returned so the
caller can fall back.

## Files touched

- `workflow/api/canonical_dispatch.py` — **new** module; pure resolution
  logic (no MCP surface of its own). Exports `resolve_canonical_for_run`,
  `is_in_flight_for_version`, and all `SOURCE_*` labels.
- `workflow/api/market.py` — new `_action_goal_run_canonical` handler +
  `run_canonical` dispatch entry. Tool docstring updated.
- `workflow/bug_investigation.py` — `_maybe_enqueue_investigation` now
  consults the canonical resolver before the env fallback. New
  `_resolve_investigation_handler` helper exported for tests.
- `workflow/daemon_server.py` — schema migration + `_goal_from_row` +
  `update_goal` extended for the two new fields.
- `workflow/universe_server.py` — `goals()` tool docstring documents
  `run_canonical`.
- `tests/test_canonical_dispatch.py` — **new** (18 cases).
- `tests/test_goals_run_canonical.py` — **new** (10 cases).
- `tests/test_bug_investigation_canonical_cutover.py` — **new** (8
  cases).
- `tests/test_api_market.py` — handler-count + key-set assertions bumped
  from 9 to 11.
- Plugin mirror auto-updated.

## Test plan

- [x] `pytest tests/test_canonical_dispatch.py tests/test_goals_run_canonical.py tests/test_bug_investigation_canonical_cutover.py tests/test_bug_investigation_wiring.py tests/test_bug_investigation_dispatcher.py tests/test_bug_investigation_flow.py tests/test_api_market.py -p no:cacheprovider` -> **141 passed**
- [x] `ruff check` on all touched files -> clean
- [x] `python packaging/claude-plugin/build_plugin.py` -> probe-ok (198 files mirrored)
- [x] Pre-commit hooks: mirror parity verified, mojibake clean, cross-provider-drift clean, skills-valid clean
- [ ] Post-merge: host calls `goals action=set_canonical` on the bug_investigation Goal to point at the current handler version. Until they do, the env-var fallback keeps the existing cheat-loop running.
- [ ] Post-merge: host sets `WORKFLOW_BUG_INVESTIGATION_GOAL_ID` in `/etc/workflow/env` to point the wiki-write hook at the Goal whose canonical should handle bug filings. Optionally flip `auto_canonical_via_leaderboard=true` via `update_goal()` once a few candidate branches are bound and have produced enough runs to clear the threshold.
- [ ] Post-merge observation window: confirm `run_canonical` calls land cleanly + the `source` field on responses shows the resolution path the chatbot/host expects. Tune `min_completed_runs_for_canonical` if the default of 5 is too restrictive.

## Deferred followups

- **Cutover plan Steps 5/6** — remove `WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID` env-fallback path once the canonical handler has been observation-windowed in production. Separate PR after merge.
- **MCP surface for the two new Goal fields** — `update_goal()` storage helper supports them today; the `goals action=update` MCP wrapper exposes them in a follow-on slice. Host scripts can set them via the storage helper today.
- **Telemetry on refresh-decision frequency** — how often each `source` label is hit. Useful for tuning the default threshold after a few weeks of observation.
- **Cheat-loop deletion** — the env-var + scheduling code attached to the round-1 path is intentionally untouched here. Cutover plan Step 6 removes it once the observation window passes.

## Codex round-2 verdict needed before merge

Substantive substrate addition wiring leaderboard signals into the
dispatch path. Checker should re-verify:

1. The threshold gate (`min_completed_runs_for_canonical`) actually
   prevents swap-in of a candidate that ranks high on judgment alone
   with insufficient run history.
2. The in-flight gate uses the right time window + status set; a
   stale orphaned run does NOT block refresh (matches
   `_recover_orphaned_runs_on_read` semantics).
3. The env-fallback path is reached only when the Goal canonical
   resolution returns ok=False or no `GOAL_ID` env is set; a successful
   canonical resolution does NOT silently fall through to the env.
4. `set_canonical_branch`'s history-audit semantics are preserved — the
   auto-refresh records itself as `auto-canonical-refresh` author in
   the canonical-history audit row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
