### PR TITLE
[auto-change] BUG-091: Branch validation allows undeclared state fields to drop initial inputs and node outputs at runtime

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branches.py
@@ -1107,6 +1107,29 @@ class BranchDefinition:
                         "running this branch."
                     )
 
+        # LangGraph's synthesized TypedDict is built from state_schema.
+        # If a branch declares a partial schema, any undeclared initial
+        # inputs or node outputs can be dropped at runtime. Keep empty-schema
+        # legacy branches in warn-only mode, but make partial schemas exact.
+        if field_names:
+            for n in self.node_defs:
+                for key in n.input_keys or []:
+                    if key not in field_names:
+                        errors.append(
+                            f"Node '{n.node_id}' input_key '{key}' is not "
+                            "declared in state_schema. Add a state_schema "
+                            "field so run_branch preserves this input at "
+                            "runtime."
+                        )
+                for key in n.output_keys or []:
+                    if key not in field_names:
+                        errors.append(
+                            f"Node '{n.node_id}' output_key '{key}' is not "
+                            "declared in state_schema. Add a state_schema "
+                            "field so run_branch preserves this output at "
+                            "runtime."
+                        )
+
         try:
             normalize_branch_skill_snapshots(self.skills)
         except ValueError as exc:

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -538,6 +538,50 @@ class TestBranchDefinition:
         assert "graph node ID 'orient'" in fixes
         assert "before running" in fixes
 
+    def test_validate_input_key_must_be_declared_when_state_schema_exists(self):
+        b = _make_sample_branch()
+        b.node_defs[0].input_keys.append("missing_runtime_input")
+
+        errors = b.validate()
+
+        assert any(
+            "Node 'orient-def' input_key 'missing_runtime_input' "
+            "is not declared in state_schema" in e
+            for e in errors
+        )
+
+    def test_validate_output_key_must_be_declared_when_state_schema_exists(self):
+        b = _make_sample_branch()
+        b.node_defs[0].output_keys.append("missing_runtime_output")
+
+        errors = b.validate()
+
+        assert any(
+            "Node 'orient-def' output_key 'missing_runtime_output' "
+            "is not declared in state_schema" in e
+            for e in errors
+        )
+
+    def test_validate_legacy_empty_state_schema_remains_allowed(self):
+        b = BranchDefinition(name="legacy", entry_point="n1")
+        b.node_defs = [
+            NodeDefinition(
+                node_id="n1",
+                display_name="N1",
+                input_keys=["topic"],
+                output_keys=["draft"],
+                prompt_template="{topic}",
+            )
+        ]
+        b.graph_nodes = [GraphNodeRef(id="n1", node_def_id="n1")]
+        b.edges = [
+            EdgeDefinition(from_node="START", to_node="n1"),
+            EdgeDefinition(from_node="n1", to_node="END"),
+        ]
+        b.state_schema = []
+
+        assert b.validate() == []
+
     def test_fork(self):
         b = _make_sample_branch()
         b.stats["run_count"] = 42

--- a/tests/test_graph_compiler_isolation_diagnostics.py
+++ b/tests/test_graph_compiler_isolation_diagnostics.py
@@ -28,11 +28,12 @@ from __future__ import annotations
 
 import pytest
 
-from workflow.branches import NodeDefinition
+from workflow.branches import BranchDefinition, EdgeDefinition, GraphNodeRef, NodeDefinition
 from workflow.graph_compiler import (
     CompilerError,
     _build_prompt_template_node,
     _state_schema_defaults,
+    compile_branch,
     seed_initial_state,
 )
 
@@ -590,3 +591,68 @@ def test_build_branch_state_schema_default_seeded_to_strict_prompt(
         assert result["draft"] == "drafted"
     finally:
         importlib.reload(us)
+
+
+# ─── BUG-091: partial state_schema must fail before runtime drops keys ───
+
+
+def test_compile_rejects_output_key_missing_from_partial_state_schema():
+    """A partial state_schema used to validate successfully, then LangGraph
+    dropped the node's undeclared output at invoke time. Validation must fail
+    before compile/run_branch can reach that silent-drop path.
+    """
+    branch = BranchDefinition(name="BUG-091 output drop", entry_point="n1")
+    branch.node_defs = [
+        NodeDefinition(
+            node_id="n1",
+            display_name="N1",
+            output_keys=["draft"],
+            prompt_template="write",
+        )
+    ]
+    branch.graph_nodes = [GraphNodeRef(id="n1", node_def_id="n1")]
+    branch.edges = [
+        EdgeDefinition(from_node="START", to_node="n1"),
+        EdgeDefinition(from_node="n1", to_node="END"),
+    ]
+    branch.state_schema = [{"name": "other", "type": "str"}]
+
+    with pytest.raises(CompilerError) as exc:
+        compile_branch(
+            branch,
+            provider_call=lambda prompt, system="", *, role="writer": "draft",
+        )
+
+    msg = str(exc.value)
+    assert "output_key 'draft' is not declared in state_schema" in msg
+
+
+def test_compile_rejects_input_key_missing_from_partial_state_schema():
+    """Initial inputs outside a non-empty state_schema are dropped by the
+    synthesized runtime state. Validation must catch the undeclared key.
+    """
+    branch = BranchDefinition(name="BUG-091 input drop", entry_point="n1")
+    branch.node_defs = [
+        NodeDefinition(
+            node_id="n1",
+            display_name="N1",
+            input_keys=["topic"],
+            output_keys=["draft"],
+            prompt_template="{topic}",
+        )
+    ]
+    branch.graph_nodes = [GraphNodeRef(id="n1", node_def_id="n1")]
+    branch.edges = [
+        EdgeDefinition(from_node="START", to_node="n1"),
+        EdgeDefinition(from_node="n1", to_node="END"),
+    ]
+    branch.state_schema = [{"name": "draft", "type": "str"}]
+
+    with pytest.raises(CompilerError) as exc:
+        compile_branch(
+            branch,
+            provider_call=lambda prompt, system="", *, role="writer": "draft",
+        )
+
+    msg = str(exc.value)
+    assert "input_key 'topic' is not declared in state_schema" in msg

--- a/workflow/branches.py
+++ b/workflow/branches.py
@@ -1107,6 +1107,29 @@ class BranchDefinition:
                         "running this branch."
                     )
 
+        # LangGraph's synthesized TypedDict is built from state_schema.
+        # If a branch declares a partial schema, any undeclared initial
+        # inputs or node outputs can be dropped at runtime. Keep empty-schema
+        # legacy branches in warn-only mode, but make partial schemas exact.
+        if field_names:
+            for n in self.node_defs:
+                for key in n.input_keys or []:
+                    if key not in field_names:
+                        errors.append(
+                            f"Node '{n.node_id}' input_key '{key}' is not "
+                            "declared in state_schema. Add a state_schema "
+                            "field so run_branch preserves this input at "
+                            "runtime."
+                        )
+                for key in n.output_keys or []:
+                    if key not in field_names:
+                        errors.append(
+                            f"Node '{n.node_id}' output_key '{key}' is not "
+                            "declared in state_schema. Add a state_schema "
+                            "field so run_branch preserves this output at "
+                            "runtime."
+                        )
+
         try:
             normalize_branch_skill_snapshots(self.skills)
         except ValueError as exc:


### PR DESCRIPTION
Fixes #924

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-091-branch-validation-allows-undeclared-state-fields-to-drop-ini.md`
- GitHub issue: #924
- Branch task: `auto-change/issue-924`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.