### PR TITLE
[auto-change] WIKI-PATCH: wiki.file_bug Jaccard duplicate detection misses substantive overlap in long-form filings (default threshold 0.25 calibrated for short-form; framing prose dilutes the technical core)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1635,6 +1635,9 @@ def _render_bug_markdown(
 
 _VALID_BUG_KINDS = frozenset({"bug", "feature", "design", "patch_request"})
 _BUG_DEDUP_THRESHOLD = 0.5
+_BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
+_BUG_DEDUP_MIN_SHARED_TOKENS = 6
+_BUG_DEDUP_SECTION_CHAR_LIMIT = 4000
 
 
 def _bug_token_set(text: str) -> set[str]:
@@ -1649,11 +1652,29 @@ def _jaccard(a: set[str], b: set[str]) -> float:
     return len(a & b) / len(union) if union else 0.0
 
 
+def _containment(a: set[str], b: set[str]) -> float:
+    if not a and not b:
+        return 1.0
+    smaller = min(len(a), len(b))
+    return len(a & b) / smaller if smaller else 0.0
+
+
+def _bug_duplicate_similarity(a: set[str], b: set[str]) -> float:
+    """Score filing overlap without letting long framing prose dilute the core."""
+    jaccard = _jaccard(a, b)
+    if len(a & b) < _BUG_DEDUP_MIN_SHARED_TOKENS:
+        return jaccard
+    containment = _containment(a, b)
+    if containment >= _BUG_DEDUP_CONTAINMENT_THRESHOLD:
+        return max(jaccard, containment)
+    return jaccard
+
+
 def _scan_existing_bugs(bugs_dir: Path) -> list[dict[str, Any]]:
     """Return a list of {bug_id, title, status, haystack_tokens} for all existing bugs.
 
-    Haystack uses only frontmatter title + "What happened" section to avoid
-    dilution from markdown scaffolding tokens (dates, template headings, etc.).
+    Haystack uses only frontmatter title + a bounded "What happened" section
+    to avoid dilution from markdown scaffolding tokens (dates, headings, etc.).
     """
     if not bugs_dir.is_dir():
         return []
@@ -1692,9 +1713,11 @@ def _scan_existing_bugs(bugs_dir: Path) -> list[dict[str, Any]]:
                         in_observed = False
                     else:
                         observed_text += " " + line
-                if len(observed_text) > 300:
+                if len(observed_text) > _BUG_DEDUP_SECTION_CHAR_LIMIT:
                     break
-        haystack = _bug_token_set(fm_title + " " + observed_text[:300])
+        haystack = _bug_token_set(
+            fm_title + " " + observed_text[:_BUG_DEDUP_SECTION_CHAR_LIMIT]
+        )
         results.append({
             "bug_id": f"{m.group(1).upper()}-{m.group(2)}",
             "title": fm_title,
@@ -1818,8 +1841,8 @@ def _wiki_file_bug(
     create guards against concurrent file_bug races.
 
     ``force_new`` skips the similarity check and always mints a new id.
-    When omitted, a Jaccard similarity ≥ 0.5 against an existing bug's
-    title+body returns {status: "similar_found"} instead of filing.
+    When omitted, a token-overlap similarity score ≥ 0.5 against an existing
+    bug's title+body returns {status: "similar_found"} instead of filing.
     """
     if not title or not component or not severity:
         return json.dumps({
@@ -1871,7 +1894,7 @@ def _wiki_file_bug(
         existing = _scan_existing_bugs(pages_dir)
         scored = []
         for entry in existing:
-            sim = _jaccard(query_tokens, entry["haystack_tokens"])
+            sim = _bug_duplicate_similarity(query_tokens, entry["haystack_tokens"])
             if sim >= _BUG_DEDUP_THRESHOLD:
                 scored.append((sim, entry))
         if scored:

--- a/tests/test_wiki_file_bug_dedup.py
+++ b/tests/test_wiki_file_bug_dedup.py
@@ -4,8 +4,8 @@ Before the fix, every call to `wiki action=file_bug` minted a fresh BUG-NNN
 even when an identical or near-identical bug already existed. At scale this
 floods the bugs directory with duplicates.
 
-Fix: server-side Jaccard similarity check (threshold 0.5) against existing
-bugs before allocating a new id. When a similar bug exists, return
+Fix: server-side token-overlap similarity check (threshold 0.5) against
+existing bugs before allocating a new id. When a similar bug exists, return
 `status: "similar_found"` with the top-3 matches. The caller can then use
 `wiki action=cosign_bug` to add context without creating a duplicate.
 `force_new=true` overrides the check and always mints a new id.
@@ -266,6 +266,30 @@ def test_file_bug_unrelated_query_does_not_trigger_similar_found(wiki_env):
     # Completely different domain — should not trigger dedup
     assert result.get("status") == "filed", (
         f"Unrelated bug should file cleanly, got: {result}"
+    )
+
+
+def test_long_form_existing_filing_matches_concise_technical_core(wiki_env):
+    """Long framing prose must not hide a substantive duplicate core."""
+    long_framing = " ".join(f"contexttoken{i}" for i in range(40))
+    core = (
+        "wiki file bug jaccard duplicate detection misses substantive overlap "
+        "framing prose dilutes technical core"
+    )
+    _seed_bug(
+        wiki_env,
+        title="Wiki filing duplicate detector misses overlap",
+        observed=f"{long_framing} {core}",
+    )
+
+    result = _file_bug(
+        wiki_env,
+        title="Jaccard duplicate detection misses substantive overlap",
+        observed=core,
+    )
+
+    assert result.get("status") == "similar_found", (
+        f"Expected similar_found for shared technical core, got: {result}"
     )
 
 

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1635,6 +1635,9 @@ def _render_bug_markdown(
 
 _VALID_BUG_KINDS = frozenset({"bug", "feature", "design", "patch_request"})
 _BUG_DEDUP_THRESHOLD = 0.5
+_BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
+_BUG_DEDUP_MIN_SHARED_TOKENS = 6
+_BUG_DEDUP_SECTION_CHAR_LIMIT = 4000
 
 
 def _bug_token_set(text: str) -> set[str]:
@@ -1649,11 +1652,29 @@ def _jaccard(a: set[str], b: set[str]) -> float:
     return len(a & b) / len(union) if union else 0.0
 
 
+def _containment(a: set[str], b: set[str]) -> float:
+    if not a and not b:
+        return 1.0
+    smaller = min(len(a), len(b))
+    return len(a & b) / smaller if smaller else 0.0
+
+
+def _bug_duplicate_similarity(a: set[str], b: set[str]) -> float:
+    """Score filing overlap without letting long framing prose dilute the core."""
+    jaccard = _jaccard(a, b)
+    if len(a & b) < _BUG_DEDUP_MIN_SHARED_TOKENS:
+        return jaccard
+    containment = _containment(a, b)
+    if containment >= _BUG_DEDUP_CONTAINMENT_THRESHOLD:
+        return max(jaccard, containment)
+    return jaccard
+
+
 def _scan_existing_bugs(bugs_dir: Path) -> list[dict[str, Any]]:
     """Return a list of {bug_id, title, status, haystack_tokens} for all existing bugs.
 
-    Haystack uses only frontmatter title + "What happened" section to avoid
-    dilution from markdown scaffolding tokens (dates, template headings, etc.).
+    Haystack uses only frontmatter title + a bounded "What happened" section
+    to avoid dilution from markdown scaffolding tokens (dates, headings, etc.).
     """
     if not bugs_dir.is_dir():
         return []
@@ -1692,9 +1713,11 @@ def _scan_existing_bugs(bugs_dir: Path) -> list[dict[str, Any]]:
                         in_observed = False
                     else:
                         observed_text += " " + line
-                if len(observed_text) > 300:
+                if len(observed_text) > _BUG_DEDUP_SECTION_CHAR_LIMIT:
                     break
-        haystack = _bug_token_set(fm_title + " " + observed_text[:300])
+        haystack = _bug_token_set(
+            fm_title + " " + observed_text[:_BUG_DEDUP_SECTION_CHAR_LIMIT]
+        )
         results.append({
             "bug_id": f"{m.group(1).upper()}-{m.group(2)}",
             "title": fm_title,
@@ -1818,8 +1841,8 @@ def _wiki_file_bug(
     create guards against concurrent file_bug races.
 
     ``force_new`` skips the similarity check and always mints a new id.
-    When omitted, a Jaccard similarity ≥ 0.5 against an existing bug's
-    title+body returns {status: "similar_found"} instead of filing.
+    When omitted, a token-overlap similarity score ≥ 0.5 against an existing
+    bug's title+body returns {status: "similar_found"} instead of filing.
     """
     if not title or not component or not severity:
         return json.dumps({
@@ -1871,7 +1894,7 @@ def _wiki_file_bug(
         existing = _scan_existing_bugs(pages_dir)
         scored = []
         for entry in existing:
-            sim = _jaccard(query_tokens, entry["haystack_tokens"])
+            sim = _bug_duplicate_similarity(query_tokens, entry["haystack_tokens"])
             if sim >= _BUG_DEDUP_THRESHOLD:
                 scored.append((sim, entry))
         if scored:


### PR DESCRIPTION
Fixes #885

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-121-wiki-file-bug-jaccard-duplicate-detection-misses-substantive.md`
- GitHub issue: #885
- Branch task: `auto-change/issue-885`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.