### PR TITLE
[auto-change] BUG-086: universe daemon_memory_status requires daemon_id but MCP schema does not expose daemon_id parameter

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
@@ -276,7 +276,7 @@ enumerate ALL FIVE. Don't list extensions actions and forget the rest.
   action is unavailable, say so; do NOT fake the run through other tools.
 - "Remember this as daemon learning" / "what does this daemon remember?"
   / "review this daemon memory" -> use the daemon mini-brain actions on
-  `universe`. Pass `daemon_id` and structured fields through
+  `universe`. Pass `daemon_id` directly and structured fields through
   `inputs_json`; use `daemon_memory_capture` for new lessons,
   `daemon_memory_search` / `daemon_memory_list` for lookup,
   `daemon_memory_review` for accept/reject/supersede, and

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -1654,21 +1654,23 @@ def _as_string_list(value: Any) -> list[str] | None:
 def _daemon_memory_inputs(
     inputs_json: str,
     *,
+    daemon_id: str = "",
     node_def_id: str = "",
 ) -> tuple[dict[str, Any], str, str | None]:
     data, err = _parse_inputs_object(inputs_json)
     if err:
         return {}, "", err
-    daemon_id = str(data.get("daemon_id") or node_def_id or "").strip()
-    if not daemon_id:
+    resolved_daemon_id = str(data.get("daemon_id") or daemon_id or node_def_id or "").strip()
+    if not resolved_daemon_id:
         return data, "", "daemon_id is required."
-    return data, daemon_id, None
+    return data, resolved_daemon_id, None
 
 
 def _action_daemon_memory_capture(
     universe_id: str = "",
     inputs_json: str = "",
     text: str = "",
+    daemon_id: str = "",
     node_def_id: str = "",
     **_kwargs: Any,
 ) -> str:
