### PR TITLE
[auto-change] BUG-105: published-scope branch listings expose published:false and omit the published version handle

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -406,11 +406,14 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
 
     summaries = []
     for r in rows:
+        published_version_id = None
         if scope == "published":
             from workflow.branch_versions import list_branch_versions
 
-            if not list_branch_versions(_base_path(), r.get("branch_def_id", ""), limit=1):
+            versions = list_branch_versions(_base_path(), r.get("branch_def_id", ""), limit=1)
+            if not versions:
                 continue
+            published_version_id = versions[0].branch_version_id
         elif scope == "mine":
             if (r.get("author") or "") != actor:
                 continue
@@ -427,7 +430,7 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
         # node_defs`` which double-counted because graph.nodes is a
         # compiled-topology view that overlaps with node_defs.
         node_count = len(node_defs)
-        summaries.append({
+        summary = {
             "branch_def_id": r.get("branch_def_id"),
             "name": r.get("name"),
             "author": r.get("author"),
@@ -435,10 +438,13 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
             "goal_id": r.get("goal_id"),
             "node_count": node_count,
             "skill_count": len(r.get("skills", []) or []),
-            "published": r.get("published", False),
+            "published": True if scope == "published" else r.get("published", False),
             "visibility": r.get("visibility", "public"),
             "has_sandbox_nodes": has_sandbox_nodes,
-        })
+        }
+        if published_version_id is not None:
+            summary["branch_version_id"] = published_version_id
+        summaries.append(summary)
     return json.dumps({"branches": summaries, "count": len(summaries)})
 
 

--- a/tests/test_branch_authoring_actions.py
+++ b/tests/test_branch_authoring_actions.py
@@ -121,6 +121,11 @@ def test_list_branches_scope_published_filters_on_published_versions(branch_env)
     names = sorted(b["name"] for b in listing["branches"])
     assert "Versioned" in names
     assert "Probe draft" not in names
+    versioned_summary = next(
+        b for b in listing["branches"] if b["branch_def_id"] == versioned["branch_def_id"]
+    )
+    assert versioned_summary["published"] is True
+    assert versioned_summary["branch_version_id"] == version["branch_version_id"]
 
 
 def test_list_branches_scope_published_is_the_default(branch_env):

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -406,11 +406,14 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
 
     summaries = []
     for r in rows:
+        published_version_id = None
         if scope == "published":
             from workflow.branch_versions import list_branch_versions
 
-            if not list_branch_versions(_base_path(), r.get("branch_def_id", ""), limit=1):
+            versions = list_branch_versions(_base_path(), r.get("branch_def_id", ""), limit=1)
+            if not versions:
                 continue
+            published_version_id = versions[0].branch_version_id
         elif scope == "mine":
             if (r.get("author") or "") != actor:
                 continue
@@ -427,7 +430,7 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
         # node_defs`` which double-counted because graph.nodes is a
         # compiled-topology view that overlaps with node_defs.
         node_count = len(node_defs)
-        summaries.append({
+        summary = {
             "branch_def_id": r.get("branch_def_id"),
             "name": r.get("name"),
             "author": r.get("author"),
@@ -435,10 +438,13 @@ def _ext_branch_list(kwargs: dict[str, Any]) -> str:
             "goal_id": r.get("goal_id"),
             "node_count": node_count,
             "skill_count": len(r.get("skills", []) or []),
-            "published": r.get("published", False),
+            "published": True if scope == "published" else r.get("published", False),
             "visibility": r.get("visibility", "public"),
             "has_sandbox_nodes": has_sandbox_nodes,
-        })
+        }
+        if published_version_id is not None:
+            summary["branch_version_id"] = published_version_id
+        summaries.append(summary)
     return json.dumps({"branches": summaries, "count": len(summaries)})
 
 


### PR DESCRIPTION
Fixes #994

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-105-published-scope-branch-listings-expose-published-false-and-o.md`
- GitHub issue: #994
- Branch task: `auto-change/issue-994`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.