### PR TITLE
[auto-change] BUG-099: PR-122 Phase 1 dry-run effector chain doesn't surface external_write_results in get_run output even when node declares effects + emits valid packet

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/runs.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/runs.py
@@ -662,6 +662,11 @@ def _compose_run_snapshot(
         "summary": summary,
         "recursion_limit": recursion_limit,
     }
+    output = run_record.get("output")
+    if isinstance(output, dict):
+        for key in ("external_write_results", "external_write_errors"):
+            if key in output:
+                snapshot[key] = output[key]
     # INTERRUPTED runs are terminal in v1 (durability guarantee — see
     # ``_action_run_branch`` docstring + ``runs.recover_in_flight_runs``).
     # The client must rerun with the same ``inputs_json``; it cannot be

--- a/tests/test_external_write_effector.py
+++ b/tests/test_external_write_effector.py
@@ -26,7 +26,12 @@ from unittest.mock import patch
 
 import pytest
 
-from workflow.branches import BranchDefinition, NodeDefinition
+from workflow.branches import (
+    BranchDefinition,
+    EdgeDefinition,
+    GraphNodeRef,
+    NodeDefinition,
+)
 from workflow.effectors import (
     EXTERNAL_WRITE_SINK_GITHUB_PR,
     run_effects_for_branch,
@@ -464,6 +469,70 @@ def test_runs_external_write_results_overwrites_quarantined_value():
         "fake": "forgery",
     }
     assert output["_branch_authored_external_write_errors"] == [{"fake": "row"}]
+
+
+def test_get_run_snapshot_surfaces_external_write_results(tmp_path, monkeypatch):
+    """Regression for BUG-099: the dry-run effector receipt persisted
+    in run output must be visible from the get_run snapshot, not only
+    from get_run_output.
+    """
+    import workflow.daemon_server as daemon_server
+    from workflow.api.runs import _compose_run_snapshot
+    from workflow.runs import execute_branch, get_run, list_events
+
+    packet = {
+        "sink": EXTERNAL_WRITE_SINK_GITHUB_PR,
+        "payload": {
+            "title": "Fix BUG-099",
+            "body": "Surface the dry-run effector evidence.",
+            "base_branch": "main",
+            "head_branch": "auto/bug-099",
+        },
+    }
+    branch = BranchDefinition(
+        name="emit-pr",
+        entry_point="draft",
+        node_defs=[
+            NodeDefinition(
+                node_id="draft",
+                display_name="Draft",
+                approved=True,
+                source_code=(
+                    "def run(state):\n"
+                    "    return {'pr_packet': state['packet']}\n"
+                ),
+                output_keys=["pr_packet"],
+                effects=[EXTERNAL_WRITE_SINK_GITHUB_PR],
+            ),
+        ],
+        graph_nodes=[GraphNodeRef(id="draft", node_def_id="draft")],
+        edges=[
+            EdgeDefinition(from_node="START", to_node="draft"),
+            EdgeDefinition(from_node="draft", to_node="END"),
+        ],
+        state_schema=[
+            {"name": "packet", "type": "dict"},
+            {"name": "pr_packet", "type": "dict"},
+        ],
+    )
+    monkeypatch.setattr(
+        daemon_server,
+        "get_branch_definition",
+        lambda *_args, **_kwargs: branch.to_dict(),
+    )
+
+    outcome = execute_branch(tmp_path, branch=branch, inputs={"packet": packet})
+    assert outcome.status == "completed"
+    record = get_run(tmp_path, outcome.run_id)
+    events = list_events(tmp_path, outcome.run_id)
+
+    snapshot = _compose_run_snapshot(record, events)
+
+    receipt = snapshot["external_write_results"]["draft"][
+        EXTERNAL_WRITE_SINK_GITHUB_PR
+    ]
+    assert receipt["dry_run"] is True
+    assert receipt["matched_output_key"] == "pr_packet"
 
 
 # ─── 8. BranchDefinition node_defs roundtrip through full to_dict path ────

--- a/workflow/api/runs.py
+++ b/workflow/api/runs.py
@@ -662,6 +662,11 @@ def _compose_run_snapshot(
         "summary": summary,
         "recursion_limit": recursion_limit,
     }
+    output = run_record.get("output")
+    if isinstance(output, dict):
+        for key in ("external_write_results", "external_write_errors"):
+            if key in output:
+                snapshot[key] = output[key]
     # INTERRUPTED runs are terminal in v1 (durability guarantee — see
     # ``_action_run_branch`` docstring + ``runs.recover_in_flight_runs``).
     # The client must rerun with the same ``inputs_json``; it cannot be


### PR DESCRIPTION
Fixes #973

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-099-pr-122-phase-1-dry-run-effector-chain-doesn-t-surface-extern.md`
- GitHub issue: #973
- Branch task: `auto-change/issue-973`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.