### PR TITLE
fix: make wiki read truncation actionable

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -528,3 +528,14 @@ Notes:
   checkpoint DB size in storage status before it becomes a disk-full outage.
 - Ship condition: focused tests pass, ruff passes, PR opened for Claude/Cowork
   review.
+
+## BUG-106 Wiki Read Truncation - 2026-05-27
+
+- 2026-05-27 create `../wf-bug106-wiki-read-truncation` on
+  `codex/bug106-wiki-read-truncation` by codex-gpt5-desktop.
+- Source: live wiki BUG-106 filed from the souled-universe draft review:
+  `wiki read` returns partial large documents without an in-band marker.
+- Purpose: make wiki read truncation unmistakable and actionable for connector
+  users.
+- Ship condition: focused wiki read tests pass, PR opened for Claude-family
+  checker review.

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -69,6 +69,8 @@ _WIKI_SEARCH_COMPLETENESS_WARNING = (
     "changed_since=<ISO timestamp>; for authoritative content read candidate "
     "pages with action=read."
 )
+_WIKI_READ_DEFAULT_MAX_CHARS = 15_000
+_WIKI_READ_MAX_CHARS = 50_000
 
 
 _logger_wiki = logging.getLogger("universe_server.wiki")
@@ -302,6 +304,24 @@ def _coerce_result_limit(value: Any) -> int:
     return max(1, min(raw, 100))
 
 
