### PR TITLE
[auto-change] BUG-103: build_branch silently drops node timeout_seconds from spec_json

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -1200,7 +1200,7 @@ def _resolve_node_spec(
         for field_key in (
             "display_name", "description", "phase", "input_keys",
             "output_keys", "strict_input_isolation", "source_code",
-            "prompt_template", "author",
+            "prompt_template", "timeout_seconds", "author",
         ):
             if field_key in raw and raw[field_key] not in (None, ""):
                 merged[field_key] = raw[field_key]
@@ -1351,6 +1351,14 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
     )
     if err:
         return err
+    timeout_seconds_raw = raw.get("timeout_seconds", 300.0)
+    if timeout_seconds_raw in (None, ""):
+        timeout_seconds = 300.0
+    else:
+        try:
+            timeout_seconds = float(timeout_seconds_raw)
+        except (TypeError, ValueError):
+            return f"node '{nid}' timeout_seconds must be a number."
     # BUG-045: thread the three sub-branch / sibling-run spec fields. The
     # compiler reads them (workflow/graph_compiler.py:_build_invoke_branch /
     # invoke_branch_version / await_run callables) and NodeDefinition
@@ -1393,6 +1401,7 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
             prompt_template=prompt_template,
             model_hint=model_hint,
             llm_policy=llm_policy,
+            timeout_seconds=timeout_seconds,
             author=raw.get("author") or _current_actor(),
             approved=bool(raw.get("approved", False)),
             invoke_branch_spec=invoke_branch_arg,

--- a/tests/test_composite_branch_actions.py
+++ b/tests/test_composite_branch_actions.py
@@ -98,6 +98,32 @@ def test_build_branch_persists(comp_env):
     assert got["name"] == "Recipe tracker"
 
 
+def test_build_branch_preserves_node_timeout_seconds(comp_env):
+    us, _ = comp_env
+    spec = {
+        **RECIPE_SPEC,
+        "node_defs": [{
+            **RECIPE_SPEC["node_defs"][0],
+            "timeout_seconds": 45,
+        }],
+        "edges": [
+            {"from": "START", "to": "capture"},
+            {"from": "capture", "to": "END"},
+        ],
+        "state_schema": [
+            {"name": "raw_recipe", "type": "str"},
+            {"name": "capture_output", "type": "str"},
+        ],
+    }
+
+    built = _call(us, "build_branch", spec_json=json.dumps(spec))
+
+    assert built["status"] == "built", built
+    got = _call(us, "get_branch", branch_def_id=built["branch_def_id"])
+    capture = next(n for n in got["node_defs"] if n["node_id"] == "capture")
+    assert capture["timeout_seconds"] == 45.0
+
+
 def test_build_branch_preserves_explicit_non_strict_input_isolation(comp_env):
     us, _ = comp_env
     spec = {

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -1200,7 +1200,7 @@ def _resolve_node_spec(
         for field_key in (
             "display_name", "description", "phase", "input_keys",
             "output_keys", "strict_input_isolation", "source_code",
-            "prompt_template", "author",
+            "prompt_template", "timeout_seconds", "author",
         ):
             if field_key in raw and raw[field_key] not in (None, ""):
                 merged[field_key] = raw[field_key]
@@ -1351,6 +1351,14 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
     )
     if err:
         return err
+    timeout_seconds_raw = raw.get("timeout_seconds", 300.0)
+    if timeout_seconds_raw in (None, ""):
+        timeout_seconds = 300.0
+    else:
+        try:
+            timeout_seconds = float(timeout_seconds_raw)
+        except (TypeError, ValueError):
+            return f"node '{nid}' timeout_seconds must be a number."
     # BUG-045: thread the three sub-branch / sibling-run spec fields. The
     # compiler reads them (workflow/graph_compiler.py:_build_invoke_branch /
     # invoke_branch_version / await_run callables) and NodeDefinition
@@ -1393,6 +1401,7 @@ def _apply_node_spec(branch: Any, raw: dict[str, Any]) -> str:
             prompt_template=prompt_template,
             model_hint=model_hint,
             llm_policy=llm_policy,
+            timeout_seconds=timeout_seconds,
             author=raw.get("author") or _current_actor(),
             approved=bool(raw.get("approved", False)),
             invoke_branch_spec=invoke_branch_arg,


### PR DESCRIPTION
Fixes #987

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-103-build-branch-silently-drops-node-timeout-seconds-from-spec-j.md`
- GitHub issue: #987
- Branch task: `auto-change/issue-987`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.