### PR TITLE
[auto-change] WIKI-PATCH: Tie PR-048 Phase B (DaemonBrain class) to the Tiny daemon as the first-migration acceptance test — give the consolidation a concrete consumer so it stops being abstract

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_brain.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_brain.py
@@ -31,8 +31,14 @@ MEMORY_KIND_REGISTRY = {
     "open_loop": "Unresolved follow-up, watch item, or incomplete learning thread.",
     "contradiction": "Conflicting claims or evidence that require reconciliation.",
     "soul_proposal": "Candidate change to the daemon's identity or role contract.",
-    "session_trace_summary": "Reviewed narrative summary of one session (run/mission/cadence); references raw artifacts, not raw payloads.",
-    "experience_lesson": "Typed lesson learned from one run; carries lineage, lesson_kind, observed_delta, and evidence_refs. Atom of cross-branch group evolution.",
+    "session_trace_summary": (
+        "Reviewed narrative summary of one session (run/mission/cadence); "
+        "references raw artifacts, not raw payloads."
+    ),
+    "experience_lesson": (
+        "Typed lesson learned from one run; carries lineage, lesson_kind, "
+        "observed_delta, and evidence_refs. Atom of cross-branch group evolution."
+    ),
 }
 VALID_MEMORY_KINDS = frozenset(MEMORY_KIND_REGISTRY)
 DEFAULT_MEMORY_KIND = "semantic"
@@ -282,6 +288,82 @@ def daemon_memory_registry() -> dict[str, Any]:
         },
         "terminal_promotion_states": sorted(TERMINAL_PROMOTION_STATES),
     }
