### PR TITLE
[auto-change] BUG-092: synthesize_source signals not processed after switch_universe: daemon stays offline/starved, activity.log empty, all sources synthesis_complete=false

### DIFF
--- a/fantasy_daemon/__main__.py
+++ b/fantasy_daemon/__main__.py
@@ -1786,7 +1786,7 @@ class DaemonController:
         # Check for cross-universe synthesis switch request
         health = output.get("health", {})
         switch_target = health.get("switch_to_universe", "")
-        if switch_target and node_name == "universe_cycle":
+        if switch_target and node_name in ("universe_cycle", "universe_cycle_wrapper"):
             self._pending_universe_switch = switch_target
             self._stop_event.set()
             logger.info(

--- a/tests/test_universe_cycle_wrapper_neutral_fields.py
+++ b/tests/test_universe_cycle_wrapper_neutral_fields.py
@@ -10,6 +10,36 @@ domain-neutral status text instead of fantasy-shaped vocabulary alone.
 from __future__ import annotations
 
 
+def test_wrapper_output_with_synthesis_switch_stops_for_universe_switch(tmp_path):
+    """Wrapper-mode output must still trigger the daemon switch path.
+
+    Direct graph execution emits the same health field from the inner
+    ``universe_cycle`` node. Under unified execution, the outer stream only
+    exposes ``universe_cycle_wrapper`` output, so the controller must honor
+    the switch request there too.
+    """
+    from fantasy_daemon.__main__ import DaemonController
+
+    universe = tmp_path / "universe-a"
+    universe.mkdir()
+    controller = DaemonController(universe_path=str(universe), no_tray=True)
+
+    controller._handle_node_output(
+        "universe_cycle_wrapper",
+        {
+            "health": {
+                "switch_to_universe": "universe-b",
+                "stopped": True,
+            },
+            "total_words": 0,
+            "total_chapters": 0,
+        },
+    )
+
+    assert controller._pending_universe_switch == "universe-b"
+    assert controller._stop_event.is_set()
+
+
 def test_neutral_fields_in_emission_when_idle_by_design():
     """When daemon idles by design (stopped=True, no work), emission includes
     reason_code=no_active_work + display_reason=idle_no_active_work."""


### PR DESCRIPTION
Fixes #940

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-092-synthesize-source-signals-not-processed-after-switch-univers.md`
- GitHub issue: #940
- Branch task: `auto-change/issue-940`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.