+def _coerce_read_offset(value: Any) -> int:
+    try:
+        raw = int(value or 0)
+    except (TypeError, ValueError):
+        raw = 0
+    return max(0, raw)
+
+
+def _coerce_read_max_chars(value: Any) -> int:
+    try:
+        raw = int(value or 0)
+    except (TypeError, ValueError):
+        raw = _WIKI_READ_DEFAULT_MAX_CHARS
+    if raw <= 0:
+        raw = _WIKI_READ_DEFAULT_MAX_CHARS
+    return max(1, min(raw, _WIKI_READ_MAX_CHARS))
+
+
 def _ambient_relevance_feed(
     *,
     source: Path,
@@ -475,6 +495,8 @@ def _wiki_read(
     query: str = "",
     changed_since: str = "",
     max_results: int = 10,
+    offset: int = 0,
+    max_chars: int = _WIKI_READ_DEFAULT_MAX_CHARS,
     **_kwargs: Any,
 ) -> str:
     if not page:
@@ -507,21 +529,46 @@ def _wiki_read(
         source_body=body,
     )
 
-    if len(text) > 15000:
+    read_start = _coerce_read_offset(offset)
+    read_limit = _coerce_read_max_chars(max_chars)
+    total_chars = len(content)
+    if read_start > total_chars:
+        read_start = total_chars
+    read_end = min(read_start + read_limit, total_chars)
+    chunk = content[read_start:read_end]
+    truncated = read_end < total_chars
+    next_offset = read_end if truncated else None
+
+    if truncated:
+        marker = (
+            "\n\n[WIKI READ TRUNCATED: showing chars "
+            f"{read_start}-{read_end} of {total_chars}. Continue with "
+            f"wiki(action=\"read\", page=\"{page}\", offset={read_end}, "
+            f"max_chars={read_limit}).]"
+        )
         return json.dumps({
             "path": rel,
             "is_draft": is_draft,
-            "content": content[:15000],
+            "content": chunk + marker,
             "truncated": True,
-            "total_chars": len(text),
+            "total_chars": total_chars,
+            "read_start": read_start,
+            "read_end": read_end,
+            "read_limit": read_limit,
+            "next_offset": next_offset,
             "source_read_proof": source_read_proof,
             "ambient_relevance_feed": ambient_feed,
         })
     return json.dumps({
         "path": rel,
         "is_draft": is_draft,
-        "content": content,
+        "content": chunk,
         "truncated": False,
+        "total_chars": total_chars,
+        "read_start": read_start,
+        "read_end": read_end,
+        "read_limit": read_limit,
+        "next_offset": None,
         "source_read_proof": source_read_proof,
         "ambient_relevance_feed": ambient_feed,
     })
@@ -2107,6 +2154,8 @@ def wiki(
     dry_run: bool = True,
     skip_lint: bool = False,
     max_results: int = 10,
+    offset: int = 0,
+    max_chars: int = _WIKI_READ_DEFAULT_MAX_CHARS,
     component: str = "",
     severity: str = "",
     title: str = "",
@@ -2204,6 +2253,8 @@ def wiki(
         "dry_run": dry_run,
         "skip_lint": skip_lint,
         "max_results": max_results,
+        "offset": offset,
+        "max_chars": max_chars,
         "component": component,
         "severity": severity,
         "title": title,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -960,6 +960,8 @@ def wiki(
     dry_run: bool = True,
     skip_lint: bool = False,
     max_results: int = 10,
+    offset: int = 0,
+    max_chars: int = 15000,
     component: str = "",
     severity: str = "",
     title: str = "",
@@ -1012,6 +1014,8 @@ def wiki(
         changed_since: Optional ISO timestamp for action="read" ambient feed
             and required ISO timestamp for action="since"; only pages updated
             after this timestamp are returned.
+        offset/max_chars: For action="read", read a bounded character window
+            from large pages. Truncated responses include `next_offset`.
     """
     return _wiki_impl(
         action=action,
@@ -1032,6 +1036,8 @@ def wiki(
         dry_run=dry_run,
         skip_lint=skip_lint,
         max_results=max_results,
+        offset=offset,
+        max_chars=max_chars,
         component=component,
         severity=severity,
         title=title,

--- a/tests/test_api_wiki.py
+++ b/tests/test_api_wiki.py
@@ -356,6 +356,45 @@ def test_wiki_read_returns_source_proof_and_ambient_feed(wiki_env):
     assert "ambient" in fresh["matched_terms"]
 
 
+def test_wiki_read_large_page_marks_content_and_supports_offset(wiki_env):
+    path = wiki_env / "pages" / "notes" / "large-read.md"
+    body = "start marker\n" + ("x" * 16000) + "\nend marker\n"
+    path.write_text(
+        "---\n"
+        "title: Large Read\n"
+        "type: note\n"
+        "updated: 2026-05-27T00:00:00Z\n"
+        "---\n\n"
+        + body,
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    first = json.loads(wiki(action="read", page="large-read", max_chars=4000))
+
+    assert first["truncated"] is True
+    assert first["read_start"] == 0
+    assert first["read_end"] == 4000
+    assert first["next_offset"] == 4000
+    assert "WIKI READ TRUNCATED" in first["content"]
+    assert "offset=4000" in first["content"]
+    assert "end marker" not in first["content"]
+
+    second = json.loads(
+        wiki(
+            action="read",
+            page="large-read",
+            offset=first["next_offset"],
+            max_chars=20000,
+        )
+    )
+
+    assert second["truncated"] is False
+    assert second["read_start"] == 4000
+    assert second["next_offset"] is None
+    assert "end marker" in second["content"]
+
+
 def test_wiki_write_requires_filename_and_content(wiki_env):
     res = json.loads(wiki(action="write", category="notes"))
     assert "error" in res

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -182,6 +182,32 @@ class TestWikiRead:
         assert result["content"].startswith("[DRAFT] # Pending Concept")
         assert not result["content"].startswith("[DRAFT] [DRAFT]")
 
+    def test_read_large_page_wrapper_exposes_offset_window(self, wiki_dir):
+        content = (
+            "---\ntitle: Huge Project\ntype: project\n---\n\n"
+            + ("a" * 6000)
+            + "\nfinal marker\n"
+        )
+        (wiki_dir / "pages" / "projects" / "huge-project.md").write_text(
+            content, encoding="utf-8"
+        )
+
+        first = json.loads(wiki("read", page="huge-project", max_chars=1000))
+        assert first["truncated"] is True
+        assert "WIKI READ TRUNCATED" in first["content"]
+        assert first["next_offset"] == 1000
+
+        second = json.loads(
+            wiki(
+                "read",
+                page="huge-project",
+                offset=first["next_offset"],
+                max_chars=10000,
+            )
+        )
+        assert second["truncated"] is False
+        assert "final marker" in second["content"]
+
 
 class TestWikiList:
     def test_list_pages(self, wiki_dir):

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -69,6 +69,8 @@ _WIKI_SEARCH_COMPLETENESS_WARNING = (
     "changed_since=<ISO timestamp>; for authoritative content read candidate "
     "pages with action=read."
 )
+_WIKI_READ_DEFAULT_MAX_CHARS = 15_000
+_WIKI_READ_MAX_CHARS = 50_000
 
 
 _logger_wiki = logging.getLogger("universe_server.wiki")
@@ -302,6 +304,24 @@ def _coerce_result_limit(value: Any) -> int:
     return max(1, min(raw, 100))
 
 
+def _coerce_read_offset(value: Any) -> int:
+    try:
+        raw = int(value or 0)
+    except (TypeError, ValueError):
+        raw = 0
+    return max(0, raw)
+
+
+def _coerce_read_max_chars(value: Any) -> int:
+    try:
+        raw = int(value or 0)
+    except (TypeError, ValueError):
+        raw = _WIKI_READ_DEFAULT_MAX_CHARS
+    if raw <= 0:
+        raw = _WIKI_READ_DEFAULT_MAX_CHARS
+    return max(1, min(raw, _WIKI_READ_MAX_CHARS))
+
+
 def _ambient_relevance_feed(
     *,
     source: Path,
@@ -475,6 +495,8 @@ def _wiki_read(
     query: str = "",
     changed_since: str = "",
     max_results: int = 10,
+    offset: int = 0,
+    max_chars: int = _WIKI_READ_DEFAULT_MAX_CHARS,
     **_kwargs: Any,
 ) -> str:
     if not page:
@@ -507,21 +529,46 @@ def _wiki_read(
         source_body=body,
     )
 
-    if len(text) > 15000:
+    read_start = _coerce_read_offset(offset)
+    read_limit = _coerce_read_max_chars(max_chars)
+    total_chars = len(content)
+    if read_start > total_chars:
+        read_start = total_chars
+    read_end = min(read_start + read_limit, total_chars)
+    chunk = content[read_start:read_end]
+    truncated = read_end < total_chars
+    next_offset = read_end if truncated else None
+
+    if truncated:
+        marker = (
+            "\n\n[WIKI READ TRUNCATED: showing chars "
+            f"{read_start}-{read_end} of {total_chars}. Continue with "
+            f"wiki(action=\"read\", page=\"{page}\", offset={read_end}, "
+            f"max_chars={read_limit}).]"
+        )
         return json.dumps({
             "path": rel,
             "is_draft": is_draft,
-            "content": content[:15000],
+            "content": chunk + marker,
             "truncated": True,
-            "total_chars": len(text),
+            "total_chars": total_chars,
+            "read_start": read_start,
+            "read_end": read_end,
+            "read_limit": read_limit,
+            "next_offset": next_offset,
             "source_read_proof": source_read_proof,
             "ambient_relevance_feed": ambient_feed,
         })
     return json.dumps({
         "path": rel,
         "is_draft": is_draft,
-        "content": content,
+        "content": chunk,
         "truncated": False,
+        "total_chars": total_chars,
+        "read_start": read_start,
+        "read_end": read_end,
+        "read_limit": read_limit,
+        "next_offset": None,
         "source_read_proof": source_read_proof,
         "ambient_relevance_feed": ambient_feed,
     })
@@ -2107,6 +2154,8 @@ def wiki(
     dry_run: bool = True,
     skip_lint: bool = False,
     max_results: int = 10,
+    offset: int = 0,
+    max_chars: int = _WIKI_READ_DEFAULT_MAX_CHARS,
     component: str = "",
     severity: str = "",
     title: str = "",
@@ -2204,6 +2253,8 @@ def wiki(
         "dry_run": dry_run,
         "skip_lint": skip_lint,
         "max_results": max_results,
+        "offset": offset,
+        "max_chars": max_chars,
         "component": component,
         "severity": severity,
         "title": title,

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -960,6 +960,8 @@ def wiki(
     dry_run: bool = True,
     skip_lint: bool = False,
     max_results: int = 10,
+    offset: int = 0,
+    max_chars: int = 15000,
     component: str = "",
     severity: str = "",
     title: str = "",
@@ -1012,6 +1014,8 @@ def wiki(
         changed_since: Optional ISO timestamp for action="read" ambient feed
             and required ISO timestamp for action="since"; only pages updated
             after this timestamp are returned.
+        offset/max_chars: For action="read", read a bounded character window
+            from large pages. Truncated responses include `next_offset`.
     """
     return _wiki_impl(
         action=action,
@@ -1032,6 +1036,8 @@ def wiki(
         dry_run=dry_run,
         skip_lint=skip_lint,
         max_results=max_results,
+        offset=offset,
+        max_chars=max_chars,
         component=component,
         severity=severity,
         title=title,


### PR DESCRIPTION
Fixes live wiki BUG-106 (wiki page: `pages/bugs/bug-106-wiki-read-truncates-large-documents-silently-large-document-.md`).

## Summary
- Adds `offset` and `max_chars` to `wiki action=read` so large pages can be read in bounded windows.
- Appends an in-band `WIKI READ TRUNCATED` marker to truncated content with the exact continuation call.
- Returns `read_start`, `read_end`, `read_limit`, `next_offset`, and `total_chars` metadata for auditable continuation.
- Mirrors the runtime changes into the packaged Claude plugin copy.

## Verification
- `python -m pytest tests/test_api_wiki.py tests/test_wiki_tools.py -q`
- `python -m ruff check workflow/api/wiki.py workflow/universe_server.py tests/test_api_wiki.py tests/test_wiki_tools.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py`
- `git diff --check`
- Pre-commit: mirror parity, mojibake scan, import-graph smoke, path-resolver bypass lint, cross-provider drift, skills validation.

## Review gate
Codex-written fix. Needs Claude-family checker before merge.