+
+
+class DaemonBrain:
+    """Daemon-scoped facade for new mini-brain consumers.
+
+    Existing module-level functions remain the stable API. The facade is kept
+    narrow until concrete consumers need more methods.
+    """
+
+    def __init__(self, base_path: str | Path, *, daemon_id: str) -> None:
+        self.base_path = Path(base_path)
+        self.daemon_id = str(daemon_id)
+
+    def capture(
+        self,
+        *,
+        content: str,
+        memory_kind: str = DEFAULT_MEMORY_KIND,
+        source_type: str = "manual",
+        source_id: str = "manual",
+        source_path: str = "",
+        source_hash: str = "",
+        reliability: str,
+        temporal_bounds: dict[str, Any] | None = None,
+        language_type: str,
+        confidence: float = 0.5,
+        importance: float = 0.5,
+        sensitivity_tier: str = "normal",
+        visibility: str = "host_private",
+        promotion_state: str = DEFAULT_PROMOTION_STATE,
+        supersedes_entry_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        embedding: Sequence[float] | None = None,
+        created_at: datetime | None = None,
+    ) -> dict[str, Any]:
+        return capture_daemon_memory(
+            self.base_path,
+            daemon_id=self.daemon_id,
+            content=content,
+            memory_kind=memory_kind,
+            source_type=source_type,
+            source_id=source_id,
+            source_path=source_path,
+            source_hash=source_hash,
+            reliability=reliability,
+            temporal_bounds=temporal_bounds,
+            language_type=language_type,
+            confidence=confidence,
+            importance=importance,
+            sensitivity_tier=sensitivity_tier,
+            visibility=visibility,
+            promotion_state=promotion_state,
+            supersedes_entry_id=supersedes_entry_id,
+            metadata=metadata,
+            embedding=embedding,
+            created_at=created_at,
+        )
+
+    def build_packet(
+        self,
+        *,
+        query: str = "",
+        max_chars: int = DEFAULT_BRAIN_PACKET_CHARS,
+        limit: int = 5,
+        min_score: float = 0.0,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        return build_daemon_brain_packet(
+            self.base_path,
+            daemon_id=self.daemon_id,
+            query=query,
+            max_chars=max_chars,
+            limit=limit,
+            min_score=min_score,
+            trace_id=trace_id,
+        )
 
 
 def _require_text(value: str, field: str) -> str:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_memory.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_memory.py
@@ -540,11 +540,9 @@ def build_daemon_memory_packet(
     if include_brain and (not truncated or reserved_brain_chars > 0):
         remaining = budget - len(context)
         if remaining > 0:
-            from workflow.daemon_brain import build_daemon_brain_packet
+            from workflow.daemon_brain import DaemonBrain
 
-            brain = build_daemon_brain_packet(
-                base_path,
-                daemon_id=daemon_id,
+            brain = DaemonBrain(base_path, daemon_id=daemon_id).build_packet(
                 query=brain_query if brain_query is not None else _default_brain_query(daemon),
                 max_chars=min(max(0, int(brain_max_chars)), remaining),
                 limit=brain_limit,

--- a/tests/test_daemon_brain.py
+++ b/tests/test_daemon_brain.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from workflow.daemon_brain import (
+    DaemonBrain,
     build_daemon_brain_packet,
     capture_daemon_memory,
     daemon_memory_cost_ledger_status,
@@ -251,7 +252,7 @@ def test_session_trace_summary_is_recognized_kind_with_full_lifecycle(
 def test_experience_lesson_is_recognized_kind_with_full_lifecycle(
     tmp_path: Path,
 ) -> None:
-    """Slice 2 of ExperiencePool (per docs/design-notes/2026-05-02-experience-pool-and-group-evolution.md).
+    """Slice 2 of ExperiencePool.
 
     Verifies experience_lesson is a recognized memory_kind that moves
     through the existing promotion state machine: candidate (capture) →
@@ -375,3 +376,38 @@ def test_open_brain_status_surface_summarizes_soul_daemons(tmp_path: Path) -> No
     assert status["daemon_count"] == 1
     assert status["daemons"][0]["daemon_id"] == ada["daemon_id"]
     assert status["daemons"][0]["cost_ledger"]["estimated_total_tokens"] > 0
+
+
+def test_tiny_daemon_external_write_packet_uses_daemonbrain_facade(
+    tmp_path: Path,
+) -> None:
+    """PR-048 Phase B first-migration acceptance: Tiny uses DaemonBrain."""
+    tiny = _create_daemon(tmp_path, "Tiny")
+    brain = DaemonBrain(tmp_path, daemon_id=tiny["daemon_id"])
+    memory = brain.capture(
+        memory_kind="policy",
+        content=(
+            "Tiny daemon external-write packets for twitter_post must check "
+            "the Brain for consent, idempotency, and voice policy before any "
+            "sink adapter writes outside Workflow."
+        ),
+        source_type="patch_request",
+        source_id="WIKI-PATCH-908",
+        reliability="host_observed",
+        language_type="policy",
+        importance=0.92,
+        visibility="borrowable_role_context",
+        promotion_state="accepted",
+    )
+
+    packet = build_daemon_memory_packet(
+        tmp_path,
+        daemon_id=tiny["daemon_id"],
+        max_chars=2600,
+        brain_query="Tiny daemon twitter_post external-write consent idempotency",
+        brain_max_chars=900,
+    )
+
+    assert packet["brain"]["selected_count"] == 1
+    assert packet["brain"]["entries"][0]["entry_id"] == memory["entry_id"]
+    assert "twitter_post must check the Brain" in packet["context"]

--- a/workflow/daemon_brain.py
+++ b/workflow/daemon_brain.py
@@ -31,8 +31,14 @@ MEMORY_KIND_REGISTRY = {
     "open_loop": "Unresolved follow-up, watch item, or incomplete learning thread.",
     "contradiction": "Conflicting claims or evidence that require reconciliation.",
     "soul_proposal": "Candidate change to the daemon's identity or role contract.",
-    "session_trace_summary": "Reviewed narrative summary of one session (run/mission/cadence); references raw artifacts, not raw payloads.",
-    "experience_lesson": "Typed lesson learned from one run; carries lineage, lesson_kind, observed_delta, and evidence_refs. Atom of cross-branch group evolution.",
+    "session_trace_summary": (
+        "Reviewed narrative summary of one session (run/mission/cadence); "
+        "references raw artifacts, not raw payloads."
+    ),
+    "experience_lesson": (
+        "Typed lesson learned from one run; carries lineage, lesson_kind, "
+        "observed_delta, and evidence_refs. Atom of cross-branch group evolution."
+    ),
 }
 VALID_MEMORY_KINDS = frozenset(MEMORY_KIND_REGISTRY)
 DEFAULT_MEMORY_KIND = "semantic"
@@ -282,6 +288,82 @@ def daemon_memory_registry() -> dict[str, Any]:
         },
         "terminal_promotion_states": sorted(TERMINAL_PROMOTION_STATES),
     }
+
+
+class DaemonBrain:
+    """Daemon-scoped facade for new mini-brain consumers.
+
+    Existing module-level functions remain the stable API. The facade is kept
+    narrow until concrete consumers need more methods.
+    """
+
+    def __init__(self, base_path: str | Path, *, daemon_id: str) -> None:
+        self.base_path = Path(base_path)
+        self.daemon_id = str(daemon_id)
+
+    def capture(
+        self,
+        *,
+        content: str,
+        memory_kind: str = DEFAULT_MEMORY_KIND,
+        source_type: str = "manual",
+        source_id: str = "manual",
+        source_path: str = "",
+        source_hash: str = "",
+        reliability: str,
+        temporal_bounds: dict[str, Any] | None = None,
+        language_type: str,
+        confidence: float = 0.5,
+        importance: float = 0.5,
+        sensitivity_tier: str = "normal",
+        visibility: str = "host_private",
+        promotion_state: str = DEFAULT_PROMOTION_STATE,
+        supersedes_entry_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        embedding: Sequence[float] | None = None,
+        created_at: datetime | None = None,
+    ) -> dict[str, Any]:
+        return capture_daemon_memory(
+            self.base_path,
+            daemon_id=self.daemon_id,
+            content=content,
+            memory_kind=memory_kind,
+            source_type=source_type,
+            source_id=source_id,
+            source_path=source_path,
+            source_hash=source_hash,
+            reliability=reliability,
+            temporal_bounds=temporal_bounds,
+            language_type=language_type,
+            confidence=confidence,
+            importance=importance,
+            sensitivity_tier=sensitivity_tier,
+            visibility=visibility,
+            promotion_state=promotion_state,
+            supersedes_entry_id=supersedes_entry_id,
+            metadata=metadata,
+            embedding=embedding,
+            created_at=created_at,
+        )
+
+    def build_packet(
+        self,
+        *,
+        query: str = "",
+        max_chars: int = DEFAULT_BRAIN_PACKET_CHARS,
+        limit: int = 5,
+        min_score: float = 0.0,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        return build_daemon_brain_packet(
+            self.base_path,
+            daemon_id=self.daemon_id,
+            query=query,
+            max_chars=max_chars,
+            limit=limit,
+            min_score=min_score,
+            trace_id=trace_id,
+        )
 
 
 def _require_text(value: str, field: str) -> str:

--- a/workflow/daemon_memory.py
+++ b/workflow/daemon_memory.py
@@ -540,11 +540,9 @@ def build_daemon_memory_packet(
     if include_brain and (not truncated or reserved_brain_chars > 0):
         remaining = budget - len(context)
         if remaining > 0:
-            from workflow.daemon_brain import build_daemon_brain_packet
+            from workflow.daemon_brain import DaemonBrain
 
-            brain = build_daemon_brain_packet(
-                base_path,
-                daemon_id=daemon_id,
+            brain = DaemonBrain(base_path, daemon_id=daemon_id).build_packet(
                 query=brain_query if brain_query is not None else _default_brain_query(daemon),
                 max_chars=min(max(0, int(brain_max_chars)), remaining),
                 limit=brain_limit,


### PR DESCRIPTION
Fixes #908

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-127-tie-pr-048-phase-b-daemonbrain-class-to-the-tiny-daemon-as-t.md`
- GitHub issue: #908
- Branch task: `auto-change/issue-908`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.