### PR TITLE
Raise wiki read default window

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -69,8 +69,8 @@ _WIKI_SEARCH_COMPLETENESS_WARNING = (
     "changed_since=<ISO timestamp>; for authoritative content read candidate "
     "pages with action=read."
 )
-_WIKI_READ_DEFAULT_MAX_CHARS = 15_000
-_WIKI_READ_MAX_CHARS = 50_000
+_WIKI_READ_DEFAULT_MAX_CHARS = 128_000
+_WIKI_READ_MAX_CHARS = 256_000
 
 
 _logger_wiki = logging.getLogger("universe_server.wiki")

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -961,7 +961,7 @@ def wiki(
     skip_lint: bool = False,
     max_results: int = 10,
     offset: int = 0,
-    max_chars: int = 15000,
+    max_chars: int = 128000,
     component: str = "",
     severity: str = "",
     title: str = "",

--- a/tests/test_api_wiki.py
+++ b/tests/test_api_wiki.py
@@ -20,6 +20,8 @@ from workflow.api.wiki import (
     _VALID_BUG_KINDS,
     _VALID_SEVERITIES,
     _WIKI_CATEGORIES,
+    _WIKI_READ_DEFAULT_MAX_CHARS,
+    _WIKI_READ_MAX_CHARS,
     _bug_token_set,
     _ensure_wiki_scaffold,
     _extract_keywords,
@@ -395,6 +397,52 @@ def test_wiki_read_large_page_marks_content_and_supports_offset(wiki_env):
     assert "end marker" in second["content"]
 
 
+def test_wiki_read_default_window_handles_medium_design_doc(wiki_env):
+    path = wiki_env / "pages" / "notes" / "medium-design-doc.md"
+    body = "start marker\n" + ("x" * 80_000) + "\nend marker\n"
+    path.write_text(
+        "---\n"
+        "title: Medium Design Doc\n"
+        "type: note\n"
+        "updated: 2026-05-27T00:00:00Z\n"
+        "---\n\n"
+        + body,
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    res = json.loads(wiki(action="read", page="medium-design-doc"))
+
+    assert res["truncated"] is False
+    assert res["read_limit"] == _WIKI_READ_DEFAULT_MAX_CHARS
+    assert res["next_offset"] is None
+    assert "end marker" in res["content"]
+
+
+def test_wiki_read_max_chars_is_capped(wiki_env):
+    path = wiki_env / "pages" / "notes" / "oversize-design-doc.md"
+    body = "start marker\n" + ("x" * 300_000) + "\nend marker\n"
+    path.write_text(
+        "---\n"
+        "title: Oversize Design Doc\n"
+        "type: note\n"
+        "updated: 2026-05-27T00:00:00Z\n"
+        "---\n\n"
+        + body,
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    res = json.loads(
+        wiki(action="read", page="oversize-design-doc", max_chars=999_999)
+    )
+
+    assert res["truncated"] is True
+    assert res["read_limit"] == _WIKI_READ_MAX_CHARS
+    assert res["next_offset"] == _WIKI_READ_MAX_CHARS
+    assert "WIKI READ TRUNCATED" in res["content"]
+
+
 def test_wiki_write_requires_filename_and_content(wiki_env):
     res = json.loads(wiki(action="write", category="notes"))
     assert "error" in res
@@ -435,7 +483,7 @@ def test_wiki_patch_updates_long_page_without_full_replace(wiki_env):
     original = (
         "---\ntitle: Long Note\ntype: note\nsources: []\n---\n\n"
         "intro marker\n"
-        + ("x" * 16000)
+        + ("x" * (_WIKI_READ_DEFAULT_MAX_CHARS + 1_000))
         + "\noriginal tail marker\n"
     )
     path.write_text(original, encoding="utf-8")
@@ -461,7 +509,7 @@ def test_wiki_patch_updates_long_page_without_full_replace(wiki_env):
     patched = path.read_text(encoding="utf-8")
     assert "intro marker\npatched detail" in patched
     assert "original tail marker" in patched
-    assert len(patched) > 15000
+    assert len(patched) > _WIKI_READ_DEFAULT_MAX_CHARS
 
 
 def test_wiki_patch_dry_run_reports_without_writing(wiki_env):

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -8,6 +8,7 @@ import json
 import pytest
 
 from workflow.api.wiki import (
+    _WIKI_READ_DEFAULT_MAX_CHARS,
     _extract_keywords,
     _parse_frontmatter,
     _sanitize_slug,
@@ -207,6 +208,23 @@ class TestWikiRead:
         )
         assert second["truncated"] is False
         assert "final marker" in second["content"]
+
+    def test_read_wrapper_default_window_handles_medium_document(self, wiki_dir):
+        content = (
+            "---\ntitle: Medium Project\ntype: project\n---\n\n"
+            + ("a" * 80_000)
+            + "\nfinal marker\n"
+        )
+        (wiki_dir / "pages" / "projects" / "medium-project.md").write_text(
+            content, encoding="utf-8"
+        )
+
+        result = json.loads(wiki("read", page="medium-project"))
+
+        assert result["truncated"] is False
+        assert result["read_limit"] == _WIKI_READ_DEFAULT_MAX_CHARS
+        assert result["next_offset"] is None
+        assert "final marker" in result["content"]
 
 
 class TestWikiList:

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -69,8 +69,8 @@ _WIKI_SEARCH_COMPLETENESS_WARNING = (
     "changed_since=<ISO timestamp>; for authoritative content read candidate "
     "pages with action=read."
 )
-_WIKI_READ_DEFAULT_MAX_CHARS = 15_000
-_WIKI_READ_MAX_CHARS = 50_000
+_WIKI_READ_DEFAULT_MAX_CHARS = 128_000
+_WIKI_READ_MAX_CHARS = 256_000
 
 
 _logger_wiki = logging.getLogger("universe_server.wiki")

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -961,7 +961,7 @@ def wiki(
     skip_lint: bool = False,
     max_results: int = 10,
     offset: int = 0,
-    max_chars: int = 15000,
+    max_chars: int = 128000,
     component: str = "",
     severity: str = "",
     title: str = "",


### PR DESCRIPTION
## Summary
- raise wiki read default window from 15,000 to 128,000 characters
- raise explicit max_chars clamp from 50,000 to 256,000 characters
- keep offset/next_offset pagination behavior for larger pages
- update packaged runtime mirror and regression tests

## Size note
16 KB of Markdown is roughly 2,500-3,000 words, or about 5-6 printed pages of prose. The new 128,000-character default is roughly 40+ pages of prose before pagination is needed.

## Verification
- python -m pytest tests/test_api_wiki.py tests/test_wiki_tools.py -q
- python scripts/invariants_run.py --check mirror-parity
- python -m ruff check workflow/api/wiki.py workflow/universe_server.py tests/test_api_wiki.py tests/test_wiki_tools.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
- git diff --check
- pre-commit hook: mirror parity, mojibake, import graph, path resolver, author_server, cross-provider drift, skills-valid