### PR TITLE
PR-128: sync WORKFLOW_GITHUB_PR_CAPABILITIES into droplet env on deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -22,6 +22,14 @@ name: Deploy prod
 #   WORKFLOW_CODEX_AUTH_JSON_B64 - base64-encoded ~/.codex/auth.json.
 #   When present, deploy syncs it into /etc/workflow/env without printing it
 #   and forces WORKFLOW_ALLOW_API_KEY_PROVIDERS=0 for the public daemon.
+#
+# Optional PR-122 Phase 2 capability secret (PR-128):
+#   WORKFLOW_GITHUB_PR_CAPABILITIES - JSON object mapping
+#   "<owner>/<repo>" -> "<token>". Read by
+#   workflow.effectors.github_pr at invocation time; never echoed
+#   into branch-visible run state. When unset, the effector emits
+#   error_kind="missing_capability" dry-run evidence on real-PR
+#   attempts.
 
 on:
   workflow_run:
@@ -61,6 +69,14 @@ jobs:
     timeout-minutes: 15
     env:
       HAS_CODEX_AUTH_BUNDLE: ${{ secrets.WORKFLOW_CODEX_AUTH_JSON_B64 != '' }}
+      # PR-128 — PR-122 Phase 2 capability map sync. When the
+      # WORKFLOW_GITHUB_PR_CAPABILITIES GH Actions secret is set
+      # (JSON object keyed by "<owner>/<repo>" -> "<token>"), the
+      # deploy step installs it into /etc/workflow/env so the Phase 2
+      # effector can pass its capability gate. Without this the
+      # effector emits error_kind="missing_capability" and stays in
+      # dry-run for real-PR attempts.
+      HAS_GITHUB_PR_CAPABILITY: ${{ secrets.WORKFLOW_GITHUB_PR_CAPABILITIES != '' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -314,6 +330,11 @@ jobs:
         id: deploy
         env:
           WORKFLOW_CODEX_AUTH_JSON_B64: ${{ secrets.WORKFLOW_CODEX_AUTH_JSON_B64 }}
+          # PR-128 — Phase 2 effector capability map. JSON object
+          # mapping "<owner>/<repo>" -> "<token>" (round-2 P1.2
+          # shape). Read by workflow.effectors.github_pr at
+          # invocation time; never echoed into branch-visible state.
+          WORKFLOW_GITHUB_PR_CAPABILITIES: ${{ secrets.WORKFLOW_GITHUB_PR_CAPABILITIES }}
         run: |
           NEW_IMAGE="${{ steps.tag.outputs.image }}:${{ steps.tag.outputs.tag }}"
           echo "Deploying: ${NEW_IMAGE}"
@@ -342,11 +363,29 @@ jobs:
           else
             echo "::warning::WORKFLOW_CODEX_AUTH_JSON_B64 is not visible to deploy; leaving any existing droplet subscription auth untouched."
           fi
+          # PR-128 — sync the Phase 2 effector capability map. Same
+          # install-workflow-env.sh helper, same atomic write
+          # contract. The map MUST decode to a JSON object keyed by
+          # "<owner>/<repo>" -> "<token>"; the effector
+          # (workflow.effectors.github_pr) validates the shape and
+          # logs loudly on malformed JSON. When the secret is unset,
+          # the effector returns missing_capability dry-run evidence
+          # — emit a deploy-time warning so the operator notices
+          # before chatbots start filing for real-write attempts.
+          if [ "${HAS_GITHUB_PR_CAPABILITY}" = "true" ]; then
+            echo "Deploy-visible WORKFLOW_GITHUB_PR_CAPABILITIES found; syncing GitHub PR capability map."
+            printf '%s' "${WORKFLOW_GITHUB_PR_CAPABILITIES}" | ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
+                "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
+                "sudo bash /tmp/install-workflow-env.sh set WORKFLOW_GITHUB_PR_CAPABILITIES"
+          else
+            echo "::warning::WORKFLOW_GITHUB_PR_CAPABILITIES is not visible to deploy; effects emission will remain dry-run with error_kind=missing_capability."
+          fi
           {
             echo "## Deploy subscription auth"
             echo ""
             echo "- WORKFLOW_CODEX_AUTH_JSON_B64 visible to deploy: \`${HAS_CODEX_AUTH_BUNDLE}\`"
             echo "- API-key providers forced off when the Codex subscription bundle is synced."
+            echo "- WORKFLOW_GITHUB_PR_CAPABILITIES visible to deploy: \`${HAS_GITHUB_PR_CAPABILITY}\`"
           } >> "$GITHUB_STEP_SUMMARY"
           # Pull + restart via the systemd unit (which runs docker
           # compose down + up with the new env).

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -378,7 +378,24 @@ jobs:
                 "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
                 "sudo bash /tmp/install-workflow-env.sh set WORKFLOW_GITHUB_PR_CAPABILITIES"
           else
-            echo "::warning::WORKFLOW_GITHUB_PR_CAPABILITIES is not visible to deploy; effects emission will remain dry-run with error_kind=missing_capability."
+            # Round-2 fix (Codex round-1 finding on PR #980): the
+            # documented contract is "absence -> dry-run". Round-1
+            # logged a warning but left any prior
+            # WORKFLOW_GITHUB_PR_CAPABILITIES value in
+            # /etc/workflow/env, which meant deleting the GH Actions
+            # secret to revoke had no effect — the next deploy
+            # restarted the daemon with the OLD capability still
+            # active. Fix: when the secret is absent, explicitly
+            # delete the key from the droplet env so the effector
+            # observes "missing capability" on its next read. The
+            # install-workflow-env.sh helper's `delete` subcommand is
+            # a no-op when the key is already absent (assert_readable
+            # still passes), so re-running this on a clean droplet
+            # is safe.
+            echo "::warning::WORKFLOW_GITHUB_PR_CAPABILITIES is not visible to deploy; removing any prior capability from /etc/workflow/env so effects emission stays dry-run with error_kind=missing_capability."
+            ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
+                "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
+                "sudo bash /tmp/install-workflow-env.sh delete WORKFLOW_GITHUB_PR_CAPABILITIES"
           fi
           {
             echo "## Deploy subscription auth"

--- a/tests/test_deploy_prod_workflow.py
+++ b/tests/test_deploy_prod_workflow.py
@@ -510,3 +510,137 @@ def test_codex_volume_step_migrates_from_running_container_once():
     assert "docker cp workflow-worker:/app/.codex/auth.json" in run_script
     assert 'chown "$WORKFLOW_UID:$WORKFLOW_GID" "$VOLUME_DIR/auth.json"' in run_script
     assert 'chmod 600 "$VOLUME_DIR/auth.json"' in run_script
+
+
+# ---------------------------------------------------------------------------
+# PR-128 — Phase 2 capability map sync into /etc/workflow/env
+# ---------------------------------------------------------------------------
+
+
+def test_deploy_job_env_has_github_pr_capability_flag():
+    """The job-level env block must surface ``HAS_GITHUB_PR_CAPABILITY``
+    so the Deploy step + summary can branch on whether the secret is
+    visible to this run. Pattern mirrors ``HAS_CODEX_AUTH_BUNDLE``."""
+    wf = _load()
+    job_env = (wf.get("jobs", {}).get("deploy", {}) or {}).get("env") or {}
+    assert "HAS_GITHUB_PR_CAPABILITY" in job_env, (
+        "deploy job env must expose HAS_GITHUB_PR_CAPABILITY so the "
+        "Deploy step and summary can branch on capability visibility"
+    )
+    raw_value = str(job_env["HAS_GITHUB_PR_CAPABILITY"])
+    assert "secrets.WORKFLOW_GITHUB_PR_CAPABILITIES" in raw_value, (
+        "HAS_GITHUB_PR_CAPABILITY must be derived from the "
+        "WORKFLOW_GITHUB_PR_CAPABILITIES secret presence check"
+    )
+    assert "!= ''" in raw_value, (
+        "HAS_GITHUB_PR_CAPABILITY must use a non-empty-string check, "
+        "matching the HAS_CODEX_AUTH_BUNDLE pattern"
+    )
+
+
+def test_deploy_step_env_imports_github_pr_capabilities_secret():
+    """The Deploy step's local env block must import the capability
+    map secret so the inline ssh-piping path can read it."""
+    wf = _load()
+    deploy_step = next(
+        (s for s in _steps(wf) if s.get("id") == "deploy"),
+        None,
+    )
+    assert deploy_step is not None, "deploy job must have a deploy step"
+    step_env = deploy_step.get("env") or {}
+    assert "WORKFLOW_GITHUB_PR_CAPABILITIES" in step_env, (
+        "Deploy step env must import WORKFLOW_GITHUB_PR_CAPABILITIES "
+        "from secrets so the inline ssh sync can pipe the value"
+    )
+    raw_value = str(step_env["WORKFLOW_GITHUB_PR_CAPABILITIES"])
+    assert "secrets.WORKFLOW_GITHUB_PR_CAPABILITIES" in raw_value
+
+
+def test_deploy_step_syncs_github_pr_capabilities_when_set():
+    """When ``HAS_GITHUB_PR_CAPABILITY=true``, the Deploy step must
+    pipe the secret into install-workflow-env.sh via the same atomic
+    helper used for WORKFLOW_CODEX_AUTH_JSON_B64."""
+    wf = _load()
+    deploy_step = next(
+        (s for s in _steps(wf) if s.get("id") == "deploy"),
+        None,
+    )
+    assert deploy_step is not None
+    run_script = deploy_step.get("run", "") or ""
+
+    # Required-shape assertions: the conditional, the pipe, the helper
+    # invocation, and the warning surface for the missing-secret case.
+    assert 'if [ "${HAS_GITHUB_PR_CAPABILITY}" = "true" ]' in run_script, (
+        "deploy must gate the WORKFLOW_GITHUB_PR_CAPABILITIES sync on "
+        "HAS_GITHUB_PR_CAPABILITY=true so absence is a warning, not "
+        "an unbound-variable failure"
+    )
+    assert (
+        'printf \'%s\' "${WORKFLOW_GITHUB_PR_CAPABILITIES}"'
+        in run_script
+    ), (
+        "deploy must pipe the secret via printf '%s' so the value is "
+        "never echoed to the GH Actions log (matches the codex-auth "
+        "pattern)"
+    )
+    assert (
+        "install-workflow-env.sh set WORKFLOW_GITHUB_PR_CAPABILITIES"
+        in run_script
+    ), (
+        "deploy must call the atomic install-workflow-env.sh helper "
+        "(the same path that enforces root:workflow 640 + post-write "
+        "readability) to write the capability map"
+    )
+    assert (
+        "WORKFLOW_GITHUB_PR_CAPABILITIES is not visible to deploy"
+        in run_script
+    ), (
+        "deploy must emit a structured ::warning:: when the secret is "
+        "absent so the operator notices before chatbots try real-PR "
+        "emission and see missing_capability dry-run evidence"
+    )
+
+
+def test_deploy_step_summary_reports_github_pr_capability_visibility():
+    """The GH Actions step summary must surface whether the capability
+    was synced this run so the operator can confirm post-deploy."""
+    wf = _load()
+    deploy_step = next(
+        (s for s in _steps(wf) if s.get("id") == "deploy"),
+        None,
+    )
+    assert deploy_step is not None
+    run_script = deploy_step.get("run", "") or ""
+    assert (
+        "WORKFLOW_GITHUB_PR_CAPABILITIES visible to deploy"
+        in run_script
+    ), (
+        "deploy step summary must report the capability-map visibility "
+        "alongside the codex-auth visibility line so the operator can "
+        "verify both auth surfaces from one place"
+    )
+
+
+def test_github_pr_capability_sync_runs_after_codex_auth_sync():
+    """Determinism: both sync blocks live in the same Deploy step, and
+    the capability sync must run AFTER the codex-auth sync so the
+    summary order matches the operator's mental model (codex first,
+    capability second)."""
+    wf = _load()
+    deploy_step = next(
+        (s for s in _steps(wf) if s.get("id") == "deploy"),
+        None,
+    )
+    assert deploy_step is not None
+    run_script = deploy_step.get("run", "") or ""
+    codex_marker = "set WORKFLOW_CODEX_AUTH_JSON_B64"
+    cap_marker = "set WORKFLOW_GITHUB_PR_CAPABILITIES"
+    codex_idx = run_script.find(codex_marker)
+    cap_idx = run_script.find(cap_marker)
+    assert codex_idx != -1, "codex-auth sync block must be present"
+    assert cap_idx != -1, "capability sync block must be present"
+    assert codex_idx < cap_idx, (
+        "capability sync must run after the codex-auth sync — both "
+        "live in the same Deploy step and the operator-facing summary "
+        "lists them in that order"
+    )

--- a/tests/test_deploy_prod_workflow.py
+++ b/tests/test_deploy_prod_workflow.py
@@ -644,3 +644,111 @@ def test_github_pr_capability_sync_runs_after_codex_auth_sync():
         "live in the same Deploy step and the operator-facing summary "
         "lists them in that order"
     )
+
+
+# ---------------------------------------------------------------------------
+# Round-2 (Codex round-1 finding) — capability-revoke must actually revoke
+# ---------------------------------------------------------------------------
+
+
+def test_deploy_step_deletes_github_pr_capability_when_secret_absent():
+    """Round-2 regression guard. Round-1 logged a warning when
+    ``WORKFLOW_GITHUB_PR_CAPABILITIES`` was absent but did NOT remove
+    the existing key from ``/etc/workflow/env``, so deleting the GH
+    Actions secret to revoke had no effect — the next deploy
+    restarted the daemon with the OLD capability still active.
+
+    The fix: when ``HAS_GITHUB_PR_CAPABILITY=false`` (or unset), the
+    Deploy step must issue an explicit
+    ``install-workflow-env.sh delete WORKFLOW_GITHUB_PR_CAPABILITIES``
+    call so the effector observes ``missing_capability`` on its next
+    read. The documented contract ("absence -> dry-run") was being
+    silently violated; this test gates the fix.
+    """
+    wf = _load()
+    deploy_step = next(
+        (s for s in _steps(wf) if s.get("id") == "deploy"),
+        None,
+    )
+    assert deploy_step is not None
+    run_script = deploy_step.get("run", "") or ""
+    assert (
+        "install-workflow-env.sh delete WORKFLOW_GITHUB_PR_CAPABILITIES"
+        in run_script
+    ), (
+        "Deploy step must issue an explicit `install-workflow-env.sh "
+        "delete WORKFLOW_GITHUB_PR_CAPABILITIES` call when the secret "
+        "is absent so revoking the GH Actions secret actually "
+        "revokes capability on the droplet (round-2 fix for PR #980 "
+        "Codex finding)."
+    )
+
+
+def test_capability_delete_is_gated_on_else_branch():
+    """The delete call must live inside the ``else`` branch of the
+    ``HAS_GITHUB_PR_CAPABILITY`` conditional — never run when the
+    secret IS present. A naive fix that placed the delete
+    unconditionally would clobber the value the previous ``set``
+    call just installed."""
+    wf = _load()
+    deploy_step = next(
+        (s for s in _steps(wf) if s.get("id") == "deploy"),
+        None,
+    )
+    assert deploy_step is not None
+    run_script = deploy_step.get("run", "") or ""
+
+    # Anchor the conditional. The set call must come before the
+    # else+delete tail.
+    set_marker = "install-workflow-env.sh set WORKFLOW_GITHUB_PR_CAPABILITIES"
+    delete_marker = (
+        "install-workflow-env.sh delete WORKFLOW_GITHUB_PR_CAPABILITIES"
+    )
+    set_idx = run_script.find(set_marker)
+    delete_idx = run_script.find(delete_marker)
+    assert set_idx != -1, "set call must remain in the truthy branch"
+    assert delete_idx != -1, "delete call must be present in else branch"
+    assert set_idx < delete_idx, (
+        "set call (truthy branch) must precede delete call (else "
+        "branch) in the source — confirms the delete lives in the "
+        "ELSE arm of the HAS_GITHUB_PR_CAPABILITY conditional"
+    )
+
+    # Walk the lines between the two markers and assert an ``else``
+    # token sits between them. This is the regression guard: a future
+    # refactor that flattens the conditional without re-checking would
+    # fail this assertion.
+    between = run_script[set_idx + len(set_marker):delete_idx]
+    assert "else" in between, (
+        "An `else` keyword must appear between the set call and the "
+        "delete call. If a refactor restructures the conditional, the "
+        "delete must remain inside an else-gated branch — never run "
+        "unconditionally."
+    )
+
+
+def test_capability_delete_warning_explains_revocation():
+    """The warning line on the else branch must convey that the
+    revocation actually happens (removing the prior key), not just
+    that the secret is absent — operators need to know the deploy
+    actively cleaned up the env."""
+    wf = _load()
+    deploy_step = next(
+        (s for s in _steps(wf) if s.get("id") == "deploy"),
+        None,
+    )
+    assert deploy_step is not None
+    run_script = deploy_step.get("run", "") or ""
+    assert "::warning::" in run_script
+    # The warning must reference removing/deleting the prior value so
+    # an operator skimming GH Actions logs can tell the difference
+    # between "noop because never set" and "actually revoked".
+    assert (
+        "removing any prior" in run_script
+        or "remove any prior" in run_script
+        or "delete WORKFLOW_GITHUB_PR_CAPABILITIES" in run_script
+    ), (
+        "the absence warning must describe the revocation action so "
+        "operators can confirm capability was actually cleared from "
+        "/etc/workflow/env, not just absent from GH Actions"
+    )


### PR DESCRIPTION
## Summary

Extends `.github/workflows/deploy-prod.yml` to sync the new
`WORKFLOW_GITHUB_PR_CAPABILITIES` GH Actions secret into the droplet's
`/etc/workflow/env` on each deploy. Mirrors the existing pattern used
for `WORKFLOW_CODEX_AUTH_JSON_B64`.

## Why this PR exists

PR-122 Phase 2 (PR #969, landed on main as `7922a21`) reads the
capability JSON map from `WORKFLOW_GITHUB_PR_CAPABILITIES` when
deciding whether a real `gh pr create` may fire. Without this PR the
env never lands on the droplet — effects emission stays in dry-run
with `error_kind="missing_capability"` even after the host populates
the secret in GH Actions.

## Changes

**`deploy-prod.yml`:**

1. **Job-level env block** — adds `HAS_GITHUB_PR_CAPABILITY` derived
   from the secret's presence check (`!= ''`), mirroring
   `HAS_CODEX_AUTH_BUNDLE`.
2. **Deploy step env** — imports the raw secret so the inline ssh
   pipe can read it without echoing the value into the GH Actions log.
3. **Conditional sync block** — when `HAS_GITHUB_PR_CAPABILITY=true`,
   pipes the value through `install-workflow-env.sh` (the same atomic
   helper that enforces `root:workflow 640` + post-write readability
   — the 2026-04-21 P0 RC-1 invariant).
4. **Missing-secret warning** — emits `::warning::` when the secret
   is absent so the operator notices before chatbots try real-PR
   emission and see `missing_capability` dry-run evidence.
5. **Step summary** — surfaces the visibility flag alongside the
   codex-auth visibility line.
6. **Header comments** — documents the new optional secret + its
   JSON-map shape + the missing_capability fallback behavior.

The capability sync runs **after** the codex-auth sync inside the same
Deploy step — both co-located so a single deploy run installs both
auth surfaces, and the summary lists them in operator-mental-model
order.

## Tests

`tests/test_deploy_prod_workflow.py` (+5 cases):

- `test_deploy_job_env_has_github_pr_capability_flag` — shape of the
  job-level env entry (`secrets.WORKFLOW_GITHUB_PR_CAPABILITIES != ''`).
- `test_deploy_step_env_imports_github_pr_capabilities_secret` —
  Deploy step env imports the secret.
- `test_deploy_step_syncs_github_pr_capabilities_when_set` — full
  shape of the sync block: gated conditional + `printf '%s'` pipe
  (so the value is never echoed) + `install-workflow-env.sh` helper
  invocation + missing-secret `::warning::`.
- `test_deploy_step_summary_reports_github_pr_capability_visibility`
  — step summary carries the visibility flag.
- `test_github_pr_capability_sync_runs_after_codex_auth_sync` —
  ordering lock so the summary stays in mental-model order.

## Verification

- [x] `pytest tests/test_deploy_prod_workflow.py -p no:cacheprovider` → **35 passed** (was 30; +5 new)
- [x] `ruff check tests/test_deploy_prod_workflow.py` → clean
- [x] YAML parse + step structure sanity (job/step env keys, sync-block presence, summary line)
- [ ] `actionlint` — binary not on local PATH; CI `actionlint.yml` workflow is the authoritative gate per repo policy. Will run on this PR push.
- [x] Pre-commit hooks: mojibake / cross-provider-drift / skills-valid all clean. No `workflow/*` changes → no mirror parity work needed.

## Operational notes

After this merges + redeploys, the next deploy will install the
capability map into `/etc/workflow/env` on the droplet. From that
point, Phase 2 effectors can emit real PRs against Jonnyton/Workflow
once `effector_consents` are granted (separate MCP call:
`extensions action=grant_effector_consent`).

If `WORKFLOW_GITHUB_PR_CAPABILITIES` is left unset in GH Actions
secrets, the warning fires but the deploy proceeds — effector stays
in dry-run, which is the safe default.

## Codex round-2 verdict needed before merge

Operational substrate change — no public-facing impact. Checker
should re-verify:

1. The secret value is never echoed to the GH Actions log (the
   `printf '%s'` pipe pattern, not `echo`).
2. The atomic write helper (`install-workflow-env.sh`) is used (not
   raw `sed -i` — the 2026-04-21 P0 RC-1 invariant).
3. Missing-secret path is a warning, not a failure — deploy must
   proceed and leave effects in safe dry-run.
4. The sync block lives inside the Deploy step (not as a separate
   step) so a single deploy run installs both auth surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)