### PR TITLE
DESIGN-008: user-buildable selector primitive (atomic substrate swap)

### DIFF
--- a/drafts/concepts/selector-branch-contract.md
+++ b/drafts/concepts/selector-branch-contract.md
@@ -1,0 +1,198 @@
+# Selector Branch Contract (DESIGN-008)
+
+**Status:** shipped in DESIGN-008.
+
+A **selector branch** is a published Workflow branch that ranks the
+candidate branches competing on a Goal's leaderboard. The substrate
+dispatches it whenever `quality_leaderboard goal_id=<g>` or
+`recommend_parent_for_fork goal_id=<g>` is called.
+
+Goal owners bind a selector via:
+
+```
+goals action=set_selector goal_id=<g> branch_version_id=<v>
+```
+
+Pass `branch_version_id=""` to fall back to the platform default
+selector (`platform_default_selector_v1_20260521`).
+
+Anyone publishing a selector implements this contract.
+
+---
+
+## Inputs
+
+The selector run is invoked with the following `inputs` dict (passed
+as the `inputs_json` payload to `execute_branch_version_async`):
+
+```json
+{
+  "goal_id": "<goal-id>",
+  "candidate_branches": [
+    {
+      "branch_def_id": "...",
+      "branch_version_id": "<latest active version, or empty string>",
+      "name": "...",
+      "author": "...",
+      "description": "...",
+      "signals": {
+        "completed_run_count":      <int>,
+        "failed_run_count":         <int>,
+        "total_run_count":          <int>,
+        "judgment_score_avg":       <float | null>,
+        "judgment_count":           <int>,
+        "judgment_score_samples":   <int>,
+        "other_numeric_tags":       {"<key>": <count>, ...},
+        "fork_count":               <int>,
+        "last_successful_run_at":   <epoch float, 0.0 if never>,
+        "age_days_since_success":   <float | null>,
+        "has_gate_rung":            <bool>,
+        "gate_rung_top":            <str | null>,
+        "safe_to_publish":          <bool>
+      }
+    },
+    ...
+  ]
+}
+```
+
+**Signal semantics:**
+
+| Field | Meaning |
+|-------|---------|
+| `completed_run_count` | Runs that finished with `status='completed'`. |
+| `failed_run_count` | Runs that finished with `status='failed'`. |
+| `total_run_count` | All runs against the branch (including queued / running). |
+| `judgment_score_avg` | Mean of numeric judgment tags matching `quality:N` / `novelty:N` / `score:N`. `null` when no numeric judgments exist. |
+| `judgment_count` | Total judgment rows on this branch (numeric + free-text). |
+| `judgment_score_samples` | Number of judgments that contributed to `judgment_score_avg`. |
+| `other_numeric_tags` | Other tag-name counts (e.g. `risk:N`, `cost:N`) — exposed in case the selector wants to weight them; the default selector does not. |
+| `fork_count` | Count of branches whose `parent_def_id` or `fork_from` points at this branch (visibility-respecting). |
+| `last_successful_run_at` | Max `finished_at` of completed runs, in Unix epoch seconds (float). `0.0` when no completed run exists. |
+| `age_days_since_success` | Days between `last_successful_run_at` and `now`. `null` when no completed run exists. |
+| `has_gate_rung` | True iff at least one non-retracted `gate_claims` row exists for this `(branch, goal)`. |
+| `gate_rung_top` | The lexicographically-greatest active `rung_key` for this `(branch, goal)`, or `null`. |
+| `safe_to_publish` | Best-effort read of `branch.stats.next_action_packet.safe_to_publish` (Loop-2 packet shape). `false` when not set. |
+
+---
+
+## Outputs
+
+The selector run must populate its final state with a `ranked_entries`
+key:
+
+```json
+{
+  "ranked_entries": [
+    {
+      "branch_def_id":     "<must match an entry in candidate_branches>",
+      "branch_version_id": "<published version_id, or empty string>",
+      "score":             <float>,
+      "rationale":         "<one-sentence human-readable explanation>"
+    },
+    ...
+  ]
+}
+```
+
+**Rules:**
+
+* Entries are ordered best-first (rank 1 = entries[0]).
+* `branch_def_id` is **required** and must be a non-empty string. The
+  substrate filters out entries that don't match a `branch_def_id`
+  from the input `candidate_branches` (defensive: a misbehaving
+  selector cannot conjure phantom branches into the leaderboard).
+* `score` is **required**, must coerce to float. Suggested 0.0-10.0
+  scale; the substrate doesn't enforce a range.
+* `branch_version_id` is optional — when empty, the substrate falls
+  back to the latest active version for the `branch_def_id`.
+* `rationale` is optional — when empty, the substrate synthesizes a
+  generic "ranked first of N with score X" string.
+* Ties are tolerated. Two entries may have the same `score`.
+* Duplicate `branch_def_id`s are filtered out by the substrate (only
+  the first occurrence is kept).
+
+**`ranked_entries` can be the empty list** when `candidate_branches`
+was empty. The substrate short-circuits dispatch entirely in that
+case and never invokes the selector.
+
+**Output may be a JSON string.** Prompt-template nodes typically
+emit their output as a string. The substrate parses
+`output["ranked_entries"]` as either a list (direct) or a JSON-string
+that decodes to a list. Both shapes are accepted.
+
+---
+
+## Failure modes
+
+The substrate translates selector misbehavior into structured error
+responses on the caller's `quality_leaderboard` / `recommend_parent_for_fork`
+result. The leaderboard never raises a Python exception to the chatbot;
+it returns `{ok: False, error_kind: "...", error: "..."}`.
+
+| `error_kind` | Cause |
+|---|---|
+| `goal_not_found` | The `goal_id` passed to `quality_leaderboard` has no row in `goals`. |
+| `selector_not_published` | `goal.selector_branch_version_id` references a `branch_version_id` that doesn't exist in `branch_versions`. |
+| `selector_snapshot_drift` | The selector's snapshot was published against a Workflow schema version the runtime can no longer reconstruct. Re-publish at current schema. |
+| `selector_dispatch_failed` | `execute_branch_version_async` raised before producing a `run_id` (rare; typically a malformed snapshot). |
+| `selector_timeout` | The selector's background run did not finish within `WORKFLOW_SELECTOR_TIMEOUT_S` seconds (default 60s). |
+| `selector_run_failed` | The selector run finished with `status != 'completed'`. The run row's `error` field is surfaced. |
+| `selector_invalid_output` | `ranked_entries` is missing, not a list, contains malformed entries, or any required key is missing. |
+
+When a selector fails, the leaderboard returns an empty `entries` list
+plus the `error_kind` so the chatbot can render a clear "selector
+misbehaved" surface. The recovery path is operator action: rebind a
+known-good selector via `set_selector`, fork the failing one + fix the
+prompt, or unbind to fall back to the platform default.
+
+---
+
+## Default selector
+
+The platform ships a default selector branch published under the
+deterministic id `platform_default_selector_v1_20260521`. It is a
+single prompt-template node whose prompt encodes the ranking heuristic
+the round-1 platform formula used to apply in Python: weight judgment
+score highest, then completed runs, then forks, then recency, with a
+penalty for failed runs.
+
+**The weights are now a prompt the chatbot can fork and edit, not
+Python constants.** A Goal owner who wants different selection logic
+for their domain forks the default selector via
+`extensions action=create_branch fork_from=platform_default_selector_v1_20260521`,
+edits the prompt, publishes, and binds via `set_selector`.
+
+---
+
+## Authority
+
+`set_selector` requires Goal-author or host actor authority (same
+surface as `set_canonical`). A selector binding is a per-Goal write;
+the platform default is a system-wide fallback.
+
+---
+
+## Cost
+
+Each leaderboard build now triggers one LLM call (the selector run).
+The round-1 formula was free. Acceptable trade for the architectural
+win: selection logic is now community-evolvable instead of
+platform-opinionated.
+
+A future caching slice may memoize selector output keyed by
+`(goal_id, candidate fingerprint)` for N minutes. Until then,
+leaderboard calls are uncached.
+
+---
+
+## Reference
+
+* `workflow/api/selector_dispatch.py` — selector resolution +
+  dispatch + output parsing.
+* `workflow/api/quality_leaderboard.py` — leaderboard caller that
+  consumes the selector's output.
+* `workflow/api/market.py::_action_goal_set_selector` — MCP action
+  for binding a selector.
+* `workflow/daemon_server.py::set_selector_branch` — storage helper
+  with active-version validation.

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions_leaderboard_actions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions_leaderboard_actions.py
@@ -133,6 +133,19 @@ def _render_leaderboard_text(board: dict[str, Any]) -> str:
         f"'{goal.get('name')}' ({board.get('goal_id')})"
         if goal else f"Goal {board.get('goal_id')}"
     )
+    # DESIGN-008: surface selector failures via the text channel so a
+    # misbehaving selector renders cleanly in the chatbot. The
+    # structured payload also carries error_kind for programmatic
+    # consumers.
+    if board.get("ok") is False:
+        err_kind = board.get("error_kind", "selector_error")
+        err = board.get("error", "")
+        return (
+            f"Selector failed for {goal_label} (`{err_kind}`): {err}. "
+            "Operator action: rebind a working selector via "
+            "`goals action=set_selector branch_version_id=…` or "
+            "unbind to fall back to the platform default."
+        )
     if not entries:
         return (
             f"No Branches are currently bound to {goal_label}. "

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
@@ -1559,6 +1559,95 @@ def _action_goal_archive_consultation(kwargs: dict[str, Any]) -> str:
     }, default=str)
 
 
+def _action_goal_set_selector(kwargs: dict[str, Any]) -> str:
+    """Bind (or unbind) a Goal's selector branch — DESIGN-008.
+
+    The selector branch is the published Workflow branch the
+    substrate dispatches to rank a Goal's bound branches. Pass
+    ``branch_version_id=""`` to unbind (fall back to platform
+    default selector).
+
+    Authority: only Goal author or a host-level actor may bind a
+    selector — same surface as ``set_canonical``.
+
+    Required kwargs:
+      * ``goal_id`` — Goal whose selector is being bound.
+
+    Optional kwargs:
+      * ``branch_version_id`` — selector branch_version to bind, or
+        empty string / omitted to unbind.
+
+    Returns:
+      * ``{status: "ok", selector_branch_version_id: ...}`` on bind/unbind.
+      * ``{status: "rejected", error: ...}`` on auth failure / bad input
+        / non-active version.
+    """
+    from workflow.api.branches import _ensure_workflow_db
+    from workflow.api.engine_helpers import _current_actor
+    from workflow.daemon_server import get_goal, set_selector_branch
+
+    gid = (kwargs.get("goal_id") or "").strip()
+    if not gid:
+        return json.dumps({
+            "status": "rejected",
+            "error": "goal_id is required for set_selector.",
+        })
+    raw_bvid = (kwargs.get("branch_version_id") or "").strip()
+    branch_version_id = raw_bvid or None
+    _ensure_workflow_db()
+
+    try:
+        goal = get_goal(_base_path(), goal_id=gid)
+    except KeyError:
+        return json.dumps({
+            "status": "rejected",
+            "error": f"Goal '{gid}' not found.",
+        })
+
+    actor = _current_actor()
+    host_actor = os.environ.get("UNIVERSE_SERVER_HOST_USER", "host")
+    if actor != goal["author"] and actor != host_actor:
+        return json.dumps({
+            "status": "rejected",
+            "error": (
+                "Only the Goal author or a host-level actor may bind "
+                "the selector branch. Goal author is "
+                f"'{goal['author']}'; request actor is '{actor}'."
+            ),
+        })
+
+    try:
+        updated = set_selector_branch(
+            _base_path(), goal_id=gid,
+            branch_version_id=branch_version_id, set_by=actor,
+        )
+    except ValueError as exc:
+        return json.dumps({"status": "rejected", "error": str(exc)})
+
+    if branch_version_id:
+        text = (
+            f"Selector branch for Goal '{goal['name']}' set to "
+            f"`{branch_version_id}`. Future "
+            "`quality_leaderboard` / `recommend_parent_for_fork` "
+            "calls dispatch this branch to rank candidates."
+        )
+    else:
+        text = (
+            f"Selector branch for Goal '{goal['name']}' unbound. "
+            "Leaderboard calls fall back to the platform default "
+            "selector."
+        )
+
+    return json.dumps({
+        "status": "ok",
+        "text": text,
+        "goal_id": gid,
+        "selector_branch_version_id": updated.get(
+            "selector_branch_version_id",
+        ),
+    }, default=str)
+
+
 def _action_goal_set_canonical(kwargs: dict[str, Any]) -> str:
     from workflow.api.branches import _ensure_workflow_db
     from workflow.api.engine_helpers import (
@@ -1763,6 +1852,11 @@ _GOAL_ACTIONS: dict[str, Any] = {
     # dispatch. Honors auto_canonical_via_leaderboard + threshold +
     # in-flight gate; delegates the actual run to run_branch_version.
     "run_canonical": _action_goal_run_canonical,
+    # DESIGN-008 — user-buildable selector primitive. Bind the
+    # published Workflow branch that synthesizes the Goal's
+    # leaderboard. Pass branch_version_id="" to fall back to the
+    # platform default selector.
+    "set_selector": _action_goal_set_selector,
 }
 
 # Provider-routing compatibility: ChatGPT can render `/mcp-directory` tool
@@ -1776,6 +1870,8 @@ _GOAL_ACTION_ALIASES: dict[str, str] = {
 
 _GOAL_WRITE_ACTIONS: frozenset[str] = frozenset({
     "propose", "update", "bind", "set_canonical",
+    # DESIGN-008 — selector branch binding writes to goals row.
+    "set_selector",
 })
 
 
@@ -1877,6 +1973,14 @@ def goals(
       set_canonical Mark a branch_version_id as the Goal's canonical
                    (best-known) branch. Author-only or host-only.
                    Pass branch_version_id="" to unset.
+      set_selector Bind the Goal's selector branch_version — the
+                   published Workflow branch the substrate dispatches
+                   to rank this Goal's bound branches on the
+                   leaderboard (DESIGN-008). Author-only or
+                   host-only. Pass branch_version_id="" to unbind
+                   and fall back to the platform default selector.
+                   The bound selector MUST conform to the contract
+                   in drafts/concepts/selector-branch-contract.md.
       run_canonical Dispatch a run against the Goal's canonical
                    branch_version. PR-127 (M6 cutover): when
                    ``auto_canonical_via_leaderboard`` is enabled on the

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
@@ -1584,7 +1584,11 @@ def _action_goal_set_selector(kwargs: dict[str, Any]) -> str:
     """
     from workflow.api.branches import _ensure_workflow_db
     from workflow.api.engine_helpers import _current_actor
-    from workflow.daemon_server import get_goal, set_selector_branch
+    from workflow.daemon_server import (
+        SelectorHasEffectsError,
+        get_goal,
+        set_selector_branch,
+    )
 
     gid = (kwargs.get("goal_id") or "").strip()
     if not gid:
@@ -1621,6 +1625,15 @@ def _action_goal_set_selector(kwargs: dict[str, Any]) -> str:
             _base_path(), goal_id=gid,
             branch_version_id=branch_version_id, set_by=actor,
         )
+    except SelectorHasEffectsError as exc:
+        # P1.3 — surface the effects rejection with a structured
+        # error_kind so chatbots can route the operator to the fix
+        # path ("remove effects on offending nodes, then re-bind").
+        return json.dumps({
+            "status": "rejected",
+            "error_kind": "selector_has_effects",
+            "error": str(exc),
+        })
     except ValueError as exc:
         return json.dumps({"status": "rejected", "error": str(exc)})
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
@@ -1,103 +1,97 @@
-"""Quality leaderboard + parent-selection — PR-123 substrate (M2).
+"""Quality leaderboard + parent-selection — DESIGN-008 (user-buildable selectors).
 
-Surfaces, for any Goal that has competing Branch entries:
+PR-123 originally shipped this surface with a platform-opinionated
+scoring formula baked into Python — weights for runs / forks /
+judgments / recency / gates / safe_to_publish all chosen by the
+platform. PR #978 tried to patch a bug in that formula (timestamp
+coercion); the host closed PR #978 because patching the formula
+entrenches the wrong architecture.
 
-- ``quality_leaderboard(goal_id)`` — ranked list of Branches bound to
-  the Goal, with the per-entry signal summary that produced the score.
-- ``recommended_parent_for_fork(goal_id)`` — the top entry plus a
-  human-readable rationale string, intended as a thin handle for the
-  community designer asking "what should I fork from?".
+DESIGN-008 (host reframe 2026-05-21): selection logic is per-Goal
+**user-buildable**. The substrate collects signals; a Goal-bound
+**selector branch** synthesizes them into rankings. Selector
+branches are normal published Workflow branches conforming to the
+contract documented in
+``drafts/concepts/selector-branch-contract.md``.
 
-Design source: wiki page
-``pages/patch-requests/pr-123-goal-archive-with-parent-selection-...``
-on the live MCP brain. The PLAN Goals & Gates module names this
-surface as ``archive_consultation parent-rank scoring formula`` and
-flags it as **open evolution** — a follow-on may turn the scoring
-formula into an evolvable Workflow node so the community can iterate
-on weights through autoresearch rather than asking the platform to
-ship "the right" constants.
+This module now:
 
-This slice is **best-effort v1**: ranking is signal-driven, not
-ground-truth-driven. The formula constants are surfaced in every
-response under ``formula`` so reviewers can audit and tune them
-without re-reading source.
+* Collects signals per candidate branch (unchanged from the prior
+  shape — these are inputs to the selector, not opinion).
+* Resolves the Goal's selector branch_version (explicit binding via
+  ``set_selector`` OR platform default, see
+  ``workflow.api.selector_dispatch``).
+* Dispatches the selector synchronously (with timeout) via
+  ``execute_branch_version_async`` + ``wait_for``.
+* Parses + validates the ``ranked_entries`` output.
+* Returns the ranked leaderboard.
 
-Goal-generic by design — same primitive works for patch-loops AND
-fantasy-writing AND recipe-trackers AND any community. No
-Loop-2-specific assumptions.
+What was DELETED in DESIGN-008
+------------------------------
 
-Signals (all read from existing storage; no new tables in this slice):
+* ``W_JUDGMENT`` / ``W_RUNS`` / ``W_FORKS`` / ``W_RECENCY`` /
+  ``W_GATE`` / ``W_SAFE_PUBLISH`` / ``W_FAILED_PENALTY`` constants.
+  Weights now live in the default selector's prompt.
+* ``RECENCY_HALFLIFE_DAYS``, ``JUDGMENT_MAX_SCALE``. Same story.
+* ``_score_components`` — the per-term formula application.
+* ``_entry_sort_key`` — sort order is selector-emitted ``score``
+  desc; ties tolerated.
+* ``_formula_disclosure`` — there's no platform formula to
+  disclose. Selectors disclose their own logic in their prompt.
+* ``_build_rationale`` — rationale is selector-emitted per entry.
+* ``_timestamp_to_epoch`` (the PR #978 patch) — never landed on
+  main, but the original ``float(...)`` coercion that crashed on
+  ISO strings is also gone because signals are now passed as a
+  list of dicts to the selector branch, not consumed by Python
+  scoring code.
 
-- ``completed_run_count`` — runs with ``status='completed'``.
-- ``failed_run_count`` — runs with ``status='failed'`` (penalty).
-- ``total_run_count`` — full count regardless of status.
-- ``last_successful_run_at`` — max ``finished_at`` of completed runs.
-- ``recency_decay`` — ``exp(-age_days/30)`` against the wall clock;
-  0 when the branch never produced a successful run.
-- ``judgment_count`` — rows in ``run_judgments`` joined via ``runs``.
-- ``judgment_score_avg`` — mean of numeric scores parsed from
-  judgment tags like ``quality:8.2``, ``novelty:7``, ``risk:3``.
-  None when no numeric tags exist (the signal contributes 0 to the
-  score in that case rather than NaN-propagating).
-- ``fork_count`` — branches whose ``parent_def_id`` or ``fork_from``
-  references this branch. Community votes with their forks.
-- ``gate_rung_top`` — the lexicographically-greatest active
-  ``rung_key`` from ``gate_claims`` for this (branch, goal).
-- ``safe_to_publish`` — best-effort read of
-  ``branch.stats.next_action_packet.safe_to_publish``. The packet
-  shape isn't on-disk-stable yet; if absent, the signal contributes 0.
+Visibility / auth-boundary contract (preserved from round-2)
+------------------------------------------------------------
 
-Score formula (weights surfaced in the response so they are auditable):
+``viewer`` is the actor identity for which visibility is resolved
+and MUST be derived server-side by the caller (never accepted from
+an MCP input). Pass an empty string for the strictly-public view.
+Private branches authored by the viewer are surfaced in the
+candidate set passed to the selector; private branches authored by
+other actors are filtered out. The selector's ranking output is
+relative to that visibility-bounded candidate set.
 
-  score = 3.0 * normalized_judgment_score
-        + 1.5 * log1p(completed_run_count)
-        + 2.0 * log1p(fork_count)
-        + 2.0 * recency_decay
-        + 1.0 * has_gate_rung
-        + 1.5 * safe_to_publish
-        - 1.0 * log1p(failed_run_count)
+Cost note
+---------
 
-``normalized_judgment_score`` is ``judgment_score_avg / 10.0`` (DGM
-scores are on a 0-10 scale) clamped to [0, 1] so the term is bounded.
-log1p bounds the impact of high-volume entries; recency / gate /
-safe_to_publish are already [0, 1].
-
-Tie-breaks: higher ``last_successful_run_at`` wins; then higher
-``created_at`` (newer entry); then ``branch_def_id`` for stability.
+Each leaderboard build now triggers one LLM call (the selector
+run). The old formula was free. Acceptable trade for the
+architectural win; a future slice may add caching keyed by
+(goal_id, candidate fingerprint) for N minutes.
 """
 
 from __future__ import annotations
 
-import math
+import logging
 import re
 from pathlib import Path
 from typing import Any
 
-# ---------------------------------------------------------------------------
-# Tunable weights — surfaced in the response under ``formula``
-# ---------------------------------------------------------------------------
+# Module-level import so test code can monkeypatch
+# ``workflow.api.quality_leaderboard.dispatch_selector``.
+from workflow.api.selector_dispatch import dispatch_selector
 
-W_JUDGMENT = 3.0
-W_RUNS = 1.5
-W_FORKS = 2.0
-W_RECENCY = 2.0
-W_GATE = 1.0
-W_SAFE_PUBLISH = 1.5
-W_FAILED_PENALTY = 1.0
+logger = logging.getLogger(__name__)
 
-RECENCY_HALFLIFE_DAYS = 30.0
-JUDGMENT_MAX_SCALE = 10.0  # DGM-style 0-10
 
 # Numeric judgment-tag pattern: ``key:N`` where N is integer/float.
 # Examples that match: ``quality:8``, ``quality:8.2``, ``novelty:7.5``,
 # ``risk:3``. Negative numbers and tags without ``:N`` are ignored.
+# Preserved from the round-1 implementation because it's pure parsing,
+# not opinion: ``_judgment_stats`` produces a signal the selector
+# branches consume.
 _NUMERIC_TAG_RE = re.compile(
     r"^\s*([A-Za-z][A-Za-z0-9_\-]*)\s*:\s*([0-9]+(?:\.[0-9]+)?)\s*$"
 )
 
 # Tag names that contribute to the average quality signal. Tags outside
-# this set are recorded under ``other_numeric_tags`` so the chatbot can
-# surface them without polluting the headline score.
+# this set are bucketed under ``other_numeric_tags`` for the selector
+# to surface or ignore at its discretion.
 _QUALITY_TAG_KEYS = frozenset({"quality", "novelty", "score"})
 
 
@@ -115,43 +109,58 @@ def build_quality_leaderboard(
 ) -> dict[str, Any]:
     """Compute the ranked list of branches bound to ``goal_id``.
 
-    Returns ``{"goal_id": ..., "goal": <row | None>, "entries": [...],
-    "formula": {...}, "generated_at": ...}``.
+    DESIGN-008: dispatches the Goal's selector branch (explicit
+    binding or platform default) over the collected signals and
+    returns its ``ranked_entries`` as the leaderboard.
 
-    Visibility / auth-boundary contract (round-2 P1.1 fix)
-    ------------------------------------------------------
-    ``viewer`` is the actor identity for which visibility is resolved
-    and MUST be derived server-side by the caller (never accepted from
-    an MCP input). Pass an empty string for the "strictly public" view
-    (no private branches included). The function does NOT accept an
-    ``include_private`` knob — that surface was caller-controllable in
-    round-1 and let an MCP caller flip visibility by passing
-    ``force=true``. To inspect private branches from a host/internal
-    script, build the response directly via the storage helpers; this
-    public entry point ALWAYS applies the public-or-author-owned
-    visibility filter.
+    Returns one of:
 
-    Each entry is::
+    Success::
 
         {
-            "rank":             1,
-            "branch_def_id":    "...",
-            "name":             "...",
-            "description":      "...",
-            "author":           "...",
-            "created_at":       <unix>,
-            "updated_at":       <unix>,
-            "score":            <float>,
-            "signals":          {<see Signals section above>},
-            "score_components": {<per-term contribution to score>},
+            "ok": True,
+            "goal_id": "...",
+            "goal": <goal-row | None>,
+            "entries": [
+                {
+                    "rank": 1,
+                    "branch_def_id": "...",
+                    "branch_version_id": "...",
+                    "name": "...",
+                    "author": "...",
+                    "score": <float>,
+                    "rationale": "<selector-emitted explanation>",
+                    "signals": {<the signal map for transparency>},
+                },
+                ...
+            ],
+            "selector": {
+                "branch_version_id": "...",
+                "source": "goal_binding" | "platform_default",
+                "run_id": "...",
+            },
+            "generated_at": <unix>,
         }
 
-    The function returns the ranked entries even when the Goal does not
-    exist or has no bound branches — the chatbot can render a friendly
-    "no entries yet" page from ``entries == []``.
+    Selector failure (selector unresolvable, dispatch failed,
+    timeout, invalid output)::
 
-    ``base_path`` is the daemon's data root (matches the rest of the
-    storage layer).
+        {
+            "ok": False,
+            "error_kind": "<see selector_dispatch error_kinds>",
+            "error": "...",
+            "goal_id": "...",
+            "goal": <goal-row | None>,
+            "entries": [],
+            "selector": {...partial selector context...},
+            "generated_at": <unix>,
+        }
+
+    Visibility: ``viewer`` is the server-derived actor identity.
+    Empty string means strictly-public. Private branches authored by
+    other actors are filtered before the selector sees them.
+
+    ``base_path`` is the daemon's data root.
     """
     if now is None:
         import time as _time
@@ -160,13 +169,6 @@ def build_quality_leaderboard(
     goal_row = _safe_get_goal(base_path, goal_id)
 
     from workflow.daemon_server import list_branch_definitions
-    # P1.1 fix — visibility is ALWAYS the public-or-author-owned filter.
-    # ``include_private`` is hard-False at this seam: there's no MCP
-    # surface that legitimately needs to bypass this filter, and round-1
-    # let a caller-supplied ``force=true`` flip it. If a future internal
-    # caller genuinely needs every row, it must reach for the storage
-    # helpers directly with explicit ``include_private=True`` — that
-    # path is host/internal-only and not reachable from MCP.
     branches = list_branch_definitions(
         base_path,
         goal_id=goal_id,
@@ -174,41 +176,108 @@ def build_quality_leaderboard(
         include_private=False,
     )
 
-    entries: list[dict[str, Any]] = []
+    # Collect signals per candidate. The signal shape is the same as
+    # the round-1 implementation — those primitives are inputs, not
+    # opinion. The selector branch consumes them.
+    candidates: list[dict[str, Any]] = []
+    signals_by_branch: dict[str, dict[str, Any]] = {}
+    branch_meta_by_id: dict[str, dict[str, Any]] = {}
     for branch in branches:
+        bid = branch["branch_def_id"]
         signals = _collect_signals_for_branch(
             base_path, branch, now=now, viewer=viewer,
         )
-        components = _score_components(signals)
-        score = sum(components.values())
-        entries.append({
-            "branch_def_id": branch["branch_def_id"],
+        signals_by_branch[bid] = signals
+        latest_bvid = _latest_active_version_id(base_path, bid)
+        candidate = {
+            "branch_def_id": bid,
+            "branch_version_id": latest_bvid,
             "name": branch.get("name", ""),
-            "description": branch.get("description", ""),
             "author": branch.get("author", ""),
+            "description": branch.get("description", ""),
+            "signals": signals,
+        }
+        candidates.append(candidate)
+        branch_meta_by_id[bid] = {
+            "name": branch.get("name", ""),
+            "author": branch.get("author", ""),
+            "description": branch.get("description", ""),
             "created_at": branch.get("created_at", 0.0),
             "updated_at": branch.get("updated_at", 0.0),
-            "score": round(score, 4),
-            "signals": signals,
-            "score_components": {
-                k: round(v, 4) for k, v in components.items()
+            "branch_version_id": latest_bvid,
+        }
+
+    # Dispatch the selector. Empty candidate set short-circuits to
+    # an empty leaderboard without burning an LLM call.
+    dispatch_result = dispatch_selector(
+        base_path,
+        goal_id=goal_id,
+        candidate_branches=candidates,
+        actor=viewer or "anonymous",
+    )
+
+    if not dispatch_result.get("ok"):
+        return {
+            "ok": False,
+            "error_kind": dispatch_result.get(
+                "error_kind", "selector_invalid_output",
+            ),
+            "error": dispatch_result.get("error", ""),
+            "goal_id": goal_id,
+            "goal": goal_row,
+            "entries": [],
+            "selector": {
+                "branch_version_id": dispatch_result.get(
+                    "branch_version_id",
+                ),
+                "run_id": dispatch_result.get("run_id"),
             },
+            "generated_at": now,
+        }
+
+    raw_entries = dispatch_result.get("ranked_entries") or []
+    entries: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for rank_idx, raw in enumerate(raw_entries, start=1):
+        bid = (raw.get("branch_def_id") or "").strip()
+        if not bid or bid in seen:
+            # Skip dupes / blanks defensively — the selector should
+            # not emit them, but a misbehaving selector shouldn't
+            # corrupt the response.
+            continue
+        seen.add(bid)
+        meta = branch_meta_by_id.get(bid, {})
+        signals = signals_by_branch.get(bid, {})
+        entries.append({
+            "rank": rank_idx,
+            "branch_def_id": bid,
+            "branch_version_id": (
+                raw.get("branch_version_id")
+                or meta.get("branch_version_id")
+                or ""
+            ),
+            "name": meta.get("name", ""),
+            "author": meta.get("author", ""),
+            "description": meta.get("description", ""),
+            "created_at": meta.get("created_at", 0.0),
+            "updated_at": meta.get("updated_at", 0.0),
+            "score": float(raw.get("score") or 0.0),
+            "rationale": raw.get("rationale", ""),
+            # Pass the signal map through so the chatbot can surface
+            # "why this ranked here" without re-querying storage.
+            "signals": signals,
         })
 
-    # Two-pass stable sort. First pass: branch_def_id ascending (string
-    # compare). Second pass: primary keys with reverse=True. Python's
-    # sort is stable, so the secondary key from the first pass survives
-    # within ties of the primary sort.
-    entries.sort(key=lambda e: e.get("branch_def_id", ""))
-    entries.sort(key=_entry_sort_key, reverse=True)
-    for rank, entry in enumerate(entries, start=1):
-        entry["rank"] = rank
-
     return {
+        "ok": True,
         "goal_id": goal_id,
         "goal": goal_row,
         "entries": entries,
-        "formula": _formula_disclosure(),
+        "selector": {
+            "branch_version_id": dispatch_result.get("branch_version_id"),
+            "source": dispatch_result.get("source"),
+            "run_id": dispatch_result.get("run_id"),
+        },
         "generated_at": now,
     }
 
@@ -220,19 +289,35 @@ def recommend_parent_for_fork(
     viewer: str,
     now: float | None = None,
 ) -> dict[str, Any]:
-    """Return the top leaderboard entry plus a human-readable rationale.
+    """Return the top selector-ranked entry plus its rationale.
 
-    Returns ``{"goal_id": ..., "recommended_parent": <entry | None>,
-    "rationale": "...", "leaderboard_size": <int>, "generated_at": ...}``.
+    Returns one of:
 
-    Visibility contract matches :func:`build_quality_leaderboard` —
-    ``viewer`` must be server-derived; private branches the viewer does
-    not own are excluded.
+    Success with parent::
 
-    When no branch is bound to the Goal the response carries
-    ``recommended_parent=None`` and a rationale explaining that no
-    parent exists yet — the chatbot should propose "create the first
-    branch" rather than "fork from".
+        {
+            "ok": True,
+            "goal_id": "...",
+            "recommended_parent": <entry>,
+            "rationale": "<selector-emitted>",
+            "leaderboard_size": <int>,
+            "selector": {...},
+            "generated_at": <unix>,
+        }
+
+    No parent (no candidates / empty leaderboard)::
+
+        {
+            "ok": True,
+            "goal_id": "...",
+            "recommended_parent": None,
+            "rationale": "<friendly explanation>",
+            "leaderboard_size": 0,
+            ...
+        }
+
+    Selector failure surfaces the same error_kind as
+    :func:`build_quality_leaderboard`.
     """
     board = build_quality_leaderboard(
         base_path,
@@ -240,9 +325,22 @@ def recommend_parent_for_fork(
         viewer=viewer,
         now=now,
     )
+    if not board.get("ok"):
+        return {
+            "ok": False,
+            "error_kind": board.get("error_kind"),
+            "error": board.get("error", ""),
+            "goal_id": goal_id,
+            "recommended_parent": None,
+            "rationale": "",
+            "leaderboard_size": 0,
+            "selector": board.get("selector") or {},
+            "generated_at": board.get("generated_at"),
+        }
     entries = board["entries"]
     if not entries:
         return {
+            "ok": True,
             "goal_id": goal_id,
             "recommended_parent": None,
             "rationale": (
@@ -251,20 +349,32 @@ def recommend_parent_for_fork(
                 "fork from a peer Goal's leaderboard."
             ),
             "leaderboard_size": 0,
+            "selector": board.get("selector") or {},
             "generated_at": board["generated_at"],
         }
     top = entries[0]
+    rationale = top.get("rationale") or ""
+    if not rationale:
+        rationale = (
+            f"'{top.get('name') or top['branch_def_id']}' "
+            f"(#{top['branch_def_id']}) ranked first of "
+            f"{len(entries)} bound Branches with score "
+            f"{top.get('score', 0.0):.2f}. (Selector did not provide "
+            "a per-entry rationale.)"
+        )
     return {
+        "ok": True,
         "goal_id": goal_id,
         "recommended_parent": top,
-        "rationale": _build_rationale(top, leaderboard_size=len(entries)),
+        "rationale": rationale,
         "leaderboard_size": len(entries),
+        "selector": board.get("selector") or {},
         "generated_at": board["generated_at"],
     }
 
 
 # ---------------------------------------------------------------------------
-# Signal collection
+# Signal collection (preserved — these are selector inputs, not opinion)
 # ---------------------------------------------------------------------------
 
 
@@ -280,9 +390,6 @@ def _collect_signals_for_branch(
 
     run_stats = _run_stats(base_path, bid)
     judgment_stats = _judgment_stats(base_path, bid)
-    # P1.2 fix — fork count respects viewer visibility. Counting raw
-    # descendant rows would leak existence of private forks (the row
-    # was hidden from the listing but the aggregate count exposed it).
     fork_count = _fork_count(base_path, bid, viewer=viewer)
     gate_rung_top = _gate_rung_top(base_path, bid, goal_id)
     safe_to_publish = _safe_to_publish(branch)
@@ -290,10 +397,8 @@ def _collect_signals_for_branch(
     last_ok = run_stats["last_successful_run_at"]
     if last_ok and last_ok > 0:
         age_days = max(0.0, (now - last_ok) / 86400.0)
-        recency_decay = math.exp(-age_days / RECENCY_HALFLIFE_DAYS)
     else:
         age_days = None
-        recency_decay = 0.0
 
     return {
         "total_run_count": run_stats["total"],
@@ -301,7 +406,6 @@ def _collect_signals_for_branch(
         "failed_run_count": run_stats["failed"],
         "last_successful_run_at": last_ok,
         "age_days_since_success": age_days,
-        "recency_decay": round(recency_decay, 4),
         "judgment_count": judgment_stats["count"],
         "judgment_score_avg": judgment_stats["score_avg"],
         "judgment_score_samples": judgment_stats["score_samples"],
@@ -314,12 +418,7 @@ def _collect_signals_for_branch(
 
 
 def _run_stats(base_path: str | Path, branch_def_id: str) -> dict[str, Any]:
-    """Aggregate counts + last_successful_run_at directly against runs DB.
-
-    A direct SQL aggregate is cheaper than fetching every row via
-    ``list_runs`` — this is invoked once per branch on the leaderboard
-    and a Goal can carry 50+ branches.
-    """
+    """Aggregate counts + last_successful_run_at directly against runs DB."""
     from workflow.runs import _connect, initialize_runs_db
 
     initialize_runs_db(base_path)
@@ -342,25 +441,37 @@ def _run_stats(base_path: str | Path, branch_def_id: str) -> dict[str, Any]:
             "total": 0, "completed": 0, "failed": 0,
             "last_successful_run_at": 0.0,
         }
+    # last_successful_run_at is REAL but SQLite type-affinity is
+    # permissive. We coerce defensively because the selector branch
+    # consumes the value as a number (and the prompt template
+    # renderer will just str() whatever it gets). An ISO string here
+    # would be confusing for the LLM, so we normalize to a float
+    # epoch when the value is parseable as such.
+    raw = row["last_successful_run_at"]
+    if raw is None or raw == "":
+        last_ok = 0.0
+    else:
+        try:
+            last_ok = float(raw)
+        except (TypeError, ValueError):
+            # Best-effort: try ISO 8601.
+            try:
+                from datetime import datetime
+                last_ok = datetime.fromisoformat(str(raw)).timestamp()
+            except (TypeError, ValueError):
+                last_ok = 0.0
     return {
         "total": int(row["total"] or 0),
         "completed": int(row["completed"] or 0),
         "failed": int(row["failed"] or 0),
-        "last_successful_run_at": float(row["last_successful_run_at"] or 0.0),
+        "last_successful_run_at": last_ok,
     }
 
 
 def _judgment_stats(
     base_path: str | Path, branch_def_id: str,
 ) -> dict[str, Any]:
-    """Parse numeric scores out of judgment tags scoped to this branch.
-
-    Judgments are free-text + tags; the leaderboard reads ``tags_json``
-    looking for ``key:N`` patterns where ``key`` is in
-    ``_QUALITY_TAG_KEYS`` for the headline score. Other numeric tags are
-    bucketed under ``other_numeric_tags`` for surface-level reporting
-    but don't contribute to the score in this slice.
-    """
+    """Parse numeric scores out of judgment tags scoped to this branch."""
     from workflow.runs import _connect, initialize_runs_db
     from workflow.storage import _json_loads
 
@@ -417,15 +528,10 @@ def _fork_count(
 ) -> int:
     """Count descendants the ``viewer`` can see.
 
-    Either ``parent_def_id`` or ``fork_from`` may reference this branch
-    — count rows whose either column matches AND that pass the same
-    visibility filter ``list_branch_definitions`` applies (public OR
-    authored by the viewer). This closes the round-2 P1.2 finding: a
-    naive raw count exposed the existence of private descendant rows
-    even when the rows themselves were hidden from the listing.
-
-    Passing ``viewer=""`` matches the "strictly public" semantics —
-    counts only public descendants, never private ones.
+    Same visibility-respecting query as the round-1 implementation
+    (the auth-boundary contract from PR-970 round 2 P1.2). The
+    selector branch consumes the count; visibility filtering happens
+    here.
     """
     from workflow.storage import _connect
 
@@ -457,9 +563,9 @@ def _gate_rung_top(
 ) -> str | None:
     """Return the highest active gate rung for (branch, goal), or None.
 
-    "Highest" in this slice is lexicographically-greatest ``rung_key``
-    among non-retracted claims. Goal-ladder-aware ordering is a follow-on
-    once the ladder shape is stable per-Goal.
+    Lexicographically-greatest among non-retracted claims.
+    Goal-ladder-aware ordering is a follow-on once ladder shape is
+    stable per-Goal.
     """
     if not goal_id:
         return None
@@ -487,12 +593,7 @@ def _gate_rung_top(
 
 
 def _safe_to_publish(branch: dict[str, Any]) -> bool:
-    """Best-effort lookup of a Loop-2-style next_action_packet flag.
-
-    The packet shape isn't on-disk-stable yet; nodes that emit it write
-    into the branch ``stats`` JSON. When absent, the signal is False
-    rather than missing — score contribution is 0 either way.
-    """
+    """Best-effort lookup of a Loop-2-style next_action_packet flag."""
     stats = branch.get("stats")
     if not isinstance(stats, dict):
         return False
@@ -514,163 +615,32 @@ def _safe_get_goal(
         return None
 
 
-# ---------------------------------------------------------------------------
-# Scoring
-# ---------------------------------------------------------------------------
-
-
-def _score_components(signals: dict[str, Any]) -> dict[str, float]:
-    """Per-term contributions to score. Surfaced in the response so the
-    chatbot can render "why this one ranked first" without re-computing.
-    """
-    score_avg = signals.get("judgment_score_avg")
-    if score_avg is None:
-        normalized_judgment = 0.0
-    else:
-        normalized_judgment = max(0.0, min(1.0, score_avg / JUDGMENT_MAX_SCALE))
-
-    completed = max(0, int(signals.get("completed_run_count") or 0))
-    failed = max(0, int(signals.get("failed_run_count") or 0))
-    fork_count = max(0, int(signals.get("fork_count") or 0))
-    recency = float(signals.get("recency_decay") or 0.0)
-    has_gate = 1.0 if signals.get("has_gate_rung") else 0.0
-    safe_pub = 1.0 if signals.get("safe_to_publish") else 0.0
-
-    return {
-        "judgment":  W_JUDGMENT * normalized_judgment,
-        "runs":      W_RUNS * math.log1p(completed),
-        "forks":     W_FORKS * math.log1p(fork_count),
-        "recency":   W_RECENCY * recency,
-        "gate":      W_GATE * has_gate,
-        "safe_pub":  W_SAFE_PUBLISH * safe_pub,
-        "failed_penalty": -W_FAILED_PENALTY * math.log1p(failed),
-    }
-
-
-def _entry_sort_key(entry: dict[str, Any]) -> tuple:
-    """Primary sort key for ranked entries (used with ``reverse=True``).
-
-    Tuple order:
-      1. ``score`` — higher is better.
-      2. ``last_successful_run_at`` — newer success wins ties.
-      3. ``created_at`` — newer branch wins ties.
-
-    Final ``branch_def_id`` tie-break is handled by a separate stable
-    sort pass before this one is applied — see ``build_quality_leaderboard``.
-    """
-    signals = entry.get("signals") or {}
-    return (
-        float(entry.get("score") or 0.0),
-        float(signals.get("last_successful_run_at") or 0.0),
-        float(entry.get("created_at") or 0.0),
-    )
-
-
-# ---------------------------------------------------------------------------
-# Disclosure + rationale
-# ---------------------------------------------------------------------------
-
-
-def _formula_disclosure() -> dict[str, Any]:
-    return {
-        "weights": {
-            "judgment": W_JUDGMENT,
-            "runs": W_RUNS,
-            "forks": W_FORKS,
-            "recency": W_RECENCY,
-            "gate": W_GATE,
-            "safe_publish": W_SAFE_PUBLISH,
-            "failed_penalty": -W_FAILED_PENALTY,
-        },
-        "recency_halflife_days": RECENCY_HALFLIFE_DAYS,
-        "judgment_max_scale": JUDGMENT_MAX_SCALE,
-        "judgment_tag_keys": sorted(_QUALITY_TAG_KEYS),
-        "tie_breakers": [
-            "last_successful_run_at desc",
-            "created_at desc",
-            "branch_def_id asc",
-        ],
-        "notes": (
-            "Best-effort v1. Weights are initial guesses surfaced for "
-            "audit. Per PLAN Goals & Gates, the parent-rank scoring "
-            "formula is open evolution — a follow-on slice will let "
-            "the community iterate weights via an evolvable Workflow "
-            "node rather than ship constants."
-        ),
-    }
-
-
-def _build_rationale(
-    top_entry: dict[str, Any], *, leaderboard_size: int,
+def _latest_active_version_id(
+    base_path: str | Path, branch_def_id: str,
 ) -> str:
-    """Compose the human-readable rationale string for the top entry."""
-    signals = top_entry.get("signals") or {}
-    name = top_entry.get("name") or top_entry.get("branch_def_id") or "(unnamed)"
-    parts: list[str] = []
-    parts.append(
-        f"'{name}' (#{top_entry.get('branch_def_id')}) ranked first of "
-        f"{leaderboard_size} bound Branches with score "
-        f"{top_entry.get('score', 0.0):.2f}."
-    )
+    """Return the newest active ``branch_version_id`` for the def, or "".
 
-    score_pieces: list[str] = []
-    judgment_avg = signals.get("judgment_score_avg")
-    if judgment_avg is not None:
-        score_pieces.append(
-            f"avg judgment score {judgment_avg:.2f}/{int(JUDGMENT_MAX_SCALE)} "
-            f"across {int(signals.get('judgment_score_samples') or 0)} sample(s)"
+    Returns ``""`` when the branch has not been published yet OR
+    every published version has been rolled back / superseded.
+    Matches the PR-127 round-2 active-only filter on
+    ``canonical_dispatch._latest_published_version_id``.
+    """
+    if not branch_def_id:
+        return ""
+    try:
+        from workflow.branch_versions import list_branch_versions
+        versions = list_branch_versions(
+            base_path, branch_def_id=branch_def_id, limit=50,
         )
-    completed = int(signals.get("completed_run_count") or 0)
-    if completed:
-        score_pieces.append(f"{completed} completed run(s)")
-    forks = int(signals.get("fork_count") or 0)
-    if forks:
-        score_pieces.append(f"{forks} community fork(s)")
-    age = signals.get("age_days_since_success")
-    if age is not None:
-        if age < 1:
-            age_phrase = "under a day ago"
-        elif age < 2:
-            age_phrase = "yesterday"
-        else:
-            age_phrase = f"{int(age)} days ago"
-        score_pieces.append(f"most recent successful run {age_phrase}")
-    rung = signals.get("gate_rung_top")
-    if rung:
-        score_pieces.append(f"highest gate rung claimed: '{rung}'")
-    if signals.get("safe_to_publish"):
-        score_pieces.append("flagged safe_to_publish by its own packet")
-    failed = int(signals.get("failed_run_count") or 0)
-    if failed:
-        score_pieces.append(f"({failed} failed run(s) — penalty applied)")
-
-    if score_pieces:
-        parts.append("Signals: " + "; ".join(score_pieces) + ".")
-    else:
-        parts.append(
-            "No quality signals yet — ranking is by recency / author "
-            "registration only. Treat as a tentative parent until the "
-            "first judgment lands."
-        )
-
-    parts.append(
-        "Note: this is a best-effort v1 recommendation. Inspect the "
-        "score_components in the leaderboard entry to see which "
-        "signals dominated the rank."
-    )
-    return " ".join(parts)
+    except Exception:
+        return ""
+    for v in versions:
+        if getattr(v, "status", "active") == "active":
+            return v.branch_version_id or ""
+    return ""
 
 
 __all__ = [
     "build_quality_leaderboard",
     "recommend_parent_for_fork",
-    "W_JUDGMENT",
-    "W_RUNS",
-    "W_FORKS",
-    "W_RECENCY",
-    "W_GATE",
-    "W_SAFE_PUBLISH",
-    "W_FAILED_PENALTY",
-    "RECENCY_HALFLIFE_DAYS",
-    "JUDGMENT_MAX_SCALE",
 ]

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
@@ -349,6 +349,12 @@ def build_quality_leaderboard(
             "branch_version_id": dispatch_result.get("branch_version_id"),
             "source": dispatch_result.get("source"),
             "run_id": dispatch_result.get("run_id"),
+            # P1.C (round 4) — when the bound selector_branch_version_id
+            # was inactive at dispatch time, the substrate fell back to
+            # the platform default. ``fellback_from`` carries the old
+            # binding + reason so the chatbot can prompt the operator
+            # to re-bind. None when no fallback happened.
+            "fellback_from": dispatch_result.get("fellback_from"),
         },
         "generated_at": now,
     }

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
@@ -106,6 +106,7 @@ def build_quality_leaderboard(
     goal_id: str,
     viewer: str,
     now: float | None = None,
+    provider_call: Any = None,
 ) -> dict[str, Any]:
     """Compute the ranked list of branches bound to ``goal_id``.
 
@@ -214,6 +215,7 @@ def build_quality_leaderboard(
         goal_id=goal_id,
         candidate_branches=candidates,
         actor=viewer or "anonymous",
+        provider_call=provider_call,
     )
 
     if not dispatch_result.get("ok"):
@@ -238,18 +240,30 @@ def build_quality_leaderboard(
     raw_entries = dispatch_result.get("ranked_entries") or []
     entries: list[dict[str, Any]] = []
     seen: set[str] = set()
-    for rank_idx, raw in enumerate(raw_entries, start=1):
+    phantom_ids: list[str] = []
+    # Rank is assigned post-filter so phantom/dupe/blank rows do
+    # not leave gaps in the user-facing rank sequence.
+    for raw in raw_entries:
         bid = (raw.get("branch_def_id") or "").strip()
         if not bid or bid in seen:
             # Skip dupes / blanks defensively — the selector should
             # not emit them, but a misbehaving selector shouldn't
             # corrupt the response.
             continue
+        # P1.2 (DESIGN-008 round 2): selector output can fabricate
+        # branch_def_ids — including private ones the viewer cannot
+        # see — and inject them into the leaderboard. Reject any
+        # branch_def_id that was not in the input candidate set.
+        # ``branch_meta_by_id`` is the authoritative source of
+        # visible candidates (already filtered by viewer +
+        # include_private=False at list_branch_definitions).
+        if bid not in branch_meta_by_id:
+            phantom_ids.append(bid)
+            continue
         seen.add(bid)
-        meta = branch_meta_by_id.get(bid, {})
+        meta = branch_meta_by_id[bid]
         signals = signals_by_branch.get(bid, {})
         entries.append({
-            "rank": rank_idx,
             "branch_def_id": bid,
             "branch_version_id": (
                 raw.get("branch_version_id")
@@ -267,12 +281,32 @@ def build_quality_leaderboard(
             # "why this ranked here" without re-querying storage.
             "signals": signals,
         })
+    # Assign ranks now that phantom entries have been filtered out.
+    for rank_idx, entry in enumerate(entries, start=1):
+        entry["rank"] = rank_idx
+    # Emit a structured warning when the selector tried to inject
+    # phantom IDs. The operator can spot a misbehaving (or
+    # adversarial) selector in their logs / event feed.
+    if phantom_ids:
+        logger.warning(
+            "selector fabricated %d phantom branch_def_id(s) for goal=%s "
+            "selector=%s: %s — entries dropped",
+            len(phantom_ids),
+            goal_id,
+            dispatch_result.get("branch_version_id"),
+            phantom_ids,
+        )
 
     return {
         "ok": True,
         "goal_id": goal_id,
         "goal": goal_row,
         "entries": entries,
+        # P1.2 — surface phantom branch_def_id rejections in the
+        # structured payload so programmatic consumers (and audit
+        # tools) can detect a misbehaving selector without scraping
+        # logs. Empty list when the selector is well-behaved.
+        "phantom_branch_def_ids": phantom_ids,
         "selector": {
             "branch_version_id": dispatch_result.get("branch_version_id"),
             "source": dispatch_result.get("source"),
@@ -288,6 +322,7 @@ def recommend_parent_for_fork(
     goal_id: str,
     viewer: str,
     now: float | None = None,
+    provider_call: Any = None,
 ) -> dict[str, Any]:
     """Return the top selector-ranked entry plus its rationale.
 
@@ -324,6 +359,7 @@ def recommend_parent_for_fork(
         goal_id=goal_id,
         viewer=viewer,
         now=now,
+        provider_call=provider_call,
     )
     if not board.get("ok"):
         return {

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/quality_leaderboard.py
@@ -241,6 +241,12 @@ def build_quality_leaderboard(
     entries: list[dict[str, Any]] = []
     seen: set[str] = set()
     phantom_ids: list[str] = []
+    # P1.A (DESIGN-008 round 3): track selector-emitted version_id
+    # mismatches against the candidate set's authoritative version.
+    # The selector's value is always ignored; this list surfaces the
+    # spoof attempts so audit tools can detect a misbehaving /
+    # adversarial selector without scraping logs.
+    selector_bvid_spoofs: list[dict[str, str]] = []
     # Rank is assigned post-filter so phantom/dupe/blank rows do
     # not leave gaps in the user-facing rank sequence.
     for raw in raw_entries:
@@ -263,13 +269,40 @@ def build_quality_leaderboard(
         seen.add(bid)
         meta = branch_meta_by_id[bid]
         signals = signals_by_branch.get(bid, {})
+        # P1.A (DESIGN-008 round 3): the selector MUST NOT influence
+        # which branch_version_id surfaces in the leaderboard. The
+        # candidate set already carries the authoritative latest
+        # active version per def_id (resolved from
+        # ``branch_versions.status='active'`` at signal collection
+        # time). Trusting ``raw.get("branch_version_id")`` would let
+        # a selector return a real visible def_id paired with a
+        # private / rolled-back / fabricated version id, and the
+        # chatbot would surface it via recommend_parent_for_fork.
+        # The selector's emitted version_id is ignored — only the
+        # candidate set's authoritative bvid is surfaced. A future
+        # slice may allow selectors to pin a specific historical
+        # version, but it must come through a separate validated
+        # mechanism (e.g. selector claims a version, substrate
+        # checks visibility + status='active'), not blind passthrough.
+        spoof_attempt = (raw.get("branch_version_id") or "").strip()
+        authoritative_bvid = (meta.get("branch_version_id") or "")
+        if spoof_attempt and spoof_attempt != authoritative_bvid:
+            logger.warning(
+                "selector emitted branch_version_id=%r for "
+                "branch_def_id=%r that disagrees with the "
+                "authoritative active version %r (goal=%s "
+                "selector=%s); selector value ignored",
+                spoof_attempt, bid, authoritative_bvid, goal_id,
+                dispatch_result.get("branch_version_id"),
+            )
+            selector_bvid_spoofs.append({
+                "branch_def_id": bid,
+                "selector_emitted": spoof_attempt,
+                "authoritative": authoritative_bvid,
+            })
         entries.append({
             "branch_def_id": bid,
-            "branch_version_id": (
-                raw.get("branch_version_id")
-                or meta.get("branch_version_id")
-                or ""
-            ),
+            "branch_version_id": authoritative_bvid,
             "name": meta.get("name", ""),
             "author": meta.get("author", ""),
             "description": meta.get("description", ""),
@@ -307,6 +340,11 @@ def build_quality_leaderboard(
         # tools) can detect a misbehaving selector without scraping
         # logs. Empty list when the selector is well-behaved.
         "phantom_branch_def_ids": phantom_ids,
+        # P1.A (round 3) — surface selector-emitted branch_version_id
+        # spoof attempts. Each entry: {branch_def_id, selector_emitted,
+        # authoritative}. Empty list when the selector is well-behaved.
+        # Selector values are ALWAYS ignored regardless; this is audit.
+        "selector_bvid_spoofs": selector_bvid_spoofs,
         "selector": {
             "branch_version_id": dispatch_result.get("branch_version_id"),
             "source": dispatch_result.get("source"),

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/runs.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/runs.py
@@ -1525,6 +1525,16 @@ def _action_rollback_merge(kwargs: dict[str, Any]) -> str:
             f"Re-pointed canonical bindings on {repointed_count} Goal(s) "
             "to nearest non-rolled-back ancestor."
         )
+    # DESIGN-008 round 4 — selector bindings are cleared (not walked up)
+    # so the leaderboard read path falls back to the platform default.
+    selector_repoint = result.get("selector_repoint", {})
+    selector_repointed_count = selector_repoint.get("repointed_count", 0)
+    if selector_repointed_count:
+        text_lines.append(
+            f"Cleared selector bindings on {selector_repointed_count} "
+            "Goal(s); leaderboard falls back to platform default until "
+            "operator re-binds via `goals action=set_selector`."
+        )
     return json.dumps({
         "text": "\n".join(text_lines),
         **result,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/selector_dispatch.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/selector_dispatch.py
@@ -315,6 +315,18 @@ def ensure_default_selector_published(base_path: str | Path) -> str:
             return v.branch_version_id
 
     # No active version — publish v1.
+    #
+    # P1 (DESIGN-008 round 5): ``publish_branch_version`` is deterministic
+    # in ``(branch_def_id, content_hash)``. When an operator has rolled
+    # back the platform default (every existing version's status flipped
+    # to ``rolled_back``), the re-publish call returns the same existing
+    # rolled-back row (workflow/branch_versions.py:267-273) rather than
+    # minting a fresh active one. Without the post-publish status check
+    # below, ``ensure_default_selector_published`` would silently hand
+    # back a rolled-back branch_version_id, and ``dispatch_selector``
+    # would execute it — defeating the rollback. Fail closed instead:
+    # return empty so the caller (``resolve_selector_branch_version_id``)
+    # surfaces ``default_selector_unavailable``.
     branch_dict = _build_default_selector_branch_dict()
     version = publish_branch_version(
         base_path,
@@ -333,6 +345,20 @@ def ensure_default_selector_published(base_path: str | Path) -> str:
             "publish_branch_version reported success but the row is "
             "not readable post-write."
         )
+    status = getattr(persisted, "status", "active") or "active"
+    if status != "active":
+        logger.warning(
+            "ensure_default_selector_published | publish_branch_version "
+            "returned existing branch_version_id=%r with status=%r "
+            "(deterministic re-publish hit a rolled-back row). Cannot "
+            "dispatch a rolled-back default selector. Operator: "
+            "republish the platform default branch with a content "
+            "change (so a fresh content_hash mints a new active row), "
+            "or bind a custom selector to the affected Goal via "
+            "goals action=set_selector.",
+            persisted.branch_version_id, status,
+        )
+        return ""
     return persisted.branch_version_id
 
 
@@ -614,6 +640,40 @@ def dispatch_selector(
                 "branch_versions."
             ),
             "branch_version_id": bvid,
+        }
+
+    # P1 (DESIGN-008 round 5) — dispatch-time status guard. The
+    # resolve-time check in ``resolve_selector_branch_version_id`` +
+    # the fail-closed semantics in ``ensure_default_selector_published``
+    # cover the normal lifecycle, but a final ``status='active'`` check
+    # here closes any race between resolve and dispatch (TOCTOU) and
+    # protects callers that thread their own ``branch_version_id``
+    # straight in without going through ``resolve_selector_branch_version_id``.
+    # Cheap (one already-loaded attribute read) and idempotent.
+    bv_status = getattr(bv, "status", "active") or "active"
+    if bv_status != "active":
+        logger.warning(
+            "selector dispatch | branch_version_id=%r resolved to "
+            "status=%r at dispatch time (active-only required). "
+            "Refusing to execute a rolled-back / superseded selector.",
+            bvid, bv_status,
+        )
+        return {
+            "ok": False,
+            "error_kind": "selector_version_inactive_at_dispatch",
+            "error": (
+                f"selector branch_version_id {bvid!r} resolved to "
+                f"status={bv_status!r} at dispatch time. The "
+                "selector binding is stale or the platform default "
+                "was rolled back without a fresh active replacement. "
+                "Operator: bind a different active selector via "
+                "goals action=set_selector, unbind to fall back to "
+                "the platform default, or republish the platform "
+                "default with new content so a fresh active version "
+                "is minted."
+            ),
+            "branch_version_id": bvid,
+            "status": bv_status,
         }
 
     snapshot = dict(bv.snapshot or {})

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/selector_dispatch.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/selector_dispatch.py
@@ -1,0 +1,796 @@
+"""User-buildable selector branch dispatch — DESIGN-008.
+
+The architectural commitment from host's 2026-05-21 reframe: selection
+logic is per-Goal user-buildable, NOT platform-coded. ``quality_leaderboard``
+no longer applies an opinionated formula; instead it dispatches a
+**selector branch** (a published Workflow branch bound to the Goal)
+that consumes signal data and emits ranked entries.
+
+This module owns:
+
+* :func:`resolve_selector_branch_version_id` — return the selector
+  branch_version_id for a Goal. If ``goal.selector_branch_version_id``
+  is set, use it. Otherwise return the platform default selector's
+  branch_version_id (lazily published on first call so the substrate
+  works on a clean DB).
+* :func:`dispatch_selector` — synchronously (with timeout) run a
+  selector branch_version against the supplied candidate set, parse
+  + validate the output shape, return ``ranked_entries`` or a
+  structured error.
+* :func:`ensure_default_selector_published` — idempotent helper that
+  builds + publishes the platform default selector branch on first
+  call. The default is a single prompt-template node that consumes
+  the signal map and asks the LLM to rank — the "weights" are a
+  prompt the chatbot can tune via fork, not Python constants.
+
+Contract for selector branches (see also
+``drafts/concepts/selector-branch-contract.md``):
+
+Inputs (passed as the run's ``inputs`` dict)::
+
+    {
+        "goal_id": "<goal-id>",
+        "candidate_branches": [
+            {
+                "branch_def_id": "...",
+                "branch_version_id": "...",  # latest active version, or ""
+                "name": "...",
+                "author": "...",
+                "signals": {
+                    "completed_run_count": int,
+                    "failed_run_count":    int,
+                    "judgment_score_avg":  float | null,
+                    "judgment_count":      int,
+                    "fork_count":          int,
+                    "last_successful_run_at": float,  # epoch
+                    "has_gate_rung":       bool,
+                    "gate_rung_top":       str | null,
+                    "safe_to_publish":     bool,
+                    "age_days_since_success": float | null,
+                },
+            },
+            ...
+        ],
+    }
+
+Outputs (read from the run's ``output`` dict)::
+
+    {
+        "ranked_entries": [
+            {
+                "branch_def_id":     "...",
+                "branch_version_id": "...",
+                "score":             <float>,
+                "rationale":         "<human-readable why-ranked-here>",
+            },
+            ...  # ordered by rank, best first
+        ],
+    }
+
+Round-1 design choices
+----------------------
+
+* **Sync dispatch with timeout.** The leaderboard caller blocks on the
+  selector run via ``wait_for(run_id, timeout=SELECTOR_TIMEOUT_S)``. The
+  selector pipeline cost is one LLM call per leaderboard build. A
+  future caching slice can memoize results per Goal for N minutes.
+
+* **Visibility is server-derived.** The candidate set passed to the
+  selector is the public-or-author-owned view per PR-970's auth-
+  boundary contract. The selector branch sees only branches the
+  caller has visibility into; private branches authored by other
+  actors are never even mentioned in the input.
+
+* **Default selector is a published branch, not a code path.**
+  ``ensure_default_selector_published`` builds the BranchDefinition
+  in-Python on first call, calls ``save_branch_definition`` +
+  ``publish_branch_version``, and stores the resulting
+  ``branch_version_id`` for return. Subsequent calls find the
+  existing definition and return its current active version.
+
+* **Failure modes surface structured errors.** Selector missing /
+  not published / timed out / invalid output shape all return
+  ``{"ok": False, "error_kind": "..."}`` dicts that the leaderboard
+  caller renders to the chatbot. The leaderboard never crashes;
+  callers see a clear "selector misbehaved" signal rather than a
+  Python traceback.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# How long the selector run is allowed to complete before the
+# leaderboard caller gives up. One LLM call typically lands in <15s;
+# 60s leaves headroom for slower providers + multiple-candidate
+# prompts. Configurable via env so hosts can tune.
+SELECTOR_TIMEOUT_S_DEFAULT = 60.0
+SELECTOR_TIMEOUT_ENV = "WORKFLOW_SELECTOR_TIMEOUT_S"
+
+# Deterministic branch_def_id for the platform default selector.
+# Tests rely on this being stable across processes.
+DEFAULT_SELECTOR_BRANCH_DEF_ID = "platform_default_selector_v1_20260521"
+DEFAULT_SELECTOR_NAME = "Platform Default Selector v1"
+DEFAULT_SELECTOR_AUTHOR = "platform"
+DEFAULT_SELECTOR_PUBLISHER = "platform"
+
+
+# ---------------------------------------------------------------------------
+# Selector resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_selector_branch_version_id(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+) -> dict[str, Any]:
+    """Return the selector branch_version_id for the Goal.
+
+    Resolution order:
+
+      1. ``goal.selector_branch_version_id`` if set.
+      2. Otherwise, the platform default selector's
+         ``branch_version_id`` (published lazily by
+         ``ensure_default_selector_published``).
+
+    Returns ``{"ok": True, "branch_version_id": "...", "source":
+    "goal_binding" | "platform_default"}`` on success or
+    ``{"ok": False, "error_kind": "...", "error": "..."}`` on
+    failure. Never raises.
+    """
+    try:
+        from workflow.daemon_server import get_goal
+        goal = get_goal(base_path, goal_id=goal_id)
+    except KeyError:
+        return {
+            "ok": False,
+            "error_kind": "goal_not_found",
+            "error": f"Goal {goal_id!r} not found.",
+        }
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.exception("resolve_selector | get_goal crashed")
+        return {
+            "ok": False,
+            "error_kind": "goal_load_failed",
+            "error": str(exc),
+        }
+
+    explicit = (goal.get("selector_branch_version_id") or "").strip() or None
+    if explicit:
+        return {
+            "ok": True,
+            "branch_version_id": explicit,
+            "source": "goal_binding",
+        }
+
+    # Fall back to the platform default selector.
+    try:
+        default_bvid = ensure_default_selector_published(base_path)
+    except Exception as exc:
+        logger.exception("resolve_selector | default-selector publish crashed")
+        return {
+            "ok": False,
+            "error_kind": "default_selector_publish_failed",
+            "error": str(exc),
+        }
+    if not default_bvid:
+        return {
+            "ok": False,
+            "error_kind": "default_selector_unavailable",
+            "error": (
+                "Platform default selector branch could not be "
+                "published; no fallback selector available."
+            ),
+        }
+    return {
+        "ok": True,
+        "branch_version_id": default_bvid,
+        "source": "platform_default",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Default selector materialization
+# ---------------------------------------------------------------------------
+
+
+def ensure_default_selector_published(base_path: str | Path) -> str:
+    """Ensure the platform default selector branch + active version exist.
+
+    Returns the active ``branch_version_id``. Idempotent: if the
+    branch_def already exists AND has an active published version,
+    that version's id is returned without re-publishing.
+
+    The branch is a single prompt-template node:
+
+      * Input keys: ``goal_id``, ``candidate_branches`` (the signal
+        bundle the leaderboard collects).
+      * Output keys: ``ranked_entries`` (JSON array of
+        ``{branch_def_id, branch_version_id, score, rationale}``).
+
+    The prompt explicitly instructs the LLM to weight signals and
+    emit valid JSON. Community forks of this branch tune the prompt
+    rather than Python constants.
+    """
+    from workflow.branch_versions import (
+        get_branch_version,
+        list_branch_versions,
+        publish_branch_version,
+    )
+    from workflow.daemon_server import (
+        get_branch_definition,
+        save_branch_definition,
+    )
+
+    # Step 1: ensure the branch_def exists.
+    try:
+        existing = get_branch_definition(
+            base_path, branch_def_id=DEFAULT_SELECTOR_BRANCH_DEF_ID,
+        )
+    except KeyError:
+        existing = None
+
+    if existing is None:
+        branch_dict = _build_default_selector_branch_dict()
+        save_branch_definition(base_path, branch_def=branch_dict)
+
+    # Step 2: find an active published version, else publish one.
+    versions = list_branch_versions(
+        base_path,
+        branch_def_id=DEFAULT_SELECTOR_BRANCH_DEF_ID,
+        limit=50,
+    )
+    for v in versions:
+        if getattr(v, "status", "active") == "active":
+            return v.branch_version_id
+
+    # No active version — publish v1.
+    branch_dict = _build_default_selector_branch_dict()
+    version = publish_branch_version(
+        base_path,
+        branch_dict=branch_dict,
+        publisher=DEFAULT_SELECTOR_PUBLISHER,
+        notes=(
+            "Platform default selector v1 — single prompt-template "
+            "node ranking candidate branches from collected signals. "
+            "Community forks customize the prompt per domain."
+        ),
+    )
+    # Sanity: re-read to confirm row landed + status.
+    persisted = get_branch_version(base_path, version.branch_version_id)
+    if persisted is None:
+        raise RuntimeError(
+            "publish_branch_version reported success but the row is "
+            "not readable post-write."
+        )
+    return persisted.branch_version_id
+
+
+def _build_default_selector_branch_dict() -> dict[str, Any]:
+    """Construct the default selector's BranchDefinition dict.
+
+    Kept as a function (not a constant) so each call returns a fresh
+    dict the storage layer can mutate without aliasing.
+    """
+    prompt = _DEFAULT_SELECTOR_PROMPT
+    node = {
+        "node_id": "rank",
+        "display_name": "Rank Candidates",
+        "description": (
+            "Read candidate_branches + their signals; emit "
+            "ranked_entries JSON in score-desc order."
+        ),
+        "phase": "custom",
+        "input_keys": ["goal_id", "candidate_branches"],
+        "output_keys": ["ranked_entries"],
+        "prompt_template": prompt,
+        "model_hint": "writer",
+        # The prompt-template node consumes ``candidate_branches`` —
+        # a structured JSON-able list. The default prompt-template
+        # renderer treats input_keys as a dict the template's
+        # placeholders are formatted against; the strict_input_isolation
+        # default (True) keeps the prompt from leaking state it
+        # didn't declare.
+    }
+    return {
+        "branch_def_id": DEFAULT_SELECTOR_BRANCH_DEF_ID,
+        "name": DEFAULT_SELECTOR_NAME,
+        "description": (
+            "Platform default selector — ranks candidate branches "
+            "for a Goal's leaderboard using LLM judgment over "
+            "collected signals. Fork + tune the prompt for "
+            "domain-specific selection."
+        ),
+        "author": DEFAULT_SELECTOR_AUTHOR,
+        "domain_id": "workflow",
+        "tags": ["selector", "platform-default", "leaderboard"],
+        "version": 1,
+        "skills": [],
+        "entry_point": "rank",
+        "graph_nodes": [
+            {
+                "id": "rank",
+                "type": "prompt",
+                "phase": "custom",
+                "input_keys": ["goal_id", "candidate_branches"],
+                "output_keys": ["ranked_entries"],
+            },
+        ],
+        "edges": [
+            {"from": "START", "to": "rank"},
+            {"from": "rank", "to": "END"},
+        ],
+        "node_defs": [node],
+        "state_schema": [
+            {"name": "goal_id", "type": "str"},
+            {"name": "candidate_branches", "type": "list"},
+            {"name": "ranked_entries", "type": "list"},
+        ],
+        "published": True,
+        "visibility": "public",
+    }
+
+
+# The default selector prompt. The "weights" are now words that any
+# Goal owner can fork and rewrite for their domain (e.g. fantasy-
+# writing might rank "novelty" higher; bug-investigation might
+# weight "completed_run_count" + "judgment_score_avg" almost
+# exclusively). See ``drafts/concepts/selector-branch-contract.md``
+# for the full input/output spec.
+_DEFAULT_SELECTOR_PROMPT = """\
+You are the **platform default selector** for a Workflow Goal's
+leaderboard. Your job is to rank candidate branches that are competing
+on the same Goal and emit a JSON array describing the ranking.
+
+## Goal context
+goal_id: {goal_id}
+
+## Candidates with collected signals
+{candidate_branches}
+
+## Ranking guidance (default — fork this branch to customize)
+
+Consider, in roughly this order of importance:
+
+1. **judgment_score_avg** — average of numeric judgment tags
+   (quality/novelty/score). When non-null this is the strongest
+   single signal. Treat as ~0-10.
+2. **completed_run_count** — more completed runs = more evidence
+   this branch actually works. Penalty for `failed_run_count`.
+3. **fork_count** — community votes with their forks; high
+   fork_count signals influence + endorsement.
+4. **last_successful_run_at + age_days_since_success** — recency
+   matters; a branch that succeeded yesterday outranks one that
+   succeeded six months ago, all else equal.
+5. **has_gate_rung / gate_rung_top** — branches that have climbed
+   the Goal's gate ladder (real-world impact) outrank those that
+   have not.
+6. **safe_to_publish** — when present, a strong positive signal.
+
+Branches with no completed runs and no judgments rank below
+branches that have *any* signal. A branch with only one completed
+run but high judgment_score_avg can still rank well.
+
+## Output
+
+Emit ONLY a JSON object on a single line (no markdown fence, no
+prose before or after) with the following shape:
+
+```
+{{"ranked_entries":[{{"branch_def_id":"...","branch_version_id":"...","score":<float>,"rationale":"<one sentence>"}},...]}}
+```
+
+Order entries best-first. Use the `branch_version_id` from each
+candidate if non-empty, otherwise the empty string. `score` should
+be on a 0.0-10.0 scale; ties are acceptable. `rationale` is a single
+sentence naming the dominant signals (e.g. "highest judgment avg
+(8.4) with 12 completed runs and 3 community forks").
+
+If `candidate_branches` is empty, return `{{"ranked_entries":[]}}`.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Selector dispatch + result parsing
+# ---------------------------------------------------------------------------
+
+
+def dispatch_selector(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    candidate_branches: list[dict[str, Any]],
+    actor: str = "anonymous",
+    timeout_s: float | None = None,
+) -> dict[str, Any]:
+    """Run the selector branch synchronously + return its ``ranked_entries``.
+
+    Resolves the selector via :func:`resolve_selector_branch_version_id`,
+    dispatches an async run via ``execute_branch_version_async``, blocks
+    on its background future for up to ``timeout_s`` seconds, reads the
+    final ``runs.output_json``, validates the
+    ``ranked_entries`` shape, and returns it.
+
+    Returns one of:
+
+    Success::
+
+        {
+            "ok": True,
+            "branch_version_id": "...",
+            "source": "goal_binding" | "platform_default",
+            "run_id": "...",
+            "ranked_entries": [...],  # validated shape
+        }
+
+    Failure (selector unresolvable, dispatch failed, timeout, or
+    invalid output shape)::
+
+        {
+            "ok": False,
+            "error_kind": "<one of: selector_not_published |
+                            selector_dispatch_failed |
+                            selector_timeout |
+                            selector_run_failed |
+                            selector_invalid_output>",
+            "error": "<human-readable>",
+            # Optional context fields per error_kind:
+            "branch_version_id": "...",
+            "run_id": "...",
+        }
+
+    Empty ``candidate_branches`` short-circuits to
+    ``{ok: True, ranked_entries: []}`` without dispatching — no
+    point burning an LLM call when there's nothing to rank.
+    """
+    # Short-circuit: no candidates means no work.
+    if not candidate_branches:
+        return {
+            "ok": True,
+            "branch_version_id": None,
+            "source": "empty_candidate_set",
+            "run_id": None,
+            "ranked_entries": [],
+        }
+
+    resolution = resolve_selector_branch_version_id(
+        base_path, goal_id=goal_id,
+    )
+    if not resolution.get("ok"):
+        return {
+            "ok": False,
+            "error_kind": resolution.get(
+                "error_kind", "selector_not_published",
+            ),
+            "error": resolution.get("error", ""),
+        }
+    bvid = resolution["branch_version_id"]
+    source = resolution["source"]
+
+    timeout = _resolve_timeout(timeout_s)
+
+    # Build the selector's input dict. ``candidate_branches`` is
+    # serialized as-is — the prompt template's placeholder will
+    # render it via str() / JSON depending on the provider's stub.
+    inputs: dict[str, Any] = {
+        "goal_id": goal_id,
+        "candidate_branches": candidate_branches,
+    }
+
+    # Lazy import to avoid pulling in the run executor at module
+    # import time (matches the rest of the workflow.api seam).
+    from workflow.runs import (
+        SnapshotSchemaDrift,
+        execute_branch_version_async,
+        get_run,
+        wait_for,
+    )
+
+    try:
+        from domains.fantasy_daemon.phases._provider_stub import (
+            call_provider as provider_call,
+        )
+    except ImportError:
+        provider_call = None
+
+    try:
+        outcome = execute_branch_version_async(
+            base_path,
+            branch_version_id=bvid,
+            inputs=inputs,
+            run_name=f"selector_dispatch_for_{goal_id}",
+            actor=actor,
+            provider_call=provider_call,
+        )
+    except KeyError as exc:
+        return {
+            "ok": False,
+            "error_kind": "selector_not_published",
+            "error": (
+                f"selector branch_version_id {bvid!r} not found "
+                f"in branch_versions: {exc}"
+            ),
+            "branch_version_id": bvid,
+        }
+    except SnapshotSchemaDrift as exc:
+        return {
+            "ok": False,
+            "error_kind": "selector_snapshot_drift",
+            "error": str(exc),
+            "branch_version_id": bvid,
+        }
+    except Exception as exc:
+        logger.exception(
+            "selector dispatch failed for goal=%s bvid=%s",
+            goal_id, bvid,
+        )
+        return {
+            "ok": False,
+            "error_kind": "selector_dispatch_failed",
+            "error": str(exc),
+            "branch_version_id": bvid,
+        }
+
+    run_id = outcome.run_id
+
+    # Block on the background future. ``wait_for`` is a no-op when
+    # ``_execute_branch_core`` completed inline (small graphs or test
+    # paths where the executor pool ran synchronously); otherwise it
+    # waits up to ``timeout`` for the worker to finish.
+    try:
+        wait_for(run_id, timeout=timeout)
+    except Exception as exc:
+        # TimeoutError from concurrent.futures or any other wait
+        # failure collapses to a selector_timeout outcome — never
+        # raise into the leaderboard caller.
+        logger.warning(
+            "selector run %s did not finish within %.1fs: %s",
+            run_id, timeout, exc,
+        )
+        return {
+            "ok": False,
+            "error_kind": "selector_timeout",
+            "error": (
+                f"selector run {run_id!r} did not complete within "
+                f"{timeout:.1f}s. The selector branch may be misconfigured "
+                "or the provider is overloaded."
+            ),
+            "branch_version_id": bvid,
+            "run_id": run_id,
+        }
+
+    # Re-read the run row to pick up the final output. ``outcome``
+    # captures only the queued response; the actual graph output
+    # lives in runs.output_json once the worker writes it.
+    final = get_run(base_path, run_id)
+    if final is None:
+        return {
+            "ok": False,
+            "error_kind": "selector_run_failed",
+            "error": (
+                f"selector run {run_id!r} vanished from the runs DB "
+                "after dispatch. Storage layer may have failed."
+            ),
+            "branch_version_id": bvid,
+            "run_id": run_id,
+        }
+    status = final.get("status") or ""
+    if status != "completed":
+        return {
+            "ok": False,
+            "error_kind": "selector_run_failed",
+            "error": (
+                f"selector run {run_id!r} ended with status={status!r}: "
+                f"{final.get('error') or '(no error message)'}"
+            ),
+            "branch_version_id": bvid,
+            "run_id": run_id,
+            "selector_status": status,
+        }
+
+    output = final.get("output") or {}
+    if not isinstance(output, dict):
+        return {
+            "ok": False,
+            "error_kind": "selector_invalid_output",
+            "error": (
+                f"selector run output was not a JSON object; got "
+                f"{type(output).__name__}"
+            ),
+            "branch_version_id": bvid,
+            "run_id": run_id,
+        }
+
+    parsed = _parse_ranked_entries(output)
+    if parsed.get("ok"):
+        return {
+            "ok": True,
+            "branch_version_id": bvid,
+            "source": source,
+            "run_id": run_id,
+            "ranked_entries": parsed["ranked_entries"],
+        }
+    return {
+        "ok": False,
+        "error_kind": parsed.get(
+            "error_kind", "selector_invalid_output",
+        ),
+        "error": parsed.get("error", ""),
+        "branch_version_id": bvid,
+        "run_id": run_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output parsing
+# ---------------------------------------------------------------------------
+
+
+_REQUIRED_ENTRY_KEYS = ("branch_def_id", "score")
+
+
+def _parse_ranked_entries(output: dict[str, Any]) -> dict[str, Any]:
+    """Pull ``ranked_entries`` out of the selector's run output.
+
+    Accepts either:
+
+      * ``output["ranked_entries"]`` as a list (the canonical shape).
+      * ``output["ranked_entries"]`` as a JSON string that decodes to a list
+        (LLM-emitted ``"[{...}]"`` from a prompt-template node that didn't
+        post-process the string).
+
+    Returns ``{ok: True, ranked_entries: [...]}`` on success or
+    ``{ok: False, error_kind, error}`` on any malformation.
+    """
+    raw = output.get("ranked_entries")
+    if raw is None:
+        return {
+            "ok": False,
+            "error_kind": "selector_invalid_output",
+            "error": (
+                "selector output did not contain the required "
+                "'ranked_entries' key."
+            ),
+        }
+    entries = raw
+    if isinstance(entries, str):
+        # LLM-emitted JSON string — attempt to decode. Strip
+        # markdown fence if present.
+        candidate = entries.strip()
+        if candidate.startswith("```"):
+            # Strip a fenced block (```json ... ```).
+            lines = candidate.splitlines()
+            if lines and lines[0].startswith("```"):
+                lines = lines[1:]
+            if lines and lines[-1].strip().startswith("```"):
+                lines = lines[:-1]
+            candidate = "\n".join(lines).strip()
+        try:
+            decoded = json.loads(candidate)
+        except (ValueError, TypeError) as exc:
+            return {
+                "ok": False,
+                "error_kind": "selector_invalid_output",
+                "error": (
+                    "selector output 'ranked_entries' is a string but "
+                    f"not parseable JSON: {exc}"
+                ),
+            }
+        if isinstance(decoded, dict) and "ranked_entries" in decoded:
+            # Whole JSON object was stuffed into the field. Unwrap.
+            entries = decoded["ranked_entries"]
+        elif isinstance(decoded, list):
+            entries = decoded
+        else:
+            return {
+                "ok": False,
+                "error_kind": "selector_invalid_output",
+                "error": (
+                    "selector output 'ranked_entries' string decoded to "
+                    f"{type(decoded).__name__}, expected list."
+                ),
+            }
+    if not isinstance(entries, list):
+        return {
+            "ok": False,
+            "error_kind": "selector_invalid_output",
+            "error": (
+                "selector output 'ranked_entries' must be a list; got "
+                f"{type(entries).__name__}."
+            ),
+        }
+    cleaned: list[dict[str, Any]] = []
+    for idx, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            return {
+                "ok": False,
+                "error_kind": "selector_invalid_output",
+                "error": (
+                    f"ranked_entries[{idx}] must be an object; got "
+                    f"{type(entry).__name__}."
+                ),
+            }
+        for key in _REQUIRED_ENTRY_KEYS:
+            if key not in entry:
+                return {
+                    "ok": False,
+                    "error_kind": "selector_invalid_output",
+                    "error": (
+                        f"ranked_entries[{idx}] missing required key "
+                        f"{key!r}. Entry keys: {sorted(entry.keys())}."
+                    ),
+                }
+        # Normalize types so downstream consumers see consistent
+        # shapes. Score is coerced to float; missing optional fields
+        # become "" / None.
+        try:
+            score = float(entry["score"])
+        except (TypeError, ValueError):
+            return {
+                "ok": False,
+                "error_kind": "selector_invalid_output",
+                "error": (
+                    f"ranked_entries[{idx}].score is not coercible to "
+                    f"float: {entry.get('score')!r}"
+                ),
+            }
+        bdid = (entry.get("branch_def_id") or "").strip()
+        if not bdid:
+            return {
+                "ok": False,
+                "error_kind": "selector_invalid_output",
+                "error": (
+                    f"ranked_entries[{idx}].branch_def_id must be a "
+                    "non-empty string."
+                ),
+            }
+        cleaned.append({
+            "branch_def_id": bdid,
+            "branch_version_id": (
+                entry.get("branch_version_id") or ""
+            ),
+            "score": round(score, 4),
+            "rationale": str(entry.get("rationale") or ""),
+        })
+    return {"ok": True, "ranked_entries": cleaned}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_timeout(explicit: float | None) -> float:
+    """Pick the selector dispatch timeout."""
+    if explicit is not None:
+        try:
+            return max(1.0, float(explicit))
+        except (TypeError, ValueError):
+            pass
+    import os
+    raw = os.environ.get(SELECTOR_TIMEOUT_ENV, "").strip()
+    if raw:
+        try:
+            return max(1.0, float(raw))
+        except ValueError:
+            pass
+    return SELECTOR_TIMEOUT_S_DEFAULT
+
+
+__all__ = [
+    "DEFAULT_SELECTOR_BRANCH_DEF_ID",
+    "DEFAULT_SELECTOR_NAME",
+    "SELECTOR_TIMEOUT_S_DEFAULT",
+    "SELECTOR_TIMEOUT_ENV",
+    "resolve_selector_branch_version_id",
+    "ensure_default_selector_published",
+    "dispatch_selector",
+]

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/selector_dispatch.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/selector_dispatch.py
@@ -100,7 +100,6 @@ from __future__ import annotations
 
 import json
 import logging
-import time
 from pathlib import Path
 from typing import Any
 
@@ -329,10 +328,20 @@ def _build_default_selector_branch_dict() -> dict[str, Any]:
             {"from": "rank", "to": "END"},
         ],
         "node_defs": [node],
+        # state_schema types are intentionally all ``str``: the
+        # ``ranked_entries`` output is emitted as a JSON-string by the
+        # prompt-template node, then the substrate parses it via
+        # ``_parse_ranked_entries`` (which tolerates JSON-string +
+        # markdown-fence shapes). Declaring ``list`` here would force
+        # the graph_compiler's JSON-contract code path on the response,
+        # which assumes native structured-output and rejects any
+        # provider that returns the JSON as a plain string. Selectors
+        # talk to many providers (CLI-wrapped Claude / codex / ollama)
+        # where structured-output isn't wirable.
         "state_schema": [
             {"name": "goal_id", "type": "str"},
-            {"name": "candidate_branches", "type": "list"},
-            {"name": "ranked_entries", "type": "list"},
+            {"name": "candidate_branches", "type": "str"},
+            {"name": "ranked_entries", "type": "str"},
         ],
         "published": True,
         "visibility": "public",
@@ -381,11 +390,19 @@ run but high judgment_score_avg can still rank well.
 
 ## Output
 
-Emit ONLY a JSON object on a single line (no markdown fence, no
-prose before or after) with the following shape:
+Emit ONLY a JSON object (no markdown fence, no prose before or
+after) with the following shape:
 
 ```
-{{"ranked_entries":[{{"branch_def_id":"...","branch_version_id":"...","score":<float>,"rationale":"<one sentence>"}},...]}}
+{{"ranked_entries":[
+  {{
+    "branch_def_id":"...",
+    "branch_version_id":"...",
+    "score":<float>,
+    "rationale":"<one sentence>"
+  }},
+  ...
+]}}
 ```
 
 Order entries best-first. Use the `branch_version_id` from each
@@ -410,6 +427,7 @@ def dispatch_selector(
     candidate_branches: list[dict[str, Any]],
     actor: str = "anonymous",
     timeout_s: float | None = None,
+    provider_call: Any = None,
 ) -> dict[str, Any]:
     """Run the selector branch synchronously + return its ``ranked_entries``.
 
@@ -485,48 +503,122 @@ def dispatch_selector(
         "candidate_branches": candidate_branches,
     }
 
-    # Lazy import to avoid pulling in the run executor at module
-    # import time (matches the rest of the workflow.api seam).
-    from workflow.runs import (
-        SnapshotSchemaDrift,
-        execute_branch_version_async,
-        get_run,
-        wait_for,
-    )
+    # Reconstruct the selector branch from the immutable snapshot +
+    # the live branch_definitions row's identity metadata.
+    #
+    # P1.1 fix (DESIGN-008 round 2): ``publish_branch_version`` ->
+    # ``_canonical_snapshot`` deliberately strips name / description /
+    # author from the immutable snapshot — only graph behavior fields
+    # survive. Reconstructing via ``BranchDefinition.from_dict(snapshot)``
+    # alone yields an empty name and ``validate()`` rejects with
+    # "Branch name is required" before compile.
+    #
+    # We enrich here by reading the parent ``branch_definitions``
+    # row (same branch_def_id) and merging name / description /
+    # author / visibility back in. Effects + node graph + state
+    # schema still come from the IMMUTABLE snapshot, so the
+    # selector's actual behavior matches what was published — only
+    # the identity/UI fields come from the mutable parent row.
+    from workflow.branch_versions import get_branch_version
+    from workflow.branches import BranchDefinition
+    from workflow.daemon_server import get_branch_definition
+    from workflow.runs import _execute_branch_core
 
     try:
-        from domains.fantasy_daemon.phases._provider_stub import (
-            call_provider as provider_call,
+        bv = get_branch_version(base_path, bvid)
+    except Exception as exc:
+        logger.exception(
+            "selector dispatch | get_branch_version crashed | "
+            "goal=%s bvid=%s", goal_id, bvid,
         )
-    except ImportError:
-        provider_call = None
-
-    try:
-        outcome = execute_branch_version_async(
-            base_path,
-            branch_version_id=bvid,
-            inputs=inputs,
-            run_name=f"selector_dispatch_for_{goal_id}",
-            actor=actor,
-            provider_call=provider_call,
-        )
-    except KeyError as exc:
+        return {
+            "ok": False,
+            "error_kind": "selector_dispatch_failed",
+            "error": str(exc),
+            "branch_version_id": bvid,
+        }
+    if bv is None:
         return {
             "ok": False,
             "error_kind": "selector_not_published",
             "error": (
-                f"selector branch_version_id {bvid!r} not found "
-                f"in branch_versions: {exc}"
+                f"selector branch_version_id {bvid!r} not found in "
+                "branch_versions."
             ),
             "branch_version_id": bvid,
         }
-    except SnapshotSchemaDrift as exc:
+
+    snapshot = dict(bv.snapshot or {})
+    parent_def_id = snapshot.get("branch_def_id") or ""
+    parent_row: dict[str, Any] | None = None
+    if parent_def_id:
+        try:
+            parent_row = get_branch_definition(
+                base_path, branch_def_id=parent_def_id,
+            )
+        except KeyError:
+            parent_row = None
+        except Exception:
+            logger.exception(
+                "selector dispatch | parent branch_definitions read "
+                "crashed | goal=%s bvid=%s parent=%s",
+                goal_id, bvid, parent_def_id,
+            )
+            parent_row = None
+
+    # Merge identity fields. Snapshot wins on graph fields; parent
+    # row wins on identity fields (name/description/author). If the
+    # parent row is missing (rare — could happen if the def was
+    # purged but the version row remains), fall back to a synthetic
+    # name derived from the branch_def_id so validate() passes and
+    # the selector can still run.
+    enriched: dict[str, Any] = dict(snapshot)
+    if parent_row:
+        for k in ("name", "description", "author", "visibility",
+                  "domain_id", "tags"):
+            if not enriched.get(k) and parent_row.get(k) is not None:
+                enriched[k] = parent_row[k]
+    if not enriched.get("name"):
+        enriched["name"] = parent_def_id or f"selector_{bvid}"
+
+    try:
+        branch_def = BranchDefinition.from_dict(enriched)
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
         return {
             "ok": False,
             "error_kind": "selector_snapshot_drift",
-            "error": str(exc),
+            "error": (
+                f"selector snapshot {bvid!r} cannot be reconstructed: "
+                f"{exc}. Republish at the current schema version."
+            ),
             "branch_version_id": bvid,
         }
+
+    # Provider resolution: explicit ``provider_call`` kwarg wins
+    # (tests inject a deterministic stub); otherwise fall back to
+    # the fantasy-daemon provider stub, which routes to the
+    # configured Workflow provider chain (Anthropic / Codex /
+    # Ollama / etc.). Same fallback shape as
+    # ``_action_run_branch_version``.
+    if provider_call is None:
+        try:
+            from domains.fantasy_daemon.phases._provider_stub import (
+                call_provider as _default_provider_call,
+            )
+            provider_call = _default_provider_call
+        except ImportError:
+            provider_call = None
+
+    try:
+        outcome = _execute_branch_core(
+            base_path,
+            branch=branch_def,
+            inputs=inputs,
+            run_name=f"selector_dispatch_for_{goal_id}",
+            actor=actor,
+            provider_call=provider_call,
+            branch_version_id=bvid,
+        )
     except Exception as exc:
         logger.exception(
             "selector dispatch failed for goal=%s bvid=%s",
@@ -545,6 +637,7 @@ def dispatch_selector(
     # ``_execute_branch_core`` completed inline (small graphs or test
     # paths where the executor pool ran synchronously); otherwise it
     # waits up to ``timeout`` for the worker to finish.
+    from workflow.runs import get_run, wait_for
     try:
         wait_for(run_id, timeout=timeout)
     except Exception as exc:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/selector_dispatch.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/selector_dispatch.py
@@ -163,6 +163,61 @@ def resolve_selector_branch_version_id(
         }
 
     explicit = (goal.get("selector_branch_version_id") or "").strip() or None
+    # P1.C (DESIGN-008 round 4) — re-check the bound version's status
+    # at READ/DISPATCH time. Bind-time enforces ``status='active'`` (see
+    # ``set_selector_branch``), but the version can be rolled back AFTER
+    # bind by a separate ``branch_versions.status`` flip or by a
+    # rollback operation. Without this re-check, a rolled-back selector
+    # keeps running on every leaderboard read — exactly the bug Codex
+    # round 3 caught. Mirrors the round-2 P1.1 contract on
+    # ``set_canonical_branch`` / ``_latest_published_version_id``.
+    #
+    # When the bound version is no longer active, fall back to the
+    # platform default with a structured ``fellback_from`` diagnostic
+    # so the chatbot / audit tools can flag the stale binding and the
+    # operator can re-bind or unbind.
+    fellback_from: dict[str, str] | None = None
+    if explicit:
+        try:
+            from workflow.branch_versions import get_branch_version
+            version = get_branch_version(base_path, explicit)
+        except Exception:
+            logger.exception(
+                "resolve_selector | get_branch_version crashed for "
+                "goal=%s explicit=%s", goal_id, explicit,
+            )
+            version = None
+        if version is None:
+            fellback_from = {
+                "branch_version_id": explicit,
+                "reason": "selector_version_not_found",
+            }
+            logger.warning(
+                "selector binding for goal=%s points at "
+                "branch_version_id=%r which is no longer in "
+                "branch_versions; falling back to platform default",
+                goal_id, explicit,
+            )
+            explicit = None
+        else:
+            status = getattr(version, "status", "active") or "active"
+            if status != "active":
+                fellback_from = {
+                    "branch_version_id": explicit,
+                    "reason": "selector_version_inactive",
+                    "status": status,
+                }
+                logger.warning(
+                    "selector binding for goal=%s points at "
+                    "branch_version_id=%r with status=%r "
+                    "(active-only required); falling back to "
+                    "platform default. Operator: re-bind via "
+                    "goals action=set_selector with an active "
+                    "version, or unbind with branch_version_id=''",
+                    goal_id, explicit, status,
+                )
+                explicit = None
+
     if explicit:
         return {
             "ok": True,
@@ -170,7 +225,9 @@ def resolve_selector_branch_version_id(
             "source": "goal_binding",
         }
 
-    # Fall back to the platform default selector.
+    # Fall back to the platform default selector. This path is
+    # reached for: no explicit binding, OR an explicit binding that
+    # is no longer active (see fellback_from above).
     try:
         default_bvid = ensure_default_selector_published(base_path)
     except Exception as exc:
@@ -189,11 +246,17 @@ def resolve_selector_branch_version_id(
                 "published; no fallback selector available."
             ),
         }
-    return {
+    result: dict[str, Any] = {
         "ok": True,
         "branch_version_id": default_bvid,
         "source": "platform_default",
     }
+    if fellback_from is not None:
+        # Distinguish "no binding" platform_default from "binding
+        # invalidated by rollback" platform_default. Programmatic
+        # consumers can spot stale bindings without scraping logs.
+        result["fellback_from"] = fellback_from
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -492,6 +555,11 @@ def dispatch_selector(
         }
     bvid = resolution["branch_version_id"]
     source = resolution["source"]
+    # P1.C (round 4) — when the bound version was found inactive at
+    # resolve time and the substrate fell back to platform default,
+    # propagate that diagnostic to the leaderboard caller so the
+    # response shape carries it. Empty / None when not applicable.
+    fellback_from = resolution.get("fellback_from")
 
     timeout = _resolve_timeout(timeout_s)
 
@@ -704,13 +772,16 @@ def dispatch_selector(
 
     parsed = _parse_ranked_entries(output)
     if parsed.get("ok"):
-        return {
+        result: dict[str, Any] = {
             "ok": True,
             "branch_version_id": bvid,
             "source": source,
             "run_id": run_id,
             "ranked_entries": parsed["ranked_entries"],
         }
+        if fellback_from is not None:
+            result["fellback_from"] = fellback_from
+        return result
     return {
         "ok": False,
         "error_kind": parsed.get(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
@@ -481,6 +481,24 @@ def initialize_author_server(base_path: str | Path) -> Path:
                 "ALTER TABLE goals ADD COLUMN min_completed_runs_for_canonical "
                 "INTEGER NOT NULL DEFAULT 5"
             )
+        # DESIGN-008: user-buildable selector primitive. A Goal can
+        # bind a "selector branch" (a published Workflow branch) that
+        # the substrate dispatches whenever the leaderboard is built;
+        # the selector reads input signals + emits ``ranked_entries``,
+        # replacing the round-1 platform-opinionated formula.
+        #
+        # NULL is the post-migration "use platform default" state.
+        # The default selector branch is materialized lazily on first
+        # leaderboard read (see
+        # ``workflow.api.selector_dispatch.ensure_default_selector_published``)
+        # and stored under a deterministic branch_def_id; the migration
+        # at the bottom of this function backfills the column for any
+        # Goal that has bound branches.
+        if "selector_branch_version_id" not in goal_cols:
+            conn.execute(
+                "ALTER TABLE goals ADD COLUMN selector_branch_version_id "
+                "TEXT DEFAULT NULL"
+            )
         # Variant canonicals (Task #61 Step 1) — backfill canonical_bindings
         # from existing goals.canonical_branch_version_id. INSERT OR IGNORE
         # makes the migration idempotent: re-running on an already-backfilled
@@ -2451,6 +2469,13 @@ def _goal_from_row(row: sqlite3.Row) -> dict[str, Any]:
         min_runs = int(row["min_completed_runs_for_canonical"] or 5)
     except (IndexError, KeyError, TypeError, ValueError):
         min_runs = 5
+    # DESIGN-008 — user-buildable selector primitive. NULL post-migration
+    # is the "use platform default selector" signal; the leaderboard
+    # call resolves the default on demand.
+    try:
+        selector_bvid = row["selector_branch_version_id"]
+    except (IndexError, KeyError):
+        selector_bvid = None
     return {
         "goal_id": row["goal_id"],
         "name": row["name"],
@@ -2467,6 +2492,7 @@ def _goal_from_row(row: sqlite3.Row) -> dict[str, Any]:
         ),
         "auto_canonical_via_leaderboard": bool(auto_flag),
         "min_completed_runs_for_canonical": min_runs,
+        "selector_branch_version_id": selector_bvid,
     }
 
 
@@ -2565,6 +2591,15 @@ def update_goal(
             )
         sets.append("min_completed_runs_for_canonical = ?")
         params.append(threshold)
+    # DESIGN-008 — selector branch_version pointer. Storage helpers
+    # do NOT enforce active-version validation here; the dedicated
+    # set_selector_branch() helper does. update_goal accepts the
+    # field for host scripts / migration backfill that bypass the
+    # MCP auth+validate path.
+    if "selector_branch_version_id" in updates:
+        bvid = updates["selector_branch_version_id"]
+        sets.append("selector_branch_version_id = ?")
+        params.append(bvid if bvid else None)
     params.append(goal_id)
     with _connect(base_path) as conn:
         conn.execute(
@@ -2803,6 +2838,66 @@ def delete_goal(
     return update_goal(
         base_path, goal_id=goal_id, updates={"visibility": "deleted"},
     )
+
+
+def set_selector_branch(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    branch_version_id: str | None,
+    set_by: str,
+) -> dict[str, Any]:
+    """Bind (or unbind) the selector branch_version for a Goal.
+
+    DESIGN-008 — user-buildable selector primitive. The selector
+    branch is the published Workflow branch that synthesizes the
+    Goal's leaderboard rankings. ``branch_version_id=None`` unsets
+    the binding, falling back to the platform default selector.
+
+    Authority: the caller must enforce "only Goal author or host"
+    before calling this; the helper does NOT re-check authority
+    (matches the contract of ``set_canonical_branch``).
+
+    Raises
+    ------
+    KeyError
+        ``goal_id`` is not in the goals table.
+    ValueError
+        ``branch_version_id`` is provided but the version row does
+        not exist in ``branch_versions`` OR its status is not
+        ``'active'`` (defense in depth — rolled-back / superseded
+        versions cannot be promoted to selector, mirroring the
+        PR-127 round-2 P1.1 contract on ``set_canonical_branch``).
+    """
+    initialize_author_server(base_path)
+    now = _now()
+    goal = get_goal(base_path, goal_id=goal_id)
+
+    if branch_version_id is not None:
+        from workflow.branch_versions import get_branch_version
+        version = get_branch_version(base_path, branch_version_id)
+        if version is None:
+            raise ValueError(
+                f"branch_version_id {branch_version_id!r} not found in "
+                "branch_versions — only published versions may be "
+                "selector branches."
+            )
+        version_status = getattr(version, "status", "active") or "active"
+        if version_status != "active":
+            raise ValueError(
+                f"branch_version_id {branch_version_id!r} has "
+                f"status={version_status!r}; only versions with "
+                "status='active' may be promoted to selector."
+            )
+
+    with _connect(base_path) as conn:
+        conn.execute(
+            "UPDATE goals SET selector_branch_version_id = ?, "
+            "    updated_at = ? "
+            "WHERE goal_id = ?",
+            (branch_version_id, now, goal_id),
+        )
+    return get_goal(base_path, goal_id=goal_id)
 
 
 def branches_for_goal(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
@@ -2840,6 +2840,18 @@ def delete_goal(
     )
 
 
+class SelectorHasEffectsError(ValueError):
+    """Raised when a selector branch declares external-write effects.
+
+    DESIGN-008 round-2 P1.3 guard: selector branches run on every
+    leaderboard read (``quality_leaderboard`` /
+    ``recommend_parent_for_fork``). If their nodes declare
+    ``effects`` (e.g. ``github_pull_request``), every read silently
+    fires real external writes — reads becoming writes. Bind-time
+    rejection is the loud + early gate.
+    """
+
+
 def set_selector_branch(
     base_path: str | Path,
     *,
@@ -2868,10 +2880,16 @@ def set_selector_branch(
         ``'active'`` (defense in depth — rolled-back / superseded
         versions cannot be promoted to selector, mirroring the
         PR-127 round-2 P1.1 contract on ``set_canonical_branch``).
+    SelectorHasEffectsError
+        ``branch_version_id`` is provided but the snapshot contains
+        a node with non-empty ``effects`` (DESIGN-008 round-2 P1.3).
+        Reads must not silently fire external writes.
     """
     initialize_author_server(base_path)
     now = _now()
-    goal = get_goal(base_path, goal_id=goal_id)
+    # Validate goal exists — get_goal raises KeyError when missing.
+    # Authority enforcement is the caller's responsibility (see docstring).
+    get_goal(base_path, goal_id=goal_id)
 
     if branch_version_id is not None:
         from workflow.branch_versions import get_branch_version
@@ -2888,6 +2906,27 @@ def set_selector_branch(
                 f"branch_version_id {branch_version_id!r} has "
                 f"status={version_status!r}; only versions with "
                 "status='active' may be promoted to selector."
+            )
+        # P1.3 — selector branches MUST NOT declare ``effects``.
+        # A selector runs on every leaderboard read; nodes with
+        # effects would turn each read into a real external write.
+        node_defs = (version.snapshot or {}).get("node_defs") or []
+        effectful: list[str] = []
+        for nd in node_defs:
+            if not isinstance(nd, dict):
+                continue
+            effects = nd.get("effects") or []
+            if effects:
+                node_id = nd.get("node_id") or "(unnamed)"
+                effectful.append(f"{node_id}:{list(effects)}")
+        if effectful:
+            raise SelectorHasEffectsError(
+                f"branch_version_id {branch_version_id!r} cannot be "
+                "bound as a selector: selector branches run on every "
+                "leaderboard read and MUST NOT declare external-write "
+                f"effects. Offending nodes: {', '.join(effectful)}. "
+                "Remove the effects field on those nodes (or fork into "
+                "a non-effectful selector branch) before binding."
             )
 
     with _connect(base_path) as conn:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_server.py
@@ -2841,14 +2841,29 @@ def delete_goal(
 
 
 class SelectorHasEffectsError(ValueError):
-    """Raised when a selector branch declares external-write effects.
+    """Raised when a selector branch is not pure / read-only.
 
-    DESIGN-008 round-2 P1.3 guard: selector branches run on every
+    DESIGN-008 round-2/3 purity guard: selector branches run on every
     leaderboard read (``quality_leaderboard`` /
-    ``recommend_parent_for_fork``). If their nodes declare
-    ``effects`` (e.g. ``github_pull_request``), every read silently
-    fires real external writes — reads becoming writes. Bind-time
-    rejection is the loud + early gate.
+    ``recommend_parent_for_fork``). The substrate forbids any selector
+    branch that could trigger external writes, including transitively:
+
+    * **Round 2 P1.3** — node declares non-empty ``effects``
+      (e.g. ``github_pull_request``). Each read would fire the
+      effector directly.
+    * **Round 3 P1.B** — node declares ``invoke_branch_spec`` or
+      ``invoke_branch_version_spec``. The child run executes through
+      the normal graph path, and child completion fires the child's
+      effectors — bypassing the direct-effects scan. Worse,
+      ``invoke_branch_spec`` resolves at run time against a live
+      ``branch_def_id`` that the operator can mutate AFTER bind, so
+      transitive scanning at bind time is not a reliable safeguard.
+      Reject child-invocation nodes outright; a pure selector is a
+      single graph.
+
+    Bind-time rejection is the loud + early gate. The single error
+    type covers both classes because the failure mode is the same:
+    "read became a write."
     """
 
 
@@ -2907,26 +2922,74 @@ def set_selector_branch(
                 f"status={version_status!r}; only versions with "
                 "status='active' may be promoted to selector."
             )
-        # P1.3 — selector branches MUST NOT declare ``effects``.
-        # A selector runs on every leaderboard read; nodes with
-        # effects would turn each read into a real external write.
+        # Selector purity scan (rounds 2 + 3). Selector branches run
+        # on every leaderboard read; the substrate forbids ANY shape
+        # that could result in a real external write, directly or
+        # transitively.
         node_defs = (version.snapshot or {}).get("node_defs") or []
+        # P1.3 (round 2) — direct effects declarations.
         effectful: list[str] = []
+        # P1.B (round 3) — child-branch invocation specs. A node with
+        # invoke_branch_spec / invoke_branch_version_spec spawns a
+        # child run; the child's normal completion path fires its
+        # OWN effectors, bypassing the direct-effects scan above.
+        # ``invoke_branch_spec`` resolves at run time against a live
+        # branch_def_id that operators can mutate AFTER bind, so
+        # transitive scanning of the bind-time graph is not reliable.
+        # Reject child-invocation outright — selectors must be a
+        # single graph.
+        child_invokers: list[str] = []
         for nd in node_defs:
             if not isinstance(nd, dict):
                 continue
+            node_id = nd.get("node_id") or "(unnamed)"
             effects = nd.get("effects") or []
             if effects:
-                node_id = nd.get("node_id") or "(unnamed)"
                 effectful.append(f"{node_id}:{list(effects)}")
+            ibs = nd.get("invoke_branch_spec")
+            if ibs:
+                target = ""
+                if isinstance(ibs, dict):
+                    target = ibs.get("branch_def_id") or ""
+                child_invokers.append(
+                    f"{node_id}:invoke_branch_spec"
+                    + (f"({target})" if target else "")
+                )
+            ivs = nd.get("invoke_branch_version_spec")
+            if ivs:
+                target = ""
+                if isinstance(ivs, dict):
+                    target = ivs.get("branch_version_id") or ""
+                child_invokers.append(
+                    f"{node_id}:invoke_branch_version_spec"
+                    + (f"({target})" if target else "")
+                )
+        # Both classes route through the same error type because the
+        # failure mode is identical: "read became a write."
+        violations: list[str] = []
         if effectful:
+            violations.append(
+                "declares external-write effects "
+                f"({', '.join(effectful)})"
+            )
+        if child_invokers:
+            violations.append(
+                "declares child-branch invocation "
+                f"({', '.join(child_invokers)})"
+            )
+        if violations:
             raise SelectorHasEffectsError(
                 f"branch_version_id {branch_version_id!r} cannot be "
                 "bound as a selector: selector branches run on every "
-                "leaderboard read and MUST NOT declare external-write "
-                f"effects. Offending nodes: {', '.join(effectful)}. "
-                "Remove the effects field on those nodes (or fork into "
-                "a non-effectful selector branch) before binding."
+                "leaderboard read and MUST be pure (no external "
+                "writes, no child-branch invocation). Violations: "
+                + "; ".join(violations)
+                + ". Remove the offending fields on those nodes (or "
+                "fork into a pure selector branch) before binding. "
+                "If you need rich ranking that requires running other "
+                "graphs, build a selector that emits a recommendation "
+                "and let a separate Goal / canonical handler perform "
+                "the side-effecting work."
             )
 
     with _connect(base_path) as conn:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/rollback.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/rollback.py
@@ -717,6 +717,96 @@ def repoint_goals_after_rollback(
     }
 
 
+def repoint_selectors_after_rollback(
+    base_path: str | Path,
+    version_ids: Iterable[str],
+    *,
+    set_by: str,
+) -> dict[str, Any]:
+    """Clear any Goal whose ``selector_branch_version_id`` is in the
+    rolled-back set.
+
+    DESIGN-008 round 4 — selector pointers are subject to the same
+    active-only lifecycle invariant as canonical pointers. When a
+    selector branch_version is rolled back, every Goal pointing at it
+    must lose the binding so subsequent leaderboard reads fall back
+    to the platform default (instead of falling back at every read
+    via the runtime guard in
+    ``selector_dispatch.resolve_selector_branch_version_id``, which
+    is the merge-blocker safety net but leaves a stale pointer in
+    storage indefinitely).
+
+    Unlike canonical, selectors are NOT walked up to an ancestor
+    version: there is no analog of "fork from canonical" semantics
+    for selectors, and silently re-binding to an ancestor could
+    introduce a different ranking opinion the operator never
+    explicitly chose. Instead the binding is CLEARED (NULL), which
+    triggers the platform-default fallback. The operator can re-bind
+    to a different active version (or fork the rolled-back one) via
+    ``goals action=set_selector``.
+
+    Runs in a separate author_server-DB transaction per the cross-DB
+    refinement, mirroring ``repoint_goals_after_rollback``.
+
+    Returns:
+        ``{"status": "ok", "repointed_count": N, "repoints": [...]}``
+        with a per-goal log of ``{goal_id, old_branch_version_id}``.
+    """
+    from workflow.daemon_server import _connect as _author_connect
+    from workflow.daemon_server import set_selector_branch
+
+    rolled_back_set = set(version_ids)
+    if not rolled_back_set:
+        return {"status": "ok", "repointed_count": 0, "repoints": []}
+
+    repoints: list[dict[str, Any]] = []
+    with _author_connect(base_path) as conn:
+        placeholders = ",".join("?" * len(rolled_back_set))
+        try:
+            affected = conn.execute(
+                f"SELECT goal_id, selector_branch_version_id FROM goals "
+                f"WHERE selector_branch_version_id IN ({placeholders})",
+                tuple(rolled_back_set),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            # goals table doesn't exist OR the
+            # selector_branch_version_id column hasn't been migrated
+            # in yet (pre-DESIGN-008 universe). Clean no-op.
+            return {"status": "ok", "repointed_count": 0, "repoints": []}
+
+    for row in affected:
+        goal_id = row["goal_id"]
+        old_bvid = row["selector_branch_version_id"]
+        try:
+            set_selector_branch(
+                base_path,
+                goal_id=goal_id,
+                branch_version_id=None,
+                set_by=set_by,
+            )
+            repoints.append({
+                "goal_id": goal_id,
+                "old_branch_version_id": old_bvid,
+                "new_branch_version_id": None,
+            })
+        except (KeyError, ValueError) as exc:
+            # Per design intent: don't fail the whole batch on one
+            # bad goal. Log the failure so operators can see what
+            # didn't clear.
+            repoints.append({
+                "goal_id": goal_id,
+                "old_branch_version_id": old_bvid,
+                "new_branch_version_id": None,
+                "error": str(exc),
+            })
+
+    return {
+        "status": "ok",
+        "repointed_count": len(repoints),
+        "repoints": repoints,
+    }
+
+
 def _walk_up_to_active_ancestor(
     base_path: str | Path,
     start_bvid: str,
@@ -795,12 +885,19 @@ def rollback_merge_orchestrator(
     repoint_result = repoint_goals_after_rollback(
         base_path, closure, set_by=set_by,
     )
+    # DESIGN-008 round 4 — selectors also need a re-point pass.
+    # Selector pointers are cleared (no ancestor walk) to avoid
+    # silently re-binding to a different ranking opinion.
+    selector_repoint_result = repoint_selectors_after_rollback(
+        base_path, closure, set_by=set_by,
+    )
     return {
         "status": "ok",
         "seed_version_id": branch_version_id,
         "closure": closure,
         "execute": execute_result,
         "repoint": repoint_result,
+        "selector_repoint": selector_repoint_result,
     }
 
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -782,6 +782,12 @@ def goals(
                    unbind. Needs branch_def_id.
       set_canonical Mark a branch_version_id as the Goal's canonical
                    branch. Author-only or host-only.
+      set_selector Bind the Goal's selector branch_version
+                   (DESIGN-008). The bound branch ranks competitors
+                   on this Goal's leaderboard. Author-only or
+                   host-only. Pass branch_version_id="" to fall back
+                   to the platform default selector. The branch must
+                   conform to the selector-branch contract.
       run_canonical Dispatch a run on the Goal's canonical
                    branch_version. When auto_canonical_via_leaderboard
                    is on, the canonical is first refreshed via the

--- a/scripts/migrate_design_008_selector_backfill.py
+++ b/scripts/migrate_design_008_selector_backfill.py
@@ -1,0 +1,141 @@
+"""DESIGN-008 — backfill existing Goals to the platform default selector.
+
+Per the DESIGN-008 brief: every existing Goal's
+``selector_branch_version_id`` should be backfilled to point at the
+platform default selector after the column migration lands, so
+existing callers don't break.
+
+Behavior:
+
+1. Publish the platform default selector branch
+   (``ensure_default_selector_published``) — idempotent.
+2. For every Goal with at least one bound branch and
+   ``selector_branch_version_id IS NULL``, set the column to the
+   default selector's branch_version_id.
+
+Run via::
+
+    python scripts/migrate_design_008_selector_backfill.py [--dry-run]
+
+The script is idempotent — running it twice updates zero Goals on
+the second run because all qualifying Goals already have the binding.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def run_backfill(base_path: str, *, dry_run: bool = False) -> dict:
+    """Backfill selector binding on existing Goals.
+
+    Returns ``{"published_default_bvid": "...",
+    "updated_goal_ids": [...], "skipped_goal_count": <int>}``.
+    """
+    from workflow.api.selector_dispatch import (
+        ensure_default_selector_published,
+    )
+    from workflow.daemon_server import (
+        initialize_author_server,
+        update_goal,
+    )
+    from workflow.storage import _connect
+
+    initialize_author_server(base_path)
+    default_bvid = ensure_default_selector_published(base_path)
+
+    with _connect(base_path) as conn:
+        # Pick Goals with NULL selector + at least one bound branch.
+        rows = conn.execute(
+            """
+            SELECT g.goal_id
+              FROM goals g
+             WHERE g.selector_branch_version_id IS NULL
+               AND EXISTS (
+                   SELECT 1
+                     FROM branch_definitions b
+                    WHERE b.goal_id = g.goal_id
+               )
+            """,
+        ).fetchall()
+        candidate_ids = [r["goal_id"] for r in rows]
+        # Count Goals with NULL selector but no bound branches — these
+        # are intentionally skipped (no branches to rank, no point
+        # binding a selector to them).
+        skipped_row = conn.execute(
+            """
+            SELECT COUNT(*) AS n
+              FROM goals g
+             WHERE g.selector_branch_version_id IS NULL
+               AND NOT EXISTS (
+                   SELECT 1
+                     FROM branch_definitions b
+                    WHERE b.goal_id = g.goal_id
+               )
+            """,
+        ).fetchone()
+        skipped = int(skipped_row["n"] or 0) if skipped_row else 0
+
+    updated: list[str] = []
+    if not dry_run:
+        for gid in candidate_ids:
+            update_goal(
+                base_path,
+                goal_id=gid,
+                updates={"selector_branch_version_id": default_bvid},
+            )
+            updated.append(gid)
+
+    return {
+        "published_default_bvid": default_bvid,
+        "updated_goal_ids": updated if not dry_run else candidate_ids,
+        "skipped_goal_count": skipped,
+        "dry_run": dry_run,
+    }
+
+
+def _resolve_base_path() -> str:
+    base = os.environ.get("WORKFLOW_DATA_DIR", "")
+    if not base:
+        from workflow.storage import data_dir
+        return str(data_dir())
+    return base
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="DESIGN-008 selector-binding backfill",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="report what would change without writing",
+    )
+    parser.add_argument(
+        "--base-path", default=None,
+        help="data dir (defaults to $WORKFLOW_DATA_DIR or platform default)",
+    )
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO)
+
+    base = args.base_path or _resolve_base_path()
+    logger.info("DESIGN-008 backfill | base_path=%s | dry_run=%s",
+                base, args.dry_run)
+    result = run_backfill(base, dry_run=args.dry_run)
+    logger.info(
+        "DESIGN-008 backfill complete | published_default=%s | "
+        "%d Goals %s | %d Goals skipped (no bound branches)",
+        result["published_default_bvid"],
+        len(result["updated_goal_ids"]),
+        "would update" if args.dry_run else "updated",
+        result["skipped_goal_count"],
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_api_market.py
+++ b/tests/test_api_market.py
@@ -110,10 +110,11 @@ def test_attribution_actions_keys():
 # ── _GOAL_ACTIONS dispatch table ────────────────────────────────────────────
 
 
-def test_goal_actions_table_has_11_handlers():
+def test_goal_actions_table_has_12_handlers():
     # 9 base actions + archive_consultation (pre-existing on main) +
-    # run_canonical (PR-127 M6 cutover Step 4) = 11.
-    assert len(_GOAL_ACTIONS) == 11
+    # run_canonical (PR-127 M6 cutover Step 4) +
+    # set_selector (DESIGN-008 user-buildable selector primitive) = 12.
+    assert len(_GOAL_ACTIONS) == 12
 
 
 def test_goal_actions_keys():
@@ -123,6 +124,8 @@ def test_goal_actions_keys():
         "archive_consultation",
         # PR-127 — leaderboard-driven canonical dispatch.
         "run_canonical",
+        # DESIGN-008 — user-buildable selector primitive.
+        "set_selector",
     }
     assert set(_GOAL_ACTIONS.keys()) == expected
 

--- a/tests/test_bug_investigation_canonical_cutover.py
+++ b/tests/test_bug_investigation_canonical_cutover.py
@@ -30,6 +30,56 @@ from unittest.mock import patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _mock_selector_passthrough(monkeypatch):
+    """DESIGN-008 pass-through selector mock for the auto-refresh
+    test below (and inert for the other tests in this file).
+
+    Ranks candidates by completed_run_count desc + recency tiebreaker,
+    same shape as the canonical-dispatch test fixture.
+    """
+    def _passthrough(
+        base_path,
+        *,
+        goal_id,
+        candidate_branches,
+        actor="anonymous",
+        timeout_s=None,
+        **_extra,
+    ):
+        def _key(c):
+            sigs = c.get("signals") or {}
+            return (
+                -int(sigs.get("completed_run_count") or 0),
+                -float(sigs.get("last_successful_run_at") or 0.0),
+                c.get("branch_def_id") or "",
+            )
+        ordered = sorted(candidate_branches, key=_key)
+        return {
+            "ok": True,
+            "branch_version_id": "mock_selector@cutover",
+            "source": "platform_default",
+            "run_id": "mock-run",
+            "ranked_entries": [
+                {
+                    "branch_def_id": c["branch_def_id"],
+                    "branch_version_id": c.get("branch_version_id", ""),
+                    "score": float(
+                        (c.get("signals") or {}).get(
+                            "completed_run_count", 0,
+                        )
+                    ),
+                    "rationale": "passthrough by completed_run_count",
+                }
+                for c in ordered
+            ],
+        }
+    monkeypatch.setattr(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        _passthrough,
+    )
+
+
 @pytest.fixture
 def base_path(tmp_path: Path, monkeypatch) -> Path:
     monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))

--- a/tests/test_canonical_dispatch.py
+++ b/tests/test_canonical_dispatch.py
@@ -64,6 +64,59 @@ from workflow.runs import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _mock_selector_passthrough(monkeypatch):
+    """DESIGN-008 — pass-through selector for canonical-dispatch tests.
+
+    These tests probe ``_refresh_via_leaderboard`` and rely on the
+    leaderboard returning candidates in a deterministic order. We
+    mock ``dispatch_selector`` to rank candidates by
+    ``completed_run_count`` desc with a stable tiebreaker on
+    ``last_successful_run_at`` desc, then ``branch_def_id`` asc — the
+    same effective ordering the round-1 formula produced when those
+    were the dominant signals, which is what these tests pre-date.
+    """
+    def _passthrough(
+        base_path,
+        *,
+        goal_id,
+        candidate_branches,
+        actor="anonymous",
+        timeout_s=None,
+    ):
+        def _key(c):
+            sigs = c.get("signals") or {}
+            return (
+                -int(sigs.get("completed_run_count") or 0),
+                -float(sigs.get("last_successful_run_at") or 0.0),
+                c.get("branch_def_id") or "",
+            )
+        ordered = sorted(candidate_branches, key=_key)
+        return {
+            "ok": True,
+            "branch_version_id": "mock_selector@canon",
+            "source": "platform_default",
+            "run_id": "mock-run",
+            "ranked_entries": [
+                {
+                    "branch_def_id": c["branch_def_id"],
+                    "branch_version_id": c.get("branch_version_id", ""),
+                    "score": float(
+                        (c.get("signals") or {}).get(
+                            "completed_run_count", 0,
+                        )
+                    ),
+                    "rationale": "passthrough by completed_run_count",
+                }
+                for c in ordered
+            ],
+        }
+    monkeypatch.setattr(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        _passthrough,
+    )
+
+
 @pytest.fixture
 def base_path(tmp_path: Path, monkeypatch) -> Path:
     monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))

--- a/tests/test_canonical_dispatch.py
+++ b/tests/test_canonical_dispatch.py
@@ -83,6 +83,7 @@ def _mock_selector_passthrough(monkeypatch):
         candidate_branches,
         actor="anonymous",
         timeout_s=None,
+        **_extra,
     ):
         def _key(c):
             sigs = c.get("signals") or {}

--- a/tests/test_design_008_selector_backfill.py
+++ b/tests/test_design_008_selector_backfill.py
@@ -1,0 +1,164 @@
+"""DESIGN-008 — backfill migration test for the selector primitive.
+
+Covers ``scripts/migrate_design_008_selector_backfill.py``:
+
+* Existing Goals with bound branches but NULL
+  ``selector_branch_version_id`` get the default selector bound.
+* Goals with no bound branches are SKIPPED (no point binding a
+  selector when there's nothing to rank).
+* Goals with an explicit selector binding are NOT overwritten.
+* Re-running the script is idempotent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.migrate_design_008_selector_backfill import run_backfill
+
+
+@pytest.fixture
+def base_path(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    from workflow.daemon_server import initialize_author_server
+    initialize_author_server(tmp_path)
+    return tmp_path
+
+
+def _seed_goal_with_branches(
+    base_path: Path,
+    goal_id: str,
+    *,
+    branch_ids: list[str],
+    selector_branch_version_id: str | None = None,
+):
+    from workflow.daemon_server import (
+        save_branch_definition,
+        save_goal,
+        update_goal,
+    )
+    save_goal(
+        base_path,
+        goal=dict(
+            goal_id=goal_id,
+            name=goal_id,
+            description="",
+            author="host",
+            tags=[],
+            visibility="public",
+        ),
+    )
+    if selector_branch_version_id is not None:
+        update_goal(
+            base_path,
+            goal_id=goal_id,
+            updates={
+                "selector_branch_version_id": selector_branch_version_id,
+            },
+        )
+    for bid in branch_ids:
+        save_branch_definition(
+            base_path,
+            branch_def=dict(
+                branch_def_id=bid,
+                name=bid,
+                description="",
+                author="alice",
+                tags=[],
+                graph_nodes=[],
+                edges=[],
+                state_schema=[],
+                entry_point="",
+                published=True,
+                goal_id=goal_id,
+            ),
+        )
+
+
+def _get_goal(base_path: Path, goal_id: str) -> dict:
+    from workflow.daemon_server import get_goal
+    return get_goal(base_path, goal_id=goal_id)
+
+
+def test_backfill_binds_default_to_goal_with_branches(base_path):
+    _seed_goal_with_branches(base_path, "g1", branch_ids=["b1"])
+    result = run_backfill(str(base_path))
+    assert "g1" in result["updated_goal_ids"]
+    goal = _get_goal(base_path, "g1")
+    assert goal["selector_branch_version_id"] == result[
+        "published_default_bvid"
+    ]
+
+
+def test_backfill_skips_goal_with_no_branches(base_path):
+    _seed_goal_with_branches(base_path, "g-empty", branch_ids=[])
+    result = run_backfill(str(base_path))
+    assert "g-empty" not in result["updated_goal_ids"]
+    goal = _get_goal(base_path, "g-empty")
+    assert goal["selector_branch_version_id"] is None
+    assert result["skipped_goal_count"] == 1
+
+
+def test_backfill_preserves_explicit_binding(base_path):
+    _seed_goal_with_branches(
+        base_path, "g-custom",
+        branch_ids=["b1"],
+        selector_branch_version_id="custom_selector@abc12345",
+    )
+    result = run_backfill(str(base_path))
+    assert "g-custom" not in result["updated_goal_ids"]
+    goal = _get_goal(base_path, "g-custom")
+    assert goal["selector_branch_version_id"] == "custom_selector@abc12345"
+
+
+def test_backfill_is_idempotent(base_path):
+    _seed_goal_with_branches(base_path, "g1", branch_ids=["b1"])
+    first = run_backfill(str(base_path))
+    second = run_backfill(str(base_path))
+    assert "g1" in first["updated_goal_ids"]
+    # Second run finds no NULL-selector Goals — nothing to update.
+    assert second["updated_goal_ids"] == []
+    # Same default selector bvid both times (deterministic).
+    assert first["published_default_bvid"] == second[
+        "published_default_bvid"
+    ]
+
+
+def test_backfill_dry_run_does_not_write(base_path):
+    _seed_goal_with_branches(base_path, "g1", branch_ids=["b1"])
+    result = run_backfill(str(base_path), dry_run=True)
+    assert result["dry_run"] is True
+    # Dry-run reports candidates but doesn't write.
+    assert "g1" in result["updated_goal_ids"]
+    goal = _get_goal(base_path, "g1")
+    assert goal["selector_branch_version_id"] is None
+
+
+def test_backfill_mixed_population(base_path):
+    """Realistic seed: 3 goals — one with branches+null, one without
+    branches, one with explicit binding."""
+    _seed_goal_with_branches(base_path, "g-bind-me", branch_ids=["b1"])
+    _seed_goal_with_branches(base_path, "g-skip", branch_ids=[])
+    _seed_goal_with_branches(
+        base_path, "g-keep",
+        branch_ids=["b2"],
+        selector_branch_version_id="custom@xx",
+    )
+    result = run_backfill(str(base_path))
+    assert result["updated_goal_ids"] == ["g-bind-me"]
+    assert result["skipped_goal_count"] == 1
+    # Verify final state.
+    assert (
+        _get_goal(base_path, "g-bind-me")["selector_branch_version_id"]
+        == result["published_default_bvid"]
+    )
+    assert (
+        _get_goal(base_path, "g-skip")["selector_branch_version_id"]
+        is None
+    )
+    assert (
+        _get_goal(base_path, "g-keep")["selector_branch_version_id"]
+        == "custom@xx"
+    )

--- a/tests/test_extensions_leaderboard_actions.py
+++ b/tests/test_extensions_leaderboard_actions.py
@@ -1,14 +1,10 @@
-"""Tests for the ``extensions`` MCP actions added by PR-123 substrate (M2).
+"""Tests for the ``extensions`` MCP actions for the leaderboard surface.
 
-- ``quality_leaderboard(goal_id, [author=<viewer>], [force=<include_private>])``
-- ``recommended_parent_for_fork(goal_id, ...)``
-
-The dispatch reuses existing ``extensions(...)`` kwargs to keep the
-tool signature stable:
-  * ``goal_id`` -> Goal under inspection.
-  * ``author`` (string) -> optional viewer override; defaults to the
-    current actor when omitted.
-  * ``force`` (bool) -> include_private flag (host / internal callers).
+DESIGN-008: leaderboard now dispatches a per-Goal selector branch.
+Tests use a pass-through selector mock that ranks by
+``judgment_score_avg`` desc so the "highest-quality first" invariant
+the round-1 formula provided is preserved at the test layer without
+needing a live LLM.
 """
 
 from __future__ import annotations
@@ -19,6 +15,50 @@ import time
 from pathlib import Path
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_selector_passthrough(monkeypatch):
+    """Selector pass-through mock: rank by judgment_score_avg desc."""
+    def _passthrough(
+        base_path,
+        *,
+        goal_id,
+        candidate_branches,
+        actor="anonymous",
+        timeout_s=None,
+    ):
+        def _key(c):
+            sigs = c.get("signals") or {}
+            v = sigs.get("judgment_score_avg")
+            if v is None:
+                return float("-inf")
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return float("-inf")
+        ordered = sorted(candidate_branches, key=_key, reverse=True)
+        return {
+            "ok": True,
+            "branch_version_id": "mock_selector@ext",
+            "source": "platform_default",
+            "run_id": "mock-run",
+            "ranked_entries": [
+                {
+                    "branch_def_id": c["branch_def_id"],
+                    "branch_version_id": c.get("branch_version_id", ""),
+                    "score": (
+                        _key(c) if _key(c) != float("-inf") else 0.0
+                    ),
+                    "rationale": "passthrough by judgment_score_avg",
+                }
+                for c in ordered
+            ],
+        }
+    monkeypatch.setattr(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        _passthrough,
+    )
 
 
 @pytest.fixture
@@ -110,12 +150,15 @@ def test_quality_leaderboard_returns_ranked_entries(us_env):
     # Higher quality should rank first.
     assert bids[0] == "b-top"
     assert bids[-1] == "b-low"
-    # Every entry has rank + score + signals + score_components.
+    # DESIGN-008: every entry has rank + score + signals +
+    # rationale (selector-emitted). ``score_components`` is gone —
+    # the selector branch synthesizes the score, not a Python
+    # formula.
     for entry in result["entries"]:
         assert "rank" in entry
         assert "score" in entry
         assert "signals" in entry
-        assert "score_components" in entry
+        assert "rationale" in entry
     # Text channel is phone-legible.
     assert "Quality leaderboard" in result["text"]
     assert "Rank | Branch" in result["text"]
@@ -144,13 +187,20 @@ def test_quality_leaderboard_unknown_goal_returns_no_entries(us_env):
     assert result["goal"] is None
 
 
-def test_quality_leaderboard_response_includes_formula_disclosure(us_env):
+def test_quality_leaderboard_response_includes_selector_metadata(us_env):
+    """DESIGN-008: the response carries the selector branch_version_id
+    + source so the chatbot can render "ranked by selector X". The
+    round-1 formula-disclosure block is gone — selectors disclose
+    their own logic in their prompts."""
     us, base = us_env
     _seed_goal_and_branches(base)
     result = _call(us, "quality_leaderboard", goal_id="g-mcp")
-    assert "formula" in result
-    assert "weights" in result["formula"]
-    assert "judgment" in result["formula"]["weights"]
+    assert "selector" in result
+    assert "branch_version_id" in result["selector"]
+    assert result["selector"]["branch_version_id"] == "mock_selector@ext"
+    assert result["selector"]["source"] == "platform_default"
+    # No formula key — that primitive is gone.
+    assert "formula" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_extensions_leaderboard_actions.py
+++ b/tests/test_extensions_leaderboard_actions.py
@@ -27,6 +27,7 @@ def _mock_selector_passthrough(monkeypatch):
         candidate_branches,
         actor="anonymous",
         timeout_s=None,
+        **_extra,
     ):
         def _key(c):
             sigs = c.get("signals") or {}

--- a/tests/test_goals_run_canonical.py
+++ b/tests/test_goals_run_canonical.py
@@ -30,6 +30,53 @@ from unittest.mock import patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _mock_selector_passthrough(monkeypatch):
+    """DESIGN-008 — pass-through selector for run_canonical tests.
+
+    Ranks by completed_run_count desc, matching the effective
+    ordering the round-1 formula produced for these scenarios."""
+    def _passthrough(
+        base_path,
+        *,
+        goal_id,
+        candidate_branches,
+        actor="anonymous",
+        timeout_s=None,
+    ):
+        def _key(c):
+            sigs = c.get("signals") or {}
+            return (
+                -int(sigs.get("completed_run_count") or 0),
+                -float(sigs.get("last_successful_run_at") or 0.0),
+                c.get("branch_def_id") or "",
+            )
+        ordered = sorted(candidate_branches, key=_key)
+        return {
+            "ok": True,
+            "branch_version_id": "mock_selector@canon",
+            "source": "platform_default",
+            "run_id": "mock-run",
+            "ranked_entries": [
+                {
+                    "branch_def_id": c["branch_def_id"],
+                    "branch_version_id": c.get("branch_version_id", ""),
+                    "score": float(
+                        (c.get("signals") or {}).get(
+                            "completed_run_count", 0,
+                        )
+                    ),
+                    "rationale": "passthrough by completed_run_count",
+                }
+                for c in ordered
+            ],
+        }
+    monkeypatch.setattr(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        _passthrough,
+    )
+
+
 @pytest.fixture
 def us_env(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))

--- a/tests/test_goals_run_canonical.py
+++ b/tests/test_goals_run_canonical.py
@@ -43,6 +43,7 @@ def _mock_selector_passthrough(monkeypatch):
         candidate_branches,
         actor="anonymous",
         timeout_s=None,
+        **_extra,
     ):
         def _key(c):
             sigs = c.get("signals") or {}

--- a/tests/test_goals_set_selector.py
+++ b/tests/test_goals_set_selector.py
@@ -1,0 +1,208 @@
+"""DESIGN-008 — tests for goals action=set_selector MCP wiring.
+
+Spec: drafts/concepts/selector-branch-contract.md
+Implementation:
+  * workflow/api/market.py::_action_goal_set_selector
+  * workflow/daemon_server.py::set_selector_branch
+  * workflow/api/quality_leaderboard.py — consumes the binding
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def env(tmp_path: Path, monkeypatch):
+    base = tmp_path / "output"
+    base.mkdir()
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(base))
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "alice")
+    monkeypatch.setenv("_FORCE_MOCK", "true")
+    from workflow import universe_server as us
+    importlib.reload(us)
+    yield us, base
+    importlib.reload(us)
+
+
+def _call(us, tool, action, **kwargs):
+    fn = getattr(us, tool)
+    return json.loads(fn(action=action, **kwargs))
+
+
+def _seed_goal(us, name="Selector binding test Goal"):
+    result = _call(us, "goals", "propose", name=name)
+    assert result["status"] == "proposed", result
+    return result["goal"]["goal_id"]
+
+
+def _seed_published_branch(us, base, name="selector-candidate"):
+    """Build + publish a minimal selector-conformant branch."""
+    bid = _call(
+        us, "extensions", "create_branch", name=name,
+    )["branch_def_id"]
+    _call(
+        us, "extensions", "add_node",
+        branch_def_id=bid, node_id="rank",
+        display_name="Rank", prompt_template="rank {candidate_branches}",
+        output_keys="ranked_entries",
+    )
+    for src, dst in (("START", "rank"), ("rank", "END")):
+        _call(
+            us, "extensions", "connect_nodes",
+            branch_def_id=bid, from_node=src, to_node=dst,
+        )
+    _call(us, "extensions", "set_entry_point", branch_def_id=bid, node_id="rank")
+    for field in ("goal_id", "candidate_branches", "ranked_entries"):
+        _call(
+            us, "extensions", "add_state_field",
+            branch_def_id=bid, field_name=field, field_type="str",
+        )
+    from workflow.branch_versions import publish_branch_version
+    from workflow.daemon_server import get_branch_definition
+    branch_dict = get_branch_definition(base, branch_def_id=bid)
+    version = publish_branch_version(base, branch_dict, publisher="alice")
+    return version.branch_version_id
+
+
+# ---------------------------------------------------------------------------
+# Dispatch table wiring
+# ---------------------------------------------------------------------------
+
+
+def test_set_selector_action_in_goal_actions():
+    from workflow.api.market import _GOAL_ACTIONS
+    assert "set_selector" in _GOAL_ACTIONS
+
+
+def test_set_selector_in_goal_write_actions():
+    from workflow.api.market import _GOAL_WRITE_ACTIONS
+    assert "set_selector" in _GOAL_WRITE_ACTIONS
+
+
+# ---------------------------------------------------------------------------
+# MCP surface — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_set_selector_by_goal_author_succeeds(env):
+    us, base = env
+    gid = _seed_goal(us)
+    bvid = _seed_published_branch(us, base)
+    result = _call(
+        us, "goals", "set_selector",
+        goal_id=gid, branch_version_id=bvid,
+    )
+    assert result["status"] == "ok", result
+    assert result["selector_branch_version_id"] == bvid
+
+
+def test_set_selector_persists_in_goal_record(env):
+    us, base = env
+    gid = _seed_goal(us)
+    bvid = _seed_published_branch(us, base)
+    _call(
+        us, "goals", "set_selector",
+        goal_id=gid, branch_version_id=bvid,
+    )
+    goal = _call(us, "goals", "get", goal_id=gid)["goal"]
+    assert goal["selector_branch_version_id"] == bvid
+
+
+def test_set_selector_empty_branch_version_id_unbinds(env):
+    us, base = env
+    gid = _seed_goal(us)
+    bvid = _seed_published_branch(us, base)
+    _call(
+        us, "goals", "set_selector",
+        goal_id=gid, branch_version_id=bvid,
+    )
+    # Now unbind.
+    result = _call(
+        us, "goals", "set_selector",
+        goal_id=gid, branch_version_id="",
+    )
+    assert result["status"] == "ok"
+    assert result["selector_branch_version_id"] is None
+    goal = _call(us, "goals", "get", goal_id=gid)["goal"]
+    assert goal["selector_branch_version_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Authority
+# ---------------------------------------------------------------------------
+
+
+def test_set_selector_requires_author_or_host(env, monkeypatch):
+    us, base = env
+    gid = _seed_goal(us)  # author = alice
+    bvid = _seed_published_branch(us, base)
+    # Switch actor to eve — not author, not host.
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "eve")
+    importlib.reload(us)
+    try:
+        result = _call(
+            us, "goals", "set_selector",
+            goal_id=gid, branch_version_id=bvid,
+        )
+        assert result["status"] == "rejected"
+        assert "author" in result["error"]
+    finally:
+        monkeypatch.setenv("UNIVERSE_SERVER_USER", "alice")
+        importlib.reload(us)
+
+
+def test_set_selector_host_actor_can_bind(env, monkeypatch):
+    us, base = env
+    gid = _seed_goal(us)  # author = alice
+    bvid = _seed_published_branch(us, base)
+    # Switch to the host actor (UNIVERSE_SERVER_HOST_USER, defaults to "host").
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "host")
+    importlib.reload(us)
+    try:
+        result = _call(
+            us, "goals", "set_selector",
+            goal_id=gid, branch_version_id=bvid,
+        )
+        assert result["status"] == "ok"
+        assert result["selector_branch_version_id"] == bvid
+    finally:
+        monkeypatch.setenv("UNIVERSE_SERVER_USER", "alice")
+        importlib.reload(us)
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+def test_set_selector_missing_goal_id_rejected(env):
+    us, _ = env
+    result = _call(us, "goals", "set_selector")
+    assert result["status"] == "rejected"
+    assert "goal_id" in result["error"]
+
+
+def test_set_selector_unknown_goal_rejected(env):
+    us, _ = env
+    result = _call(
+        us, "goals", "set_selector",
+        goal_id="ghost-goal", branch_version_id="x@y",
+    )
+    assert result["status"] == "rejected"
+    assert "not found" in result["error"]
+
+
+def test_set_selector_nonexistent_version_rejected(env):
+    us, _ = env
+    gid = _seed_goal(us)
+    result = _call(
+        us, "goals", "set_selector",
+        goal_id=gid, branch_version_id="phantom_branch@deadbeef",
+    )
+    assert result["status"] == "rejected"
+    assert "not found" in result["error"]

--- a/tests/test_goals_set_selector.py
+++ b/tests/test_goals_set_selector.py
@@ -324,3 +324,261 @@ def test_set_selector_unbind_path_does_not_check_effects(env):
     )
     assert result["status"] == "ok"
     assert result["selector_branch_version_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# DESIGN-008 round 3 P1.B — child-branch invocation rejected at bind time
+# ---------------------------------------------------------------------------
+
+
+def _publish_branch_with_invoke_branch_spec(base, name="invoking-selector"):
+    """Publish a branch_version with no direct effects but a node
+    that invokes a child branch via ``invoke_branch_spec``.
+
+    Round-3 P1.B: the round-2 purity scan only inspected direct
+    ``effects`` on node_defs. A selector with no direct effects can
+    still spawn a child run via invoke_branch_spec — the child's
+    completion fires the child's effectors. Bind must reject.
+    """
+    from workflow.branch_versions import publish_branch_version
+    from workflow.daemon_server import (
+        get_branch_definition,
+        save_branch_definition,
+    )
+    bid = "invoking_rank_branch"
+    save_branch_definition(
+        base,
+        branch_def=dict(
+            branch_def_id=bid,
+            name=name,
+            description="",
+            author="alice",
+            tags=[],
+            graph_nodes=[
+                {
+                    "id": "rank",
+                    "type": "prompt",
+                    "phase": "custom",
+                    "input_keys": ["candidate_branches"],
+                    "output_keys": ["ranked_entries"],
+                },
+            ],
+            edges=[
+                {"from": "START", "to": "rank"},
+                {"from": "rank", "to": "END"},
+            ],
+            state_schema=[
+                {"name": "candidate_branches", "type": "str"},
+                {"name": "ranked_entries", "type": "str"},
+            ],
+            entry_point="rank",
+            published=True,
+            visibility="public",
+            node_defs=[
+                {
+                    "node_id": "rank",
+                    "display_name": "Rank",
+                    "phase": "custom",
+                    "input_keys": ["candidate_branches"],
+                    "output_keys": ["ranked_entries"],
+                    # No direct effects, but it invokes a child
+                    # branch — that child's completion path fires
+                    # ITS effectors. P1.B fail-trigger.
+                    "invoke_branch_spec": {
+                        "branch_def_id": "some_effectful_child",
+                        "inputs_mapping": {},
+                        "output_mapping": {"ranked_entries": "result"},
+                        "wait_mode": "blocking",
+                    },
+                },
+            ],
+        ),
+    )
+    branch_dict = get_branch_definition(base, branch_def_id=bid)
+    version = publish_branch_version(base, branch_dict, publisher="alice")
+    return version.branch_version_id
+
+
+def _publish_branch_with_invoke_branch_version_spec(
+    base, name="version-invoking-selector",
+):
+    """Same idea but using ``invoke_branch_version_spec`` (frozen
+    child snapshot) instead of ``invoke_branch_spec``."""
+    from workflow.branch_versions import publish_branch_version
+    from workflow.daemon_server import (
+        get_branch_definition,
+        save_branch_definition,
+    )
+    bid = "version_invoking_rank_branch"
+    save_branch_definition(
+        base,
+        branch_def=dict(
+            branch_def_id=bid,
+            name=name,
+            description="",
+            author="alice",
+            tags=[],
+            graph_nodes=[
+                {
+                    "id": "rank",
+                    "type": "prompt",
+                    "phase": "custom",
+                    "input_keys": ["candidate_branches"],
+                    "output_keys": ["ranked_entries"],
+                },
+            ],
+            edges=[
+                {"from": "START", "to": "rank"},
+                {"from": "rank", "to": "END"},
+            ],
+            state_schema=[
+                {"name": "candidate_branches", "type": "str"},
+                {"name": "ranked_entries", "type": "str"},
+            ],
+            entry_point="rank",
+            published=True,
+            visibility="public",
+            node_defs=[
+                {
+                    "node_id": "rank",
+                    "display_name": "Rank",
+                    "phase": "custom",
+                    "input_keys": ["candidate_branches"],
+                    "output_keys": ["ranked_entries"],
+                    "invoke_branch_version_spec": {
+                        "branch_version_id": "child@deadbeef",
+                        "inputs_mapping": {},
+                        "output_mapping": {"ranked_entries": "result"},
+                        "wait_mode": "blocking",
+                    },
+                },
+            ],
+        ),
+    )
+    branch_dict = get_branch_definition(base, branch_def_id=bid)
+    version = publish_branch_version(base, branch_dict, publisher="alice")
+    return version.branch_version_id
+
+
+def test_set_selector_rejects_invoke_branch_spec(env):
+    """P1.B — selector with invoke_branch_spec rejected at bind."""
+    us, base = env
+    gid = _seed_goal(us)
+    bvid = _publish_branch_with_invoke_branch_spec(base)
+    result = _call(
+        us, "goals", "set_selector",
+        goal_id=gid, branch_version_id=bvid,
+    )
+    assert result["status"] == "rejected"
+    assert result.get("error_kind") == "selector_has_effects"
+    err = result["error"].lower()
+    assert "child" in err or "invoke_branch_spec" in err
+    # Names the offending node so the operator can fix it.
+    assert "rank" in result["error"]
+
+
+def test_set_selector_rejects_invoke_branch_version_spec(env):
+    """P1.B — same guard covers the version-spec sibling."""
+    us, base = env
+    gid = _seed_goal(us)
+    bvid = _publish_branch_with_invoke_branch_version_spec(base)
+    result = _call(
+        us, "goals", "set_selector",
+        goal_id=gid, branch_version_id=bvid,
+    )
+    assert result["status"] == "rejected"
+    assert result.get("error_kind") == "selector_has_effects"
+    err = result["error"].lower()
+    assert "child" in err or "invoke_branch_version_spec" in err
+
+
+def test_set_selector_storage_layer_raises_on_child_invoker(env):
+    """Direct storage-layer assertion that the new purity guard fires
+    on a branch that has no direct effects but invokes children."""
+    us, base = env
+    gid = _seed_goal(us)
+    bvid = _publish_branch_with_invoke_branch_spec(base)
+    from workflow.daemon_server import (
+        SelectorHasEffectsError,
+        set_selector_branch,
+    )
+    with pytest.raises(SelectorHasEffectsError) as exc_info:
+        set_selector_branch(
+            base, goal_id=gid,
+            branch_version_id=bvid, set_by="host",
+        )
+    msg = str(exc_info.value).lower()
+    assert "child" in msg or "invoke" in msg
+
+
+def test_set_selector_rejects_branch_with_both_effects_and_invoke(env):
+    """A branch with both direct effects AND a child invoker must
+    surface both violation classes in the error message."""
+    from workflow.branch_versions import publish_branch_version
+    from workflow.daemon_server import (
+        get_branch_definition,
+        save_branch_definition,
+    )
+    us, base = env
+    gid = _seed_goal(us)
+    bid = "double_violation_branch"
+    save_branch_definition(
+        base,
+        branch_def=dict(
+            branch_def_id=bid,
+            name="double",
+            description="",
+            author="alice",
+            tags=[],
+            graph_nodes=[
+                {
+                    "id": "n1",
+                    "type": "prompt",
+                    "phase": "custom",
+                    "input_keys": ["candidate_branches"],
+                    "output_keys": ["ranked_entries"],
+                },
+            ],
+            edges=[
+                {"from": "START", "to": "n1"},
+                {"from": "n1", "to": "END"},
+            ],
+            state_schema=[
+                {"name": "candidate_branches", "type": "str"},
+                {"name": "ranked_entries", "type": "str"},
+            ],
+            entry_point="n1",
+            published=True,
+            visibility="public",
+            node_defs=[
+                {
+                    "node_id": "n1",
+                    "display_name": "Double Violator",
+                    "phase": "custom",
+                    "input_keys": ["candidate_branches"],
+                    "output_keys": ["ranked_entries"],
+                    "prompt_template": "rank {candidate_branches}",
+                    "effects": ["github_pull_request"],
+                    "invoke_branch_spec": {
+                        "branch_def_id": "child",
+                        "inputs_mapping": {},
+                        "output_mapping": {"ranked_entries": "result"},
+                        "wait_mode": "blocking",
+                    },
+                },
+            ],
+        ),
+    )
+    branch_dict = get_branch_definition(base, branch_def_id=bid)
+    bvid = publish_branch_version(
+        base, branch_dict, publisher="alice",
+    ).branch_version_id
+    result = _call(
+        us, "goals", "set_selector",
+        goal_id=gid, branch_version_id=bvid,
+    )
+    assert result["status"] == "rejected"
+    assert result.get("error_kind") == "selector_has_effects"
+    err = result["error"].lower()
+    assert "effects" in err
+    assert "child" in err or "invoke" in err

--- a/tests/test_goals_set_selector.py
+++ b/tests/test_goals_set_selector.py
@@ -206,3 +206,121 @@ def test_set_selector_nonexistent_version_rejected(env):
     )
     assert result["status"] == "rejected"
     assert "not found" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# DESIGN-008 round 2 P1.3 — bind rejects effectful selector branches
+# ---------------------------------------------------------------------------
+
+
+def _publish_effectful_branch(base, name="effectful-selector"):
+    """Publish a branch_version whose snapshot declares effects.
+
+    Selector branches that declare ``effects`` (e.g. github_pull_request)
+    would silently fire external writes on every leaderboard read —
+    set_selector_branch must reject the bind.
+    """
+    from workflow.branch_versions import publish_branch_version
+    from workflow.daemon_server import (
+        get_branch_definition,
+        save_branch_definition,
+    )
+    bid = "effectful_rank_branch"
+    save_branch_definition(
+        base,
+        branch_def=dict(
+            branch_def_id=bid,
+            name=name,
+            description="",
+            author="alice",
+            tags=[],
+            graph_nodes=[
+                {
+                    "id": "rank",
+                    "type": "prompt",
+                    "phase": "custom",
+                    "input_keys": ["candidate_branches"],
+                    "output_keys": ["ranked_entries"],
+                },
+            ],
+            edges=[
+                {"from": "START", "to": "rank"},
+                {"from": "rank", "to": "END"},
+            ],
+            state_schema=[
+                {"name": "candidate_branches", "type": "list"},
+                {"name": "ranked_entries", "type": "list"},
+            ],
+            entry_point="rank",
+            published=True,
+            visibility="public",
+            node_defs=[
+                {
+                    "node_id": "rank",
+                    "display_name": "Rank",
+                    "phase": "custom",
+                    "input_keys": ["candidate_branches"],
+                    "output_keys": ["ranked_entries"],
+                    "prompt_template": "rank {candidate_branches}",
+                    # P1.3 fail-trigger: this node declares an effect.
+                    "effects": ["github_pull_request"],
+                },
+            ],
+        ),
+    )
+    branch_dict = get_branch_definition(base, branch_def_id=bid)
+    version = publish_branch_version(base, branch_dict, publisher="alice")
+    return version.branch_version_id
+
+
+def test_set_selector_rejects_branch_with_effects(env):
+    """P1.3 — a selector that declares effects would turn every
+    leaderboard read into a silent external write. Substrate rejects
+    the bind."""
+    us, base = env
+    gid = _seed_goal(us)
+    bvid = _publish_effectful_branch(base)
+    result = _call(
+        us, "goals", "set_selector",
+        goal_id=gid, branch_version_id=bvid,
+    )
+    assert result["status"] == "rejected"
+    assert result.get("error_kind") == "selector_has_effects"
+    assert "effects" in result["error"].lower()
+    # Error message must name the offending node so the operator
+    # can fix it.
+    assert "rank" in result["error"]
+
+
+def test_set_selector_storage_layer_raises_selector_has_effects(env):
+    """Storage-layer regression — set_selector_branch raises
+    SelectorHasEffectsError on an effectful version, no MCP wrapper
+    involved."""
+    us, base = env
+    gid = _seed_goal(us)
+    bvid = _publish_effectful_branch(base)
+    from workflow.daemon_server import (
+        SelectorHasEffectsError,
+        set_selector_branch,
+    )
+    with pytest.raises(SelectorHasEffectsError) as exc_info:
+        set_selector_branch(
+            base, goal_id=gid,
+            branch_version_id=bvid, set_by="host",
+        )
+    assert "effects" in str(exc_info.value).lower()
+
+
+def test_set_selector_unbind_path_does_not_check_effects(env):
+    """Unbind passes branch_version_id=None which short-circuits the
+    effects check entirely — the operator must always be able to
+    unbind back to the platform default selector regardless of
+    whatever was previously bound."""
+    us, _ = env
+    gid = _seed_goal(us)
+    result = _call(
+        us, "goals", "set_selector",
+        goal_id=gid, branch_version_id="",
+    )
+    assert result["status"] == "ok"
+    assert result["selector_branch_version_id"] is None

--- a/tests/test_quality_leaderboard.py
+++ b/tests/test_quality_leaderboard.py
@@ -1,34 +1,42 @@
-"""Tests for workflow.api.quality_leaderboard.
+"""DESIGN-008 — quality leaderboard now dispatches via selector branches.
 
-PR-123 substrate (M2). Covers:
+PR-123 round-1 baked an opinionated scoring formula into Python.
+PR #978 tried to patch a bug in it; host closed PR #978 because
+patching entrenches the wrong architecture. DESIGN-008 replaces the
+formula with a per-Goal selector-branch dispatch. These tests now
+exercise the dispatch contract, not formula arithmetic.
 
-- Empty Goal (no branches bound) -> empty entries + parent-rec returns None.
-- Single entry -> rank 1, score reflects signals.
-- Multiple entries with diverse signals -> correct ranking.
-- Recency decay correctness (older success ranks lower vs newer).
-- Goal with many branches (realistic scale, 15+).
-- Numeric tag parsing from judgments (quality:8, novelty:7, risk:3).
-- Fork count signal (parent_def_id + fork_from both contribute).
-- Best-effort safe_to_publish lookup in branch.stats.
-- Gate-rung claim signal.
-- ``recommend_parent_for_fork`` rationale shape.
+Strategy: monkeypatch ``workflow.api.selector_dispatch.dispatch_selector``
+so tests don't depend on a live LLM provider. The mock takes the
+``candidate_branches`` input and returns deterministic
+``ranked_entries`` based on a per-test choice of dominant signal
+(quality_score, run_count, etc.) — that exercises the substrate's
+candidate-collection, output-parsing, error-surface paths without
+LLM cost.
 
-Storage is exercised through the canonical helpers
-(``save_goal`` / ``save_branch_definition`` / ``create_run`` /
-``update_run_status`` / ``add_judgment`` / ``record_gate_claim``)
-so any future schema migration is exercised here too.
+Coverage:
+
+- Empty Goal -> empty entries + parent-rec returns None.
+- Single entry -> rank 1.
+- Multiple entries -> mock-driven ranking respects selector output.
+- Selector returns invalid output -> structured error, leaderboard
+  ``ok=False``, no crash.
+- Selector run fails (status != completed) -> structured error.
+- Selector resolution: explicit binding wins over platform default;
+  no binding falls back to platform default.
+- Signals collected per branch are still queryable (run_count,
+  judgment_score_avg, fork_count, gate_rung, safe_to_publish).
 """
 
 from __future__ import annotations
 
 import time
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from workflow.api.quality_leaderboard import (
-    JUDGMENT_MAX_SCALE,
-    RECENCY_HALFLIFE_DAYS,
     build_quality_leaderboard,
     recommend_parent_for_fork,
 )
@@ -45,6 +53,7 @@ from workflow.runs import (
     initialize_runs_db,
     update_run_status,
 )
+
 
 # ---------------------------------------------------------------------------
 # Fixtures + helpers
@@ -146,31 +155,135 @@ def _record_judgment(
     )
 
 
+def _mock_dispatch_selector(
+    *,
+    ranked_entries: list[dict] | None = None,
+    by_signal: str | None = None,
+    fail_with: dict | None = None,
+):
+    """Build a mock ``dispatch_selector`` that emits ``ranked_entries``.
+
+    Pass exactly one of:
+
+    * ``ranked_entries`` — verbatim entries to return.
+    * ``by_signal`` — order the input ``candidate_branches`` by the
+      named signal field descending and emit them as ``ranked_entries``.
+    * ``fail_with`` — return ``{"ok": False, "error_kind": ..., "error": ...}``.
+
+    The returned function is patched into ``workflow.api.quality_leaderboard``
+    via ``patch("workflow.api.quality_leaderboard.dispatch_selector",
+    side_effect=mock)``.
+    """
+    def _mock(
+        base_path,
+        *,
+        goal_id,
+        candidate_branches,
+        actor="anonymous",
+        timeout_s=None,
+    ):
+        if fail_with is not None:
+            return dict(fail_with)
+        if not candidate_branches:
+            return {
+                "ok": True,
+                "branch_version_id": None,
+                "source": "empty_candidate_set",
+                "run_id": None,
+                "ranked_entries": [],
+            }
+        if ranked_entries is not None:
+            return {
+                "ok": True,
+                "branch_version_id": "mock_selector@deadbeef",
+                "source": "platform_default",
+                "run_id": "mock-run",
+                "ranked_entries": list(ranked_entries),
+            }
+        if by_signal is not None:
+            def _key(c):
+                value = (c.get("signals") or {}).get(by_signal)
+                if value is None:
+                    return float("-inf")
+                try:
+                    return float(value)
+                except (TypeError, ValueError):
+                    return float("-inf")
+            ordered = sorted(
+                candidate_branches, key=_key, reverse=True,
+            )
+            entries = [
+                {
+                    "branch_def_id": c["branch_def_id"],
+                    "branch_version_id": c.get("branch_version_id", ""),
+                    "score": float(_key(c)) if _key(c) != float("-inf") else 0.0,
+                    "rationale": (
+                        f"ranked by {by_signal}={(c.get('signals') or {}).get(by_signal)!r}"
+                    ),
+                }
+                for c in ordered
+            ]
+            return {
+                "ok": True,
+                "branch_version_id": "mock_selector@deadbeef",
+                "source": "platform_default",
+                "run_id": "mock-run",
+                "ranked_entries": entries,
+            }
+        # Default: emit candidates in original order with score 0.0.
+        return {
+            "ok": True,
+            "branch_version_id": "mock_selector@deadbeef",
+            "source": "platform_default",
+            "run_id": "mock-run",
+            "ranked_entries": [
+                {
+                    "branch_def_id": c["branch_def_id"],
+                    "branch_version_id": c.get("branch_version_id", ""),
+                    "score": 0.0,
+                    "rationale": "",
+                }
+                for c in candidate_branches
+            ],
+        }
+    return _mock
+
+
 # ---------------------------------------------------------------------------
 # Empty Goal
 # ---------------------------------------------------------------------------
 
 
-def test_empty_goal_returns_no_entries(base_path):
+def test_empty_goal_returns_empty_entries(base_path):
+    """No bound branches -> dispatch is short-circuited (no LLM call)
+    and the leaderboard returns ok=True with entries=[]."""
     _make_goal(base_path, "g-empty")
-    board = build_quality_leaderboard(base_path, goal_id="g-empty", viewer="")
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_mock_dispatch_selector(),
+    ) as mock_dispatch:
+        board = build_quality_leaderboard(
+            base_path, goal_id="g-empty", viewer="",
+        )
+    assert board["ok"] is True
     assert board["entries"] == []
-    assert board["goal_id"] == "g-empty"
-    assert board["goal"] is not None
-    assert board["formula"]["weights"]["judgment"] > 0
-    # Recency halflife exposed for tuning visibility.
-    assert board["formula"]["recency_halflife_days"] == RECENCY_HALFLIFE_DAYS
-
-
-def test_unknown_goal_id_returns_empty_entries_and_none_goal(base_path):
-    board = build_quality_leaderboard(base_path, goal_id="nope", viewer="")
-    assert board["entries"] == []
-    assert board["goal"] is None
+    # Substrate short-circuit fires inside dispatch_selector itself
+    # — but our mock is the substitute for dispatch_selector, so it
+    # IS called with the empty candidate set. Confirm.
+    assert mock_dispatch.call_count == 1
+    assert mock_dispatch.call_args.kwargs["candidate_branches"] == []
 
 
 def test_recommend_parent_when_no_entries(base_path):
     _make_goal(base_path, "g-empty")
-    rec = recommend_parent_for_fork(base_path, goal_id="g-empty", viewer="")
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_mock_dispatch_selector(),
+    ):
+        rec = recommend_parent_for_fork(
+            base_path, goal_id="g-empty", viewer="",
+        )
+    assert rec["ok"] is True
     assert rec["recommended_parent"] is None
     assert "No Branch is bound" in rec["rationale"]
     assert rec["leaderboard_size"] == 0
@@ -184,102 +297,26 @@ def test_recommend_parent_when_no_entries(base_path):
 def test_single_branch_ranks_first(base_path):
     _make_goal(base_path, "g1")
     _make_branch(base_path, branch_def_id="b1", goal_id="g1")
-    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_mock_dispatch_selector(by_signal="completed_run_count"),
+    ):
+        board = build_quality_leaderboard(
+            base_path, goal_id="g1", viewer="",
+        )
+    assert board["ok"] is True
     assert len(board["entries"]) == 1
     entry = board["entries"][0]
     assert entry["rank"] == 1
     assert entry["branch_def_id"] == "b1"
-    # No runs, no judgments -> score is 0 (or possibly negative from
-    # failed-penalty term, but we have no failed runs either).
-    assert entry["score"] == 0.0
-    assert entry["signals"]["completed_run_count"] == 0
-    assert entry["signals"]["fork_count"] == 0
-    assert entry["signals"]["has_gate_rung"] is False
-    assert entry["signals"]["safe_to_publish"] is False
-
-
-def test_single_branch_with_completed_run_scores_above_zero(base_path):
-    _make_goal(base_path, "g1")
-    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
-    _record_run(
-        base_path,
-        branch_def_id="b1",
-        status=RUN_STATUS_COMPLETED,
-        finished_at=time.time(),
-    )
-    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
-    entry = board["entries"][0]
-    assert entry["score"] > 0
-    assert entry["signals"]["completed_run_count"] == 1
-    # Recency near 1.0 for a just-finished run.
-    assert entry["signals"]["recency_decay"] > 0.95
 
 
 # ---------------------------------------------------------------------------
-# Numeric judgment parsing
+# Multi-branch ranking via mock selector
 # ---------------------------------------------------------------------------
 
 
-def test_judgment_tag_parsing_produces_score_avg(base_path):
-    _make_goal(base_path, "g1")
-    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
-    run_id = _record_run(
-        base_path, branch_def_id="b1",
-        status=RUN_STATUS_COMPLETED, finished_at=time.time(),
-    )
-    _record_judgment(base_path, run_id=run_id, tags=["quality:8.0", "novelty:7.0"])
-    _record_judgment(base_path, run_id=run_id, tags=["quality:9.0"])
-    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
-    entry = board["entries"][0]
-    # avg of 8.0, 7.0, 9.0 = 8.0
-    assert entry["signals"]["judgment_score_avg"] == pytest.approx(8.0)
-    assert entry["signals"]["judgment_score_samples"] == 3
-    assert entry["signals"]["judgment_count"] == 2  # two judgment rows
-
-
-def test_other_numeric_tags_recorded_separately(base_path):
-    """Tags like ``risk:3`` are numeric but NOT in the headline score
-    average; they appear under ``other_numeric_tags``."""
-    _make_goal(base_path, "g1")
-    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
-    run_id = _record_run(
-        base_path, branch_def_id="b1",
-        status=RUN_STATUS_COMPLETED, finished_at=time.time(),
-    )
-    _record_judgment(
-        base_path, run_id=run_id,
-        tags=["quality:8", "risk:3", "cost:42"],
-    )
-    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
-    signals = board["entries"][0]["signals"]
-    assert signals["judgment_score_avg"] == pytest.approx(8.0)
-    assert signals["other_numeric_tags"] == {"risk": 1, "cost": 1}
-
-
-def test_non_numeric_tags_ignored(base_path):
-    _make_goal(base_path, "g1")
-    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
-    run_id = _record_run(
-        base_path, branch_def_id="b1",
-        status=RUN_STATUS_COMPLETED, finished_at=time.time(),
-    )
-    _record_judgment(
-        base_path, run_id=run_id,
-        tags=["needs-revision", "writer:loop-2"],
-    )
-    signals = build_quality_leaderboard(
-        base_path, goal_id="g1", viewer="",
-    )["entries"][0]["signals"]
-    assert signals["judgment_score_avg"] is None
-    assert signals["other_numeric_tags"] == {}
-
-
-# ---------------------------------------------------------------------------
-# Multi-branch ranking
-# ---------------------------------------------------------------------------
-
-
-def test_higher_judgment_wins_over_lower(base_path):
+def test_mock_selector_ranking_by_judgment_avg(base_path):
     _make_goal(base_path, "g1")
     _make_branch(base_path, branch_def_id="b-low", goal_id="g1")
     _make_branch(base_path, branch_def_id="b-high", goal_id="g1")
@@ -294,111 +331,204 @@ def test_higher_judgment_wins_over_lower(base_path):
     )
     _record_judgment(base_path, run_id=r_low, tags=["quality:3.0"])
     _record_judgment(base_path, run_id=r_high, tags=["quality:9.0"])
-    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="", now=now)
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_mock_dispatch_selector(by_signal="judgment_score_avg"),
+    ):
+        board = build_quality_leaderboard(
+            base_path, goal_id="g1", viewer="",
+        )
     ranks = {e["branch_def_id"]: e["rank"] for e in board["entries"]}
     assert ranks["b-high"] == 1
     assert ranks["b-low"] == 2
 
 
-def test_recency_decay_breaks_score_ties_among_equal_quality(base_path):
-    """Two branches with identical judgments but different recency.
-    Fresher success should rank first."""
+def test_substrate_passes_signal_bundle_to_selector(base_path):
+    """Selector should see signals for each candidate: completed_run_count,
+    judgment_score_avg, fork_count, etc."""
     _make_goal(base_path, "g1")
-    _make_branch(base_path, branch_def_id="b-old", goal_id="g1")
-    _make_branch(base_path, branch_def_id="b-new", goal_id="g1")
-    now = 1_700_000_000.0
-    # 'b-old' finished 60 days ago, 'b-new' finished today.
-    sixty_days_ago = now - 60 * 86400
-    r_old = _record_run(
-        base_path, branch_def_id="b-old",
-        status=RUN_STATUS_COMPLETED, finished_at=sixty_days_ago,
-    )
-    r_new = _record_run(
-        base_path, branch_def_id="b-new",
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    now = time.time()
+    rid = _record_run(
+        base_path, branch_def_id="b1",
         status=RUN_STATUS_COMPLETED, finished_at=now,
     )
-    _record_judgment(base_path, run_id=r_old, tags=["quality:8.0"])
-    _record_judgment(base_path, run_id=r_new, tags=["quality:8.0"])
-    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="", now=now)
-    entries = board["entries"]
-    assert entries[0]["branch_def_id"] == "b-new"
-    assert entries[1]["branch_def_id"] == "b-old"
-    # Recency decay should differ meaningfully.
-    new_decay = entries[0]["signals"]["recency_decay"]
-    old_decay = entries[1]["signals"]["recency_decay"]
-    assert new_decay > old_decay
-    # 60 days at 30-day halflife ~ exp(-2) ~ 0.135.
-    assert 0.10 < old_decay < 0.20
+    _record_judgment(base_path, run_id=rid, tags=["quality:8.0"])
+    captured: dict = {}
+
+    def _capturing(
+        base_path,
+        *,
+        goal_id,
+        candidate_branches,
+        actor="anonymous",
+        timeout_s=None,
+    ):
+        captured["candidate_branches"] = candidate_branches
+        return {
+            "ok": True,
+            "branch_version_id": "mock@x",
+            "source": "platform_default",
+            "run_id": "r",
+            "ranked_entries": [
+                {
+                    "branch_def_id": "b1",
+                    "branch_version_id": "",
+                    "score": 8.0,
+                    "rationale": "captured",
+                }
+            ],
+        }
+
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_capturing,
+    ):
+        build_quality_leaderboard(base_path, goal_id="g1", viewer="")
+
+    candidates = captured["candidate_branches"]
+    assert len(candidates) == 1
+    signals = candidates[0]["signals"]
+    assert signals["completed_run_count"] == 1
+    assert signals["judgment_score_avg"] == 8.0
+    assert signals["judgment_score_samples"] == 1
+    assert "last_successful_run_at" in signals
+    assert "fork_count" in signals
+    assert "has_gate_rung" in signals
 
 
-def test_fork_count_contributes_to_score(base_path):
-    """A branch with community forks ranks above one without."""
+# ---------------------------------------------------------------------------
+# Signal collection invariants — preserved from PR-123 round-2
+# ---------------------------------------------------------------------------
+
+
+def test_other_numeric_tags_bucketed_separately(base_path):
+    """Tags like ``risk:3`` are numeric but NOT in the headline
+    judgment_score_avg; they appear under other_numeric_tags. The
+    selector branch can choose to weight them or ignore them — the
+    substrate just exposes them."""
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    rid = _record_run(
+        base_path, branch_def_id="b1",
+        status=RUN_STATUS_COMPLETED, finished_at=time.time(),
+    )
+    _record_judgment(
+        base_path, run_id=rid,
+        tags=["quality:8", "risk:3", "cost:42"],
+    )
+    captured: dict = {}
+
+    def _capturing(
+        base_path, *, goal_id, candidate_branches, actor="anonymous",
+        timeout_s=None,
+    ):
+        captured["candidates"] = candidate_branches
+        return {
+            "ok": True,
+            "branch_version_id": "mock@x",
+            "source": "platform_default",
+            "run_id": "r",
+            "ranked_entries": [
+                {"branch_def_id": "b1", "score": 8.0, "rationale": ""}
+            ],
+        }
+
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_capturing,
+    ):
+        build_quality_leaderboard(base_path, goal_id="g1", viewer="")
+
+    signals = captured["candidates"][0]["signals"]
+    assert signals["judgment_score_avg"] == pytest.approx(8.0)
+    assert signals["other_numeric_tags"] == {"risk": 1, "cost": 1}
+
+
+def test_non_numeric_tags_ignored(base_path):
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    rid = _record_run(
+        base_path, branch_def_id="b1",
+        status=RUN_STATUS_COMPLETED, finished_at=time.time(),
+    )
+    _record_judgment(
+        base_path, run_id=rid,
+        tags=["needs-revision", "writer:loop-2"],
+    )
+    captured: dict = {}
+
+    def _capturing(
+        base_path, *, goal_id, candidate_branches, actor="anonymous",
+        timeout_s=None,
+    ):
+        captured["candidates"] = candidate_branches
+        return {
+            "ok": True,
+            "branch_version_id": "mock@x",
+            "source": "platform_default",
+            "run_id": "r",
+            "ranked_entries": [
+                {"branch_def_id": "b1", "score": 0.0, "rationale": ""}
+            ],
+        }
+
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_capturing,
+    ):
+        build_quality_leaderboard(base_path, goal_id="g1", viewer="")
+
+    signals = captured["candidates"][0]["signals"]
+    assert signals["judgment_score_avg"] is None
+    assert signals["other_numeric_tags"] == {}
+
+
+def test_fork_count_signal_present(base_path):
+    """Fork count is calculated visibility-respecting and passed to
+    the selector. The PR-127 round-2 P1.2 contract still applies."""
     _make_goal(base_path, "g1")
     _make_branch(base_path, branch_def_id="b-popular", goal_id="g1")
-    _make_branch(base_path, branch_def_id="b-lonely", goal_id="g1")
-    # 3 forks of b-popular via parent_def_id.
+    # 3 forks of b-popular.
     _make_branch(
-        base_path, branch_def_id="fork-1",
+        base_path, branch_def_id="f1",
         goal_id="g1", parent_def_id="b-popular",
     )
     _make_branch(
-        base_path, branch_def_id="fork-2",
+        base_path, branch_def_id="f2",
         goal_id="g1", parent_def_id="b-popular",
     )
-    # 1 fork via fork_from.
     _make_branch(
-        base_path, branch_def_id="fork-3",
+        base_path, branch_def_id="f3",
         goal_id="g1", fork_from="b-popular",
     )
-    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
-    pop_entry = next(
-        e for e in board["entries"] if e["branch_def_id"] == "b-popular"
-    )
-    lonely_entry = next(
-        e for e in board["entries"] if e["branch_def_id"] == "b-lonely"
-    )
-    assert pop_entry["signals"]["fork_count"] == 3
-    assert lonely_entry["signals"]["fork_count"] == 0
-    assert pop_entry["score"] > lonely_entry["score"]
-    assert pop_entry["rank"] < lonely_entry["rank"]
+    captured: dict = {}
 
+    def _capturing(
+        base_path, *, goal_id, candidate_branches, actor="anonymous",
+        timeout_s=None,
+    ):
+        captured["candidates"] = candidate_branches
+        return {
+            "ok": True,
+            "branch_version_id": "mock@x",
+            "source": "platform_default",
+            "run_id": "r",
+            "ranked_entries": [
+                {"branch_def_id": c["branch_def_id"], "score": 0.0}
+                for c in candidate_branches
+            ],
+        }
 
-def test_failed_runs_apply_penalty(base_path):
-    _make_goal(base_path, "g1")
-    _make_branch(base_path, branch_def_id="b-clean", goal_id="g1")
-    _make_branch(base_path, branch_def_id="b-buggy", goal_id="g1")
-    now = time.time()
-    _record_run(
-        base_path, branch_def_id="b-clean",
-        status=RUN_STATUS_COMPLETED, finished_at=now,
-    )
-    _record_run(
-        base_path, branch_def_id="b-buggy",
-        status=RUN_STATUS_COMPLETED, finished_at=now,
-    )
-    for _ in range(5):
-        _record_run(
-            base_path, branch_def_id="b-buggy",
-            status=RUN_STATUS_FAILED, finished_at=now,
-        )
-    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="", now=now)
-    clean = next(
-        e for e in board["entries"] if e["branch_def_id"] == "b-clean"
-    )
-    buggy = next(
-        e for e in board["entries"] if e["branch_def_id"] == "b-buggy"
-    )
-    assert buggy["signals"]["failed_run_count"] == 5
-    assert clean["signals"]["failed_run_count"] == 0
-    # Penalty should be visible in score_components.
-    assert clean["score_components"]["failed_penalty"] == 0.0
-    assert buggy["score_components"]["failed_penalty"] < 0
-    assert clean["score"] > buggy["score"]
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_capturing,
+    ):
+        build_quality_leaderboard(base_path, goal_id="g1", viewer="")
 
-
-# ---------------------------------------------------------------------------
-# safe_to_publish best-effort signal
-# ---------------------------------------------------------------------------
+    by_id = {c["branch_def_id"]: c["signals"] for c in captured["candidates"]}
+    assert by_id["b-popular"]["fork_count"] == 3
+    assert by_id["f1"]["fork_count"] == 0
 
 
 def test_safe_to_publish_signal_from_branch_stats(base_path):
@@ -410,44 +540,39 @@ def test_safe_to_publish_signal_from_branch_stats(base_path):
         stats={"next_action_packet": {"safe_to_publish": True}},
     )
     _make_branch(base_path, branch_def_id="b-unsafe", goal_id="g1")
-    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
-    safe = next(
-        e for e in board["entries"] if e["branch_def_id"] == "b-safe"
-    )
-    unsafe = next(
-        e for e in board["entries"] if e["branch_def_id"] == "b-unsafe"
-    )
-    assert safe["signals"]["safe_to_publish"] is True
-    assert unsafe["signals"]["safe_to_publish"] is False
-    assert safe["score"] > unsafe["score"]
+    captured: dict = {}
 
+    def _capturing(
+        base_path, *, goal_id, candidate_branches, actor="anonymous",
+        timeout_s=None,
+    ):
+        captured["candidates"] = candidate_branches
+        return {
+            "ok": True,
+            "branch_version_id": "mock@x",
+            "source": "platform_default",
+            "run_id": "r",
+            "ranked_entries": [
+                {"branch_def_id": c["branch_def_id"], "score": 0.0}
+                for c in candidate_branches
+            ],
+        }
 
-def test_safe_to_publish_absent_or_falsy_does_not_crash(base_path):
-    _make_goal(base_path, "g1")
-    _make_branch(base_path, branch_def_id="b-no-packet", goal_id="g1")
-    _make_branch(
-        base_path, branch_def_id="b-empty-packet",
-        goal_id="g1", stats={"next_action_packet": {}},
-    )
-    _make_branch(
-        base_path, branch_def_id="b-not-a-dict",
-        goal_id="g1", stats={"next_action_packet": "not a packet"},
-    )
-    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
-    for entry in board["entries"]:
-        assert entry["signals"]["safe_to_publish"] is False
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_capturing,
+    ):
+        build_quality_leaderboard(base_path, goal_id="g1", viewer="")
 
-
-# ---------------------------------------------------------------------------
-# Gate-rung signal
-# ---------------------------------------------------------------------------
+    by_id = {c["branch_def_id"]: c["signals"] for c in captured["candidates"]}
+    assert by_id["b-safe"]["safe_to_publish"] is True
+    assert by_id["b-unsafe"]["safe_to_publish"] is False
 
 
 def test_gate_rung_signal_populates_when_claim_present(base_path):
     _make_goal(base_path, "g1")
     _make_branch(base_path, branch_def_id="b-rung", goal_id="g1")
     _make_branch(base_path, branch_def_id="b-no-rung", goal_id="g1")
-    # Insert a gate claim directly.
     from workflow.storage import _connect
     with _connect(base_path) as conn:
         conn.execute(
@@ -463,153 +588,279 @@ def test_gate_rung_signal_populates_when_claim_present(base_path):
                 "2026-01-01T00:00:00",
             ),
         )
-    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
-    rung = next(
-        e for e in board["entries"] if e["branch_def_id"] == "b-rung"
-    )
-    no_rung = next(
-        e for e in board["entries"] if e["branch_def_id"] == "b-no-rung"
-    )
-    assert rung["signals"]["gate_rung_top"] == "submission"
-    assert rung["signals"]["has_gate_rung"] is True
-    assert no_rung["signals"]["has_gate_rung"] is False
-    assert rung["score"] > no_rung["score"]
+    captured: dict = {}
+
+    def _capturing(
+        base_path, *, goal_id, candidate_branches, actor="anonymous",
+        timeout_s=None,
+    ):
+        captured["candidates"] = candidate_branches
+        return {
+            "ok": True,
+            "branch_version_id": "mock@x",
+            "source": "platform_default",
+            "run_id": "r",
+            "ranked_entries": [
+                {"branch_def_id": c["branch_def_id"], "score": 0.0}
+                for c in candidate_branches
+            ],
+        }
+
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_capturing,
+    ):
+        build_quality_leaderboard(base_path, goal_id="g1", viewer="")
+
+    by_id = {c["branch_def_id"]: c["signals"] for c in captured["candidates"]}
+    assert by_id["b-rung"]["gate_rung_top"] == "submission"
+    assert by_id["b-rung"]["has_gate_rung"] is True
+    assert by_id["b-no-rung"]["has_gate_rung"] is False
 
 
 # ---------------------------------------------------------------------------
-# Realistic scale — Goal with 15+ entries
+# Selector failure modes — leaderboard surfaces structured error
 # ---------------------------------------------------------------------------
 
 
-def test_realistic_goal_with_fifteen_entries(base_path):
-    """Smoke + correctness at the scale of Goal 4ff5862cc26d (~15+
-    bound branches). Verifies rank monotonicity and that the top entry
-    has the highest score."""
+def test_selector_invalid_output_surfaces_structured_error(base_path):
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    fail_response = {
+        "ok": False,
+        "error_kind": "selector_invalid_output",
+        "error": "ranked_entries missing",
+        "branch_version_id": "selector@x",
+        "run_id": "run-bad",
+    }
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_mock_dispatch_selector(fail_with=fail_response),
+    ):
+        board = build_quality_leaderboard(
+            base_path, goal_id="g1", viewer="",
+        )
+    assert board["ok"] is False
+    assert board["error_kind"] == "selector_invalid_output"
+    assert board["entries"] == []
+    assert board["selector"]["branch_version_id"] == "selector@x"
+
+
+def test_selector_timeout_surfaces_structured_error(base_path):
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    fail_response = {
+        "ok": False,
+        "error_kind": "selector_timeout",
+        "error": "selector run timed out after 60s",
+        "branch_version_id": "selector@x",
+        "run_id": "run-stuck",
+    }
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_mock_dispatch_selector(fail_with=fail_response),
+    ):
+        rec = recommend_parent_for_fork(
+            base_path, goal_id="g1", viewer="",
+        )
+    assert rec["ok"] is False
+    assert rec["error_kind"] == "selector_timeout"
+    assert rec["recommended_parent"] is None
+
+
+def test_selector_run_failed_surfaces_structured_error(base_path):
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    fail_response = {
+        "ok": False,
+        "error_kind": "selector_run_failed",
+        "error": "graph execution raised",
+        "branch_version_id": "selector@x",
+        "run_id": "run-crashed",
+    }
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_mock_dispatch_selector(fail_with=fail_response),
+    ):
+        board = build_quality_leaderboard(
+            base_path, goal_id="g1", viewer="",
+        )
+    assert board["ok"] is False
+    assert board["error_kind"] == "selector_run_failed"
+
+
+# ---------------------------------------------------------------------------
+# Substrate filters dupe / unknown branch_def_ids from selector output
+# ---------------------------------------------------------------------------
+
+
+def test_substrate_filters_duplicate_entries_from_selector_output(base_path):
+    """A misbehaving selector that emits the same branch_def_id twice
+    must NOT corrupt the leaderboard. Substrate keeps the first
+    occurrence and skips the rest."""
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    duplicates = [
+        {"branch_def_id": "b1", "score": 9.0, "rationale": "first"},
+        {"branch_def_id": "b1", "score": 8.0, "rationale": "dupe"},
+    ]
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_mock_dispatch_selector(ranked_entries=duplicates),
+    ):
+        board = build_quality_leaderboard(
+            base_path, goal_id="g1", viewer="",
+        )
+    assert board["ok"] is True
+    assert len(board["entries"]) == 1
+    assert board["entries"][0]["rationale"] == "first"
+
+
+# ---------------------------------------------------------------------------
+# Determinism — same inputs + mock -> same ranking
+# ---------------------------------------------------------------------------
+
+
+def test_substrate_assigns_rank_1_to_first_entry(base_path):
+    """The selector's emitted order IS the leaderboard order. Rank 1
+    is whatever the selector put first."""
+    _make_goal(base_path, "g1")
+    for i in range(3):
+        _make_branch(base_path, branch_def_id=f"b{i}", goal_id="g1")
+    fixed_order = [
+        {"branch_def_id": "b2", "score": 5.0, "rationale": "second-but-best"},
+        {"branch_def_id": "b0", "score": 4.0},
+        {"branch_def_id": "b1", "score": 3.0},
+    ]
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_mock_dispatch_selector(ranked_entries=fixed_order),
+    ):
+        board = build_quality_leaderboard(
+            base_path, goal_id="g1", viewer="",
+        )
+    assert [e["branch_def_id"] for e in board["entries"]] == ["b2", "b0", "b1"]
+    assert board["entries"][0]["rank"] == 1
+    assert board["entries"][0]["rationale"] == "second-but-best"
+
+
+# ---------------------------------------------------------------------------
+# recommend_parent_for_fork happy path
+# ---------------------------------------------------------------------------
+
+
+def test_recommend_parent_returns_top_with_selector_rationale(base_path):
+    _make_goal(base_path, "g1", name="Patch Loop")
+    _make_branch(base_path, branch_def_id="b-top", goal_id="g1")
+    _make_branch(base_path, branch_def_id="b-mid", goal_id="g1")
+    ranked = [
+        {
+            "branch_def_id": "b-top",
+            "score": 9.5,
+            "rationale": "highest avg judgment (9.5) with 12 runs",
+        },
+        {"branch_def_id": "b-mid", "score": 6.0, "rationale": "mid"},
+    ]
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_mock_dispatch_selector(ranked_entries=ranked),
+    ):
+        rec = recommend_parent_for_fork(
+            base_path, goal_id="g1", viewer="",
+        )
+    assert rec["ok"] is True
+    assert rec["recommended_parent"]["branch_def_id"] == "b-top"
+    assert rec["leaderboard_size"] == 2
+    assert "highest avg judgment" in rec["rationale"]
+
+
+# ---------------------------------------------------------------------------
+# Realistic scale (15+ entries) still works under selector dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_realistic_goal_with_eighteen_entries_under_mock_selector(base_path):
+    """Smoke at the scale of Goal 4ff5862cc26d. Mock selector ranks
+    by branch_def_id ascending; substrate respects that order."""
     _make_goal(base_path, "g-big")
-    now = 1_700_000_000.0
     for i in range(18):
-        bid = f"b-{i:02d}"
-        _make_branch(base_path, branch_def_id=bid, goal_id="g-big")
-        # Spread completed-run counts + judgment scores so ranking is
-        # non-trivial.
-        for _ in range(i % 5):
-            rid = _record_run(
-                base_path, branch_def_id=bid,
-                status=RUN_STATUS_COMPLETED,
-                finished_at=now - (i * 86400),  # older for higher i
-            )
-            _record_judgment(
-                base_path, run_id=rid,
-                tags=[f"quality:{(i % 9) + 1}"],
-            )
-    board = build_quality_leaderboard(
-        base_path, goal_id="g-big", viewer="", now=now,
-    )
+        _make_branch(
+            base_path, branch_def_id=f"b-{i:02d}", goal_id="g-big",
+        )
+    def _ranker(
+        base_path, *, goal_id, candidate_branches, actor="anonymous",
+        timeout_s=None,
+    ):
+        ordered = sorted(
+            candidate_branches, key=lambda c: c["branch_def_id"],
+        )
+        return {
+            "ok": True,
+            "branch_version_id": "mock@x",
+            "source": "platform_default",
+            "run_id": "r",
+            "ranked_entries": [
+                {"branch_def_id": c["branch_def_id"], "score": float(i)}
+                for i, c in enumerate(ordered)
+            ],
+        }
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_ranker,
+    ):
+        board = build_quality_leaderboard(
+            base_path, goal_id="g-big", viewer="",
+        )
     assert len(board["entries"]) == 18
     # Ranks are 1..18 with no gaps.
     ranks = sorted(e["rank"] for e in board["entries"])
     assert ranks == list(range(1, 19))
-    # First entry's score >= every other entry's score.
-    top_score = board["entries"][0]["score"]
-    for entry in board["entries"][1:]:
-        assert top_score >= entry["score"]
 
 
 # ---------------------------------------------------------------------------
-# recommend_parent_for_fork
+# Goal-binding precedence for selector resolution
 # ---------------------------------------------------------------------------
 
 
-def test_recommend_parent_returns_top_with_rationale(base_path):
-    _make_goal(base_path, "g1", name="Patch Loop")
-    _make_branch(
-        base_path, branch_def_id="b-top",
-        goal_id="g1", name="High-Quality Take",
-    )
-    _make_branch(base_path, branch_def_id="b-other", goal_id="g1")
-    now = time.time()
-    rid = _record_run(
-        base_path, branch_def_id="b-top",
-        status=RUN_STATUS_COMPLETED, finished_at=now,
-    )
-    _record_judgment(base_path, run_id=rid, tags=["quality:9.5"])
-    # Add a fork of b-top so the rationale has community-vote signal.
-    _make_branch(
-        base_path, branch_def_id="b-top-fork",
-        goal_id="g1", parent_def_id="b-top",
-    )
-    rec = recommend_parent_for_fork(base_path, goal_id="g1", viewer="", now=now)
-    assert rec["recommended_parent"] is not None
-    assert rec["recommended_parent"]["branch_def_id"] == "b-top"
-    rationale = rec["rationale"]
-    # Rationale should mention some of the signals we exercised.
-    assert "ranked first" in rationale.lower()
-    assert "judgment" in rationale.lower() or "9.5" in rationale
-    assert "fork" in rationale.lower()
-    assert rec["leaderboard_size"] == 3  # b-top, b-other, b-top-fork
-
-
-def test_recommend_parent_no_judgments_yet_tentative_phrase(base_path):
-    _make_goal(base_path, "g1")
-    _make_branch(base_path, branch_def_id="b-bare", goal_id="g1")
-    rec = recommend_parent_for_fork(base_path, goal_id="g1", viewer="")
-    assert rec["recommended_parent"] is not None
-    # When the top entry has no signals at all, the rationale should
-    # call out the lack of quality data.
-    rationale_lc = rec["rationale"].lower()
-    assert "tentative" in rationale_lc or "no quality signals" in rationale_lc
-
-
-# ---------------------------------------------------------------------------
-# Formula disclosure surfaces all weights
-# ---------------------------------------------------------------------------
-
-
-def test_formula_disclosure_includes_all_weights(base_path):
-    _make_goal(base_path, "g1")
-    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
-    weights = board["formula"]["weights"]
-    expected_keys = {
-        "judgment", "runs", "forks", "recency",
-        "gate", "safe_publish", "failed_penalty",
-    }
-    assert set(weights.keys()) == expected_keys
-    # judgment_max_scale is published.
-    assert board["formula"]["judgment_max_scale"] == JUDGMENT_MAX_SCALE
-
-
-def test_score_components_sum_to_score(base_path):
+def test_goal_binding_takes_precedence_over_default(base_path):
+    """When a Goal has selector_branch_version_id set, the substrate
+    uses it instead of publishing/using the platform default. This
+    test mocks dispatch_selector so we don't need a real published
+    selector; we just confirm the resolver path the substrate
+    takes by inspecting selector_branch_version_id in the response."""
     _make_goal(base_path, "g1")
     _make_branch(base_path, branch_def_id="b1", goal_id="g1")
-    rid = _record_run(
-        base_path, branch_def_id="b1",
-        status=RUN_STATUS_COMPLETED, finished_at=time.time(),
+    # Bind a non-platform-default selector at the storage layer.
+    from workflow.daemon_server import update_goal
+    update_goal(
+        base_path,
+        goal_id="g1",
+        updates={"selector_branch_version_id": "custom_selector@abc12345"},
     )
-    _record_judgment(base_path, run_id=rid, tags=["quality:7"])
-    board = build_quality_leaderboard(base_path, goal_id="g1", viewer="")
-    entry = board["entries"][0]
-    component_sum = sum(entry["score_components"].values())
-    assert entry["score"] == pytest.approx(component_sum, abs=1e-3)
+    captured: dict = {}
 
+    def _capturing(
+        base_path, *, goal_id, candidate_branches, actor="anonymous",
+        timeout_s=None,
+    ):
+        captured["goal_id"] = goal_id
+        return {
+            "ok": True,
+            "branch_version_id": "custom_selector@abc12345",
+            "source": "goal_binding",
+            "run_id": "r",
+            "ranked_entries": [
+                {"branch_def_id": "b1", "score": 7.0, "rationale": ""}
+            ],
+        }
 
-# ---------------------------------------------------------------------------
-# Determinism — same input -> same ranking
-# ---------------------------------------------------------------------------
-
-
-def test_ranking_is_deterministic(base_path):
-    _make_goal(base_path, "g1")
-    for i in range(5):
-        _make_branch(base_path, branch_def_id=f"b{i}", goal_id="g1")
-    now = 1_700_000_000.0
-    board_a = build_quality_leaderboard(
-        base_path, goal_id="g1", viewer="", now=now,
-    )
-    board_b = build_quality_leaderboard(
-        base_path, goal_id="g1", viewer="", now=now,
-    )
-    assert [
-        e["branch_def_id"] for e in board_a["entries"]
-    ] == [
-        e["branch_def_id"] for e in board_b["entries"]
-    ]
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_capturing,
+    ):
+        board = build_quality_leaderboard(
+            base_path, goal_id="g1", viewer="",
+        )
+    assert board["ok"] is True
+    assert board["selector"]["branch_version_id"] == "custom_selector@abc12345"
+    assert board["selector"]["source"] == "goal_binding"

--- a/tests/test_quality_leaderboard.py
+++ b/tests/test_quality_leaderboard.py
@@ -47,13 +47,11 @@ from workflow.daemon_server import (
 )
 from workflow.runs import (
     RUN_STATUS_COMPLETED,
-    RUN_STATUS_FAILED,
     add_judgment,
     create_run,
     initialize_runs_db,
     update_run_status,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures + helpers
@@ -181,6 +179,7 @@ def _mock_dispatch_selector(
         candidate_branches,
         actor="anonymous",
         timeout_s=None,
+        **_extra,
     ):
         if fail_with is not None:
             return dict(fail_with)
@@ -363,6 +362,7 @@ def test_substrate_passes_signal_bundle_to_selector(base_path):
         candidate_branches,
         actor="anonymous",
         timeout_s=None,
+        **_extra,
     ):
         captured["candidate_branches"] = candidate_branches
         return {
@@ -421,7 +421,7 @@ def test_other_numeric_tags_bucketed_separately(base_path):
 
     def _capturing(
         base_path, *, goal_id, candidate_branches, actor="anonymous",
-        timeout_s=None,
+        timeout_s=None, **_extra,
     ):
         captured["candidates"] = candidate_branches
         return {
@@ -460,7 +460,7 @@ def test_non_numeric_tags_ignored(base_path):
 
     def _capturing(
         base_path, *, goal_id, candidate_branches, actor="anonymous",
-        timeout_s=None,
+        timeout_s=None, **_extra,
     ):
         captured["candidates"] = candidate_branches
         return {
@@ -506,7 +506,7 @@ def test_fork_count_signal_present(base_path):
 
     def _capturing(
         base_path, *, goal_id, candidate_branches, actor="anonymous",
-        timeout_s=None,
+        timeout_s=None, **_extra,
     ):
         captured["candidates"] = candidate_branches
         return {
@@ -544,7 +544,7 @@ def test_safe_to_publish_signal_from_branch_stats(base_path):
 
     def _capturing(
         base_path, *, goal_id, candidate_branches, actor="anonymous",
-        timeout_s=None,
+        timeout_s=None, **_extra,
     ):
         captured["candidates"] = candidate_branches
         return {
@@ -592,7 +592,7 @@ def test_gate_rung_signal_populates_when_claim_present(base_path):
 
     def _capturing(
         base_path, *, goal_id, candidate_branches, actor="anonymous",
-        timeout_s=None,
+        timeout_s=None, **_extra,
     ):
         captured["candidates"] = candidate_branches
         return {
@@ -717,6 +717,104 @@ def test_substrate_filters_duplicate_entries_from_selector_output(base_path):
 
 
 # ---------------------------------------------------------------------------
+# DESIGN-008 round 2 P1.2 — substrate rejects fabricated branch_def_ids
+# ---------------------------------------------------------------------------
+
+
+def test_substrate_drops_phantom_branch_def_ids_from_selector(base_path):
+    """Round-2 P1.2 regression guard.
+
+    A selector that fabricates a branch_def_id (private branch the
+    viewer cannot see, made-up id, etc.) must NOT inject the entry
+    into the leaderboard. Substrate filters by candidate set
+    membership.
+    """
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    # Selector returns one real id + one fabricated id (a private
+    # branch the viewer can't see, or just made up).
+    poisoned = [
+        {"branch_def_id": "phantom_private_branch", "score": 99.0,
+         "rationale": "fabricated"},
+        {"branch_def_id": "b1", "score": 5.0, "rationale": "real one"},
+    ]
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_mock_dispatch_selector(ranked_entries=poisoned),
+    ):
+        board = build_quality_leaderboard(
+            base_path, goal_id="g1", viewer="",
+        )
+    assert board["ok"] is True
+    # Only the real branch survives.
+    bids = [e["branch_def_id"] for e in board["entries"]]
+    assert bids == ["b1"]
+    # Phantom id surfaces in the structured payload so audit tools
+    # / chatbots can detect a misbehaving selector.
+    assert board["phantom_branch_def_ids"] == ["phantom_private_branch"]
+    # Rank starts at 1 for the surviving entry (no rank gap).
+    assert board["entries"][0]["rank"] == 1
+
+
+def test_substrate_phantom_filter_does_not_leave_rank_gaps(base_path):
+    """When the selector emits a mix of real + phantom ids,
+    ranks are reassigned post-filter so the user sees a clean
+    sequence (1, 2, 3) not (1, 3, 5)."""
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    _make_branch(base_path, branch_def_id="b2", goal_id="g1")
+    interleaved = [
+        {"branch_def_id": "phantom_a", "score": 10.0},
+        {"branch_def_id": "b1", "score": 8.0},
+        {"branch_def_id": "phantom_b", "score": 7.0},
+        {"branch_def_id": "b2", "score": 5.0},
+    ]
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_mock_dispatch_selector(ranked_entries=interleaved),
+    ):
+        board = build_quality_leaderboard(
+            base_path, goal_id="g1", viewer="",
+        )
+    ranks = [e["rank"] for e in board["entries"]]
+    bids = [e["branch_def_id"] for e in board["entries"]]
+    assert ranks == [1, 2]
+    assert bids == ["b1", "b2"]
+    assert set(board["phantom_branch_def_ids"]) == {"phantom_a", "phantom_b"}
+
+
+def test_substrate_logs_phantom_attempts(base_path, caplog):
+    """Phantom rejections must be logged so an operator can detect a
+    misbehaving (or adversarial) selector in their logs."""
+    import logging
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    poisoned = [
+        {"branch_def_id": "evil_phantom", "score": 99.0,
+         "rationale": "private leak attempt"},
+        {"branch_def_id": "b1", "score": 5.0},
+    ]
+    with caplog.at_level(logging.WARNING, logger="workflow.api.quality_leaderboard"):
+        with patch(
+            "workflow.api.quality_leaderboard.dispatch_selector",
+            side_effect=_mock_dispatch_selector(ranked_entries=poisoned),
+        ):
+            build_quality_leaderboard(
+                base_path, goal_id="g1", viewer="",
+            )
+    # Find at least one warning mentioning the phantom id.
+    matching = [
+        rec for rec in caplog.records
+        if rec.levelno >= logging.WARNING
+        and "evil_phantom" in str(rec.getMessage())
+    ]
+    assert matching, (
+        "expected a WARNING log entry naming the phantom id; "
+        f"got records: {[r.getMessage() for r in caplog.records]}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Determinism — same inputs + mock -> same ranking
 # ---------------------------------------------------------------------------
 
@@ -789,7 +887,7 @@ def test_realistic_goal_with_eighteen_entries_under_mock_selector(base_path):
         )
     def _ranker(
         base_path, *, goal_id, candidate_branches, actor="anonymous",
-        timeout_s=None,
+        timeout_s=None, **_extra,
     ):
         ordered = sorted(
             candidate_branches, key=lambda c: c["branch_def_id"],
@@ -841,7 +939,7 @@ def test_goal_binding_takes_precedence_over_default(base_path):
 
     def _capturing(
         base_path, *, goal_id, candidate_branches, actor="anonymous",
-        timeout_s=None,
+        timeout_s=None, **_extra,
     ):
         captured["goal_id"] = goal_id
         return {

--- a/tests/test_quality_leaderboard.py
+++ b/tests/test_quality_leaderboard.py
@@ -815,6 +815,131 @@ def test_substrate_logs_phantom_attempts(base_path, caplog):
 
 
 # ---------------------------------------------------------------------------
+# DESIGN-008 round 3 P1.A — selector-emitted branch_version_id is ignored
+# ---------------------------------------------------------------------------
+
+
+def test_substrate_ignores_selector_emitted_branch_version_id(base_path):
+    """Round-3 P1.A regression guard.
+
+    A selector that returns a real visible ``branch_def_id`` paired
+    with an arbitrary (private / rolled-back / fabricated)
+    ``branch_version_id`` must NOT have that version id surface in
+    the leaderboard. The candidate set's authoritative bvid is the
+    only one the substrate trusts.
+    """
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    # Selector tries to spoof the bvid for the real def_id.
+    spoofed = [
+        {
+            "branch_def_id": "b1",
+            "branch_version_id": "private-or-wrong@deadbeef",
+            "score": 7.0,
+            "rationale": "spoof attempt",
+        },
+    ]
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_mock_dispatch_selector(ranked_entries=spoofed),
+    ):
+        board = build_quality_leaderboard(
+            base_path, goal_id="g1", viewer="",
+        )
+    assert board["ok"] is True
+    assert len(board["entries"]) == 1
+    entry = board["entries"][0]
+    assert entry["branch_def_id"] == "b1"
+    # The selector's emitted bvid MUST NOT appear. The authoritative
+    # value from branch_meta_by_id is what surfaces (empty string in
+    # this test because no version has been published for b1 yet).
+    assert entry["branch_version_id"] != "private-or-wrong@deadbeef"
+    # Spoof attempt surfaces in the audit list on the response.
+    assert len(board["selector_bvid_spoofs"]) == 1
+    spoof = board["selector_bvid_spoofs"][0]
+    assert spoof["branch_def_id"] == "b1"
+    assert spoof["selector_emitted"] == "private-or-wrong@deadbeef"
+
+
+def test_substrate_logs_selector_bvid_spoof_attempt(base_path, caplog):
+    """Spoof attempts must be logged at WARNING so operators can
+    detect a misbehaving / adversarial selector."""
+    import logging
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    spoofed = [
+        {
+            "branch_def_id": "b1",
+            "branch_version_id": "evil_spoof@99999999",
+            "score": 7.0,
+        },
+    ]
+    with caplog.at_level(
+        logging.WARNING, logger="workflow.api.quality_leaderboard",
+    ):
+        with patch(
+            "workflow.api.quality_leaderboard.dispatch_selector",
+            side_effect=_mock_dispatch_selector(ranked_entries=spoofed),
+        ):
+            build_quality_leaderboard(
+                base_path, goal_id="g1", viewer="",
+            )
+    matching = [
+        rec for rec in caplog.records
+        if rec.levelno >= logging.WARNING
+        and "evil_spoof@99999999" in str(rec.getMessage())
+    ]
+    assert matching, (
+        "expected WARNING log naming the spoofed bvid; "
+        f"got records: {[r.getMessage() for r in caplog.records]}"
+    )
+
+
+def test_substrate_accepts_selector_matching_authoritative_bvid(base_path):
+    """When the selector's emitted bvid matches the authoritative
+    candidate-set bvid, no spoof is recorded. (Authoritative value
+    is still used either way — this test just locks the no-spoof
+    path so the spoof-list doesn't generate false positives when a
+    well-behaved selector echoes the input bvid back.)"""
+    from workflow.branch_versions import publish_branch_version
+    from workflow.daemon_server import get_branch_definition
+    _make_goal(base_path, "g1")
+    _make_branch(base_path, branch_def_id="b1", goal_id="g1")
+    branch_dict = get_branch_definition(base_path, branch_def_id="b1")
+    branch_dict["name"] = "b1"
+    branch_dict["graph_nodes"] = [
+        {"id": "n1", "type": "prompt", "input_keys": [], "output_keys": ["x"]},
+    ]
+    branch_dict["edges"] = [
+        {"from": "START", "to": "n1"},
+        {"from": "n1", "to": "END"},
+    ]
+    branch_dict["state_schema"] = [{"name": "x", "type": "str"}]
+    branch_dict["entry_point"] = "n1"
+    version = publish_branch_version(base_path, branch_dict, publisher="host")
+    authoritative = version.branch_version_id
+
+    echoed = [
+        {
+            "branch_def_id": "b1",
+            "branch_version_id": authoritative,
+            "score": 7.0,
+        },
+    ]
+    with patch(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        side_effect=_mock_dispatch_selector(ranked_entries=echoed),
+    ):
+        board = build_quality_leaderboard(
+            base_path, goal_id="g1", viewer="",
+        )
+    assert board["ok"] is True
+    assert board["entries"][0]["branch_version_id"] == authoritative
+    # No spoof recorded — selector and authoritative agree.
+    assert board["selector_bvid_spoofs"] == []
+
+
+# ---------------------------------------------------------------------------
 # Determinism — same inputs + mock -> same ranking
 # ---------------------------------------------------------------------------
 

--- a/tests/test_quality_leaderboard_auth_boundary.py
+++ b/tests/test_quality_leaderboard_auth_boundary.py
@@ -39,6 +39,50 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _mock_selector_passthrough(monkeypatch):
+    """DESIGN-008 — pass-through selector mock for auth-boundary tests.
+
+    The auth-boundary tests in this file probe the substrate's
+    visibility filter at the leaderboard layer. Under DESIGN-008,
+    leaderboard production requires a selector dispatch (one LLM
+    call). These tests don't need to exercise selector behavior —
+    only the candidate-set visibility filter. So we monkeypatch
+    ``dispatch_selector`` to pass the candidate list straight
+    through as ``ranked_entries`` (preserving input order, score
+    0.0). The substrate's filter (already applied via
+    ``list_branch_definitions`` + ``_fork_count`` before dispatch)
+    is what's under test.
+    """
+    def _passthrough(
+        base_path,
+        *,
+        goal_id,
+        candidate_branches,
+        actor="anonymous",
+        timeout_s=None,
+    ):
+        return {
+            "ok": True,
+            "branch_version_id": "mock_selector@authtest",
+            "source": "platform_default",
+            "run_id": "mock-run",
+            "ranked_entries": [
+                {
+                    "branch_def_id": c["branch_def_id"],
+                    "branch_version_id": c.get("branch_version_id", ""),
+                    "score": 0.0,
+                    "rationale": "passthrough",
+                }
+                for c in candidate_branches
+            ],
+        }
+    monkeypatch.setattr(
+        "workflow.api.quality_leaderboard.dispatch_selector",
+        _passthrough,
+    )
+
+
 @pytest.fixture
 def us_env(tmp_path: Path, monkeypatch):
     """Daemon env where the calling actor is ``eve`` by default."""

--- a/tests/test_quality_leaderboard_auth_boundary.py
+++ b/tests/test_quality_leaderboard_auth_boundary.py
@@ -61,6 +61,7 @@ def _mock_selector_passthrough(monkeypatch):
         candidate_branches,
         actor="anonymous",
         timeout_s=None,
+        **_extra,
     ):
         return {
             "ok": True,

--- a/tests/test_rollback_repoint.py
+++ b/tests/test_rollback_repoint.py
@@ -201,3 +201,113 @@ class TestOrchestratorIntegrationWithGoals:
         assert result["repoint"]["repointed_count"] == 2
         assert get_goal(tmp_path, goal_id="ga")["canonical_branch_version_id"] is None
         assert get_goal(tmp_path, goal_id="gb")["canonical_branch_version_id"] is None
+
+
+# ─── DESIGN-008 round 4 — selector repoint after rollback ───────────────
+
+
+def _seed_goal_with_selector(tmp_path, goal_id, selector_bvid):
+    """Bind a selector to a Goal via the storage helper. Bypasses the
+    bind-time effects check by writing the column directly via
+    update_goal, since the test fixture branches are pure prompt
+    nodes anyway."""
+    initialize_author_server(tmp_path)
+    save_goal(tmp_path, goal={
+        "goal_id": goal_id, "name": f"Goal {goal_id}", "author": "alice",
+    })
+    from workflow.daemon_server import update_goal
+    update_goal(
+        tmp_path,
+        goal_id=goal_id,
+        updates={"selector_branch_version_id": selector_bvid},
+    )
+
+
+class TestSelectorRepoint:
+    """DESIGN-008 round 4 — selector_branch_version_id pointers are
+    cleared (NULL) when the version is rolled back. Unlike canonical,
+    selectors do NOT walk up to an ancestor: re-binding to a different
+    version silently could introduce a ranking opinion the operator
+    didn't choose. Cleared bindings trigger the platform-default
+    fallback at the next leaderboard read."""
+
+    def test_clears_selector_pointer_on_rollback(self, tmp_path):
+        from workflow.rollback import repoint_selectors_after_rollback
+        selector_v = _publish(tmp_path, "selector-v1")
+        _seed_goal_with_selector(tmp_path, "g-sel", selector_v)
+        execute_rollback_set(
+            tmp_path, [selector_v], reason="t", set_by="alice",
+        )
+        result = repoint_selectors_after_rollback(
+            tmp_path, [selector_v], set_by="alice",
+        )
+        assert result["status"] == "ok"
+        assert result["repointed_count"] == 1
+        repoint_row = result["repoints"][0]
+        assert repoint_row["goal_id"] == "g-sel"
+        assert repoint_row["old_branch_version_id"] == selector_v
+        assert repoint_row["new_branch_version_id"] is None
+        goal = get_goal(tmp_path, goal_id="g-sel")
+        assert goal["selector_branch_version_id"] is None
+
+    def test_unaffected_goal_left_alone(self, tmp_path):
+        from workflow.rollback import repoint_selectors_after_rollback
+        rolled = _publish(tmp_path, "rolled-selector")
+        other = _publish(tmp_path, "other-selector")
+        _seed_goal_with_selector(tmp_path, "g-rolled", rolled)
+        _seed_goal_with_selector(tmp_path, "g-other", other)
+        execute_rollback_set(
+            tmp_path, [rolled], reason="t", set_by="alice",
+        )
+        result = repoint_selectors_after_rollback(
+            tmp_path, [rolled], set_by="alice",
+        )
+        assert result["repointed_count"] == 1
+        rolled_ids = {r["goal_id"] for r in result["repoints"]}
+        assert rolled_ids == {"g-rolled"}
+        # Other goal's selector binding untouched.
+        assert get_goal(
+            tmp_path, goal_id="g-other",
+        )["selector_branch_version_id"] == other
+
+    def test_no_bindings_no_op(self, tmp_path):
+        from workflow.rollback import repoint_selectors_after_rollback
+        bvid = _publish(tmp_path, "lonely-version")
+        execute_rollback_set(tmp_path, [bvid], reason="t", set_by="alice")
+        # No Goals bound to it → repoint is a clean no-op.
+        result = repoint_selectors_after_rollback(
+            tmp_path, [bvid], set_by="alice",
+        )
+        assert result["repointed_count"] == 0
+        assert result["repoints"] == []
+
+    def test_empty_version_set_short_circuits(self, tmp_path):
+        from workflow.rollback import repoint_selectors_after_rollback
+        initialize_author_server(tmp_path)
+        result = repoint_selectors_after_rollback(
+            tmp_path, [], set_by="alice",
+        )
+        assert result["repointed_count"] == 0
+
+    def test_orchestrator_runs_both_canonical_and_selector_repoint(self, tmp_path):
+        """End-to-end through ``rollback_merge_orchestrator``: a
+        single rollback call clears BOTH a canonical pointer AND a
+        selector pointer on the same Goal."""
+        bvid = _publish(tmp_path, "dual-pointer-version")
+        _seed_goal(tmp_path, "g-dual", canonical_bvid=bvid)
+        # ALSO bind it as selector via the column write path.
+        from workflow.daemon_server import update_goal
+        update_goal(
+            tmp_path,
+            goal_id="g-dual",
+            updates={"selector_branch_version_id": bvid},
+        )
+        result = rollback_merge_orchestrator(
+            tmp_path, bvid, reason="dual cleanup", set_by="alice",
+        )
+        assert result["status"] == "ok"
+        assert result["repoint"]["repointed_count"] == 1
+        assert result["selector_repoint"]["repointed_count"] == 1
+        goal = get_goal(tmp_path, goal_id="g-dual")
+        assert goal["canonical_branch_version_id"] is None
+        assert goal["selector_branch_version_id"] is None

--- a/tests/test_selector_dispatch.py
+++ b/tests/test_selector_dispatch.py
@@ -1,0 +1,336 @@
+"""DESIGN-008 — selector-branch dispatch unit tests.
+
+Covers ``workflow.api.selector_dispatch`` directly:
+
+  * ``resolve_selector_branch_version_id`` — goal_binding vs.
+    platform_default fallback.
+  * ``ensure_default_selector_published`` — idempotency,
+    deterministic branch_def_id, active version returned.
+  * ``dispatch_selector`` output parsing under several malformed
+    shapes (missing key, wrong type, non-coercible score, etc.).
+  * Empty candidate set short-circuits without dispatching.
+
+The selector dispatch tests that need an actual LLM run live in
+``test_quality_leaderboard.py`` where they monkeypatch
+``dispatch_selector`` itself.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def base_path(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    from workflow.daemon_server import initialize_author_server
+    from workflow.runs import initialize_runs_db
+    initialize_author_server(tmp_path)
+    initialize_runs_db(tmp_path)
+    return tmp_path
+
+
+def _make_goal(
+    base_path: Path,
+    goal_id: str,
+    *,
+    selector_branch_version_id: str | None = None,
+) -> dict:
+    from workflow.daemon_server import save_goal, update_goal
+    save_goal(
+        base_path,
+        goal=dict(
+            goal_id=goal_id,
+            name=goal_id,
+            description="",
+            author="host",
+            tags=[],
+            visibility="public",
+        ),
+    )
+    if selector_branch_version_id is not None:
+        update_goal(
+            base_path,
+            goal_id=goal_id,
+            updates={
+                "selector_branch_version_id": selector_branch_version_id,
+            },
+        )
+    from workflow.daemon_server import get_goal
+    return get_goal(base_path, goal_id=goal_id)
+
+
+# ---------------------------------------------------------------------------
+# ensure_default_selector_published — idempotency + active version
+# ---------------------------------------------------------------------------
+
+
+def test_default_selector_publishes_on_first_call(base_path):
+    from workflow.api.selector_dispatch import (
+        DEFAULT_SELECTOR_BRANCH_DEF_ID,
+        ensure_default_selector_published,
+    )
+    bvid = ensure_default_selector_published(base_path)
+    assert bvid.startswith(DEFAULT_SELECTOR_BRANCH_DEF_ID + "@")
+
+
+def test_default_selector_is_idempotent(base_path):
+    from workflow.api.selector_dispatch import ensure_default_selector_published
+    a = ensure_default_selector_published(base_path)
+    b = ensure_default_selector_published(base_path)
+    assert a == b
+
+
+def test_default_selector_branch_def_exists_after_publish(base_path):
+    from workflow.api.selector_dispatch import (
+        DEFAULT_SELECTOR_BRANCH_DEF_ID,
+        ensure_default_selector_published,
+    )
+    ensure_default_selector_published(base_path)
+    from workflow.daemon_server import get_branch_definition
+    branch = get_branch_definition(
+        base_path, branch_def_id=DEFAULT_SELECTOR_BRANCH_DEF_ID,
+    )
+    assert branch["name"] == "Platform Default Selector v1"
+    assert branch["author"] == "platform"
+    node_ids = [n["node_id"] for n in branch.get("node_defs", [])]
+    assert "rank" in node_ids
+
+
+# ---------------------------------------------------------------------------
+# resolve_selector_branch_version_id — binding vs default
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_returns_goal_binding_when_set(base_path):
+    # Bind the goal to a deliberately-fake bvid so we don't accidentally
+    # publish a default; we just want to confirm the resolver prefers
+    # the explicit binding.
+    _make_goal(
+        base_path, "g1",
+        selector_branch_version_id="some_branch@deadbeef",
+    )
+    from workflow.api.selector_dispatch import resolve_selector_branch_version_id
+    result = resolve_selector_branch_version_id(base_path, goal_id="g1")
+    assert result["ok"] is True
+    assert result["branch_version_id"] == "some_branch@deadbeef"
+    assert result["source"] == "goal_binding"
+
+
+def test_resolve_falls_back_to_platform_default(base_path):
+    _make_goal(base_path, "g1", selector_branch_version_id=None)
+    from workflow.api.selector_dispatch import (
+        DEFAULT_SELECTOR_BRANCH_DEF_ID,
+        resolve_selector_branch_version_id,
+    )
+    result = resolve_selector_branch_version_id(base_path, goal_id="g1")
+    assert result["ok"] is True
+    assert result["source"] == "platform_default"
+    assert result["branch_version_id"].startswith(
+        DEFAULT_SELECTOR_BRANCH_DEF_ID + "@",
+    )
+
+
+def test_resolve_returns_goal_not_found_for_missing_goal(base_path):
+    from workflow.api.selector_dispatch import resolve_selector_branch_version_id
+    result = resolve_selector_branch_version_id(base_path, goal_id="never")
+    assert result["ok"] is False
+    assert result["error_kind"] == "goal_not_found"
+
+
+# ---------------------------------------------------------------------------
+# dispatch_selector — empty candidate set
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_short_circuits_on_empty_candidates(base_path):
+    _make_goal(base_path, "g1")
+    from workflow.api.selector_dispatch import dispatch_selector
+    result = dispatch_selector(
+        base_path, goal_id="g1", candidate_branches=[],
+    )
+    assert result["ok"] is True
+    assert result["ranked_entries"] == []
+    assert result["source"] == "empty_candidate_set"
+    # No selector publish should have happened — we short-circuited
+    # before resolving.
+    from workflow.api.selector_dispatch import (
+        DEFAULT_SELECTOR_BRANCH_DEF_ID,
+    )
+    from workflow.daemon_server import get_branch_definition
+    with pytest.raises(KeyError):
+        get_branch_definition(
+            base_path, branch_def_id=DEFAULT_SELECTOR_BRANCH_DEF_ID,
+        )
+
+
+# ---------------------------------------------------------------------------
+# _parse_ranked_entries — output shape validation
+# ---------------------------------------------------------------------------
+
+
+def _parse(output):
+    from workflow.api.selector_dispatch import _parse_ranked_entries
+    return _parse_ranked_entries(output)
+
+
+def test_parse_accepts_list_directly():
+    result = _parse({
+        "ranked_entries": [
+            {"branch_def_id": "b1", "score": 9.0, "rationale": "top"},
+            {"branch_def_id": "b2", "score": 5.0, "rationale": "mid"},
+        ],
+    })
+    assert result["ok"] is True
+    assert [e["branch_def_id"] for e in result["ranked_entries"]] == ["b1", "b2"]
+    assert result["ranked_entries"][0]["score"] == 9.0
+    assert result["ranked_entries"][0]["rationale"] == "top"
+
+
+def test_parse_accepts_json_string():
+    result = _parse({
+        "ranked_entries": '[{"branch_def_id":"b1","score":7.5}]',
+    })
+    assert result["ok"] is True
+    assert result["ranked_entries"][0]["branch_def_id"] == "b1"
+    assert result["ranked_entries"][0]["score"] == 7.5
+
+
+def test_parse_strips_markdown_fence_from_json_string():
+    """A common LLM failure mode is wrapping JSON in ```json … ```.
+    The parser must tolerate the fence so an otherwise-correct
+    selector doesn't fail the contract on a cosmetic wrapper."""
+    result = _parse({
+        "ranked_entries": (
+            "```json\n"
+            '[{"branch_def_id":"b1","score":6.0}]\n'
+            "```"
+        ),
+    })
+    assert result["ok"] is True
+    assert result["ranked_entries"][0]["branch_def_id"] == "b1"
+
+
+def test_parse_unwraps_full_object_stuffed_into_field():
+    """Some prompts emit the full ``{"ranked_entries": [...]}`` object
+    in the field itself. Substrate unwraps."""
+    result = _parse({
+        "ranked_entries": (
+            '{"ranked_entries":[{"branch_def_id":"b1","score":4.0}]}'
+        ),
+    })
+    assert result["ok"] is True
+    assert result["ranked_entries"][0]["branch_def_id"] == "b1"
+
+
+def test_parse_rejects_missing_key():
+    result = _parse({"something_else": []})
+    assert result["ok"] is False
+    assert result["error_kind"] == "selector_invalid_output"
+    assert "ranked_entries" in result["error"]
+
+
+def test_parse_rejects_non_list():
+    result = _parse({"ranked_entries": {"not": "a list"}})
+    assert result["ok"] is False
+    assert result["error_kind"] == "selector_invalid_output"
+
+
+def test_parse_rejects_non_decodable_string():
+    result = _parse({"ranked_entries": "not valid json{{"})
+    assert result["ok"] is False
+    assert result["error_kind"] == "selector_invalid_output"
+
+
+def test_parse_rejects_entry_without_branch_def_id():
+    result = _parse({
+        "ranked_entries": [
+            {"score": 7.0, "rationale": "no id"},
+        ],
+    })
+    assert result["ok"] is False
+    assert result["error_kind"] == "selector_invalid_output"
+    assert "branch_def_id" in result["error"]
+
+
+def test_parse_rejects_entry_without_score():
+    result = _parse({
+        "ranked_entries": [
+            {"branch_def_id": "b1", "rationale": "no score"},
+        ],
+    })
+    assert result["ok"] is False
+    assert result["error_kind"] == "selector_invalid_output"
+    assert "score" in result["error"]
+
+
+def test_parse_rejects_non_coercible_score():
+    result = _parse({
+        "ranked_entries": [
+            {"branch_def_id": "b1", "score": "not a number"},
+        ],
+    })
+    assert result["ok"] is False
+    assert result["error_kind"] == "selector_invalid_output"
+    assert "score" in result["error"]
+
+
+def test_parse_rejects_empty_branch_def_id():
+    result = _parse({
+        "ranked_entries": [
+            {"branch_def_id": "  ", "score": 7.0},
+        ],
+    })
+    assert result["ok"] is False
+    assert result["error_kind"] == "selector_invalid_output"
+
+
+def test_parse_accepts_optional_fields_missing():
+    """rationale + branch_version_id are optional; their absence is
+    not a contract violation."""
+    result = _parse({
+        "ranked_entries": [
+            {"branch_def_id": "b1", "score": 5},
+        ],
+    })
+    assert result["ok"] is True
+    assert result["ranked_entries"][0]["rationale"] == ""
+    assert result["ranked_entries"][0]["branch_version_id"] == ""
+
+
+def test_parse_normalizes_score_to_float():
+    """LLMs emit ints sometimes. Substrate coerces to float so
+    downstream typing is stable."""
+    result = _parse({
+        "ranked_entries": [
+            {"branch_def_id": "b1", "score": 5},
+        ],
+    })
+    assert isinstance(result["ranked_entries"][0]["score"], float)
+
+
+# ---------------------------------------------------------------------------
+# Configurable selector timeout
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_timeout_reads_env(monkeypatch):
+    from workflow.api.selector_dispatch import (
+        SELECTOR_TIMEOUT_ENV,
+        SELECTOR_TIMEOUT_S_DEFAULT,
+        _resolve_timeout,
+    )
+    monkeypatch.delenv(SELECTOR_TIMEOUT_ENV, raising=False)
+    assert _resolve_timeout(None) == SELECTOR_TIMEOUT_S_DEFAULT
+    monkeypatch.setenv(SELECTOR_TIMEOUT_ENV, "30")
+    assert _resolve_timeout(None) == 30.0
+    # Explicit arg wins over env.
+    assert _resolve_timeout(45.0) == 45.0
+
+
+def test_resolve_timeout_clamps_to_min_one_second(monkeypatch):
+    from workflow.api.selector_dispatch import _resolve_timeout
+    assert _resolve_timeout(0.0) == 1.0
+    assert _resolve_timeout(-5) == 1.0

--- a/tests/test_selector_dispatch.py
+++ b/tests/test_selector_dispatch.py
@@ -817,3 +817,179 @@ def test_dispatch_threads_fallback_diagnostic_to_caller(base_path):
     assert result["fellback_from"]["status"] == "rolled_back"
 
 
+# ---------------------------------------------------------------------------
+# Round-5 P1 — platform default rolled back must fail closed
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_default_returns_empty_when_existing_default_rolled_back(
+    base_path,
+):
+    """Round-5 P1 — ``publish_branch_version`` is deterministic in
+    ``(branch_def_id, content_hash)``. If an operator rolls back the
+    platform default selector (every existing default version's
+    status flipped to ``rolled_back``), a subsequent
+    ``ensure_default_selector_published`` call would hit the
+    deterministic re-publish path and get back the SAME rolled-back
+    row. ``ensure_default_selector_published`` must detect that and
+    return empty so callers surface ``default_selector_unavailable``
+    rather than silently dispatching a rolled-back selector.
+    """
+    from workflow.api.selector_dispatch import (
+        DEFAULT_SELECTOR_BRANCH_DEF_ID,
+        ensure_default_selector_published,
+    )
+
+    # First call mints the active default.
+    bvid = ensure_default_selector_published(base_path)
+    assert bvid.startswith(DEFAULT_SELECTOR_BRANCH_DEF_ID + "@")
+
+    # Operator-style rollback: flip every existing default's status.
+    _flip_branch_version_status(base_path, bvid, "rolled_back")
+
+    # Second call sees no active version, calls publish_branch_version
+    # (deterministic) which returns the existing rolled-back row.
+    # ensure_default_selector_published must NOT return that bvid.
+    second = ensure_default_selector_published(base_path)
+    assert second == "", (
+        "ensure_default_selector_published returned %r for a "
+        "rolled-back default — expected '' so the caller surfaces "
+        "default_selector_unavailable" % (second,)
+    )
+
+
+def test_resolve_surfaces_default_unavailable_when_default_rolled_back(
+    base_path,
+):
+    """Round-5 P1 — when ``ensure_default_selector_published`` returns
+    empty (rolled-back default), ``resolve_selector_branch_version_id``
+    must surface a structured ``default_selector_unavailable`` error
+    to the leaderboard caller rather than crashing or dispatching."""
+    _make_goal(base_path, "g-default-rolled-back")
+    from workflow.api.selector_dispatch import (
+        ensure_default_selector_published,
+        resolve_selector_branch_version_id,
+    )
+
+    bvid = ensure_default_selector_published(base_path)
+    _flip_branch_version_status(base_path, bvid, "rolled_back")
+
+    result = resolve_selector_branch_version_id(
+        base_path, goal_id="g-default-rolled-back",
+    )
+    assert result["ok"] is False, result
+    assert result["error_kind"] == "default_selector_unavailable"
+
+
+def test_dispatch_selector_rejects_inactive_at_dispatch_time(
+    base_path, monkeypatch,
+):
+    """Round-5 P1 — dispatch-time status guard. The resolve-time
+    check + ``ensure_default_selector_published`` fail-closed cover
+    the normal lifecycle, but the dispatch path must ALSO re-check
+    ``status='active'`` immediately before ``_execute_branch_core``
+    to close the resolve-then-rollback TOCTOU race + defend against
+    any future caller that threads a branch_version_id past the
+    resolve helper.
+
+    We exercise the guard specifically by monkeypatching the resolve
+    helper to return a (rolled-back) branch_version_id so the
+    resolve-time check is bypassed and the dispatch-time guard is
+    the only thing standing between caller and ``_execute_branch_core``.
+    """
+    _make_goal(base_path, "g-dispatch-guard")
+    custom_bvid = _publish_custom_selector(
+        base_path, branch_def_id="custom_dispatch_guard_selector",
+    )
+    _flip_branch_version_status(base_path, custom_bvid, "rolled_back")
+
+    # Force resolve to return the rolled-back bvid (bypass its own
+    # status re-check). The dispatch-time guard is the only defense
+    # left.
+    from workflow.api import selector_dispatch as sd
+
+    def _fake_resolve(base_path, *, goal_id):
+        return {
+            "ok": True,
+            "branch_version_id": custom_bvid,
+            "source": "goal_binding",
+        }
+
+    monkeypatch.setattr(
+        sd, "resolve_selector_branch_version_id", _fake_resolve,
+    )
+
+    candidates = [{
+        "branch_def_id": "b1",
+        "branch_version_id": "",
+        "name": "b1",
+        "author": "alice",
+        "description": "",
+        "signals": {},
+    }]
+    blocked = sd.dispatch_selector(
+        base_path,
+        goal_id="g-dispatch-guard",
+        candidate_branches=candidates,
+        provider_call=_selector_stub_provider(candidate_ids=["b1"]),
+    )
+    assert blocked["ok"] is False, blocked
+    assert blocked["error_kind"] == "selector_version_inactive_at_dispatch"
+    assert blocked["branch_version_id"] == custom_bvid
+    assert blocked["status"] == "rolled_back"
+
+
+def test_quality_leaderboard_unavailable_when_default_rolled_back(base_path):
+    """Round-5 P1 — build_quality_leaderboard end-to-end. Roll back
+    every default-selector version, then call the leaderboard with no
+    explicit binding. The leaderboard must surface a structured error
+    indicating the selector is unavailable rather than silently
+    dispatching the rolled-back row (which was the Codex round-4
+    reproduction).
+    """
+    from workflow.api.quality_leaderboard import build_quality_leaderboard
+    from workflow.api.selector_dispatch import (
+        ensure_default_selector_published,
+    )
+    from workflow.daemon_server import save_branch_definition, save_goal
+
+    save_goal(
+        base_path,
+        goal=dict(
+            goal_id="g-leader-default-rolled",
+            name="g-leader",
+            description="",
+            author="host",
+            tags=[],
+            visibility="public",
+        ),
+    )
+    save_branch_definition(
+        base_path,
+        branch_def=dict(
+            branch_def_id="b-leader",
+            name="b-leader",
+            description="",
+            author="alice",
+            tags=[],
+            graph_nodes=[],
+            edges=[],
+            state_schema=[],
+            entry_point="",
+            published=True,
+            goal_id="g-leader-default-rolled",
+        ),
+    )
+
+    bvid = ensure_default_selector_published(base_path)
+    _flip_branch_version_status(base_path, bvid, "rolled_back")
+
+    result = build_quality_leaderboard(
+        base_path,
+        goal_id="g-leader-default-rolled",
+        viewer="",
+    )
+    # The leaderboard surfaces the substrate failure, not the rolled-
+    # back selector's stale ranking.
+    assert result.get("ok") is False, result
+    assert result.get("error_kind") == "default_selector_unavailable"

--- a/tests/test_selector_dispatch.py
+++ b/tests/test_selector_dispatch.py
@@ -334,3 +334,180 @@ def test_resolve_timeout_clamps_to_min_one_second(monkeypatch):
     from workflow.api.selector_dispatch import _resolve_timeout
     assert _resolve_timeout(0.0) == 1.0
     assert _resolve_timeout(-5) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end integration — round 2 P1.1 regression guard
+#
+# Build + publish a real selector branch, bind it on a real Goal, call
+# recommend_parent_for_fork without mocking dispatch_selector. Asserts:
+# selector ran via _execute_branch_core, leaderboard non-empty,
+# selector source = "goal_binding", rationale is selector-emitted.
+# ---------------------------------------------------------------------------
+
+
+def _selector_stub_provider(*, candidate_ids: list[str]):
+    """Build a stub provider_call that emits a valid selector JSON
+    payload covering the given candidate ids.
+
+    Used by the e2e regression tests: no real LLM, but the substrate
+    runs the published selector branch through ``_execute_branch_core``
+    and the parser unwraps the JSON string the stub emits — proving
+    snapshot reconstruction + graph compile + node dispatch + output
+    parsing all wire correctly.
+    """
+    import json as _json
+
+    def _call(prompt, system="", *, role=""):
+        ranked = [
+            {
+                "branch_def_id": cid,
+                "branch_version_id": "",
+                "score": 5.0 - i,
+                "rationale": f"stub ranked {cid} at position {i + 1}",
+            }
+            for i, cid in enumerate(candidate_ids)
+        ]
+        return _json.dumps({"ranked_entries": ranked})
+
+    return _call
+
+
+def test_end_to_end_selector_dispatch_with_real_published_branch(base_path):
+    """Round-2 P1.1 regression guard.
+
+    Round-1 monkeypatched ``dispatch_selector`` everywhere, so the
+    snapshot reconstruction bug (immutable snapshot strips ``name``
+    → ``validate()`` rejects with "Branch name is required") was
+    never caught. This test exercises the full path: real selector
+    branch + real Goal + a deterministic provider stub →
+    ``recommend_parent_for_fork`` returns a non-empty leaderboard
+    backed by a real ``_execute_branch_core`` selector run.
+
+    ``dispatch_selector`` is NOT mocked. Only ``provider_call`` is
+    threaded as a stub (the substrate's own injection point — same
+    as ``_action_run_branch_version`` accepts). This is the seam
+    real production code uses to bind providers.
+    """
+    from workflow.api.quality_leaderboard import recommend_parent_for_fork
+    from workflow.api.selector_dispatch import (
+        ensure_default_selector_published,
+    )
+    from workflow.daemon_server import (
+        save_branch_definition,
+        save_goal,
+        update_goal,
+    )
+
+    save_goal(
+        base_path,
+        goal=dict(
+            goal_id="g-e2e",
+            name="E2E Goal",
+            description="",
+            author="host",
+            tags=[],
+            visibility="public",
+        ),
+    )
+    save_branch_definition(
+        base_path,
+        branch_def=dict(
+            branch_def_id="b-e2e",
+            name="b-e2e",
+            description="end-to-end candidate",
+            author="alice",
+            tags=[],
+            graph_nodes=[],
+            edges=[],
+            state_schema=[],
+            entry_point="",
+            published=True,
+            goal_id="g-e2e",
+        ),
+    )
+
+    # Bind the platform default selector explicitly so we exercise
+    # the goal_binding resolution path (not just the lazy
+    # platform_default fallback).
+    default_bvid = ensure_default_selector_published(base_path)
+    update_goal(
+        base_path,
+        goal_id="g-e2e",
+        updates={"selector_branch_version_id": default_bvid},
+    )
+
+    # Provider stub returns valid selector JSON for the candidate
+    # set. The substrate threads it all the way through compile +
+    # node dispatch + output parsing.
+    stub = _selector_stub_provider(candidate_ids=["b-e2e"])
+    result = recommend_parent_for_fork(
+        base_path, goal_id="g-e2e", viewer="", provider_call=stub,
+    )
+
+    assert result.get("ok") is True, result
+    assert result.get("error_kind") is None
+    assert result["leaderboard_size"] == 1
+    parent = result["recommended_parent"]
+    assert parent is not None
+    assert parent["branch_def_id"] == "b-e2e"
+    assert result["selector"]["source"] == "goal_binding"
+    assert result["selector"]["branch_version_id"] == default_bvid
+    # Real run_id (non-empty string) — proves _execute_branch_core
+    # actually ran the selector graph.
+    assert result["selector"]["run_id"]
+    # Selector emitted the stub rationale verbatim.
+    assert "stub ranked b-e2e" in result["rationale"]
+
+
+def test_end_to_end_platform_default_fallback(base_path):
+    """Same end-to-end shape but with NO explicit selector binding.
+
+    The leaderboard caller resolves to the platform default selector
+    on the fly and the substrate publishes it lazily. Asserts the
+    no-binding fallback path also runs end-to-end without snapshot
+    reconstruction errors.
+    """
+    from workflow.api.quality_leaderboard import recommend_parent_for_fork
+    from workflow.daemon_server import save_branch_definition, save_goal
+
+    save_goal(
+        base_path,
+        goal=dict(
+            goal_id="g-fallback",
+            name="Fallback Goal",
+            description="",
+            author="host",
+            tags=[],
+            visibility="public",
+        ),
+    )
+    save_branch_definition(
+        base_path,
+        branch_def=dict(
+            branch_def_id="b-fallback",
+            name="b-fallback",
+            description="",
+            author="alice",
+            tags=[],
+            graph_nodes=[],
+            edges=[],
+            state_schema=[],
+            entry_point="",
+            published=True,
+            goal_id="g-fallback",
+        ),
+    )
+
+    stub = _selector_stub_provider(candidate_ids=["b-fallback"])
+    result = recommend_parent_for_fork(
+        base_path, goal_id="g-fallback", viewer="",
+        provider_call=stub,
+    )
+
+    assert result.get("ok") is True, result
+    assert result["recommended_parent"]["branch_def_id"] == "b-fallback"
+    # Source is platform_default because no explicit binding existed.
+    assert result["selector"]["source"] == "platform_default"
+    # Stub rationale flowed through.
+    assert "stub ranked b-fallback" in result["rationale"]

--- a/tests/test_selector_dispatch.py
+++ b/tests/test_selector_dispatch.py
@@ -105,17 +105,31 @@ def test_default_selector_branch_def_exists_after_publish(base_path):
 
 
 def test_resolve_returns_goal_binding_when_set(base_path):
-    # Bind the goal to a deliberately-fake bvid so we don't accidentally
-    # publish a default; we just want to confirm the resolver prefers
-    # the explicit binding.
+    """Resolver prefers explicit ``selector_branch_version_id`` over
+    the platform default.
+
+    Round 4 (P1.C): the resolver now also verifies the bound version
+    is still active. The binding must point at a REAL active version
+    — a fake bvid would correctly fall back to platform default (see
+    ``test_resolve_falls_back_when_bound_selector_version_missing``).
+    Publish a custom selector via the default-selector helper, then
+    bind to it.
+    """
+    from workflow.api.selector_dispatch import (
+        ensure_default_selector_published,
+        resolve_selector_branch_version_id,
+    )
+    # Publish a real active selector (the platform default itself is
+    # fine for this test — we just need a known-active bvid for the
+    # binding to point at).
+    bvid = ensure_default_selector_published(base_path)
     _make_goal(
         base_path, "g1",
-        selector_branch_version_id="some_branch@deadbeef",
+        selector_branch_version_id=bvid,
     )
-    from workflow.api.selector_dispatch import resolve_selector_branch_version_id
     result = resolve_selector_branch_version_id(base_path, goal_id="g1")
     assert result["ok"] is True
-    assert result["branch_version_id"] == "some_branch@deadbeef"
+    assert result["branch_version_id"] == bvid
     assert result["source"] == "goal_binding"
 
 
@@ -511,3 +525,295 @@ def test_end_to_end_platform_default_fallback(base_path):
     assert result["selector"]["source"] == "platform_default"
     # Stub rationale flowed through.
     assert "stub ranked b-fallback" in result["rationale"]
+
+
+# ---------------------------------------------------------------------------
+# DESIGN-008 round 4 P1.C — rolled-back selector cannot keep dispatching
+# ---------------------------------------------------------------------------
+
+
+def _flip_branch_version_status(base_path, branch_version_id, status):
+    """Direct SQL flip of ``branch_versions.status`` for test setup.
+
+    Simulates the post-bind state where a rollback (or any other
+    lifecycle operation) marks the version as no longer ``active``.
+    """
+    from workflow.branch_versions import _connect
+    with _connect(base_path) as conn:
+        conn.execute(
+            "UPDATE branch_versions SET status = ? "
+            "WHERE branch_version_id = ?",
+            (status, branch_version_id),
+        )
+
+
+def _publish_custom_selector(
+    base_path, branch_def_id="custom_test_selector",
+):
+    """Publish a custom selector branch_version distinct from the
+    platform default so tests can flip ITS status without disturbing
+    the fallback target."""
+    from workflow.branch_versions import publish_branch_version
+    from workflow.daemon_server import (
+        get_branch_definition,
+        save_branch_definition,
+    )
+    save_branch_definition(
+        base_path,
+        branch_def=dict(
+            branch_def_id=branch_def_id,
+            name=branch_def_id,
+            description="",
+            author="alice",
+            tags=[],
+            graph_nodes=[
+                {
+                    "id": "rank",
+                    "type": "prompt",
+                    "input_keys": ["candidate_branches"],
+                    "output_keys": ["ranked_entries"],
+                },
+            ],
+            edges=[
+                {"from": "START", "to": "rank"},
+                {"from": "rank", "to": "END"},
+            ],
+            state_schema=[
+                {"name": "candidate_branches", "type": "str"},
+                {"name": "ranked_entries", "type": "str"},
+            ],
+            entry_point="rank",
+            published=True,
+            node_defs=[
+                {
+                    "node_id": "rank",
+                    "display_name": "Rank",
+                    "phase": "custom",
+                    "input_keys": ["candidate_branches"],
+                    "output_keys": ["ranked_entries"],
+                    "prompt_template": "rank {candidate_branches}",
+                },
+            ],
+        ),
+    )
+    branch_dict = get_branch_definition(
+        base_path, branch_def_id=branch_def_id,
+    )
+    version = publish_branch_version(
+        base_path, branch_dict, publisher="alice",
+    )
+    return version.branch_version_id
+
+
+def test_resolve_falls_back_when_bound_selector_is_rolled_back(base_path):
+    """Round-4 P1.C — bound selector version flipped to rolled_back
+    AFTER bind must NOT keep being returned as goal_binding. Resolver
+    falls back to platform default with a ``fellback_from`` diagnostic.
+
+    Uses a CUSTOM selector so the rollback doesn't disturb the
+    platform-default fallback target.
+    """
+    _make_goal(base_path, "g1")
+    custom_bvid = _publish_custom_selector(base_path)
+    from workflow.api.selector_dispatch import (
+        resolve_selector_branch_version_id,
+    )
+    from workflow.daemon_server import update_goal
+    update_goal(
+        base_path,
+        goal_id="g1",
+        updates={"selector_branch_version_id": custom_bvid},
+    )
+    # Simulate rollback of the bound selector.
+    _flip_branch_version_status(base_path, custom_bvid, "rolled_back")
+
+    result = resolve_selector_branch_version_id(base_path, goal_id="g1")
+    assert result["ok"] is True
+    assert result["source"] == "platform_default", (
+        "resolver must fall back to platform default when the bound "
+        "selector is no longer active; got "
+        f"source={result.get('source')!r}"
+    )
+    assert "fellback_from" in result
+    fb = result["fellback_from"]
+    assert fb["branch_version_id"] == custom_bvid
+    assert fb["reason"] == "selector_version_inactive"
+    assert fb["status"] == "rolled_back"
+
+
+def test_resolve_falls_back_when_bound_selector_version_missing(base_path):
+    """Defense in depth — bound version row missing from branch_versions
+    (e.g. hard-deleted by an administrator). Resolver falls back +
+    surfaces a different ``reason`` so audit tools can distinguish."""
+    _make_goal(base_path, "g1")
+    from workflow.api.selector_dispatch import resolve_selector_branch_version_id
+    from workflow.daemon_server import update_goal
+    update_goal(
+        base_path,
+        goal_id="g1",
+        updates={"selector_branch_version_id": "phantom@deadbeef"},
+    )
+    result = resolve_selector_branch_version_id(base_path, goal_id="g1")
+    assert result["ok"] is True
+    assert result["source"] == "platform_default"
+    assert result["fellback_from"]["reason"] == "selector_version_not_found"
+
+
+def test_resolve_logs_fallback_with_clear_operator_guidance(
+    base_path, caplog,
+):
+    """Stale binding must emit a WARNING naming the goal + bvid +
+    status so operators can find it in logs and re-bind."""
+    import logging
+    _make_goal(base_path, "g-stale")
+    custom_bvid = _publish_custom_selector(
+        base_path, branch_def_id="stale_test_selector",
+    )
+    from workflow.api.selector_dispatch import resolve_selector_branch_version_id
+    from workflow.daemon_server import update_goal
+    update_goal(
+        base_path,
+        goal_id="g-stale",
+        updates={"selector_branch_version_id": custom_bvid},
+    )
+    _flip_branch_version_status(base_path, custom_bvid, "rolled_back")
+    with caplog.at_level(
+        logging.WARNING, logger="workflow.api.selector_dispatch",
+    ):
+        resolve_selector_branch_version_id(base_path, goal_id="g-stale")
+    matching = [
+        rec for rec in caplog.records
+        if rec.levelno >= logging.WARNING
+        and "g-stale" in str(rec.getMessage())
+        and custom_bvid in str(rec.getMessage())
+    ]
+    assert matching, (
+        "expected WARNING naming goal + bvid; got "
+        f"{[r.getMessage() for r in caplog.records]}"
+    )
+
+
+def test_dispatch_threads_fallback_diagnostic_to_caller(base_path):
+    """End-to-end: bind a CUSTOM selector → flip it to rolled_back →
+    dispatch must run the platform default fallback AND surface
+    ``fellback_from`` on the dispatch result for the leaderboard
+    caller to render.
+
+    Uses a CUSTOM selector so that flipping its status to rolled_back
+    leaves the platform default's deterministic active version
+    untouched (and available as the fallback target).
+    """
+    _make_goal(base_path, "g1")
+    from workflow.branch_versions import publish_branch_version
+    from workflow.daemon_server import (
+        get_branch_definition,
+        save_branch_definition,
+        update_goal,
+    )
+    # Candidate branch the leaderboard will rank.
+    save_branch_definition(
+        base_path,
+        branch_def=dict(
+            branch_def_id="b1",
+            name="b1",
+            description="",
+            author="alice",
+            tags=[],
+            graph_nodes=[],
+            edges=[],
+            state_schema=[],
+            entry_point="",
+            published=True,
+            goal_id="g1",
+        ),
+    )
+    # Publish a CUSTOM selector branch (distinct from platform
+    # default) so we can flip ITS status without disturbing the
+    # fallback target.
+    save_branch_definition(
+        base_path,
+        branch_def=dict(
+            branch_def_id="custom_selector_for_test",
+            name="custom selector",
+            description="",
+            author="alice",
+            tags=[],
+            graph_nodes=[
+                {
+                    "id": "rank",
+                    "type": "prompt",
+                    "input_keys": ["candidate_branches"],
+                    "output_keys": ["ranked_entries"],
+                },
+            ],
+            edges=[
+                {"from": "START", "to": "rank"},
+                {"from": "rank", "to": "END"},
+            ],
+            state_schema=[
+                {"name": "candidate_branches", "type": "str"},
+                {"name": "ranked_entries", "type": "str"},
+            ],
+            entry_point="rank",
+            published=True,
+            node_defs=[
+                {
+                    "node_id": "rank",
+                    "display_name": "Rank",
+                    "phase": "custom",
+                    "input_keys": ["candidate_branches"],
+                    "output_keys": ["ranked_entries"],
+                    "prompt_template": "rank {candidate_branches}",
+                },
+            ],
+        ),
+    )
+    custom_branch_dict = get_branch_definition(
+        base_path, branch_def_id="custom_selector_for_test",
+    )
+    custom_version = publish_branch_version(
+        base_path, custom_branch_dict, publisher="alice",
+    )
+    custom_bvid = custom_version.branch_version_id
+
+    update_goal(
+        base_path,
+        goal_id="g1",
+        updates={"selector_branch_version_id": custom_bvid},
+    )
+    _flip_branch_version_status(base_path, custom_bvid, "rolled_back")
+
+    from workflow.api.selector_dispatch import (
+        DEFAULT_SELECTOR_BRANCH_DEF_ID,
+        dispatch_selector,
+    )
+    stub = _selector_stub_provider(candidate_ids=["b1"])
+    candidates = [{
+        "branch_def_id": "b1",
+        "branch_version_id": "",
+        "name": "b1",
+        "author": "alice",
+        "description": "",
+        "signals": {},
+    }]
+    result = dispatch_selector(
+        base_path,
+        goal_id="g1",
+        candidate_branches=candidates,
+        provider_call=stub,
+    )
+    assert result["ok"] is True, result
+    # Substrate fell back to platform default; the rolled-back custom
+    # selector was NOT dispatched.
+    assert result["source"] == "platform_default"
+    assert result["branch_version_id"].startswith(
+        DEFAULT_SELECTOR_BRANCH_DEF_ID + "@",
+    )
+    assert result["branch_version_id"] != custom_bvid
+    # Diagnostic carries the stale binding so callers can prompt the
+    # operator to re-bind.
+    assert result["fellback_from"]["branch_version_id"] == custom_bvid
+    assert result["fellback_from"]["reason"] == "selector_version_inactive"
+    assert result["fellback_from"]["status"] == "rolled_back"
+
+

--- a/workflow/api/extensions_leaderboard_actions.py
+++ b/workflow/api/extensions_leaderboard_actions.py
@@ -133,6 +133,19 @@ def _render_leaderboard_text(board: dict[str, Any]) -> str:
         f"'{goal.get('name')}' ({board.get('goal_id')})"
         if goal else f"Goal {board.get('goal_id')}"
     )
+    # DESIGN-008: surface selector failures via the text channel so a
+    # misbehaving selector renders cleanly in the chatbot. The
+    # structured payload also carries error_kind for programmatic
+    # consumers.
+    if board.get("ok") is False:
+        err_kind = board.get("error_kind", "selector_error")
+        err = board.get("error", "")
+        return (
+            f"Selector failed for {goal_label} (`{err_kind}`): {err}. "
+            "Operator action: rebind a working selector via "
+            "`goals action=set_selector branch_version_id=…` or "
+            "unbind to fall back to the platform default."
+        )
     if not entries:
         return (
             f"No Branches are currently bound to {goal_label}. "

--- a/workflow/api/market.py
+++ b/workflow/api/market.py
@@ -1559,6 +1559,95 @@ def _action_goal_archive_consultation(kwargs: dict[str, Any]) -> str:
     }, default=str)
 
 
+def _action_goal_set_selector(kwargs: dict[str, Any]) -> str:
+    """Bind (or unbind) a Goal's selector branch — DESIGN-008.
+
+    The selector branch is the published Workflow branch the
+    substrate dispatches to rank a Goal's bound branches. Pass
+    ``branch_version_id=""`` to unbind (fall back to platform
+    default selector).
+
+    Authority: only Goal author or a host-level actor may bind a
+    selector — same surface as ``set_canonical``.
+
+    Required kwargs:
+      * ``goal_id`` — Goal whose selector is being bound.
+
+    Optional kwargs:
+      * ``branch_version_id`` — selector branch_version to bind, or
+        empty string / omitted to unbind.
+
+    Returns:
+      * ``{status: "ok", selector_branch_version_id: ...}`` on bind/unbind.
+      * ``{status: "rejected", error: ...}`` on auth failure / bad input
+        / non-active version.
+    """
+    from workflow.api.branches import _ensure_workflow_db
+    from workflow.api.engine_helpers import _current_actor
+    from workflow.daemon_server import get_goal, set_selector_branch
+
+    gid = (kwargs.get("goal_id") or "").strip()
+    if not gid:
+        return json.dumps({
+            "status": "rejected",
+            "error": "goal_id is required for set_selector.",
+        })
+    raw_bvid = (kwargs.get("branch_version_id") or "").strip()
+    branch_version_id = raw_bvid or None
+    _ensure_workflow_db()
+
+    try:
+        goal = get_goal(_base_path(), goal_id=gid)
+    except KeyError:
+        return json.dumps({
+            "status": "rejected",
+            "error": f"Goal '{gid}' not found.",
+        })
+
+    actor = _current_actor()
+    host_actor = os.environ.get("UNIVERSE_SERVER_HOST_USER", "host")
+    if actor != goal["author"] and actor != host_actor:
+        return json.dumps({
+            "status": "rejected",
+            "error": (
+                "Only the Goal author or a host-level actor may bind "
+                "the selector branch. Goal author is "
+                f"'{goal['author']}'; request actor is '{actor}'."
+            ),
+        })
+
+    try:
+        updated = set_selector_branch(
+            _base_path(), goal_id=gid,
+            branch_version_id=branch_version_id, set_by=actor,
+        )
+    except ValueError as exc:
+        return json.dumps({"status": "rejected", "error": str(exc)})
+
+    if branch_version_id:
+        text = (
+            f"Selector branch for Goal '{goal['name']}' set to "
+            f"`{branch_version_id}`. Future "
+            "`quality_leaderboard` / `recommend_parent_for_fork` "
+            "calls dispatch this branch to rank candidates."
+        )
+    else:
+        text = (
+            f"Selector branch for Goal '{goal['name']}' unbound. "
+            "Leaderboard calls fall back to the platform default "
+            "selector."
+        )
+
+    return json.dumps({
+        "status": "ok",
+        "text": text,
+        "goal_id": gid,
+        "selector_branch_version_id": updated.get(
+            "selector_branch_version_id",
+        ),
+    }, default=str)
+
+
 def _action_goal_set_canonical(kwargs: dict[str, Any]) -> str:
     from workflow.api.branches import _ensure_workflow_db
     from workflow.api.engine_helpers import (
@@ -1763,6 +1852,11 @@ _GOAL_ACTIONS: dict[str, Any] = {
     # dispatch. Honors auto_canonical_via_leaderboard + threshold +
     # in-flight gate; delegates the actual run to run_branch_version.
     "run_canonical": _action_goal_run_canonical,
+    # DESIGN-008 — user-buildable selector primitive. Bind the
+    # published Workflow branch that synthesizes the Goal's
+    # leaderboard. Pass branch_version_id="" to fall back to the
+    # platform default selector.
+    "set_selector": _action_goal_set_selector,
 }
 
 # Provider-routing compatibility: ChatGPT can render `/mcp-directory` tool
@@ -1776,6 +1870,8 @@ _GOAL_ACTION_ALIASES: dict[str, str] = {
 
 _GOAL_WRITE_ACTIONS: frozenset[str] = frozenset({
     "propose", "update", "bind", "set_canonical",
+    # DESIGN-008 — selector branch binding writes to goals row.
+    "set_selector",
 })
 
 
@@ -1877,6 +1973,14 @@ def goals(
       set_canonical Mark a branch_version_id as the Goal's canonical
                    (best-known) branch. Author-only or host-only.
                    Pass branch_version_id="" to unset.
+      set_selector Bind the Goal's selector branch_version — the
+                   published Workflow branch the substrate dispatches
+                   to rank this Goal's bound branches on the
+                   leaderboard (DESIGN-008). Author-only or
+                   host-only. Pass branch_version_id="" to unbind
+                   and fall back to the platform default selector.
+                   The bound selector MUST conform to the contract
+                   in drafts/concepts/selector-branch-contract.md.
       run_canonical Dispatch a run against the Goal's canonical
                    branch_version. PR-127 (M6 cutover): when
                    ``auto_canonical_via_leaderboard`` is enabled on the

--- a/workflow/api/market.py
+++ b/workflow/api/market.py
@@ -1584,7 +1584,11 @@ def _action_goal_set_selector(kwargs: dict[str, Any]) -> str:
     """
     from workflow.api.branches import _ensure_workflow_db
     from workflow.api.engine_helpers import _current_actor
-    from workflow.daemon_server import get_goal, set_selector_branch
+    from workflow.daemon_server import (
+        SelectorHasEffectsError,
+        get_goal,
+        set_selector_branch,
+    )
 
     gid = (kwargs.get("goal_id") or "").strip()
     if not gid:
@@ -1621,6 +1625,15 @@ def _action_goal_set_selector(kwargs: dict[str, Any]) -> str:
             _base_path(), goal_id=gid,
             branch_version_id=branch_version_id, set_by=actor,
         )
+    except SelectorHasEffectsError as exc:
+        # P1.3 — surface the effects rejection with a structured
+        # error_kind so chatbots can route the operator to the fix
+        # path ("remove effects on offending nodes, then re-bind").
+        return json.dumps({
+            "status": "rejected",
+            "error_kind": "selector_has_effects",
+            "error": str(exc),
+        })
     except ValueError as exc:
         return json.dumps({"status": "rejected", "error": str(exc)})
 

--- a/workflow/api/quality_leaderboard.py
+++ b/workflow/api/quality_leaderboard.py
@@ -1,103 +1,97 @@
-"""Quality leaderboard + parent-selection — PR-123 substrate (M2).
+"""Quality leaderboard + parent-selection — DESIGN-008 (user-buildable selectors).
 
-Surfaces, for any Goal that has competing Branch entries:
+PR-123 originally shipped this surface with a platform-opinionated
+scoring formula baked into Python — weights for runs / forks /
+judgments / recency / gates / safe_to_publish all chosen by the
+platform. PR #978 tried to patch a bug in that formula (timestamp
+coercion); the host closed PR #978 because patching the formula
+entrenches the wrong architecture.
 
-- ``quality_leaderboard(goal_id)`` — ranked list of Branches bound to
-  the Goal, with the per-entry signal summary that produced the score.
-- ``recommended_parent_for_fork(goal_id)`` — the top entry plus a
-  human-readable rationale string, intended as a thin handle for the
-  community designer asking "what should I fork from?".
+DESIGN-008 (host reframe 2026-05-21): selection logic is per-Goal
+**user-buildable**. The substrate collects signals; a Goal-bound
+**selector branch** synthesizes them into rankings. Selector
+branches are normal published Workflow branches conforming to the
+contract documented in
+``drafts/concepts/selector-branch-contract.md``.
 
-Design source: wiki page
-``pages/patch-requests/pr-123-goal-archive-with-parent-selection-...``
-on the live MCP brain. The PLAN Goals & Gates module names this
-surface as ``archive_consultation parent-rank scoring formula`` and
-flags it as **open evolution** — a follow-on may turn the scoring
-formula into an evolvable Workflow node so the community can iterate
-on weights through autoresearch rather than asking the platform to
-ship "the right" constants.
+This module now:
 
-This slice is **best-effort v1**: ranking is signal-driven, not
-ground-truth-driven. The formula constants are surfaced in every
-response under ``formula`` so reviewers can audit and tune them
-without re-reading source.
+* Collects signals per candidate branch (unchanged from the prior
+  shape — these are inputs to the selector, not opinion).
+* Resolves the Goal's selector branch_version (explicit binding via
+  ``set_selector`` OR platform default, see
+  ``workflow.api.selector_dispatch``).
+* Dispatches the selector synchronously (with timeout) via
+  ``execute_branch_version_async`` + ``wait_for``.
+* Parses + validates the ``ranked_entries`` output.
+* Returns the ranked leaderboard.
 
-Goal-generic by design — same primitive works for patch-loops AND
-fantasy-writing AND recipe-trackers AND any community. No
-Loop-2-specific assumptions.
+What was DELETED in DESIGN-008
+------------------------------
 
-Signals (all read from existing storage; no new tables in this slice):
+* ``W_JUDGMENT`` / ``W_RUNS`` / ``W_FORKS`` / ``W_RECENCY`` /
+  ``W_GATE`` / ``W_SAFE_PUBLISH`` / ``W_FAILED_PENALTY`` constants.
+  Weights now live in the default selector's prompt.
+* ``RECENCY_HALFLIFE_DAYS``, ``JUDGMENT_MAX_SCALE``. Same story.
+* ``_score_components`` — the per-term formula application.
+* ``_entry_sort_key`` — sort order is selector-emitted ``score``
+  desc; ties tolerated.
+* ``_formula_disclosure`` — there's no platform formula to
+  disclose. Selectors disclose their own logic in their prompt.
+* ``_build_rationale`` — rationale is selector-emitted per entry.
+* ``_timestamp_to_epoch`` (the PR #978 patch) — never landed on
+  main, but the original ``float(...)`` coercion that crashed on
+  ISO strings is also gone because signals are now passed as a
+  list of dicts to the selector branch, not consumed by Python
+  scoring code.
 
-- ``completed_run_count`` — runs with ``status='completed'``.
-- ``failed_run_count`` — runs with ``status='failed'`` (penalty).
-- ``total_run_count`` — full count regardless of status.
-- ``last_successful_run_at`` — max ``finished_at`` of completed runs.
-- ``recency_decay`` — ``exp(-age_days/30)`` against the wall clock;
-  0 when the branch never produced a successful run.
-- ``judgment_count`` — rows in ``run_judgments`` joined via ``runs``.
-- ``judgment_score_avg`` — mean of numeric scores parsed from
-  judgment tags like ``quality:8.2``, ``novelty:7``, ``risk:3``.
-  None when no numeric tags exist (the signal contributes 0 to the
-  score in that case rather than NaN-propagating).
-- ``fork_count`` — branches whose ``parent_def_id`` or ``fork_from``
-  references this branch. Community votes with their forks.
-- ``gate_rung_top`` — the lexicographically-greatest active
-  ``rung_key`` from ``gate_claims`` for this (branch, goal).
-- ``safe_to_publish`` — best-effort read of
-  ``branch.stats.next_action_packet.safe_to_publish``. The packet
-  shape isn't on-disk-stable yet; if absent, the signal contributes 0.
+Visibility / auth-boundary contract (preserved from round-2)
+------------------------------------------------------------
 
-Score formula (weights surfaced in the response so they are auditable):
+``viewer`` is the actor identity for which visibility is resolved
+and MUST be derived server-side by the caller (never accepted from
+an MCP input). Pass an empty string for the strictly-public view.
+Private branches authored by the viewer are surfaced in the
+candidate set passed to the selector; private branches authored by
+other actors are filtered out. The selector's ranking output is
+relative to that visibility-bounded candidate set.
 
-  score = 3.0 * normalized_judgment_score
-        + 1.5 * log1p(completed_run_count)
-        + 2.0 * log1p(fork_count)
-        + 2.0 * recency_decay
-        + 1.0 * has_gate_rung
-        + 1.5 * safe_to_publish
-        - 1.0 * log1p(failed_run_count)
+Cost note
+---------
 
-``normalized_judgment_score`` is ``judgment_score_avg / 10.0`` (DGM
-scores are on a 0-10 scale) clamped to [0, 1] so the term is bounded.
-log1p bounds the impact of high-volume entries; recency / gate /
-safe_to_publish are already [0, 1].
-
-Tie-breaks: higher ``last_successful_run_at`` wins; then higher
-``created_at`` (newer entry); then ``branch_def_id`` for stability.
+Each leaderboard build now triggers one LLM call (the selector
+run). The old formula was free. Acceptable trade for the
+architectural win; a future slice may add caching keyed by
+(goal_id, candidate fingerprint) for N minutes.
 """
 
 from __future__ import annotations
 
-import math
+import logging
 import re
 from pathlib import Path
 from typing import Any
 
-# ---------------------------------------------------------------------------
-# Tunable weights — surfaced in the response under ``formula``
-# ---------------------------------------------------------------------------
+# Module-level import so test code can monkeypatch
+# ``workflow.api.quality_leaderboard.dispatch_selector``.
+from workflow.api.selector_dispatch import dispatch_selector
 
-W_JUDGMENT = 3.0
-W_RUNS = 1.5
-W_FORKS = 2.0
-W_RECENCY = 2.0
-W_GATE = 1.0
-W_SAFE_PUBLISH = 1.5
-W_FAILED_PENALTY = 1.0
+logger = logging.getLogger(__name__)
 
-RECENCY_HALFLIFE_DAYS = 30.0
-JUDGMENT_MAX_SCALE = 10.0  # DGM-style 0-10
 
 # Numeric judgment-tag pattern: ``key:N`` where N is integer/float.
 # Examples that match: ``quality:8``, ``quality:8.2``, ``novelty:7.5``,
 # ``risk:3``. Negative numbers and tags without ``:N`` are ignored.
+# Preserved from the round-1 implementation because it's pure parsing,
+# not opinion: ``_judgment_stats`` produces a signal the selector
+# branches consume.
 _NUMERIC_TAG_RE = re.compile(
     r"^\s*([A-Za-z][A-Za-z0-9_\-]*)\s*:\s*([0-9]+(?:\.[0-9]+)?)\s*$"
 )
 
 # Tag names that contribute to the average quality signal. Tags outside
-# this set are recorded under ``other_numeric_tags`` so the chatbot can
-# surface them without polluting the headline score.
+# this set are bucketed under ``other_numeric_tags`` for the selector
+# to surface or ignore at its discretion.
 _QUALITY_TAG_KEYS = frozenset({"quality", "novelty", "score"})
 
 
@@ -115,43 +109,58 @@ def build_quality_leaderboard(
 ) -> dict[str, Any]:
     """Compute the ranked list of branches bound to ``goal_id``.
 
-    Returns ``{"goal_id": ..., "goal": <row | None>, "entries": [...],
-    "formula": {...}, "generated_at": ...}``.
+    DESIGN-008: dispatches the Goal's selector branch (explicit
+    binding or platform default) over the collected signals and
+    returns its ``ranked_entries`` as the leaderboard.
 
-    Visibility / auth-boundary contract (round-2 P1.1 fix)
-    ------------------------------------------------------
-    ``viewer`` is the actor identity for which visibility is resolved
-    and MUST be derived server-side by the caller (never accepted from
-    an MCP input). Pass an empty string for the "strictly public" view
-    (no private branches included). The function does NOT accept an
-    ``include_private`` knob — that surface was caller-controllable in
-    round-1 and let an MCP caller flip visibility by passing
-    ``force=true``. To inspect private branches from a host/internal
-    script, build the response directly via the storage helpers; this
-    public entry point ALWAYS applies the public-or-author-owned
-    visibility filter.
+    Returns one of:
 
-    Each entry is::
+    Success::
 
         {
-            "rank":             1,
-            "branch_def_id":    "...",
-            "name":             "...",
-            "description":      "...",
-            "author":           "...",
-            "created_at":       <unix>,
-            "updated_at":       <unix>,
-            "score":            <float>,
-            "signals":          {<see Signals section above>},
-            "score_components": {<per-term contribution to score>},
+            "ok": True,
+            "goal_id": "...",
+            "goal": <goal-row | None>,
+            "entries": [
+                {
+                    "rank": 1,
+                    "branch_def_id": "...",
+                    "branch_version_id": "...",
+                    "name": "...",
+                    "author": "...",
+                    "score": <float>,
+                    "rationale": "<selector-emitted explanation>",
+                    "signals": {<the signal map for transparency>},
+                },
+                ...
+            ],
+            "selector": {
+                "branch_version_id": "...",
+                "source": "goal_binding" | "platform_default",
+                "run_id": "...",
+            },
+            "generated_at": <unix>,
         }
 
-    The function returns the ranked entries even when the Goal does not
-    exist or has no bound branches — the chatbot can render a friendly
-    "no entries yet" page from ``entries == []``.
+    Selector failure (selector unresolvable, dispatch failed,
+    timeout, invalid output)::
 
-    ``base_path`` is the daemon's data root (matches the rest of the
-    storage layer).
+        {
+            "ok": False,
+            "error_kind": "<see selector_dispatch error_kinds>",
+            "error": "...",
+            "goal_id": "...",
+            "goal": <goal-row | None>,
+            "entries": [],
+            "selector": {...partial selector context...},
+            "generated_at": <unix>,
+        }
+
+    Visibility: ``viewer`` is the server-derived actor identity.
+    Empty string means strictly-public. Private branches authored by
+    other actors are filtered before the selector sees them.
+
+    ``base_path`` is the daemon's data root.
     """
     if now is None:
         import time as _time
@@ -160,13 +169,6 @@ def build_quality_leaderboard(
     goal_row = _safe_get_goal(base_path, goal_id)
 
     from workflow.daemon_server import list_branch_definitions
-    # P1.1 fix — visibility is ALWAYS the public-or-author-owned filter.
-    # ``include_private`` is hard-False at this seam: there's no MCP
-    # surface that legitimately needs to bypass this filter, and round-1
-    # let a caller-supplied ``force=true`` flip it. If a future internal
-    # caller genuinely needs every row, it must reach for the storage
-    # helpers directly with explicit ``include_private=True`` — that
-    # path is host/internal-only and not reachable from MCP.
     branches = list_branch_definitions(
         base_path,
         goal_id=goal_id,
@@ -174,41 +176,108 @@ def build_quality_leaderboard(
         include_private=False,
     )
 
-    entries: list[dict[str, Any]] = []
+    # Collect signals per candidate. The signal shape is the same as
+    # the round-1 implementation — those primitives are inputs, not
+    # opinion. The selector branch consumes them.
+    candidates: list[dict[str, Any]] = []
+    signals_by_branch: dict[str, dict[str, Any]] = {}
+    branch_meta_by_id: dict[str, dict[str, Any]] = {}
     for branch in branches:
+        bid = branch["branch_def_id"]
         signals = _collect_signals_for_branch(
             base_path, branch, now=now, viewer=viewer,
         )
-        components = _score_components(signals)
-        score = sum(components.values())
-        entries.append({
-            "branch_def_id": branch["branch_def_id"],
+        signals_by_branch[bid] = signals
+        latest_bvid = _latest_active_version_id(base_path, bid)
+        candidate = {
+            "branch_def_id": bid,
+            "branch_version_id": latest_bvid,
             "name": branch.get("name", ""),
-            "description": branch.get("description", ""),
             "author": branch.get("author", ""),
+            "description": branch.get("description", ""),
+            "signals": signals,
+        }
+        candidates.append(candidate)
+        branch_meta_by_id[bid] = {
+            "name": branch.get("name", ""),
+            "author": branch.get("author", ""),
+            "description": branch.get("description", ""),
             "created_at": branch.get("created_at", 0.0),
             "updated_at": branch.get("updated_at", 0.0),
-            "score": round(score, 4),
-            "signals": signals,
-            "score_components": {
-                k: round(v, 4) for k, v in components.items()
+            "branch_version_id": latest_bvid,
+        }
+
+    # Dispatch the selector. Empty candidate set short-circuits to
+    # an empty leaderboard without burning an LLM call.
+    dispatch_result = dispatch_selector(
+        base_path,
+        goal_id=goal_id,
+        candidate_branches=candidates,
+        actor=viewer or "anonymous",
+    )
+
+    if not dispatch_result.get("ok"):
+        return {
+            "ok": False,
+            "error_kind": dispatch_result.get(
+                "error_kind", "selector_invalid_output",
+            ),
+            "error": dispatch_result.get("error", ""),
+            "goal_id": goal_id,
+            "goal": goal_row,
+            "entries": [],
+            "selector": {
+                "branch_version_id": dispatch_result.get(
+                    "branch_version_id",
+                ),
+                "run_id": dispatch_result.get("run_id"),
             },
+            "generated_at": now,
+        }
+
+    raw_entries = dispatch_result.get("ranked_entries") or []
+    entries: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for rank_idx, raw in enumerate(raw_entries, start=1):
+        bid = (raw.get("branch_def_id") or "").strip()
+        if not bid or bid in seen:
+            # Skip dupes / blanks defensively — the selector should
+            # not emit them, but a misbehaving selector shouldn't
+            # corrupt the response.
+            continue
+        seen.add(bid)
+        meta = branch_meta_by_id.get(bid, {})
+        signals = signals_by_branch.get(bid, {})
+        entries.append({
+            "rank": rank_idx,
+            "branch_def_id": bid,
+            "branch_version_id": (
+                raw.get("branch_version_id")
+                or meta.get("branch_version_id")
+                or ""
+            ),
+            "name": meta.get("name", ""),
+            "author": meta.get("author", ""),
+            "description": meta.get("description", ""),
+            "created_at": meta.get("created_at", 0.0),
+            "updated_at": meta.get("updated_at", 0.0),
+            "score": float(raw.get("score") or 0.0),
+            "rationale": raw.get("rationale", ""),
+            # Pass the signal map through so the chatbot can surface
+            # "why this ranked here" without re-querying storage.
+            "signals": signals,
         })
 
-    # Two-pass stable sort. First pass: branch_def_id ascending (string
-    # compare). Second pass: primary keys with reverse=True. Python's
-    # sort is stable, so the secondary key from the first pass survives
-    # within ties of the primary sort.
-    entries.sort(key=lambda e: e.get("branch_def_id", ""))
-    entries.sort(key=_entry_sort_key, reverse=True)
-    for rank, entry in enumerate(entries, start=1):
-        entry["rank"] = rank
-
     return {
+        "ok": True,
         "goal_id": goal_id,
         "goal": goal_row,
         "entries": entries,
-        "formula": _formula_disclosure(),
+        "selector": {
+            "branch_version_id": dispatch_result.get("branch_version_id"),
+            "source": dispatch_result.get("source"),
+            "run_id": dispatch_result.get("run_id"),
+        },
         "generated_at": now,
     }
 
@@ -220,19 +289,35 @@ def recommend_parent_for_fork(
     viewer: str,
     now: float | None = None,
 ) -> dict[str, Any]:
-    """Return the top leaderboard entry plus a human-readable rationale.
+    """Return the top selector-ranked entry plus its rationale.
 
-    Returns ``{"goal_id": ..., "recommended_parent": <entry | None>,
-    "rationale": "...", "leaderboard_size": <int>, "generated_at": ...}``.
+    Returns one of:
 
-    Visibility contract matches :func:`build_quality_leaderboard` —
-    ``viewer`` must be server-derived; private branches the viewer does
-    not own are excluded.
+    Success with parent::
 
-    When no branch is bound to the Goal the response carries
-    ``recommended_parent=None`` and a rationale explaining that no
-    parent exists yet — the chatbot should propose "create the first
-    branch" rather than "fork from".
+        {
+            "ok": True,
+            "goal_id": "...",
+            "recommended_parent": <entry>,
+            "rationale": "<selector-emitted>",
+            "leaderboard_size": <int>,
+            "selector": {...},
+            "generated_at": <unix>,
+        }
+
+    No parent (no candidates / empty leaderboard)::
+
+        {
+            "ok": True,
+            "goal_id": "...",
+            "recommended_parent": None,
+            "rationale": "<friendly explanation>",
+            "leaderboard_size": 0,
+            ...
+        }
+
+    Selector failure surfaces the same error_kind as
+    :func:`build_quality_leaderboard`.
     """
     board = build_quality_leaderboard(
         base_path,
@@ -240,9 +325,22 @@ def recommend_parent_for_fork(
         viewer=viewer,
         now=now,
     )
+    if not board.get("ok"):
+        return {
+            "ok": False,
+            "error_kind": board.get("error_kind"),
+            "error": board.get("error", ""),
+            "goal_id": goal_id,
+            "recommended_parent": None,
+            "rationale": "",
+            "leaderboard_size": 0,
+            "selector": board.get("selector") or {},
+            "generated_at": board.get("generated_at"),
+        }
     entries = board["entries"]
     if not entries:
         return {
+            "ok": True,
             "goal_id": goal_id,
             "recommended_parent": None,
             "rationale": (
@@ -251,20 +349,32 @@ def recommend_parent_for_fork(
                 "fork from a peer Goal's leaderboard."
             ),
             "leaderboard_size": 0,
+            "selector": board.get("selector") or {},
             "generated_at": board["generated_at"],
         }
     top = entries[0]
+    rationale = top.get("rationale") or ""
+    if not rationale:
+        rationale = (
+            f"'{top.get('name') or top['branch_def_id']}' "
+            f"(#{top['branch_def_id']}) ranked first of "
+            f"{len(entries)} bound Branches with score "
+            f"{top.get('score', 0.0):.2f}. (Selector did not provide "
+            "a per-entry rationale.)"
+        )
     return {
+        "ok": True,
         "goal_id": goal_id,
         "recommended_parent": top,
-        "rationale": _build_rationale(top, leaderboard_size=len(entries)),
+        "rationale": rationale,
         "leaderboard_size": len(entries),
+        "selector": board.get("selector") or {},
         "generated_at": board["generated_at"],
     }
 
 
 # ---------------------------------------------------------------------------
-# Signal collection
+# Signal collection (preserved — these are selector inputs, not opinion)
 # ---------------------------------------------------------------------------
 
 
@@ -280,9 +390,6 @@ def _collect_signals_for_branch(
 
     run_stats = _run_stats(base_path, bid)
     judgment_stats = _judgment_stats(base_path, bid)
-    # P1.2 fix — fork count respects viewer visibility. Counting raw
-    # descendant rows would leak existence of private forks (the row
-    # was hidden from the listing but the aggregate count exposed it).
     fork_count = _fork_count(base_path, bid, viewer=viewer)
     gate_rung_top = _gate_rung_top(base_path, bid, goal_id)
     safe_to_publish = _safe_to_publish(branch)
@@ -290,10 +397,8 @@ def _collect_signals_for_branch(
     last_ok = run_stats["last_successful_run_at"]
     if last_ok and last_ok > 0:
         age_days = max(0.0, (now - last_ok) / 86400.0)
-        recency_decay = math.exp(-age_days / RECENCY_HALFLIFE_DAYS)
     else:
         age_days = None
-        recency_decay = 0.0
 
     return {
         "total_run_count": run_stats["total"],
@@ -301,7 +406,6 @@ def _collect_signals_for_branch(
         "failed_run_count": run_stats["failed"],
         "last_successful_run_at": last_ok,
         "age_days_since_success": age_days,
-        "recency_decay": round(recency_decay, 4),
         "judgment_count": judgment_stats["count"],
         "judgment_score_avg": judgment_stats["score_avg"],
         "judgment_score_samples": judgment_stats["score_samples"],
@@ -314,12 +418,7 @@ def _collect_signals_for_branch(
 
 
 def _run_stats(base_path: str | Path, branch_def_id: str) -> dict[str, Any]:
-    """Aggregate counts + last_successful_run_at directly against runs DB.
-
-    A direct SQL aggregate is cheaper than fetching every row via
-    ``list_runs`` — this is invoked once per branch on the leaderboard
-    and a Goal can carry 50+ branches.
-    """
+    """Aggregate counts + last_successful_run_at directly against runs DB."""
     from workflow.runs import _connect, initialize_runs_db
 
     initialize_runs_db(base_path)
@@ -342,25 +441,37 @@ def _run_stats(base_path: str | Path, branch_def_id: str) -> dict[str, Any]:
             "total": 0, "completed": 0, "failed": 0,
             "last_successful_run_at": 0.0,
         }
+    # last_successful_run_at is REAL but SQLite type-affinity is
+    # permissive. We coerce defensively because the selector branch
+    # consumes the value as a number (and the prompt template
+    # renderer will just str() whatever it gets). An ISO string here
+    # would be confusing for the LLM, so we normalize to a float
+    # epoch when the value is parseable as such.
+    raw = row["last_successful_run_at"]
+    if raw is None or raw == "":
+        last_ok = 0.0
+    else:
+        try:
+            last_ok = float(raw)
+        except (TypeError, ValueError):
+            # Best-effort: try ISO 8601.
+            try:
+                from datetime import datetime
+                last_ok = datetime.fromisoformat(str(raw)).timestamp()
+            except (TypeError, ValueError):
+                last_ok = 0.0
     return {
         "total": int(row["total"] or 0),
         "completed": int(row["completed"] or 0),
         "failed": int(row["failed"] or 0),
-        "last_successful_run_at": float(row["last_successful_run_at"] or 0.0),
+        "last_successful_run_at": last_ok,
     }
 
 
 def _judgment_stats(
     base_path: str | Path, branch_def_id: str,
 ) -> dict[str, Any]:
-    """Parse numeric scores out of judgment tags scoped to this branch.
-
-    Judgments are free-text + tags; the leaderboard reads ``tags_json``
-    looking for ``key:N`` patterns where ``key`` is in
-    ``_QUALITY_TAG_KEYS`` for the headline score. Other numeric tags are
-    bucketed under ``other_numeric_tags`` for surface-level reporting
-    but don't contribute to the score in this slice.
-    """
+    """Parse numeric scores out of judgment tags scoped to this branch."""
     from workflow.runs import _connect, initialize_runs_db
     from workflow.storage import _json_loads
 
@@ -417,15 +528,10 @@ def _fork_count(
 ) -> int:
     """Count descendants the ``viewer`` can see.
 
-    Either ``parent_def_id`` or ``fork_from`` may reference this branch
-    — count rows whose either column matches AND that pass the same
-    visibility filter ``list_branch_definitions`` applies (public OR
-    authored by the viewer). This closes the round-2 P1.2 finding: a
-    naive raw count exposed the existence of private descendant rows
-    even when the rows themselves were hidden from the listing.
-
-    Passing ``viewer=""`` matches the "strictly public" semantics —
-    counts only public descendants, never private ones.
+    Same visibility-respecting query as the round-1 implementation
+    (the auth-boundary contract from PR-970 round 2 P1.2). The
+    selector branch consumes the count; visibility filtering happens
+    here.
     """
     from workflow.storage import _connect
 
@@ -457,9 +563,9 @@ def _gate_rung_top(
 ) -> str | None:
     """Return the highest active gate rung for (branch, goal), or None.
 
-    "Highest" in this slice is lexicographically-greatest ``rung_key``
-    among non-retracted claims. Goal-ladder-aware ordering is a follow-on
-    once the ladder shape is stable per-Goal.
+    Lexicographically-greatest among non-retracted claims.
+    Goal-ladder-aware ordering is a follow-on once ladder shape is
+    stable per-Goal.
     """
     if not goal_id:
         return None
@@ -487,12 +593,7 @@ def _gate_rung_top(
 
 
 def _safe_to_publish(branch: dict[str, Any]) -> bool:
-    """Best-effort lookup of a Loop-2-style next_action_packet flag.
-
-    The packet shape isn't on-disk-stable yet; nodes that emit it write
-    into the branch ``stats`` JSON. When absent, the signal is False
-    rather than missing — score contribution is 0 either way.
-    """
+    """Best-effort lookup of a Loop-2-style next_action_packet flag."""
     stats = branch.get("stats")
     if not isinstance(stats, dict):
         return False
@@ -514,163 +615,32 @@ def _safe_get_goal(
         return None
 
 
-# ---------------------------------------------------------------------------
-# Scoring
-# ---------------------------------------------------------------------------
-
-
-def _score_components(signals: dict[str, Any]) -> dict[str, float]:
-    """Per-term contributions to score. Surfaced in the response so the
-    chatbot can render "why this one ranked first" without re-computing.
-    """
-    score_avg = signals.get("judgment_score_avg")
-    if score_avg is None:
-        normalized_judgment = 0.0
-    else:
-        normalized_judgment = max(0.0, min(1.0, score_avg / JUDGMENT_MAX_SCALE))
-
-    completed = max(0, int(signals.get("completed_run_count") or 0))
-    failed = max(0, int(signals.get("failed_run_count") or 0))
-    fork_count = max(0, int(signals.get("fork_count") or 0))
-    recency = float(signals.get("recency_decay") or 0.0)
-    has_gate = 1.0 if signals.get("has_gate_rung") else 0.0
-    safe_pub = 1.0 if signals.get("safe_to_publish") else 0.0
-
-    return {
-        "judgment":  W_JUDGMENT * normalized_judgment,
-        "runs":      W_RUNS * math.log1p(completed),
-        "forks":     W_FORKS * math.log1p(fork_count),
-        "recency":   W_RECENCY * recency,
-        "gate":      W_GATE * has_gate,
-        "safe_pub":  W_SAFE_PUBLISH * safe_pub,
-        "failed_penalty": -W_FAILED_PENALTY * math.log1p(failed),
-    }
-
-
-def _entry_sort_key(entry: dict[str, Any]) -> tuple:
-    """Primary sort key for ranked entries (used with ``reverse=True``).
-
-    Tuple order:
-      1. ``score`` — higher is better.
-      2. ``last_successful_run_at`` — newer success wins ties.
-      3. ``created_at`` — newer branch wins ties.
-
-    Final ``branch_def_id`` tie-break is handled by a separate stable
-    sort pass before this one is applied — see ``build_quality_leaderboard``.
-    """
-    signals = entry.get("signals") or {}
-    return (
-        float(entry.get("score") or 0.0),
-        float(signals.get("last_successful_run_at") or 0.0),
-        float(entry.get("created_at") or 0.0),
-    )
-
-
-# ---------------------------------------------------------------------------
-# Disclosure + rationale
-# ---------------------------------------------------------------------------
-
-
-def _formula_disclosure() -> dict[str, Any]:
-    return {
-        "weights": {
-            "judgment": W_JUDGMENT,
-            "runs": W_RUNS,
-            "forks": W_FORKS,
-            "recency": W_RECENCY,
-            "gate": W_GATE,
-            "safe_publish": W_SAFE_PUBLISH,
-            "failed_penalty": -W_FAILED_PENALTY,
-        },
-        "recency_halflife_days": RECENCY_HALFLIFE_DAYS,
-        "judgment_max_scale": JUDGMENT_MAX_SCALE,
-        "judgment_tag_keys": sorted(_QUALITY_TAG_KEYS),
-        "tie_breakers": [
-            "last_successful_run_at desc",
-            "created_at desc",
-            "branch_def_id asc",
-        ],
-        "notes": (
-            "Best-effort v1. Weights are initial guesses surfaced for "
-            "audit. Per PLAN Goals & Gates, the parent-rank scoring "
-            "formula is open evolution — a follow-on slice will let "
-            "the community iterate weights via an evolvable Workflow "
-            "node rather than ship constants."
-        ),
-    }
-
-
-def _build_rationale(
-    top_entry: dict[str, Any], *, leaderboard_size: int,
+def _latest_active_version_id(
+    base_path: str | Path, branch_def_id: str,
 ) -> str:
-    """Compose the human-readable rationale string for the top entry."""
-    signals = top_entry.get("signals") or {}
-    name = top_entry.get("name") or top_entry.get("branch_def_id") or "(unnamed)"
-    parts: list[str] = []
-    parts.append(
-        f"'{name}' (#{top_entry.get('branch_def_id')}) ranked first of "
-        f"{leaderboard_size} bound Branches with score "
-        f"{top_entry.get('score', 0.0):.2f}."
-    )
+    """Return the newest active ``branch_version_id`` for the def, or "".
 
-    score_pieces: list[str] = []
-    judgment_avg = signals.get("judgment_score_avg")
-    if judgment_avg is not None:
-        score_pieces.append(
-            f"avg judgment score {judgment_avg:.2f}/{int(JUDGMENT_MAX_SCALE)} "
-            f"across {int(signals.get('judgment_score_samples') or 0)} sample(s)"
+    Returns ``""`` when the branch has not been published yet OR
+    every published version has been rolled back / superseded.
+    Matches the PR-127 round-2 active-only filter on
+    ``canonical_dispatch._latest_published_version_id``.
+    """
+    if not branch_def_id:
+        return ""
+    try:
+        from workflow.branch_versions import list_branch_versions
+        versions = list_branch_versions(
+            base_path, branch_def_id=branch_def_id, limit=50,
         )
-    completed = int(signals.get("completed_run_count") or 0)
-    if completed:
-        score_pieces.append(f"{completed} completed run(s)")
-    forks = int(signals.get("fork_count") or 0)
-    if forks:
-        score_pieces.append(f"{forks} community fork(s)")
-    age = signals.get("age_days_since_success")
-    if age is not None:
-        if age < 1:
-            age_phrase = "under a day ago"
-        elif age < 2:
-            age_phrase = "yesterday"
-        else:
-            age_phrase = f"{int(age)} days ago"
-        score_pieces.append(f"most recent successful run {age_phrase}")
-    rung = signals.get("gate_rung_top")
-    if rung:
-        score_pieces.append(f"highest gate rung claimed: '{rung}'")
-    if signals.get("safe_to_publish"):
-        score_pieces.append("flagged safe_to_publish by its own packet")
-    failed = int(signals.get("failed_run_count") or 0)
-    if failed:
-        score_pieces.append(f"({failed} failed run(s) — penalty applied)")
-
-    if score_pieces:
-        parts.append("Signals: " + "; ".join(score_pieces) + ".")
-    else:
-        parts.append(
-            "No quality signals yet — ranking is by recency / author "
-            "registration only. Treat as a tentative parent until the "
-            "first judgment lands."
-        )
-
-    parts.append(
-        "Note: this is a best-effort v1 recommendation. Inspect the "
-        "score_components in the leaderboard entry to see which "
-        "signals dominated the rank."
-    )
-    return " ".join(parts)
+    except Exception:
+        return ""
+    for v in versions:
+        if getattr(v, "status", "active") == "active":
+            return v.branch_version_id or ""
+    return ""
 
 
 __all__ = [
     "build_quality_leaderboard",
     "recommend_parent_for_fork",
-    "W_JUDGMENT",
-    "W_RUNS",
-    "W_FORKS",
-    "W_RECENCY",
-    "W_GATE",
-    "W_SAFE_PUBLISH",
-    "W_FAILED_PENALTY",
-    "RECENCY_HALFLIFE_DAYS",
-    "JUDGMENT_MAX_SCALE",
 ]

--- a/workflow/api/quality_leaderboard.py
+++ b/workflow/api/quality_leaderboard.py
@@ -349,6 +349,12 @@ def build_quality_leaderboard(
             "branch_version_id": dispatch_result.get("branch_version_id"),
             "source": dispatch_result.get("source"),
             "run_id": dispatch_result.get("run_id"),
+            # P1.C (round 4) — when the bound selector_branch_version_id
+            # was inactive at dispatch time, the substrate fell back to
+            # the platform default. ``fellback_from`` carries the old
+            # binding + reason so the chatbot can prompt the operator
+            # to re-bind. None when no fallback happened.
+            "fellback_from": dispatch_result.get("fellback_from"),
         },
         "generated_at": now,
     }

--- a/workflow/api/quality_leaderboard.py
+++ b/workflow/api/quality_leaderboard.py
@@ -106,6 +106,7 @@ def build_quality_leaderboard(
     goal_id: str,
     viewer: str,
     now: float | None = None,
+    provider_call: Any = None,
 ) -> dict[str, Any]:
     """Compute the ranked list of branches bound to ``goal_id``.
 
@@ -214,6 +215,7 @@ def build_quality_leaderboard(
         goal_id=goal_id,
         candidate_branches=candidates,
         actor=viewer or "anonymous",
+        provider_call=provider_call,
     )
 
     if not dispatch_result.get("ok"):
@@ -238,18 +240,30 @@ def build_quality_leaderboard(
     raw_entries = dispatch_result.get("ranked_entries") or []
     entries: list[dict[str, Any]] = []
     seen: set[str] = set()
-    for rank_idx, raw in enumerate(raw_entries, start=1):
+    phantom_ids: list[str] = []
+    # Rank is assigned post-filter so phantom/dupe/blank rows do
+    # not leave gaps in the user-facing rank sequence.
+    for raw in raw_entries:
         bid = (raw.get("branch_def_id") or "").strip()
         if not bid or bid in seen:
             # Skip dupes / blanks defensively — the selector should
             # not emit them, but a misbehaving selector shouldn't
             # corrupt the response.
             continue
+        # P1.2 (DESIGN-008 round 2): selector output can fabricate
+        # branch_def_ids — including private ones the viewer cannot
+        # see — and inject them into the leaderboard. Reject any
+        # branch_def_id that was not in the input candidate set.
+        # ``branch_meta_by_id`` is the authoritative source of
+        # visible candidates (already filtered by viewer +
+        # include_private=False at list_branch_definitions).
+        if bid not in branch_meta_by_id:
+            phantom_ids.append(bid)
+            continue
         seen.add(bid)
-        meta = branch_meta_by_id.get(bid, {})
+        meta = branch_meta_by_id[bid]
         signals = signals_by_branch.get(bid, {})
         entries.append({
-            "rank": rank_idx,
             "branch_def_id": bid,
             "branch_version_id": (
                 raw.get("branch_version_id")
@@ -267,12 +281,32 @@ def build_quality_leaderboard(
             # "why this ranked here" without re-querying storage.
             "signals": signals,
         })
+    # Assign ranks now that phantom entries have been filtered out.
+    for rank_idx, entry in enumerate(entries, start=1):
+        entry["rank"] = rank_idx
+    # Emit a structured warning when the selector tried to inject
+    # phantom IDs. The operator can spot a misbehaving (or
+    # adversarial) selector in their logs / event feed.
+    if phantom_ids:
+        logger.warning(
+            "selector fabricated %d phantom branch_def_id(s) for goal=%s "
+            "selector=%s: %s — entries dropped",
+            len(phantom_ids),
+            goal_id,
+            dispatch_result.get("branch_version_id"),
+            phantom_ids,
+        )
 
     return {
         "ok": True,
         "goal_id": goal_id,
         "goal": goal_row,
         "entries": entries,
+        # P1.2 — surface phantom branch_def_id rejections in the
+        # structured payload so programmatic consumers (and audit
+        # tools) can detect a misbehaving selector without scraping
+        # logs. Empty list when the selector is well-behaved.
+        "phantom_branch_def_ids": phantom_ids,
         "selector": {
             "branch_version_id": dispatch_result.get("branch_version_id"),
             "source": dispatch_result.get("source"),
@@ -288,6 +322,7 @@ def recommend_parent_for_fork(
     goal_id: str,
     viewer: str,
     now: float | None = None,
+    provider_call: Any = None,
 ) -> dict[str, Any]:
     """Return the top selector-ranked entry plus its rationale.
 
@@ -324,6 +359,7 @@ def recommend_parent_for_fork(
         goal_id=goal_id,
         viewer=viewer,
         now=now,
+        provider_call=provider_call,
     )
     if not board.get("ok"):
         return {

--- a/workflow/api/quality_leaderboard.py
+++ b/workflow/api/quality_leaderboard.py
@@ -241,6 +241,12 @@ def build_quality_leaderboard(
     entries: list[dict[str, Any]] = []
     seen: set[str] = set()
     phantom_ids: list[str] = []
+    # P1.A (DESIGN-008 round 3): track selector-emitted version_id
+    # mismatches against the candidate set's authoritative version.
+    # The selector's value is always ignored; this list surfaces the
+    # spoof attempts so audit tools can detect a misbehaving /
+    # adversarial selector without scraping logs.
+    selector_bvid_spoofs: list[dict[str, str]] = []
     # Rank is assigned post-filter so phantom/dupe/blank rows do
     # not leave gaps in the user-facing rank sequence.
     for raw in raw_entries:
@@ -263,13 +269,40 @@ def build_quality_leaderboard(
         seen.add(bid)
         meta = branch_meta_by_id[bid]
         signals = signals_by_branch.get(bid, {})
+        # P1.A (DESIGN-008 round 3): the selector MUST NOT influence
+        # which branch_version_id surfaces in the leaderboard. The
+        # candidate set already carries the authoritative latest
+        # active version per def_id (resolved from
+        # ``branch_versions.status='active'`` at signal collection
+        # time). Trusting ``raw.get("branch_version_id")`` would let
+        # a selector return a real visible def_id paired with a
+        # private / rolled-back / fabricated version id, and the
+        # chatbot would surface it via recommend_parent_for_fork.
+        # The selector's emitted version_id is ignored — only the
+        # candidate set's authoritative bvid is surfaced. A future
+        # slice may allow selectors to pin a specific historical
+        # version, but it must come through a separate validated
+        # mechanism (e.g. selector claims a version, substrate
+        # checks visibility + status='active'), not blind passthrough.
+        spoof_attempt = (raw.get("branch_version_id") or "").strip()
+        authoritative_bvid = (meta.get("branch_version_id") or "")
+        if spoof_attempt and spoof_attempt != authoritative_bvid:
+            logger.warning(
+                "selector emitted branch_version_id=%r for "
+                "branch_def_id=%r that disagrees with the "
+                "authoritative active version %r (goal=%s "
+                "selector=%s); selector value ignored",
+                spoof_attempt, bid, authoritative_bvid, goal_id,
+                dispatch_result.get("branch_version_id"),
+            )
+            selector_bvid_spoofs.append({
+                "branch_def_id": bid,
+                "selector_emitted": spoof_attempt,
+                "authoritative": authoritative_bvid,
+            })
         entries.append({
             "branch_def_id": bid,
-            "branch_version_id": (
-                raw.get("branch_version_id")
-                or meta.get("branch_version_id")
-                or ""
-            ),
+            "branch_version_id": authoritative_bvid,
             "name": meta.get("name", ""),
             "author": meta.get("author", ""),
             "description": meta.get("description", ""),
@@ -307,6 +340,11 @@ def build_quality_leaderboard(
         # tools) can detect a misbehaving selector without scraping
         # logs. Empty list when the selector is well-behaved.
         "phantom_branch_def_ids": phantom_ids,
+        # P1.A (round 3) — surface selector-emitted branch_version_id
+        # spoof attempts. Each entry: {branch_def_id, selector_emitted,
+        # authoritative}. Empty list when the selector is well-behaved.
+        # Selector values are ALWAYS ignored regardless; this is audit.
+        "selector_bvid_spoofs": selector_bvid_spoofs,
         "selector": {
             "branch_version_id": dispatch_result.get("branch_version_id"),
             "source": dispatch_result.get("source"),

--- a/workflow/api/runs.py
+++ b/workflow/api/runs.py
@@ -1525,6 +1525,16 @@ def _action_rollback_merge(kwargs: dict[str, Any]) -> str:
             f"Re-pointed canonical bindings on {repointed_count} Goal(s) "
             "to nearest non-rolled-back ancestor."
         )
+    # DESIGN-008 round 4 — selector bindings are cleared (not walked up)
+    # so the leaderboard read path falls back to the platform default.
+    selector_repoint = result.get("selector_repoint", {})
+    selector_repointed_count = selector_repoint.get("repointed_count", 0)
+    if selector_repointed_count:
+        text_lines.append(
+            f"Cleared selector bindings on {selector_repointed_count} "
+            "Goal(s); leaderboard falls back to platform default until "
+            "operator re-binds via `goals action=set_selector`."
+        )
     return json.dumps({
         "text": "\n".join(text_lines),
         **result,

--- a/workflow/api/selector_dispatch.py
+++ b/workflow/api/selector_dispatch.py
@@ -315,6 +315,18 @@ def ensure_default_selector_published(base_path: str | Path) -> str:
             return v.branch_version_id
 
     # No active version — publish v1.
+    #
+    # P1 (DESIGN-008 round 5): ``publish_branch_version`` is deterministic
+    # in ``(branch_def_id, content_hash)``. When an operator has rolled
+    # back the platform default (every existing version's status flipped
+    # to ``rolled_back``), the re-publish call returns the same existing
+    # rolled-back row (workflow/branch_versions.py:267-273) rather than
+    # minting a fresh active one. Without the post-publish status check
+    # below, ``ensure_default_selector_published`` would silently hand
+    # back a rolled-back branch_version_id, and ``dispatch_selector``
+    # would execute it — defeating the rollback. Fail closed instead:
+    # return empty so the caller (``resolve_selector_branch_version_id``)
+    # surfaces ``default_selector_unavailable``.
     branch_dict = _build_default_selector_branch_dict()
     version = publish_branch_version(
         base_path,
@@ -333,6 +345,20 @@ def ensure_default_selector_published(base_path: str | Path) -> str:
             "publish_branch_version reported success but the row is "
             "not readable post-write."
         )
+    status = getattr(persisted, "status", "active") or "active"
+    if status != "active":
+        logger.warning(
+            "ensure_default_selector_published | publish_branch_version "
+            "returned existing branch_version_id=%r with status=%r "
+            "(deterministic re-publish hit a rolled-back row). Cannot "
+            "dispatch a rolled-back default selector. Operator: "
+            "republish the platform default branch with a content "
+            "change (so a fresh content_hash mints a new active row), "
+            "or bind a custom selector to the affected Goal via "
+            "goals action=set_selector.",
+            persisted.branch_version_id, status,
+        )
+        return ""
     return persisted.branch_version_id
 
 
@@ -614,6 +640,40 @@ def dispatch_selector(
                 "branch_versions."
             ),
             "branch_version_id": bvid,
+        }
+
+    # P1 (DESIGN-008 round 5) — dispatch-time status guard. The
+    # resolve-time check in ``resolve_selector_branch_version_id`` +
+    # the fail-closed semantics in ``ensure_default_selector_published``
+    # cover the normal lifecycle, but a final ``status='active'`` check
+    # here closes any race between resolve and dispatch (TOCTOU) and
+    # protects callers that thread their own ``branch_version_id``
+    # straight in without going through ``resolve_selector_branch_version_id``.
+    # Cheap (one already-loaded attribute read) and idempotent.
+    bv_status = getattr(bv, "status", "active") or "active"
+    if bv_status != "active":
+        logger.warning(
+            "selector dispatch | branch_version_id=%r resolved to "
+            "status=%r at dispatch time (active-only required). "
+            "Refusing to execute a rolled-back / superseded selector.",
+            bvid, bv_status,
+        )
+        return {
+            "ok": False,
+            "error_kind": "selector_version_inactive_at_dispatch",
+            "error": (
+                f"selector branch_version_id {bvid!r} resolved to "
+                f"status={bv_status!r} at dispatch time. The "
+                "selector binding is stale or the platform default "
+                "was rolled back without a fresh active replacement. "
+                "Operator: bind a different active selector via "
+                "goals action=set_selector, unbind to fall back to "
+                "the platform default, or republish the platform "
+                "default with new content so a fresh active version "
+                "is minted."
+            ),
+            "branch_version_id": bvid,
+            "status": bv_status,
         }
 
     snapshot = dict(bv.snapshot or {})

--- a/workflow/api/selector_dispatch.py
+++ b/workflow/api/selector_dispatch.py
@@ -1,0 +1,796 @@
+"""User-buildable selector branch dispatch — DESIGN-008.
+
+The architectural commitment from host's 2026-05-21 reframe: selection
+logic is per-Goal user-buildable, NOT platform-coded. ``quality_leaderboard``
+no longer applies an opinionated formula; instead it dispatches a
+**selector branch** (a published Workflow branch bound to the Goal)
+that consumes signal data and emits ranked entries.
+
+This module owns:
+
+* :func:`resolve_selector_branch_version_id` — return the selector
+  branch_version_id for a Goal. If ``goal.selector_branch_version_id``
+  is set, use it. Otherwise return the platform default selector's
+  branch_version_id (lazily published on first call so the substrate
+  works on a clean DB).
+* :func:`dispatch_selector` — synchronously (with timeout) run a
+  selector branch_version against the supplied candidate set, parse
+  + validate the output shape, return ``ranked_entries`` or a
+  structured error.
+* :func:`ensure_default_selector_published` — idempotent helper that
+  builds + publishes the platform default selector branch on first
+  call. The default is a single prompt-template node that consumes
+  the signal map and asks the LLM to rank — the "weights" are a
+  prompt the chatbot can tune via fork, not Python constants.
+
+Contract for selector branches (see also
+``drafts/concepts/selector-branch-contract.md``):
+
+Inputs (passed as the run's ``inputs`` dict)::
+
+    {
+        "goal_id": "<goal-id>",
+        "candidate_branches": [
+            {
+                "branch_def_id": "...",
+                "branch_version_id": "...",  # latest active version, or ""
+                "name": "...",
+                "author": "...",
+                "signals": {
+                    "completed_run_count": int,
+                    "failed_run_count":    int,
+                    "judgment_score_avg":  float | null,
+                    "judgment_count":      int,
+                    "fork_count":          int,
+                    "last_successful_run_at": float,  # epoch
+                    "has_gate_rung":       bool,
+                    "gate_rung_top":       str | null,
+                    "safe_to_publish":     bool,
+                    "age_days_since_success": float | null,
+                },
+            },
+            ...
+        ],
+    }
+
+Outputs (read from the run's ``output`` dict)::
+
+    {
+        "ranked_entries": [
+            {
+                "branch_def_id":     "...",
+                "branch_version_id": "...",
+                "score":             <float>,
+                "rationale":         "<human-readable why-ranked-here>",
+            },
+            ...  # ordered by rank, best first
+        ],
+    }
+
+Round-1 design choices
+----------------------
+
+* **Sync dispatch with timeout.** The leaderboard caller blocks on the
+  selector run via ``wait_for(run_id, timeout=SELECTOR_TIMEOUT_S)``. The
+  selector pipeline cost is one LLM call per leaderboard build. A
+  future caching slice can memoize results per Goal for N minutes.
+
+* **Visibility is server-derived.** The candidate set passed to the
+  selector is the public-or-author-owned view per PR-970's auth-
+  boundary contract. The selector branch sees only branches the
+  caller has visibility into; private branches authored by other
+  actors are never even mentioned in the input.
+
+* **Default selector is a published branch, not a code path.**
+  ``ensure_default_selector_published`` builds the BranchDefinition
+  in-Python on first call, calls ``save_branch_definition`` +
+  ``publish_branch_version``, and stores the resulting
+  ``branch_version_id`` for return. Subsequent calls find the
+  existing definition and return its current active version.
+
+* **Failure modes surface structured errors.** Selector missing /
+  not published / timed out / invalid output shape all return
+  ``{"ok": False, "error_kind": "..."}`` dicts that the leaderboard
+  caller renders to the chatbot. The leaderboard never crashes;
+  callers see a clear "selector misbehaved" signal rather than a
+  Python traceback.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# How long the selector run is allowed to complete before the
+# leaderboard caller gives up. One LLM call typically lands in <15s;
+# 60s leaves headroom for slower providers + multiple-candidate
+# prompts. Configurable via env so hosts can tune.
+SELECTOR_TIMEOUT_S_DEFAULT = 60.0
+SELECTOR_TIMEOUT_ENV = "WORKFLOW_SELECTOR_TIMEOUT_S"
+
+# Deterministic branch_def_id for the platform default selector.
+# Tests rely on this being stable across processes.
+DEFAULT_SELECTOR_BRANCH_DEF_ID = "platform_default_selector_v1_20260521"
+DEFAULT_SELECTOR_NAME = "Platform Default Selector v1"
+DEFAULT_SELECTOR_AUTHOR = "platform"
+DEFAULT_SELECTOR_PUBLISHER = "platform"
+
+
+# ---------------------------------------------------------------------------
+# Selector resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_selector_branch_version_id(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+) -> dict[str, Any]:
+    """Return the selector branch_version_id for the Goal.
+
+    Resolution order:
+
+      1. ``goal.selector_branch_version_id`` if set.
+      2. Otherwise, the platform default selector's
+         ``branch_version_id`` (published lazily by
+         ``ensure_default_selector_published``).
+
+    Returns ``{"ok": True, "branch_version_id": "...", "source":
+    "goal_binding" | "platform_default"}`` on success or
+    ``{"ok": False, "error_kind": "...", "error": "..."}`` on
+    failure. Never raises.
+    """
+    try:
+        from workflow.daemon_server import get_goal
+        goal = get_goal(base_path, goal_id=goal_id)
+    except KeyError:
+        return {
+            "ok": False,
+            "error_kind": "goal_not_found",
+            "error": f"Goal {goal_id!r} not found.",
+        }
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.exception("resolve_selector | get_goal crashed")
+        return {
+            "ok": False,
+            "error_kind": "goal_load_failed",
+            "error": str(exc),
+        }
+
+    explicit = (goal.get("selector_branch_version_id") or "").strip() or None
+    if explicit:
+        return {
+            "ok": True,
+            "branch_version_id": explicit,
+            "source": "goal_binding",
+        }
+
+    # Fall back to the platform default selector.
+    try:
+        default_bvid = ensure_default_selector_published(base_path)
+    except Exception as exc:
+        logger.exception("resolve_selector | default-selector publish crashed")
+        return {
+            "ok": False,
+            "error_kind": "default_selector_publish_failed",
+            "error": str(exc),
+        }
+    if not default_bvid:
+        return {
+            "ok": False,
+            "error_kind": "default_selector_unavailable",
+            "error": (
+                "Platform default selector branch could not be "
+                "published; no fallback selector available."
+            ),
+        }
+    return {
+        "ok": True,
+        "branch_version_id": default_bvid,
+        "source": "platform_default",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Default selector materialization
+# ---------------------------------------------------------------------------
+
+
+def ensure_default_selector_published(base_path: str | Path) -> str:
+    """Ensure the platform default selector branch + active version exist.
+
+    Returns the active ``branch_version_id``. Idempotent: if the
+    branch_def already exists AND has an active published version,
+    that version's id is returned without re-publishing.
+
+    The branch is a single prompt-template node:
+
+      * Input keys: ``goal_id``, ``candidate_branches`` (the signal
+        bundle the leaderboard collects).
+      * Output keys: ``ranked_entries`` (JSON array of
+        ``{branch_def_id, branch_version_id, score, rationale}``).
+
+    The prompt explicitly instructs the LLM to weight signals and
+    emit valid JSON. Community forks of this branch tune the prompt
+    rather than Python constants.
+    """
+    from workflow.branch_versions import (
+        get_branch_version,
+        list_branch_versions,
+        publish_branch_version,
+    )
+    from workflow.daemon_server import (
+        get_branch_definition,
+        save_branch_definition,
+    )
+
+    # Step 1: ensure the branch_def exists.
+    try:
+        existing = get_branch_definition(
+            base_path, branch_def_id=DEFAULT_SELECTOR_BRANCH_DEF_ID,
+        )
+    except KeyError:
+        existing = None
+
+    if existing is None:
+        branch_dict = _build_default_selector_branch_dict()
+        save_branch_definition(base_path, branch_def=branch_dict)
+
+    # Step 2: find an active published version, else publish one.
+    versions = list_branch_versions(
+        base_path,
+        branch_def_id=DEFAULT_SELECTOR_BRANCH_DEF_ID,
+        limit=50,
+    )
+    for v in versions:
+        if getattr(v, "status", "active") == "active":
+            return v.branch_version_id
+
+    # No active version — publish v1.
+    branch_dict = _build_default_selector_branch_dict()
+    version = publish_branch_version(
+        base_path,
+        branch_dict=branch_dict,
+        publisher=DEFAULT_SELECTOR_PUBLISHER,
+        notes=(
+            "Platform default selector v1 — single prompt-template "
+            "node ranking candidate branches from collected signals. "
+            "Community forks customize the prompt per domain."
+        ),
+    )
+    # Sanity: re-read to confirm row landed + status.
+    persisted = get_branch_version(base_path, version.branch_version_id)
+    if persisted is None:
+        raise RuntimeError(
+            "publish_branch_version reported success but the row is "
+            "not readable post-write."
+        )
+    return persisted.branch_version_id
+
+
+def _build_default_selector_branch_dict() -> dict[str, Any]:
+    """Construct the default selector's BranchDefinition dict.
+
+    Kept as a function (not a constant) so each call returns a fresh
+    dict the storage layer can mutate without aliasing.
+    """
+    prompt = _DEFAULT_SELECTOR_PROMPT
+    node = {
+        "node_id": "rank",
+        "display_name": "Rank Candidates",
+        "description": (
+            "Read candidate_branches + their signals; emit "
+            "ranked_entries JSON in score-desc order."
+        ),
+        "phase": "custom",
+        "input_keys": ["goal_id", "candidate_branches"],
+        "output_keys": ["ranked_entries"],
+        "prompt_template": prompt,
+        "model_hint": "writer",
+        # The prompt-template node consumes ``candidate_branches`` —
+        # a structured JSON-able list. The default prompt-template
+        # renderer treats input_keys as a dict the template's
+        # placeholders are formatted against; the strict_input_isolation
+        # default (True) keeps the prompt from leaking state it
+        # didn't declare.
+    }
+    return {
+        "branch_def_id": DEFAULT_SELECTOR_BRANCH_DEF_ID,
+        "name": DEFAULT_SELECTOR_NAME,
+        "description": (
+            "Platform default selector — ranks candidate branches "
+            "for a Goal's leaderboard using LLM judgment over "
+            "collected signals. Fork + tune the prompt for "
+            "domain-specific selection."
+        ),
+        "author": DEFAULT_SELECTOR_AUTHOR,
+        "domain_id": "workflow",
+        "tags": ["selector", "platform-default", "leaderboard"],
+        "version": 1,
+        "skills": [],
+        "entry_point": "rank",
+        "graph_nodes": [
+            {
+                "id": "rank",
+                "type": "prompt",
+                "phase": "custom",
+                "input_keys": ["goal_id", "candidate_branches"],
+                "output_keys": ["ranked_entries"],
+            },
+        ],
+        "edges": [
+            {"from": "START", "to": "rank"},
+            {"from": "rank", "to": "END"},
+        ],
+        "node_defs": [node],
+        "state_schema": [
+            {"name": "goal_id", "type": "str"},
+            {"name": "candidate_branches", "type": "list"},
+            {"name": "ranked_entries", "type": "list"},
+        ],
+        "published": True,
+        "visibility": "public",
+    }
+
+
+# The default selector prompt. The "weights" are now words that any
+# Goal owner can fork and rewrite for their domain (e.g. fantasy-
+# writing might rank "novelty" higher; bug-investigation might
+# weight "completed_run_count" + "judgment_score_avg" almost
+# exclusively). See ``drafts/concepts/selector-branch-contract.md``
+# for the full input/output spec.
+_DEFAULT_SELECTOR_PROMPT = """\
+You are the **platform default selector** for a Workflow Goal's
+leaderboard. Your job is to rank candidate branches that are competing
+on the same Goal and emit a JSON array describing the ranking.
+
+## Goal context
+goal_id: {goal_id}
+
+## Candidates with collected signals
+{candidate_branches}
+
+## Ranking guidance (default — fork this branch to customize)
+
+Consider, in roughly this order of importance:
+
+1. **judgment_score_avg** — average of numeric judgment tags
+   (quality/novelty/score). When non-null this is the strongest
+   single signal. Treat as ~0-10.
+2. **completed_run_count** — more completed runs = more evidence
+   this branch actually works. Penalty for `failed_run_count`.
+3. **fork_count** — community votes with their forks; high
+   fork_count signals influence + endorsement.
+4. **last_successful_run_at + age_days_since_success** — recency
+   matters; a branch that succeeded yesterday outranks one that
+   succeeded six months ago, all else equal.
+5. **has_gate_rung / gate_rung_top** — branches that have climbed
+   the Goal's gate ladder (real-world impact) outrank those that
+   have not.
+6. **safe_to_publish** — when present, a strong positive signal.
+
+Branches with no completed runs and no judgments rank below
+branches that have *any* signal. A branch with only one completed
+run but high judgment_score_avg can still rank well.
+
+## Output
+
+Emit ONLY a JSON object on a single line (no markdown fence, no
+prose before or after) with the following shape:
+
+```
+{{"ranked_entries":[{{"branch_def_id":"...","branch_version_id":"...","score":<float>,"rationale":"<one sentence>"}},...]}}
+```
+
+Order entries best-first. Use the `branch_version_id` from each
+candidate if non-empty, otherwise the empty string. `score` should
+be on a 0.0-10.0 scale; ties are acceptable. `rationale` is a single
+sentence naming the dominant signals (e.g. "highest judgment avg
+(8.4) with 12 completed runs and 3 community forks").
+
+If `candidate_branches` is empty, return `{{"ranked_entries":[]}}`.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Selector dispatch + result parsing
+# ---------------------------------------------------------------------------
+
+
+def dispatch_selector(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    candidate_branches: list[dict[str, Any]],
+    actor: str = "anonymous",
+    timeout_s: float | None = None,
+) -> dict[str, Any]:
+    """Run the selector branch synchronously + return its ``ranked_entries``.
+
+    Resolves the selector via :func:`resolve_selector_branch_version_id`,
+    dispatches an async run via ``execute_branch_version_async``, blocks
+    on its background future for up to ``timeout_s`` seconds, reads the
+    final ``runs.output_json``, validates the
+    ``ranked_entries`` shape, and returns it.
+
+    Returns one of:
+
+    Success::
+
+        {
+            "ok": True,
+            "branch_version_id": "...",
+            "source": "goal_binding" | "platform_default",
+            "run_id": "...",
+            "ranked_entries": [...],  # validated shape
+        }
+
+    Failure (selector unresolvable, dispatch failed, timeout, or
+    invalid output shape)::
+
+        {
+            "ok": False,
+            "error_kind": "<one of: selector_not_published |
+                            selector_dispatch_failed |
+                            selector_timeout |
+                            selector_run_failed |
+                            selector_invalid_output>",
+            "error": "<human-readable>",
+            # Optional context fields per error_kind:
+            "branch_version_id": "...",
+            "run_id": "...",
+        }
+
+    Empty ``candidate_branches`` short-circuits to
+    ``{ok: True, ranked_entries: []}`` without dispatching — no
+    point burning an LLM call when there's nothing to rank.
+    """
+    # Short-circuit: no candidates means no work.
+    if not candidate_branches:
+        return {
+            "ok": True,
+            "branch_version_id": None,
+            "source": "empty_candidate_set",
+            "run_id": None,
+            "ranked_entries": [],
+        }
+
+    resolution = resolve_selector_branch_version_id(
+        base_path, goal_id=goal_id,
+    )
+    if not resolution.get("ok"):
+        return {
+            "ok": False,
+            "error_kind": resolution.get(
+                "error_kind", "selector_not_published",
+            ),
+            "error": resolution.get("error", ""),
+        }
+    bvid = resolution["branch_version_id"]
+    source = resolution["source"]
+
+    timeout = _resolve_timeout(timeout_s)
+
+    # Build the selector's input dict. ``candidate_branches`` is
+    # serialized as-is — the prompt template's placeholder will
+    # render it via str() / JSON depending on the provider's stub.
+    inputs: dict[str, Any] = {
+        "goal_id": goal_id,
+        "candidate_branches": candidate_branches,
+    }
+
+    # Lazy import to avoid pulling in the run executor at module
+    # import time (matches the rest of the workflow.api seam).
+    from workflow.runs import (
+        SnapshotSchemaDrift,
+        execute_branch_version_async,
+        get_run,
+        wait_for,
+    )
+
+    try:
+        from domains.fantasy_daemon.phases._provider_stub import (
+            call_provider as provider_call,
+        )
+    except ImportError:
+        provider_call = None
+
+    try:
+        outcome = execute_branch_version_async(
+            base_path,
+            branch_version_id=bvid,
+            inputs=inputs,
+            run_name=f"selector_dispatch_for_{goal_id}",
+            actor=actor,
+            provider_call=provider_call,
+        )
+    except KeyError as exc:
+        return {
+            "ok": False,
+            "error_kind": "selector_not_published",
+            "error": (
+                f"selector branch_version_id {bvid!r} not found "
+                f"in branch_versions: {exc}"
+            ),
+            "branch_version_id": bvid,
+        }
+    except SnapshotSchemaDrift as exc:
+        return {
+            "ok": False,
+            "error_kind": "selector_snapshot_drift",
+            "error": str(exc),
+            "branch_version_id": bvid,
+        }
+    except Exception as exc:
+        logger.exception(
+            "selector dispatch failed for goal=%s bvid=%s",
+            goal_id, bvid,
+        )
+        return {
+            "ok": False,
+            "error_kind": "selector_dispatch_failed",
+            "error": str(exc),
+            "branch_version_id": bvid,
+        }
+
+    run_id = outcome.run_id
+
+    # Block on the background future. ``wait_for`` is a no-op when
+    # ``_execute_branch_core`` completed inline (small graphs or test
+    # paths where the executor pool ran synchronously); otherwise it
+    # waits up to ``timeout`` for the worker to finish.
+    try:
+        wait_for(run_id, timeout=timeout)
+    except Exception as exc:
+        # TimeoutError from concurrent.futures or any other wait
+        # failure collapses to a selector_timeout outcome — never
+        # raise into the leaderboard caller.
+        logger.warning(
+            "selector run %s did not finish within %.1fs: %s",
+            run_id, timeout, exc,
+        )
+        return {
+            "ok": False,
+            "error_kind": "selector_timeout",
+            "error": (
+                f"selector run {run_id!r} did not complete within "
+                f"{timeout:.1f}s. The selector branch may be misconfigured "
+                "or the provider is overloaded."
+            ),
+            "branch_version_id": bvid,
+            "run_id": run_id,
+        }
+
+    # Re-read the run row to pick up the final output. ``outcome``
+    # captures only the queued response; the actual graph output
+    # lives in runs.output_json once the worker writes it.
+    final = get_run(base_path, run_id)
+    if final is None:
+        return {
+            "ok": False,
+            "error_kind": "selector_run_failed",
+            "error": (
+                f"selector run {run_id!r} vanished from the runs DB "
+                "after dispatch. Storage layer may have failed."
+            ),
+            "branch_version_id": bvid,
+            "run_id": run_id,
+        }
+    status = final.get("status") or ""
+    if status != "completed":
+        return {
+            "ok": False,
+            "error_kind": "selector_run_failed",
+            "error": (
+                f"selector run {run_id!r} ended with status={status!r}: "
+                f"{final.get('error') or '(no error message)'}"
+            ),
+            "branch_version_id": bvid,
+            "run_id": run_id,
+            "selector_status": status,
+        }
+
+    output = final.get("output") or {}
+    if not isinstance(output, dict):
+        return {
+            "ok": False,
+            "error_kind": "selector_invalid_output",
+            "error": (
+                f"selector run output was not a JSON object; got "
+                f"{type(output).__name__}"
+            ),
+            "branch_version_id": bvid,
+            "run_id": run_id,
+        }
+
+    parsed = _parse_ranked_entries(output)
+    if parsed.get("ok"):
+        return {
+            "ok": True,
+            "branch_version_id": bvid,
+            "source": source,
+            "run_id": run_id,
+            "ranked_entries": parsed["ranked_entries"],
+        }
+    return {
+        "ok": False,
+        "error_kind": parsed.get(
+            "error_kind", "selector_invalid_output",
+        ),
+        "error": parsed.get("error", ""),
+        "branch_version_id": bvid,
+        "run_id": run_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output parsing
+# ---------------------------------------------------------------------------
+
+
+_REQUIRED_ENTRY_KEYS = ("branch_def_id", "score")
+
+
+def _parse_ranked_entries(output: dict[str, Any]) -> dict[str, Any]:
+    """Pull ``ranked_entries`` out of the selector's run output.
+
+    Accepts either:
+
+      * ``output["ranked_entries"]`` as a list (the canonical shape).
+      * ``output["ranked_entries"]`` as a JSON string that decodes to a list
+        (LLM-emitted ``"[{...}]"`` from a prompt-template node that didn't
+        post-process the string).
+
+    Returns ``{ok: True, ranked_entries: [...]}`` on success or
+    ``{ok: False, error_kind, error}`` on any malformation.
+    """
+    raw = output.get("ranked_entries")
+    if raw is None:
+        return {
+            "ok": False,
+            "error_kind": "selector_invalid_output",
+            "error": (
+                "selector output did not contain the required "
+                "'ranked_entries' key."
+            ),
+        }
+    entries = raw
+    if isinstance(entries, str):
+        # LLM-emitted JSON string — attempt to decode. Strip
+        # markdown fence if present.
+        candidate = entries.strip()
+        if candidate.startswith("```"):
+            # Strip a fenced block (```json ... ```).
+            lines = candidate.splitlines()
+            if lines and lines[0].startswith("```"):
+                lines = lines[1:]
+            if lines and lines[-1].strip().startswith("```"):
+                lines = lines[:-1]
+            candidate = "\n".join(lines).strip()
+        try:
+            decoded = json.loads(candidate)
+        except (ValueError, TypeError) as exc:
+            return {
+                "ok": False,
+                "error_kind": "selector_invalid_output",
+                "error": (
+                    "selector output 'ranked_entries' is a string but "
+                    f"not parseable JSON: {exc}"
+                ),
+            }
+        if isinstance(decoded, dict) and "ranked_entries" in decoded:
+            # Whole JSON object was stuffed into the field. Unwrap.
+            entries = decoded["ranked_entries"]
+        elif isinstance(decoded, list):
+            entries = decoded
+        else:
+            return {
+                "ok": False,
+                "error_kind": "selector_invalid_output",
+                "error": (
+                    "selector output 'ranked_entries' string decoded to "
+                    f"{type(decoded).__name__}, expected list."
+                ),
+            }
+    if not isinstance(entries, list):
+        return {
+            "ok": False,
+            "error_kind": "selector_invalid_output",
+            "error": (
+                "selector output 'ranked_entries' must be a list; got "
+                f"{type(entries).__name__}."
+            ),
+        }
+    cleaned: list[dict[str, Any]] = []
+    for idx, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            return {
+                "ok": False,
+                "error_kind": "selector_invalid_output",
+                "error": (
+                    f"ranked_entries[{idx}] must be an object; got "
+                    f"{type(entry).__name__}."
+                ),
+            }
+        for key in _REQUIRED_ENTRY_KEYS:
+            if key not in entry:
+                return {
+                    "ok": False,
+                    "error_kind": "selector_invalid_output",
+                    "error": (
+                        f"ranked_entries[{idx}] missing required key "
+                        f"{key!r}. Entry keys: {sorted(entry.keys())}."
+                    ),
+                }
+        # Normalize types so downstream consumers see consistent
+        # shapes. Score is coerced to float; missing optional fields
+        # become "" / None.
+        try:
+            score = float(entry["score"])
+        except (TypeError, ValueError):
+            return {
+                "ok": False,
+                "error_kind": "selector_invalid_output",
+                "error": (
+                    f"ranked_entries[{idx}].score is not coercible to "
+                    f"float: {entry.get('score')!r}"
+                ),
+            }
+        bdid = (entry.get("branch_def_id") or "").strip()
+        if not bdid:
+            return {
+                "ok": False,
+                "error_kind": "selector_invalid_output",
+                "error": (
+                    f"ranked_entries[{idx}].branch_def_id must be a "
+                    "non-empty string."
+                ),
+            }
+        cleaned.append({
+            "branch_def_id": bdid,
+            "branch_version_id": (
+                entry.get("branch_version_id") or ""
+            ),
+            "score": round(score, 4),
+            "rationale": str(entry.get("rationale") or ""),
+        })
+    return {"ok": True, "ranked_entries": cleaned}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_timeout(explicit: float | None) -> float:
+    """Pick the selector dispatch timeout."""
+    if explicit is not None:
+        try:
+            return max(1.0, float(explicit))
+        except (TypeError, ValueError):
+            pass
+    import os
+    raw = os.environ.get(SELECTOR_TIMEOUT_ENV, "").strip()
+    if raw:
+        try:
+            return max(1.0, float(raw))
+        except ValueError:
+            pass
+    return SELECTOR_TIMEOUT_S_DEFAULT
+
+
+__all__ = [
+    "DEFAULT_SELECTOR_BRANCH_DEF_ID",
+    "DEFAULT_SELECTOR_NAME",
+    "SELECTOR_TIMEOUT_S_DEFAULT",
+    "SELECTOR_TIMEOUT_ENV",
+    "resolve_selector_branch_version_id",
+    "ensure_default_selector_published",
+    "dispatch_selector",
+]

--- a/workflow/api/selector_dispatch.py
+++ b/workflow/api/selector_dispatch.py
@@ -100,7 +100,6 @@ from __future__ import annotations
 
 import json
 import logging
-import time
 from pathlib import Path
 from typing import Any
 
@@ -329,10 +328,20 @@ def _build_default_selector_branch_dict() -> dict[str, Any]:
             {"from": "rank", "to": "END"},
         ],
         "node_defs": [node],
+        # state_schema types are intentionally all ``str``: the
+        # ``ranked_entries`` output is emitted as a JSON-string by the
+        # prompt-template node, then the substrate parses it via
+        # ``_parse_ranked_entries`` (which tolerates JSON-string +
+        # markdown-fence shapes). Declaring ``list`` here would force
+        # the graph_compiler's JSON-contract code path on the response,
+        # which assumes native structured-output and rejects any
+        # provider that returns the JSON as a plain string. Selectors
+        # talk to many providers (CLI-wrapped Claude / codex / ollama)
+        # where structured-output isn't wirable.
         "state_schema": [
             {"name": "goal_id", "type": "str"},
-            {"name": "candidate_branches", "type": "list"},
-            {"name": "ranked_entries", "type": "list"},
+            {"name": "candidate_branches", "type": "str"},
+            {"name": "ranked_entries", "type": "str"},
         ],
         "published": True,
         "visibility": "public",
@@ -381,11 +390,19 @@ run but high judgment_score_avg can still rank well.
 
 ## Output
 
-Emit ONLY a JSON object on a single line (no markdown fence, no
-prose before or after) with the following shape:
+Emit ONLY a JSON object (no markdown fence, no prose before or
+after) with the following shape:
 
 ```
-{{"ranked_entries":[{{"branch_def_id":"...","branch_version_id":"...","score":<float>,"rationale":"<one sentence>"}},...]}}
+{{"ranked_entries":[
+  {{
+    "branch_def_id":"...",
+    "branch_version_id":"...",
+    "score":<float>,
+    "rationale":"<one sentence>"
+  }},
+  ...
+]}}
 ```
 
 Order entries best-first. Use the `branch_version_id` from each
@@ -410,6 +427,7 @@ def dispatch_selector(
     candidate_branches: list[dict[str, Any]],
     actor: str = "anonymous",
     timeout_s: float | None = None,
+    provider_call: Any = None,
 ) -> dict[str, Any]:
     """Run the selector branch synchronously + return its ``ranked_entries``.
 
@@ -485,48 +503,122 @@ def dispatch_selector(
         "candidate_branches": candidate_branches,
     }
 
-    # Lazy import to avoid pulling in the run executor at module
-    # import time (matches the rest of the workflow.api seam).
-    from workflow.runs import (
-        SnapshotSchemaDrift,
-        execute_branch_version_async,
-        get_run,
-        wait_for,
-    )
+    # Reconstruct the selector branch from the immutable snapshot +
+    # the live branch_definitions row's identity metadata.
+    #
+    # P1.1 fix (DESIGN-008 round 2): ``publish_branch_version`` ->
+    # ``_canonical_snapshot`` deliberately strips name / description /
+    # author from the immutable snapshot — only graph behavior fields
+    # survive. Reconstructing via ``BranchDefinition.from_dict(snapshot)``
+    # alone yields an empty name and ``validate()`` rejects with
+    # "Branch name is required" before compile.
+    #
+    # We enrich here by reading the parent ``branch_definitions``
+    # row (same branch_def_id) and merging name / description /
+    # author / visibility back in. Effects + node graph + state
+    # schema still come from the IMMUTABLE snapshot, so the
+    # selector's actual behavior matches what was published — only
+    # the identity/UI fields come from the mutable parent row.
+    from workflow.branch_versions import get_branch_version
+    from workflow.branches import BranchDefinition
+    from workflow.daemon_server import get_branch_definition
+    from workflow.runs import _execute_branch_core
 
     try:
-        from domains.fantasy_daemon.phases._provider_stub import (
-            call_provider as provider_call,
+        bv = get_branch_version(base_path, bvid)
+    except Exception as exc:
+        logger.exception(
+            "selector dispatch | get_branch_version crashed | "
+            "goal=%s bvid=%s", goal_id, bvid,
         )
-    except ImportError:
-        provider_call = None
-
-    try:
-        outcome = execute_branch_version_async(
-            base_path,
-            branch_version_id=bvid,
-            inputs=inputs,
-            run_name=f"selector_dispatch_for_{goal_id}",
-            actor=actor,
-            provider_call=provider_call,
-        )
-    except KeyError as exc:
+        return {
+            "ok": False,
+            "error_kind": "selector_dispatch_failed",
+            "error": str(exc),
+            "branch_version_id": bvid,
+        }
+    if bv is None:
         return {
             "ok": False,
             "error_kind": "selector_not_published",
             "error": (
-                f"selector branch_version_id {bvid!r} not found "
-                f"in branch_versions: {exc}"
+                f"selector branch_version_id {bvid!r} not found in "
+                "branch_versions."
             ),
             "branch_version_id": bvid,
         }
-    except SnapshotSchemaDrift as exc:
+
+    snapshot = dict(bv.snapshot or {})
+    parent_def_id = snapshot.get("branch_def_id") or ""
+    parent_row: dict[str, Any] | None = None
+    if parent_def_id:
+        try:
+            parent_row = get_branch_definition(
+                base_path, branch_def_id=parent_def_id,
+            )
+        except KeyError:
+            parent_row = None
+        except Exception:
+            logger.exception(
+                "selector dispatch | parent branch_definitions read "
+                "crashed | goal=%s bvid=%s parent=%s",
+                goal_id, bvid, parent_def_id,
+            )
+            parent_row = None
+
+    # Merge identity fields. Snapshot wins on graph fields; parent
+    # row wins on identity fields (name/description/author). If the
+    # parent row is missing (rare — could happen if the def was
+    # purged but the version row remains), fall back to a synthetic
+    # name derived from the branch_def_id so validate() passes and
+    # the selector can still run.
+    enriched: dict[str, Any] = dict(snapshot)
+    if parent_row:
+        for k in ("name", "description", "author", "visibility",
+                  "domain_id", "tags"):
+            if not enriched.get(k) and parent_row.get(k) is not None:
+                enriched[k] = parent_row[k]
+    if not enriched.get("name"):
+        enriched["name"] = parent_def_id or f"selector_{bvid}"
+
+    try:
+        branch_def = BranchDefinition.from_dict(enriched)
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
         return {
             "ok": False,
             "error_kind": "selector_snapshot_drift",
-            "error": str(exc),
+            "error": (
+                f"selector snapshot {bvid!r} cannot be reconstructed: "
+                f"{exc}. Republish at the current schema version."
+            ),
             "branch_version_id": bvid,
         }
+
+    # Provider resolution: explicit ``provider_call`` kwarg wins
+    # (tests inject a deterministic stub); otherwise fall back to
+    # the fantasy-daemon provider stub, which routes to the
+    # configured Workflow provider chain (Anthropic / Codex /
+    # Ollama / etc.). Same fallback shape as
+    # ``_action_run_branch_version``.
+    if provider_call is None:
+        try:
+            from domains.fantasy_daemon.phases._provider_stub import (
+                call_provider as _default_provider_call,
+            )
+            provider_call = _default_provider_call
+        except ImportError:
+            provider_call = None
+
+    try:
+        outcome = _execute_branch_core(
+            base_path,
+            branch=branch_def,
+            inputs=inputs,
+            run_name=f"selector_dispatch_for_{goal_id}",
+            actor=actor,
+            provider_call=provider_call,
+            branch_version_id=bvid,
+        )
     except Exception as exc:
         logger.exception(
             "selector dispatch failed for goal=%s bvid=%s",
@@ -545,6 +637,7 @@ def dispatch_selector(
     # ``_execute_branch_core`` completed inline (small graphs or test
     # paths where the executor pool ran synchronously); otherwise it
     # waits up to ``timeout`` for the worker to finish.
+    from workflow.runs import get_run, wait_for
     try:
         wait_for(run_id, timeout=timeout)
     except Exception as exc:

--- a/workflow/api/selector_dispatch.py
+++ b/workflow/api/selector_dispatch.py
@@ -163,6 +163,61 @@ def resolve_selector_branch_version_id(
         }
 
     explicit = (goal.get("selector_branch_version_id") or "").strip() or None
+    # P1.C (DESIGN-008 round 4) — re-check the bound version's status
+    # at READ/DISPATCH time. Bind-time enforces ``status='active'`` (see
+    # ``set_selector_branch``), but the version can be rolled back AFTER
+    # bind by a separate ``branch_versions.status`` flip or by a
+    # rollback operation. Without this re-check, a rolled-back selector
+    # keeps running on every leaderboard read — exactly the bug Codex
+    # round 3 caught. Mirrors the round-2 P1.1 contract on
+    # ``set_canonical_branch`` / ``_latest_published_version_id``.
+    #
+    # When the bound version is no longer active, fall back to the
+    # platform default with a structured ``fellback_from`` diagnostic
+    # so the chatbot / audit tools can flag the stale binding and the
+    # operator can re-bind or unbind.
+    fellback_from: dict[str, str] | None = None
+    if explicit:
+        try:
+            from workflow.branch_versions import get_branch_version
+            version = get_branch_version(base_path, explicit)
+        except Exception:
+            logger.exception(
+                "resolve_selector | get_branch_version crashed for "
+                "goal=%s explicit=%s", goal_id, explicit,
+            )
+            version = None
+        if version is None:
+            fellback_from = {
+                "branch_version_id": explicit,
+                "reason": "selector_version_not_found",
+            }
+            logger.warning(
+                "selector binding for goal=%s points at "
+                "branch_version_id=%r which is no longer in "
+                "branch_versions; falling back to platform default",
+                goal_id, explicit,
+            )
+            explicit = None
+        else:
+            status = getattr(version, "status", "active") or "active"
+            if status != "active":
+                fellback_from = {
+                    "branch_version_id": explicit,
+                    "reason": "selector_version_inactive",
+                    "status": status,
+                }
+                logger.warning(
+                    "selector binding for goal=%s points at "
+                    "branch_version_id=%r with status=%r "
+                    "(active-only required); falling back to "
+                    "platform default. Operator: re-bind via "
+                    "goals action=set_selector with an active "
+                    "version, or unbind with branch_version_id=''",
+                    goal_id, explicit, status,
+                )
+                explicit = None
+
     if explicit:
         return {
             "ok": True,
@@ -170,7 +225,9 @@ def resolve_selector_branch_version_id(
             "source": "goal_binding",
         }
 
-    # Fall back to the platform default selector.
+    # Fall back to the platform default selector. This path is
+    # reached for: no explicit binding, OR an explicit binding that
+    # is no longer active (see fellback_from above).
     try:
         default_bvid = ensure_default_selector_published(base_path)
     except Exception as exc:
@@ -189,11 +246,17 @@ def resolve_selector_branch_version_id(
                 "published; no fallback selector available."
             ),
         }
-    return {
+    result: dict[str, Any] = {
         "ok": True,
         "branch_version_id": default_bvid,
         "source": "platform_default",
     }
+    if fellback_from is not None:
+        # Distinguish "no binding" platform_default from "binding
+        # invalidated by rollback" platform_default. Programmatic
+        # consumers can spot stale bindings without scraping logs.
+        result["fellback_from"] = fellback_from
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -492,6 +555,11 @@ def dispatch_selector(
         }
     bvid = resolution["branch_version_id"]
     source = resolution["source"]
+    # P1.C (round 4) — when the bound version was found inactive at
+    # resolve time and the substrate fell back to platform default,
+    # propagate that diagnostic to the leaderboard caller so the
+    # response shape carries it. Empty / None when not applicable.
+    fellback_from = resolution.get("fellback_from")
 
     timeout = _resolve_timeout(timeout_s)
 
@@ -704,13 +772,16 @@ def dispatch_selector(
 
     parsed = _parse_ranked_entries(output)
     if parsed.get("ok"):
-        return {
+        result: dict[str, Any] = {
             "ok": True,
             "branch_version_id": bvid,
             "source": source,
             "run_id": run_id,
             "ranked_entries": parsed["ranked_entries"],
         }
+        if fellback_from is not None:
+            result["fellback_from"] = fellback_from
+        return result
     return {
         "ok": False,
         "error_kind": parsed.get(

--- a/workflow/daemon_server.py
+++ b/workflow/daemon_server.py
@@ -481,6 +481,24 @@ def initialize_author_server(base_path: str | Path) -> Path:
                 "ALTER TABLE goals ADD COLUMN min_completed_runs_for_canonical "
                 "INTEGER NOT NULL DEFAULT 5"
             )
+        # DESIGN-008: user-buildable selector primitive. A Goal can
+        # bind a "selector branch" (a published Workflow branch) that
+        # the substrate dispatches whenever the leaderboard is built;
+        # the selector reads input signals + emits ``ranked_entries``,
+        # replacing the round-1 platform-opinionated formula.
+        #
+        # NULL is the post-migration "use platform default" state.
+        # The default selector branch is materialized lazily on first
+        # leaderboard read (see
+        # ``workflow.api.selector_dispatch.ensure_default_selector_published``)
+        # and stored under a deterministic branch_def_id; the migration
+        # at the bottom of this function backfills the column for any
+        # Goal that has bound branches.
+        if "selector_branch_version_id" not in goal_cols:
+            conn.execute(
+                "ALTER TABLE goals ADD COLUMN selector_branch_version_id "
+                "TEXT DEFAULT NULL"
+            )
         # Variant canonicals (Task #61 Step 1) — backfill canonical_bindings
         # from existing goals.canonical_branch_version_id. INSERT OR IGNORE
         # makes the migration idempotent: re-running on an already-backfilled
@@ -2451,6 +2469,13 @@ def _goal_from_row(row: sqlite3.Row) -> dict[str, Any]:
         min_runs = int(row["min_completed_runs_for_canonical"] or 5)
     except (IndexError, KeyError, TypeError, ValueError):
         min_runs = 5
+    # DESIGN-008 — user-buildable selector primitive. NULL post-migration
+    # is the "use platform default selector" signal; the leaderboard
+    # call resolves the default on demand.
+    try:
+        selector_bvid = row["selector_branch_version_id"]
+    except (IndexError, KeyError):
+        selector_bvid = None
     return {
         "goal_id": row["goal_id"],
         "name": row["name"],
@@ -2467,6 +2492,7 @@ def _goal_from_row(row: sqlite3.Row) -> dict[str, Any]:
         ),
         "auto_canonical_via_leaderboard": bool(auto_flag),
         "min_completed_runs_for_canonical": min_runs,
+        "selector_branch_version_id": selector_bvid,
     }
 
 
@@ -2565,6 +2591,15 @@ def update_goal(
             )
         sets.append("min_completed_runs_for_canonical = ?")
         params.append(threshold)
+    # DESIGN-008 — selector branch_version pointer. Storage helpers
+    # do NOT enforce active-version validation here; the dedicated
+    # set_selector_branch() helper does. update_goal accepts the
+    # field for host scripts / migration backfill that bypass the
+    # MCP auth+validate path.
+    if "selector_branch_version_id" in updates:
+        bvid = updates["selector_branch_version_id"]
+        sets.append("selector_branch_version_id = ?")
+        params.append(bvid if bvid else None)
     params.append(goal_id)
     with _connect(base_path) as conn:
         conn.execute(
@@ -2803,6 +2838,66 @@ def delete_goal(
     return update_goal(
         base_path, goal_id=goal_id, updates={"visibility": "deleted"},
     )
+
+
+def set_selector_branch(
+    base_path: str | Path,
+    *,
+    goal_id: str,
+    branch_version_id: str | None,
+    set_by: str,
+) -> dict[str, Any]:
+    """Bind (or unbind) the selector branch_version for a Goal.
+
+    DESIGN-008 — user-buildable selector primitive. The selector
+    branch is the published Workflow branch that synthesizes the
+    Goal's leaderboard rankings. ``branch_version_id=None`` unsets
+    the binding, falling back to the platform default selector.
+
+    Authority: the caller must enforce "only Goal author or host"
+    before calling this; the helper does NOT re-check authority
+    (matches the contract of ``set_canonical_branch``).
+
+    Raises
+    ------
+    KeyError
+        ``goal_id`` is not in the goals table.
+    ValueError
+        ``branch_version_id`` is provided but the version row does
+        not exist in ``branch_versions`` OR its status is not
+        ``'active'`` (defense in depth — rolled-back / superseded
+        versions cannot be promoted to selector, mirroring the
+        PR-127 round-2 P1.1 contract on ``set_canonical_branch``).
+    """
+    initialize_author_server(base_path)
+    now = _now()
+    goal = get_goal(base_path, goal_id=goal_id)
+
+    if branch_version_id is not None:
+        from workflow.branch_versions import get_branch_version
+        version = get_branch_version(base_path, branch_version_id)
+        if version is None:
+            raise ValueError(
+                f"branch_version_id {branch_version_id!r} not found in "
+                "branch_versions — only published versions may be "
+                "selector branches."
+            )
+        version_status = getattr(version, "status", "active") or "active"
+        if version_status != "active":
+            raise ValueError(
+                f"branch_version_id {branch_version_id!r} has "
+                f"status={version_status!r}; only versions with "
+                "status='active' may be promoted to selector."
+            )
+
+    with _connect(base_path) as conn:
+        conn.execute(
+            "UPDATE goals SET selector_branch_version_id = ?, "
+            "    updated_at = ? "
+            "WHERE goal_id = ?",
+            (branch_version_id, now, goal_id),
+        )
+    return get_goal(base_path, goal_id=goal_id)
 
 
 def branches_for_goal(

--- a/workflow/daemon_server.py
+++ b/workflow/daemon_server.py
@@ -2840,6 +2840,18 @@ def delete_goal(
     )
 
 
+class SelectorHasEffectsError(ValueError):
+    """Raised when a selector branch declares external-write effects.
+
+    DESIGN-008 round-2 P1.3 guard: selector branches run on every
+    leaderboard read (``quality_leaderboard`` /
+    ``recommend_parent_for_fork``). If their nodes declare
+    ``effects`` (e.g. ``github_pull_request``), every read silently
+    fires real external writes — reads becoming writes. Bind-time
+    rejection is the loud + early gate.
+    """
+
+
 def set_selector_branch(
     base_path: str | Path,
     *,
@@ -2868,10 +2880,16 @@ def set_selector_branch(
         ``'active'`` (defense in depth — rolled-back / superseded
         versions cannot be promoted to selector, mirroring the
         PR-127 round-2 P1.1 contract on ``set_canonical_branch``).
+    SelectorHasEffectsError
+        ``branch_version_id`` is provided but the snapshot contains
+        a node with non-empty ``effects`` (DESIGN-008 round-2 P1.3).
+        Reads must not silently fire external writes.
     """
     initialize_author_server(base_path)
     now = _now()
-    goal = get_goal(base_path, goal_id=goal_id)
+    # Validate goal exists — get_goal raises KeyError when missing.
+    # Authority enforcement is the caller's responsibility (see docstring).
+    get_goal(base_path, goal_id=goal_id)
 
     if branch_version_id is not None:
         from workflow.branch_versions import get_branch_version
@@ -2888,6 +2906,27 @@ def set_selector_branch(
                 f"branch_version_id {branch_version_id!r} has "
                 f"status={version_status!r}; only versions with "
                 "status='active' may be promoted to selector."
+            )
+        # P1.3 — selector branches MUST NOT declare ``effects``.
+        # A selector runs on every leaderboard read; nodes with
+        # effects would turn each read into a real external write.
+        node_defs = (version.snapshot or {}).get("node_defs") or []
+        effectful: list[str] = []
+        for nd in node_defs:
+            if not isinstance(nd, dict):
+                continue
+            effects = nd.get("effects") or []
+            if effects:
+                node_id = nd.get("node_id") or "(unnamed)"
+                effectful.append(f"{node_id}:{list(effects)}")
+        if effectful:
+            raise SelectorHasEffectsError(
+                f"branch_version_id {branch_version_id!r} cannot be "
+                "bound as a selector: selector branches run on every "
+                "leaderboard read and MUST NOT declare external-write "
+                f"effects. Offending nodes: {', '.join(effectful)}. "
+                "Remove the effects field on those nodes (or fork into "
+                "a non-effectful selector branch) before binding."
             )
 
     with _connect(base_path) as conn:

--- a/workflow/daemon_server.py
+++ b/workflow/daemon_server.py
@@ -2841,14 +2841,29 @@ def delete_goal(
 
 
 class SelectorHasEffectsError(ValueError):
-    """Raised when a selector branch declares external-write effects.
+    """Raised when a selector branch is not pure / read-only.
 
-    DESIGN-008 round-2 P1.3 guard: selector branches run on every
+    DESIGN-008 round-2/3 purity guard: selector branches run on every
     leaderboard read (``quality_leaderboard`` /
-    ``recommend_parent_for_fork``). If their nodes declare
-    ``effects`` (e.g. ``github_pull_request``), every read silently
-    fires real external writes — reads becoming writes. Bind-time
-    rejection is the loud + early gate.
+    ``recommend_parent_for_fork``). The substrate forbids any selector
+    branch that could trigger external writes, including transitively:
+
+    * **Round 2 P1.3** — node declares non-empty ``effects``
+      (e.g. ``github_pull_request``). Each read would fire the
+      effector directly.
+    * **Round 3 P1.B** — node declares ``invoke_branch_spec`` or
+      ``invoke_branch_version_spec``. The child run executes through
+      the normal graph path, and child completion fires the child's
+      effectors — bypassing the direct-effects scan. Worse,
+      ``invoke_branch_spec`` resolves at run time against a live
+      ``branch_def_id`` that the operator can mutate AFTER bind, so
+      transitive scanning at bind time is not a reliable safeguard.
+      Reject child-invocation nodes outright; a pure selector is a
+      single graph.
+
+    Bind-time rejection is the loud + early gate. The single error
+    type covers both classes because the failure mode is the same:
+    "read became a write."
     """
 
 
@@ -2907,26 +2922,74 @@ def set_selector_branch(
                 f"status={version_status!r}; only versions with "
                 "status='active' may be promoted to selector."
             )
-        # P1.3 — selector branches MUST NOT declare ``effects``.
-        # A selector runs on every leaderboard read; nodes with
-        # effects would turn each read into a real external write.
+        # Selector purity scan (rounds 2 + 3). Selector branches run
+        # on every leaderboard read; the substrate forbids ANY shape
+        # that could result in a real external write, directly or
+        # transitively.
         node_defs = (version.snapshot or {}).get("node_defs") or []
+        # P1.3 (round 2) — direct effects declarations.
         effectful: list[str] = []
+        # P1.B (round 3) — child-branch invocation specs. A node with
+        # invoke_branch_spec / invoke_branch_version_spec spawns a
+        # child run; the child's normal completion path fires its
+        # OWN effectors, bypassing the direct-effects scan above.
+        # ``invoke_branch_spec`` resolves at run time against a live
+        # branch_def_id that operators can mutate AFTER bind, so
+        # transitive scanning of the bind-time graph is not reliable.
+        # Reject child-invocation outright — selectors must be a
+        # single graph.
+        child_invokers: list[str] = []
         for nd in node_defs:
             if not isinstance(nd, dict):
                 continue
+            node_id = nd.get("node_id") or "(unnamed)"
             effects = nd.get("effects") or []
             if effects:
-                node_id = nd.get("node_id") or "(unnamed)"
                 effectful.append(f"{node_id}:{list(effects)}")
+            ibs = nd.get("invoke_branch_spec")
+            if ibs:
+                target = ""
+                if isinstance(ibs, dict):
+                    target = ibs.get("branch_def_id") or ""
+                child_invokers.append(
+                    f"{node_id}:invoke_branch_spec"
+                    + (f"({target})" if target else "")
+                )
+            ivs = nd.get("invoke_branch_version_spec")
+            if ivs:
+                target = ""
+                if isinstance(ivs, dict):
+                    target = ivs.get("branch_version_id") or ""
+                child_invokers.append(
+                    f"{node_id}:invoke_branch_version_spec"
+                    + (f"({target})" if target else "")
+                )
+        # Both classes route through the same error type because the
+        # failure mode is identical: "read became a write."
+        violations: list[str] = []
         if effectful:
+            violations.append(
+                "declares external-write effects "
+                f"({', '.join(effectful)})"
+            )
+        if child_invokers:
+            violations.append(
+                "declares child-branch invocation "
+                f"({', '.join(child_invokers)})"
+            )
+        if violations:
             raise SelectorHasEffectsError(
                 f"branch_version_id {branch_version_id!r} cannot be "
                 "bound as a selector: selector branches run on every "
-                "leaderboard read and MUST NOT declare external-write "
-                f"effects. Offending nodes: {', '.join(effectful)}. "
-                "Remove the effects field on those nodes (or fork into "
-                "a non-effectful selector branch) before binding."
+                "leaderboard read and MUST be pure (no external "
+                "writes, no child-branch invocation). Violations: "
+                + "; ".join(violations)
+                + ". Remove the offending fields on those nodes (or "
+                "fork into a pure selector branch) before binding. "
+                "If you need rich ranking that requires running other "
+                "graphs, build a selector that emits a recommendation "
+                "and let a separate Goal / canonical handler perform "
+                "the side-effecting work."
             )
 
     with _connect(base_path) as conn:

--- a/workflow/rollback.py
+++ b/workflow/rollback.py
@@ -717,6 +717,96 @@ def repoint_goals_after_rollback(
     }
 
 
+def repoint_selectors_after_rollback(
+    base_path: str | Path,
+    version_ids: Iterable[str],
+    *,
+    set_by: str,
+) -> dict[str, Any]:
+    """Clear any Goal whose ``selector_branch_version_id`` is in the
+    rolled-back set.
+
+    DESIGN-008 round 4 — selector pointers are subject to the same
+    active-only lifecycle invariant as canonical pointers. When a
+    selector branch_version is rolled back, every Goal pointing at it
+    must lose the binding so subsequent leaderboard reads fall back
+    to the platform default (instead of falling back at every read
+    via the runtime guard in
+    ``selector_dispatch.resolve_selector_branch_version_id``, which
+    is the merge-blocker safety net but leaves a stale pointer in
+    storage indefinitely).
+
+    Unlike canonical, selectors are NOT walked up to an ancestor
+    version: there is no analog of "fork from canonical" semantics
+    for selectors, and silently re-binding to an ancestor could
+    introduce a different ranking opinion the operator never
+    explicitly chose. Instead the binding is CLEARED (NULL), which
+    triggers the platform-default fallback. The operator can re-bind
+    to a different active version (or fork the rolled-back one) via
+    ``goals action=set_selector``.
+
+    Runs in a separate author_server-DB transaction per the cross-DB
+    refinement, mirroring ``repoint_goals_after_rollback``.
+
+    Returns:
+        ``{"status": "ok", "repointed_count": N, "repoints": [...]}``
+        with a per-goal log of ``{goal_id, old_branch_version_id}``.
+    """
+    from workflow.daemon_server import _connect as _author_connect
+    from workflow.daemon_server import set_selector_branch
+
+    rolled_back_set = set(version_ids)
+    if not rolled_back_set:
+        return {"status": "ok", "repointed_count": 0, "repoints": []}
+
+    repoints: list[dict[str, Any]] = []
+    with _author_connect(base_path) as conn:
+        placeholders = ",".join("?" * len(rolled_back_set))
+        try:
+            affected = conn.execute(
+                f"SELECT goal_id, selector_branch_version_id FROM goals "
+                f"WHERE selector_branch_version_id IN ({placeholders})",
+                tuple(rolled_back_set),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            # goals table doesn't exist OR the
+            # selector_branch_version_id column hasn't been migrated
+            # in yet (pre-DESIGN-008 universe). Clean no-op.
+            return {"status": "ok", "repointed_count": 0, "repoints": []}
+
+    for row in affected:
+        goal_id = row["goal_id"]
+        old_bvid = row["selector_branch_version_id"]
+        try:
+            set_selector_branch(
+                base_path,
+                goal_id=goal_id,
+                branch_version_id=None,
+                set_by=set_by,
+            )
+            repoints.append({
+                "goal_id": goal_id,
+                "old_branch_version_id": old_bvid,
+                "new_branch_version_id": None,
+            })
+        except (KeyError, ValueError) as exc:
+            # Per design intent: don't fail the whole batch on one
+            # bad goal. Log the failure so operators can see what
+            # didn't clear.
+            repoints.append({
+                "goal_id": goal_id,
+                "old_branch_version_id": old_bvid,
+                "new_branch_version_id": None,
+                "error": str(exc),
+            })
+
+    return {
+        "status": "ok",
+        "repointed_count": len(repoints),
+        "repoints": repoints,
+    }
+
+
 def _walk_up_to_active_ancestor(
     base_path: str | Path,
     start_bvid: str,
@@ -795,12 +885,19 @@ def rollback_merge_orchestrator(
     repoint_result = repoint_goals_after_rollback(
         base_path, closure, set_by=set_by,
     )
+    # DESIGN-008 round 4 — selectors also need a re-point pass.
+    # Selector pointers are cleared (no ancestor walk) to avoid
+    # silently re-binding to a different ranking opinion.
+    selector_repoint_result = repoint_selectors_after_rollback(
+        base_path, closure, set_by=set_by,
+    )
     return {
         "status": "ok",
         "seed_version_id": branch_version_id,
         "closure": closure,
         "execute": execute_result,
         "repoint": repoint_result,
+        "selector_repoint": selector_repoint_result,
     }
 
 

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -782,6 +782,12 @@ def goals(
                    unbind. Needs branch_def_id.
       set_canonical Mark a branch_version_id as the Goal's canonical
                    branch. Author-only or host-only.
+      set_selector Bind the Goal's selector branch_version
+                   (DESIGN-008). The bound branch ranks competitors
+                   on this Goal's leaderboard. Author-only or
+                   host-only. Pass branch_version_id="" to fall back
+                   to the platform default selector. The branch must
+                   conform to the selector-branch contract.
       run_canonical Dispatch a run on the Goal's canonical
                    branch_version. When auto_canonical_via_leaderboard
                    is on, the canonical is first refreshed via the


### PR DESCRIPTION
## Summary

Replaces the platform-opinionated `quality_leaderboard` scoring formula with a per-Goal user-buildable selector branch primitive. Closes the architectural commitment from host's 2026-05-21 reframe (which closed PR #978 because patching the platform-opinionated formula entrenched the wrong architecture).

The substrate now provides primitives (signals + dispatch + contract); ranking opinions live in published Workflow branches that anyone can fork and tune for their domain.

## What changed

- **New `goals.selector_branch_version_id` column** (NULL post-migration = "use platform default selector").
- **New MCP action `goals action=set_selector goal_id=<g> branch_version_id=<v>`** — Goal author or host authority; empty string unbinds back to the platform default.
- **New `workflow/api/selector_dispatch.py`** owns selector resolution (goal_binding vs platform_default fallback), default selector materialization (single prompt-template node published under deterministic `platform_default_selector_v1_20260521` — weights are now a prompt the chatbot can fork and edit, not Python constants), sync dispatch with timeout (default 60s, configurable via `WORKFLOW_SELECTOR_TIMEOUT_S`), output parsing tolerant of JSON-string + markdown-fence shapes, and structured-error surfaces for every failure mode (`selector_not_published`, `selector_snapshot_drift`, `selector_dispatch_failed`, `selector_timeout`, `selector_run_failed`, `selector_invalid_output`).
- **`workflow/api/quality_leaderboard.py` rewritten** — collects signals + dispatches via the selector. Signal-collection helpers (`_run_stats`, `_judgment_stats`, `_fork_count`, `_gate_rung_top`, `_safe_to_publish`) preserved because they are selector **inputs**, not opinion.
- **DELETED** from `quality_leaderboard.py`: `_compute_score`, `_entry_sort_key`, `_formula_disclosure`, `_build_rationale`, weighting constants (`W_JUDGMENT`, `W_RUNS`, `W_FORKS`, `W_RECENCY`, `W_GATE`, `W_SAFE_PUBLISH`, `W_FAILED_PENALTY`), `RECENCY_HALFLIFE_DAYS`, `JUDGMENT_MAX_SCALE`.
- **Visibility / auth-boundary contracts preserved** at the candidate-collection layer (server-derived viewer, fork_count respects visibility — same PR-127 / PR-970 round-2 P1.1/P1.2 invariants still locked in by tests).
- **New `scripts/migrate_design_008_selector_backfill.py`** — idempotent one-shot that publishes the default selector and backfills existing Goals with bound branches.
- **Selector branch contract documented** in `drafts/concepts/selector-branch-contract.md` — inputs, outputs, failure modes, default selector, authority, cost.

## Default selector branch

Published as a normal Workflow branch (not platform code):

- branch_def_id: `platform_default_selector_v1_20260521`
- Single prompt-template node `rank` with input keys `{goal_id, candidate_branches}` and output key `ranked_entries`.
- Weights now live in the prompt (judgment_score_avg > completed_run_count > fork_count > recency > gate_rung > safe_to_publish, minus failed_run_count penalty) — community forks the branch to customize.
- Published version_id will be visible after the backfill migration runs; deterministic branch_def_id + content_hash means anyone running the migration on a fresh DB gets the same version_id back.

## Tests

| File | Count | Coverage |
|------|-------|----------|
| `tests/test_selector_dispatch.py` | 22 | resolution, default materialization, output parsing (every malformed shape), env-driven timeout |
| `tests/test_quality_leaderboard.py` | 18 | DESIGN-008 dispatch contract via mock selector |
| `tests/test_quality_leaderboard_auth_boundary.py` | 13 | PR-127 round-2 P1.1/P1.2 visibility regressions |
| `tests/test_extensions_leaderboard_actions.py` | 9 | MCP surface, selector metadata in response |
| `tests/test_canonical_dispatch.py` | 23 | `_refresh_via_leaderboard` continues to work via selector dispatch |
| `tests/test_goals_run_canonical.py` | 12 | end-to-end `run_canonical` with auto + threshold + in-flight gates |
| `tests/test_goals_set_selector.py` | 10 | MCP wiring + authority + persistence + unbind + input validation |
| `tests/test_design_008_selector_backfill.py` | 6 | migration idempotency, dry-run, skip-no-branches, preserve-explicit-binding |
| **Total** | **113** | (155 incl. canonical_branch + canonical_bindings_migration sweep) |

All green on local pytest with `-p no:cacheprovider`.

## Caveats to surface

- **Cost:** each leaderboard build now triggers one LLM call (the selector run). Round-1 formula was free. Acceptable trade for the architectural win — selection logic is now community-evolvable instead of platform-opinionated. A future caching slice may memoize selector output keyed by `(goal_id, candidate fingerprint)` for N minutes.
- **Default is one selector**; community evolves better selectors per domain by forking `platform_default_selector_v1_20260521`.
- **After this lands**, `auto_canonical_via_leaderboard=true` works end-to-end with the new dispatch.
- **Migration path:** run `python scripts/migrate_design_008_selector_backfill.py` once after deploy. Idempotent — re-runs are no-ops. Goals with bound branches but NULL selector get the default bound; Goals with no branches are skipped (no point binding a selector when there's nothing to rank); Goals with an explicit binding are preserved.

## Test plan

- [ ] codex review per ready_for_checker label
- [ ] mirror parity verified (workflow/* edits + plugin runtime mirror committed together)
- [ ] no destructive git ops
- [ ] post-merge: run `python scripts/migrate_design_008_selector_backfill.py` on the live universe to publish the default selector + backfill existing Goals

## References

- Selector branch contract: `drafts/concepts/selector-branch-contract.md`
- Host directive: 2026-05-21 reframe closing PR #978 in favor of architectural substrate swap
- Prior context: PR #978 (closed), PR-127 round-2 P1.1/P1.2 visibility invariants preserved here