### PR TITLE
[auto-change] BUG-087: run_branch fails immediately with AllProvidersExhaustedError instead of retry/backoff despite actionable retry message

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
@@ -33,6 +33,7 @@ import operator
 import os
 import re
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Any, Callable
@@ -40,8 +41,11 @@ from typing import Annotated, Any, Callable
 from langgraph.graph import END, START, StateGraph
 
 from workflow.branches import BranchDefinition, GraphNodeRef, NodeDefinition
+from workflow.exceptions import AllProvidersExhaustedError
 
 logger = logging.getLogger(__name__)
+
+_POLICY_PROVIDER_RETRY_BACKOFF_SECONDS = (2.0, 4.0)
 
 
 class CompilerError(Exception):
@@ -207,6 +211,32 @@ def _run_with_timeout(
             "its own subprocess/HTTP timeout is the backstop.",
             node_id=node_id,
         ) from exc
+
+
+def _call_policy_router_with_retry(
+    router: Any,
+    *,
+    role: str,
+    prompt: str,
+    system: str,
+    policy: dict[str, Any],
+) -> tuple[str, str]:
+    """Retry policy-aware provider dispatch on transient chain exhaustion."""
+    attempts = len(_POLICY_PROVIDER_RETRY_BACKOFF_SECONDS) + 1
+    for attempt_index in range(attempts):
+        try:
+            return router.call_with_policy_sync(role, prompt, system, policy)
+        except AllProvidersExhaustedError:
+            if attempt_index == attempts - 1:
+                raise
+            delay = _POLICY_PROVIDER_RETRY_BACKOFF_SECONDS[attempt_index]
+            logger.warning(
+                "Policy provider chain exhausted for role=%s; retrying in %.1fs",
+                role,
+                delay,
+            )
+            time.sleep(delay)
+    raise AssertionError("unreachable policy provider retry state")
 
 
 _DANGEROUS_PATTERNS = (
@@ -1038,8 +1068,12 @@ def _build_prompt_template_node(
                     )
                     if _policy_router is not None and router_has_providers:
                         def _policy_call() -> tuple[str, str]:
-                            return _policy_router.call_with_policy_sync(
-                                role, prompt, "", effective_policy,
+                            return _call_policy_router_with_retry(
+                                _policy_router,
+                                role=role,
+                                prompt=prompt,
+                                system="",
+                                policy=effective_policy,
                             )
                         text_and_name = _run_with_timeout(
                             _policy_call,

--- a/tests/test_llm_policy_override.py
+++ b/tests/test_llm_policy_override.py
@@ -26,6 +26,7 @@ from workflow.branches import (
     NodeDefinition,
     _validate_llm_policy_shape,
 )
+from workflow.exceptions import AllProvidersExhaustedError
 from workflow.graph_compiler import compile_branch
 
 # ─── helpers ──────────────────────────────────────────────────────────────────
@@ -301,6 +302,42 @@ def test_fallback_fires_when_preferred_exhausted():
                 {"topic": "x"},
                 config={"configurable": {"thread_id": "t-fallback"}},
             )
+
+
+def test_policy_dispatch_retries_transient_provider_exhaustion(monkeypatch):
+    """Policy-aware run_branch dispatch should honor the router retry contract."""
+    import workflow.graph_compiler as graph_compiler
+
+    policy = {"preferred": {"provider": "groq-free"}}
+    node = _make_node(llm_policy=policy)
+    branch = _make_branch(node)
+
+    mock_router = MagicMock()
+    mock_router.call_with_policy_sync.side_effect = [
+        AllProvidersExhaustedError(
+            "All providers exhausted for role=writer. Daemon should retry with backoff."
+        ),
+        ("success after retry", "groq-free"),
+    ]
+
+    monkeypatch.setattr(
+        graph_compiler, "_POLICY_PROVIDER_RETRY_BACKOFF_SECONDS", (0.0, 0.0),
+    )
+    with patch(
+        "workflow.graph_compiler._get_shared_router", return_value=mock_router,
+    ):
+        compiled = compile_branch(
+            branch,
+            provider_call=lambda p, s, *, role="writer": "[plain]",
+        )
+        app = compiled.graph.compile()
+        out = app.invoke(
+            {"topic": "x"},
+            config={"configurable": {"thread_id": "t-policy-retry"}},
+        )
+
+    assert out["out"] == "success after retry"
+    assert mock_router.call_with_policy_sync.call_count == 2
 
 
 def test_difficulty_override_passed_through():

--- a/workflow/graph_compiler.py
+++ b/workflow/graph_compiler.py
@@ -33,6 +33,7 @@ import operator
 import os
 import re
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Any, Callable
@@ -40,8 +41,11 @@ from typing import Annotated, Any, Callable
 from langgraph.graph import END, START, StateGraph
 
 from workflow.branches import BranchDefinition, GraphNodeRef, NodeDefinition
+from workflow.exceptions import AllProvidersExhaustedError
 
 logger = logging.getLogger(__name__)
+
+_POLICY_PROVIDER_RETRY_BACKOFF_SECONDS = (2.0, 4.0)
 
 
 class CompilerError(Exception):
@@ -207,6 +211,32 @@ def _run_with_timeout(
             "its own subprocess/HTTP timeout is the backstop.",
             node_id=node_id,
         ) from exc
+
+
+def _call_policy_router_with_retry(
+    router: Any,
+    *,
+    role: str,
+    prompt: str,
+    system: str,
+    policy: dict[str, Any],
+) -> tuple[str, str]:
+    """Retry policy-aware provider dispatch on transient chain exhaustion."""
+    attempts = len(_POLICY_PROVIDER_RETRY_BACKOFF_SECONDS) + 1
+    for attempt_index in range(attempts):
+        try:
+            return router.call_with_policy_sync(role, prompt, system, policy)
+        except AllProvidersExhaustedError:
+            if attempt_index == attempts - 1:
+                raise
+            delay = _POLICY_PROVIDER_RETRY_BACKOFF_SECONDS[attempt_index]
+            logger.warning(
+                "Policy provider chain exhausted for role=%s; retrying in %.1fs",
+                role,
+                delay,
+            )
+            time.sleep(delay)
+    raise AssertionError("unreachable policy provider retry state")
 
 
 _DANGEROUS_PATTERNS = (
@@ -1038,8 +1068,12 @@ def _build_prompt_template_node(
                     )
                     if _policy_router is not None and router_has_providers:
                         def _policy_call() -> tuple[str, str]:
-                            return _policy_router.call_with_policy_sync(
-                                role, prompt, "", effective_policy,
+                            return _call_policy_router_with_retry(
+                                _policy_router,
+                                role=role,
+                                prompt=prompt,
+                                system="",
+                                policy=effective_policy,
                             )
                         text_and_name = _run_with_timeout(
                             _policy_call,


### PR DESCRIPTION
Fixes #917

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-087-run-branch-fails-immediately-with-allprovidersexhaustederror.md`
- GitHub issue: #917
- Branch task: `auto-change/issue-917`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.