@@ -1676,7 +1678,9 @@ def _action_daemon_memory_capture(
     from workflow.daemon_brain import capture_daemon_memory
 
     uid = universe_id or _default_universe()
-    data, daemon_id, err = _daemon_memory_inputs(inputs_json, node_def_id=node_def_id)
+    data, daemon_id, err = _daemon_memory_inputs(
+        inputs_json, daemon_id=daemon_id, node_def_id=node_def_id
+    )
     if err:
         return json.dumps({"universe_id": uid, "error": err})
     content = str(data.get("content") or text or "").strip()
@@ -1720,13 +1724,16 @@ def _action_daemon_memory_search(
     text: str = "",
     filter_text: str = "",
     limit: Any = 5,
+    daemon_id: str = "",
     node_def_id: str = "",
     **_kwargs: Any,
 ) -> str:
     from workflow.daemon_brain import search_daemon_memory
 
     uid = universe_id or _default_universe()
-    data, daemon_id, err = _daemon_memory_inputs(inputs_json, node_def_id=node_def_id)
+    data, daemon_id, err = _daemon_memory_inputs(
+        inputs_json, daemon_id=daemon_id, node_def_id=node_def_id
+    )
     if err:
         return json.dumps({"universe_id": uid, "error": err})
     query = str(data.get("query") or text or filter_text or "").strip()
@@ -1754,13 +1761,16 @@ def _action_daemon_memory_list(
     universe_id: str = "",
     inputs_json: str = "",
     limit: Any = 50,
+    daemon_id: str = "",
     node_def_id: str = "",
     **_kwargs: Any,
 ) -> str:
     from workflow.daemon_brain import list_daemon_memory
 
     uid = universe_id or _default_universe()
-    data, daemon_id, err = _daemon_memory_inputs(inputs_json, node_def_id=node_def_id)
+    data, daemon_id, err = _daemon_memory_inputs(
+        inputs_json, daemon_id=daemon_id, node_def_id=node_def_id
+    )
     if err:
         return json.dumps({"universe_id": uid, "error": err})
     try:
@@ -1782,6 +1792,7 @@ def _action_daemon_memory_review(
     inputs_json: str = "",
     text: str = "",
     branch_task_id: str = "",
+    daemon_id: str = "",
     node_def_id: str = "",
     **_kwargs: Any,
 ) -> str:
@@ -1789,7 +1800,9 @@ def _action_daemon_memory_review(
     from workflow.daemon_brain import review_daemon_memory
 
     uid = universe_id or _default_universe()
-    data, daemon_id, err = _daemon_memory_inputs(inputs_json, node_def_id=node_def_id)
+    data, daemon_id, err = _daemon_memory_inputs(
+        inputs_json, daemon_id=daemon_id, node_def_id=node_def_id
+    )
     if err:
         return json.dumps({"universe_id": uid, "error": err})
     entry_id = str(data.get("entry_id") or branch_task_id or "").strip()
@@ -1821,13 +1834,16 @@ def _action_daemon_memory_promote(
     inputs_json: str = "",
     text: str = "",
     branch_task_id: str = "",
+    daemon_id: str = "",
     node_def_id: str = "",
     **_kwargs: Any,
 ) -> str:
     from workflow.daemon_brain import promote_daemon_memory_to_wiki
 
     uid = universe_id or _default_universe()
-    data, daemon_id, err = _daemon_memory_inputs(inputs_json, node_def_id=node_def_id)
+    data, daemon_id, err = _daemon_memory_inputs(
+        inputs_json, daemon_id=daemon_id, node_def_id=node_def_id
+    )
     if err:
         return json.dumps({"universe_id": uid, "error": err})
     entry_ids = _as_string_list(data.get("entry_ids")) or _as_string_list(branch_task_id)
@@ -1852,13 +1868,16 @@ def _action_daemon_memory_promote(
 def _action_daemon_memory_status(
     universe_id: str = "",
     inputs_json: str = "",
+    daemon_id: str = "",
     node_def_id: str = "",
     **_kwargs: Any,
 ) -> str:
     from workflow.daemon_brain import memory_observability_status
 
     uid = universe_id or _default_universe()
-    data, daemon_id, err = _daemon_memory_inputs(inputs_json, node_def_id=node_def_id)
+    data, daemon_id, err = _daemon_memory_inputs(
+        inputs_json, daemon_id=daemon_id, node_def_id=node_def_id
+    )
     if err:
         return json.dumps({"universe_id": uid, "error": err})
     try:
@@ -4258,6 +4277,7 @@ def _universe_impl(
     pickup_incentive: str = "",
     directed_daemon_id: str = "",
     directed_daemon_instruction: str = "",
+    daemon_id: str = "",
     branch_task_id: str = "",
     goal_id: str = "",
     branch_def_id: str = "",
@@ -4349,6 +4369,7 @@ def _universe_impl(
         "pickup_incentive": pickup_incentive,
         "directed_daemon_id": directed_daemon_id,
         "directed_daemon_instruction": directed_daemon_instruction,
+        "daemon_id": daemon_id,
         "branch_task_id": branch_task_id,
         "goal_id": goal_id,
         "branch_def_id": branch_def_id,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -325,6 +325,7 @@ def universe(
     pickup_incentive: str = "",
     directed_daemon_id: str = "",
     directed_daemon_instruction: str = "",
+    daemon_id: str = "",
     branch_task_id: str = "",
     goal_id: str = "",
     branch_def_id: str = "",
@@ -369,6 +370,7 @@ def universe(
         branch_id/request_type: Request routing fields.
         pickup_incentive/directed_daemon_id: Optional patch-request pickup
             signals; these do not affect acceptance, release, or merge odds.
+        daemon_id: Target daemon for daemon memory/status actions.
         filename/provenance_tag/limit/tag: Optional read/write filters.
         anchor_json: Optional JSON object for `give_direction` line/span notes.
     """
@@ -390,6 +392,7 @@ def universe(
         pickup_incentive=pickup_incentive,
         directed_daemon_id=directed_daemon_id,
         directed_daemon_instruction=directed_daemon_instruction,
+        daemon_id=daemon_id,
         branch_task_id=branch_task_id,
         goal_id=goal_id,
         branch_def_id=branch_def_id,

--- a/tests/test_api_universe.py
+++ b/tests/test_api_universe.py
@@ -503,6 +503,14 @@ def test_daemon_actions_create_summon_and_banish(tmp_path, monkeypatch) -> None:
     assert status_out["daemon_count"] == 1
     assert status_out["runtime_count"] == 1
 
+    memory_status_out = json.loads(univ_mod._universe_impl(
+        action="daemon_memory_status",
+        universe_id="u1",
+        daemon_id=daemon["daemon_id"],
+    ))
+    assert memory_status_out["daemon_id"] == daemon["daemon_id"]
+    assert memory_status_out["schema_version"] == 1
+
     banish_out = json.loads(univ_mod._universe_impl(
         action="daemon_banish",
         universe_id="u1",

--- a/tests/test_universe_server_framing.py
+++ b/tests/test_universe_server_framing.py
@@ -189,6 +189,17 @@ def test_control_station_routes_daemon_memory_actions() -> None:
     assert "daemon_id" in text
 
 
+def test_universe_schema_exposes_daemon_id_for_daemon_memory_actions() -> None:
+    """BUG-086: daemon memory status requires daemon_id, so the MCP schema
+    must expose a top-level daemon_id field instead of forcing callers through
+    hidden inputs_json.
+    """
+    tool = next(t for t in _list_tools() if t.name == "universe")
+    properties = tool.parameters.get("properties", {})
+    assert "daemon_id" in properties
+    assert "daemon_id" not in tool.parameters.get("required", [])
+
+
 def test_control_station_routes_treasury_status_as_read_only() -> None:
     """Treasury/cost-ledger status must be discoverable as a read-only route."""
     from workflow.api.prompts import _CONTROL_STATION_PROMPT

--- a/workflow/api/prompts.py
+++ b/workflow/api/prompts.py
@@ -276,7 +276,7 @@ enumerate ALL FIVE. Don't list extensions actions and forget the rest.
   action is unavailable, say so; do NOT fake the run through other tools.
 - "Remember this as daemon learning" / "what does this daemon remember?"
   / "review this daemon memory" -> use the daemon mini-brain actions on
-  `universe`. Pass `daemon_id` and structured fields through
+  `universe`. Pass `daemon_id` directly and structured fields through
   `inputs_json`; use `daemon_memory_capture` for new lessons,
   `daemon_memory_search` / `daemon_memory_list` for lookup,
   `daemon_memory_review` for accept/reject/supersede, and

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -1654,21 +1654,23 @@ def _as_string_list(value: Any) -> list[str] | None:
 def _daemon_memory_inputs(
     inputs_json: str,
     *,
+    daemon_id: str = "",
     node_def_id: str = "",
 ) -> tuple[dict[str, Any], str, str | None]:
     data, err = _parse_inputs_object(inputs_json)
     if err:
         return {}, "", err
-    daemon_id = str(data.get("daemon_id") or node_def_id or "").strip()
-    if not daemon_id:
+    resolved_daemon_id = str(data.get("daemon_id") or daemon_id or node_def_id or "").strip()
+    if not resolved_daemon_id:
         return data, "", "daemon_id is required."
-    return data, daemon_id, None
+    return data, resolved_daemon_id, None
 
 
 def _action_daemon_memory_capture(
     universe_id: str = "",
     inputs_json: str = "",
     text: str = "",
+    daemon_id: str = "",
     node_def_id: str = "",
     **_kwargs: Any,
 ) -> str:
@@ -1676,7 +1678,9 @@ def _action_daemon_memory_capture(
     from workflow.daemon_brain import capture_daemon_memory
 
     uid = universe_id or _default_universe()
-    data, daemon_id, err = _daemon_memory_inputs(inputs_json, node_def_id=node_def_id)
+    data, daemon_id, err = _daemon_memory_inputs(
+        inputs_json, daemon_id=daemon_id, node_def_id=node_def_id
+    )
     if err:
         return json.dumps({"universe_id": uid, "error": err})
     content = str(data.get("content") or text or "").strip()
@@ -1720,13 +1724,16 @@ def _action_daemon_memory_search(
     text: str = "",
     filter_text: str = "",
     limit: Any = 5,
+    daemon_id: str = "",
     node_def_id: str = "",
     **_kwargs: Any,
 ) -> str:
     from workflow.daemon_brain import search_daemon_memory
 
     uid = universe_id or _default_universe()
-    data, daemon_id, err = _daemon_memory_inputs(inputs_json, node_def_id=node_def_id)
+    data, daemon_id, err = _daemon_memory_inputs(
+        inputs_json, daemon_id=daemon_id, node_def_id=node_def_id
+    )
     if err:
         return json.dumps({"universe_id": uid, "error": err})
     query = str(data.get("query") or text or filter_text or "").strip()
@@ -1754,13 +1761,16 @@ def _action_daemon_memory_list(
     universe_id: str = "",
     inputs_json: str = "",
     limit: Any = 50,
+    daemon_id: str = "",
     node_def_id: str = "",
     **_kwargs: Any,
 ) -> str:
     from workflow.daemon_brain import list_daemon_memory
 
     uid = universe_id or _default_universe()
-    data, daemon_id, err = _daemon_memory_inputs(inputs_json, node_def_id=node_def_id)
+    data, daemon_id, err = _daemon_memory_inputs(
+        inputs_json, daemon_id=daemon_id, node_def_id=node_def_id
+    )
     if err:
         return json.dumps({"universe_id": uid, "error": err})
     try:
@@ -1782,6 +1792,7 @@ def _action_daemon_memory_review(
     inputs_json: str = "",
     text: str = "",
     branch_task_id: str = "",
+    daemon_id: str = "",
     node_def_id: str = "",
     **_kwargs: Any,
 ) -> str:
@@ -1789,7 +1800,9 @@ def _action_daemon_memory_review(
     from workflow.daemon_brain import review_daemon_memory
 
     uid = universe_id or _default_universe()
-    data, daemon_id, err = _daemon_memory_inputs(inputs_json, node_def_id=node_def_id)
+    data, daemon_id, err = _daemon_memory_inputs(
+        inputs_json, daemon_id=daemon_id, node_def_id=node_def_id
+    )
     if err:
         return json.dumps({"universe_id": uid, "error": err})
     entry_id = str(data.get("entry_id") or branch_task_id or "").strip()
@@ -1821,13 +1834,16 @@ def _action_daemon_memory_promote(
     inputs_json: str = "",
     text: str = "",
     branch_task_id: str = "",
+    daemon_id: str = "",
     node_def_id: str = "",
     **_kwargs: Any,
 ) -> str:
     from workflow.daemon_brain import promote_daemon_memory_to_wiki
 
     uid = universe_id or _default_universe()
-    data, daemon_id, err = _daemon_memory_inputs(inputs_json, node_def_id=node_def_id)
+    data, daemon_id, err = _daemon_memory_inputs(
+        inputs_json, daemon_id=daemon_id, node_def_id=node_def_id
+    )
     if err:
         return json.dumps({"universe_id": uid, "error": err})
     entry_ids = _as_string_list(data.get("entry_ids")) or _as_string_list(branch_task_id)
@@ -1852,13 +1868,16 @@ def _action_daemon_memory_promote(
 def _action_daemon_memory_status(
     universe_id: str = "",
     inputs_json: str = "",
+    daemon_id: str = "",
     node_def_id: str = "",
     **_kwargs: Any,
 ) -> str:
     from workflow.daemon_brain import memory_observability_status
 
     uid = universe_id or _default_universe()
-    data, daemon_id, err = _daemon_memory_inputs(inputs_json, node_def_id=node_def_id)
+    data, daemon_id, err = _daemon_memory_inputs(
+        inputs_json, daemon_id=daemon_id, node_def_id=node_def_id
+    )
     if err:
         return json.dumps({"universe_id": uid, "error": err})
     try:
@@ -4258,6 +4277,7 @@ def _universe_impl(
     pickup_incentive: str = "",
     directed_daemon_id: str = "",
     directed_daemon_instruction: str = "",
+    daemon_id: str = "",
     branch_task_id: str = "",
     goal_id: str = "",
     branch_def_id: str = "",
@@ -4349,6 +4369,7 @@ def _universe_impl(
         "pickup_incentive": pickup_incentive,
         "directed_daemon_id": directed_daemon_id,
         "directed_daemon_instruction": directed_daemon_instruction,
+        "daemon_id": daemon_id,
         "branch_task_id": branch_task_id,
         "goal_id": goal_id,
         "branch_def_id": branch_def_id,

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -325,6 +325,7 @@ def universe(
     pickup_incentive: str = "",
     directed_daemon_id: str = "",
     directed_daemon_instruction: str = "",
+    daemon_id: str = "",
     branch_task_id: str = "",
     goal_id: str = "",
     branch_def_id: str = "",
@@ -369,6 +370,7 @@ def universe(
         branch_id/request_type: Request routing fields.
         pickup_incentive/directed_daemon_id: Optional patch-request pickup
             signals; these do not affect acceptance, release, or merge odds.
+        daemon_id: Target daemon for daemon memory/status actions.
         filename/provenance_tag/limit/tag: Optional read/write filters.
         anchor_json: Optional JSON object for `give_direction` line/span notes.
     """
@@ -390,6 +392,7 @@ def universe(
         pickup_incentive=pickup_incentive,
         directed_daemon_id=directed_daemon_id,
         directed_daemon_instruction=directed_daemon_instruction,
+        daemon_id=daemon_id,
         branch_task_id=branch_task_id,
         goal_id=goal_id,
         branch_def_id=branch_def_id,


### PR DESCRIPTION
Fixes #916

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-086-universe-daemon-memory-status-requires-daemon-id-but-mcp-sch.md`
- GitHub issue: #916
- Branch task: `auto-change/issue-916`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.