### PR TITLE
Add PR-139 authority resolver contract

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -539,3 +539,14 @@ Notes:
   users.
 - Ship condition: focused wiki read tests pass, PR opened for Claude-family
   checker review.
+
+## PR-139 Resolver Contract - 2026-05-27
+
+- 2026-05-27 create `../wf-pr139-resolver-contract` on
+  `codex/pr139-resolver-contract` by codex-gpt5-desktop.
+- Source: live wiki PR-139 souled-universe consolidation program; dispatcher
+  request failed from provider exhaustion before creating a GitHub lane.
+- Purpose: implement build-order step 1 only: frozen resolver decision contract,
+  fixture shape, and tests.
+- Ship condition: focused resolution contract tests pass, branch pushed, PR
+  opened for opposite-family checker review.

--- a/docs/specs/2026-05-27-authority-resolver-contract-v1.md
+++ b/docs/specs/2026-05-27-authority-resolver-contract-v1.md
@@ -1,0 +1,91 @@
+# Authority Resolver Contract v1
+
+Source: live wiki PR-139, CHILD-4 build-order step 1.
+
+This spec freezes the decision payload shape that later PR-139 slices may
+consume before a resolver runtime exists. It is intentionally a contract, not a
+policy engine.
+
+## Version
+
+- Decision schema: `resolver-decision-v1`
+- Contract/runtime placeholder: `authority-resolver-contract-v1`
+- Fixture pack: `tests/fixtures/resolution/resolver_decision_v1.json`
+- Python contract: `workflow.resolution`
+
+Schema changes require a new schema version, fixture updates, and a
+compatibility/deprecation note. A consumer must not silently treat a future
+schema as v1.
+
+## Inputs
+
+`ResolverInput` contains:
+
+- `question`: the authority or evidence question being resolved.
+- `scope`: universe-first resource boundary.
+- `conflict_type`: typed conflict label.
+- `citations`: evidence handles with source role, surface type, reference, and
+  claim text.
+
+Unknown source roles or surface types are accepted at the input boundary so the
+resolver can produce an auditable fail-closed decision.
+
+## Decision Payload
+
+`ResolverDecision` contains:
+
+- `schema_version`: exactly `resolver-decision-v1`.
+- `status`: one of `resolved`, `unresolved`, `needs-human-decision`.
+- `confidence`: float from `0.0` to `1.0`.
+- `evidence_handles`: cited handles preserved in the decision.
+- `source_role_map`: map from evidence handle to the resolved source-role label.
+- `resolver_version`: resolver or contract version.
+- `reason`: concise audit reason.
+
+`unresolved` is a structural status. No universe setting, authority weight, or
+configuration may remove it from the contract.
+
+## Taxonomy Guard
+
+Known surface types in v1:
+
+- `merged`
+- `running`
+- `proposed`
+- `compiled`
+- `released`
+- `worktree-head`
+- `worktree-snapshot`
+- `local-snapshot`
+
+Unknown surface types fail closed as `unresolved`; they do not receive guessed
+precedence. New surface types enter through brain/wiki convention and host gate
+when security implications exist.
+
+Known source roles in v1 are intentionally small and may be expanded by a later
+contract version. Unknown source roles fail closed as `unresolved`.
+
+Known source-role labels in v1:
+
+- `claimant`
+- `reviewer`
+- `operator`
+- `runtime-observation`
+- `evidence-source`
+- `merged-code`
+- `running-system`
+- `proposed-change`
+- `compiled-artifact`
+- `released-artifact`
+- `worktree-snapshot`
+
+## Required Fixture Cases
+
+The v1 fixture pack must include:
+
+- Constructed real conflict returning `unresolved`.
+- Surface mismatch where claims are reframed under typed surfaces and preserved.
+- Unknown surface type returning `unresolved`.
+
+Later resolver runtime work must keep these cases passing before it can consume
+the contract for permission or tag-matrix behavior.

--- a/tests/fixtures/resolution/resolver_decision_v1.json
+++ b/tests/fixtures/resolution/resolver_decision_v1.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "resolver-decision-v1",
+  "fixture_cases": [
+    {
+      "case_id": "constructed-real-conflict-unresolved",
+      "description": "Two same-surface citations disagree; the contract permits unresolved.",
+      "decision": {
+        "schema_version": "resolver-decision-v1",
+        "status": "unresolved",
+        "confidence": 0.0,
+        "evidence_handles": ["evidence:repo-main", "evidence:live-deploy"],
+        "source_role_map": {
+          "evidence:repo-main": "merged-code",
+          "evidence:live-deploy": "running-system"
+        },
+        "resolver_version": "authority-resolver-contract-v1",
+        "reason": "Claims conflict and no contract rule may force a winner."
+      }
+    },
+    {
+      "case_id": "surface-mismatch-reframe-preserves-claims",
+      "description": "Different surfaces are reframed, not dropped.",
+      "decision": {
+        "schema_version": "resolver-decision-v1",
+        "status": "resolved",
+        "confidence": 0.82,
+        "evidence_handles": ["evidence:github-commit", "evidence:local-worktree"],
+        "source_role_map": {
+          "evidence:github-commit": "merged-code",
+          "evidence:local-worktree": "worktree-snapshot"
+        },
+        "resolver_version": "authority-resolver-contract-v1",
+        "reason": "Both claims are preserved under typed surface labels."
+      }
+    },
+    {
+      "case_id": "unknown-surface-type-unresolved",
+      "description": "Unknown surfaces fail closed instead of receiving guessed precedence.",
+      "decision": {
+        "schema_version": "resolver-decision-v1",
+        "status": "unresolved",
+        "confidence": 0.0,
+        "evidence_handles": ["evidence:unknown-surface"],
+        "source_role_map": {
+          "evidence:unknown-surface": "unknown-surface"
+        },
+        "resolver_version": "authority-resolver-contract-v1",
+        "reason": "Unknown surface type is unresolved until typed by governance."
+      }
+    }
+  ]
+}

--- a/tests/test_resolution_contract.py
+++ b/tests/test_resolution_contract.py
@@ -1,0 +1,116 @@
+"""Tests for the PR-139 authority resolver frozen-shape contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from workflow.resolution import (
+    FIXTURE_LOCATION,
+    RESOLVER_DECISION_SCHEMA_VERSION,
+    VALID_DECISION_STATUSES,
+    EvidenceCitation,
+    ResolutionScope,
+    ResolverDecision,
+    ResolverInput,
+    guard_unknown_taxonomy,
+    validate_decision_payload,
+)
+
+
+def test_unresolved_is_a_structural_decision_status() -> None:
+    assert "unresolved" in VALID_DECISION_STATUSES
+
+    decision = ResolverDecision(
+        status="unresolved",
+        confidence=0.0,
+        evidence_handles=["evidence:repo-main"],
+        source_role_map={"evidence:repo-main": "merged-code"},
+        reason="The evidence is genuinely conflicting.",
+    )
+
+    assert decision.to_dict()["status"] == "unresolved"
+    assert decision.schema_version == RESOLVER_DECISION_SCHEMA_VERSION
+
+
+def test_unknown_surface_type_fails_closed() -> None:
+    resolver_input = ResolverInput(
+        question="Does this code exist on a load-bearing surface?",
+        scope=ResolutionScope(universe_id="u-1", resource_type="code", resource_id="auth"),
+        conflict_type="surface-mismatch",
+        citations=[
+            EvidenceCitation(
+                evidence_handle="evidence:custom-dashboard",
+                source_role="claimant",
+                surface_type="dashboard-screenshot",
+                reference="https://example.invalid/screenshot",
+                claim="The branch is deployed.",
+            )
+        ],
+    )
+
+    decision = guard_unknown_taxonomy(resolver_input)
+
+    assert decision is not None
+    assert decision.status == "unresolved"
+    assert decision.confidence == 0.0
+    assert "unknown surface" in decision.reason
+
+
+def test_unknown_source_role_fails_closed() -> None:
+    resolver_input = ResolverInput(
+        question="Which source role should control this permission rule?",
+        scope=ResolutionScope(
+            universe_id="u-1",
+            resource_type="permission",
+            resource_id="soul.edit",
+        ),
+        conflict_type="direct-conflict",
+        citations=[
+            EvidenceCitation(
+                evidence_handle="evidence:private-note",
+                source_role="secret-founder",
+                surface_type="merged",
+                reference="git:abc123",
+                claim="This user always wins.",
+            )
+        ],
+    )
+
+    decision = guard_unknown_taxonomy(resolver_input)
+
+    assert decision is not None
+    assert decision.status == "unresolved"
+    assert "unknown source role" in decision.reason
+
+
+def test_decision_round_trip_preserves_source_role_map() -> None:
+    decision = ResolverDecision(
+        status="resolved",
+        confidence=0.75,
+        evidence_handles=["evidence:main", "evidence:worktree"],
+        source_role_map={
+            "evidence:main": "merged-code",
+            "evidence:worktree": "worktree-snapshot",
+        },
+        resolver_version="authority-resolver-contract-v1",
+        reason="Surface mismatch reframed; both claims preserved.",
+    )
+
+    assert ResolverDecision.from_dict(decision.to_dict()) == decision
+
+
+def test_fixture_pack_matches_contract() -> None:
+    fixture_path = Path(FIXTURE_LOCATION)
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == RESOLVER_DECISION_SCHEMA_VERSION
+    case_ids = {case["case_id"] for case in payload["fixture_cases"]}
+    assert {
+        "constructed-real-conflict-unresolved",
+        "surface-mismatch-reframe-preserves-claims",
+        "unknown-surface-type-unresolved",
+    }.issubset(case_ids)
+
+    for case in payload["fixture_cases"]:
+        validate_decision_payload(case["decision"])

--- a/workflow/resolution/__init__.py
+++ b/workflow/resolution/__init__.py
@@ -1,0 +1,35 @@
+"""Authority resolver contract primitives.
+
+PR-139 build-order step 1 freezes the resolver decision shape before any
+permission cutover or resolver runtime work consumes it.
+"""
+
+from workflow.resolution.contracts import (
+    FIXTURE_LOCATION,
+    KNOWN_SOURCE_ROLES,
+    KNOWN_SURFACE_TYPES,
+    RESOLVER_CONTRACT_VERSION,
+    RESOLVER_DECISION_SCHEMA_VERSION,
+    VALID_DECISION_STATUSES,
+    EvidenceCitation,
+    ResolutionScope,
+    ResolverDecision,
+    ResolverInput,
+    guard_unknown_taxonomy,
+    validate_decision_payload,
+)
+
+__all__ = [
+    "FIXTURE_LOCATION",
+    "KNOWN_SOURCE_ROLES",
+    "KNOWN_SURFACE_TYPES",
+    "RESOLVER_CONTRACT_VERSION",
+    "RESOLVER_DECISION_SCHEMA_VERSION",
+    "VALID_DECISION_STATUSES",
+    "EvidenceCitation",
+    "ResolutionScope",
+    "ResolverDecision",
+    "ResolverInput",
+    "guard_unknown_taxonomy",
+    "validate_decision_payload",
+]

--- a/workflow/resolution/contracts.py
+++ b/workflow/resolution/contracts.py
@@ -1,0 +1,233 @@
+"""Frozen-shape contract for authority-resolution decisions.
+
+This module intentionally does not implement resolver policy. It defines the
+stable data shape that later PR-139 slices can consume for permission checks,
+tag-matrix conflict surfacing, and surface-precedence review.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+RESOLVER_DECISION_SCHEMA_VERSION = "resolver-decision-v1"
+RESOLVER_CONTRACT_VERSION = "authority-resolver-contract-v1"
+FIXTURE_LOCATION = "tests/fixtures/resolution/resolver_decision_v1.json"
+
+VALID_DECISION_STATUSES = frozenset({
+    "resolved",
+    "unresolved",
+    "needs-human-decision",
+})
+
+KNOWN_SURFACE_TYPES = frozenset({
+    "merged",
+    "running",
+    "proposed",
+    "compiled",
+    "released",
+    "worktree-head",
+    "worktree-snapshot",
+    "local-snapshot",
+})
+
+KNOWN_SOURCE_ROLES = frozenset({
+    "claimant",
+    "reviewer",
+    "operator",
+    "runtime-observation",
+    "evidence-source",
+    "merged-code",
+    "running-system",
+    "proposed-change",
+    "compiled-artifact",
+    "released-artifact",
+    "worktree-snapshot",
+})
+
+
+@dataclass(frozen=True)
+class ResolutionScope:
+    """The resource boundary a resolver input is about."""
+
+    universe_id: str
+    goal_id: str | None = None
+    branch_id: str | None = None
+    resource_type: str = ""
+    resource_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.universe_id:
+            raise ValueError("ResolutionScope.universe_id is required")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class EvidenceCitation:
+    """One cited claim and the surface it came from.
+
+    Unknown ``source_role`` or ``surface_type`` values are allowed at this
+    boundary so the contract guard can fail closed with an auditable decision
+    instead of raising before a resolver can report the issue.
+    """
+
+    evidence_handle: str
+    source_role: str
+    surface_type: str
+    reference: str
+    claim: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.evidence_handle:
+            raise ValueError("EvidenceCitation.evidence_handle is required")
+        if not self.source_role:
+            raise ValueError("EvidenceCitation.source_role is required")
+        if not self.surface_type:
+            raise ValueError("EvidenceCitation.surface_type is required")
+        if not self.reference:
+            raise ValueError("EvidenceCitation.reference is required")
+
+    @property
+    def has_known_surface_type(self) -> bool:
+        return self.surface_type in KNOWN_SURFACE_TYPES
+
+    @property
+    def has_known_source_role(self) -> bool:
+        return self.source_role in KNOWN_SOURCE_ROLES
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ResolverInput:
+    """Inputs accepted by a future authority resolver runtime."""
+
+    question: str
+    scope: ResolutionScope
+    conflict_type: str
+    citations: list[EvidenceCitation]
+
+    def __post_init__(self) -> None:
+        if not self.question:
+            raise ValueError("ResolverInput.question is required")
+        if not self.conflict_type:
+            raise ValueError("ResolverInput.conflict_type is required")
+        if not self.citations:
+            raise ValueError("ResolverInput.citations must not be empty")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "question": self.question,
+            "scope": self.scope.to_dict(),
+            "conflict_type": self.conflict_type,
+            "citations": [citation.to_dict() for citation in self.citations],
+        }
+
+
+@dataclass(frozen=True)
+class ResolverDecision:
+    """Stable decision payload produced by authority-resolution logic."""
+
+    status: str
+    confidence: float
+    evidence_handles: list[str]
+    source_role_map: dict[str, str]
+    reason: str
+    resolver_version: str = RESOLVER_CONTRACT_VERSION
+    schema_version: str = RESOLVER_DECISION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != RESOLVER_DECISION_SCHEMA_VERSION:
+            raise ValueError(
+                "schema_version must be "
+                f"{RESOLVER_DECISION_SCHEMA_VERSION!r}, got {self.schema_version!r}"
+            )
+        if self.status not in VALID_DECISION_STATUSES:
+            raise ValueError(
+                f"status must be one of {sorted(VALID_DECISION_STATUSES)}, "
+                f"got {self.status!r}"
+            )
+        if not 0.0 <= float(self.confidence) <= 1.0:
+            raise ValueError("confidence must be between 0.0 and 1.0")
+        if not self.evidence_handles:
+            raise ValueError("evidence_handles must not be empty")
+        missing = set(self.evidence_handles) - set(self.source_role_map)
+        if missing:
+            raise ValueError(
+                "source_role_map must include every evidence handle; "
+                f"missing {sorted(missing)!r}"
+            )
+        if not self.resolver_version:
+            raise ValueError("resolver_version is required")
+        if not self.reason:
+            raise ValueError("reason is required")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ResolverDecision":
+        unknown = set(data) - set(cls.__dataclass_fields__)
+        if unknown:
+            raise ValueError(f"Unknown ResolverDecision fields: {sorted(unknown)!r}")
+        return cls(**data)
+
+
+def validate_decision_payload(payload: dict[str, Any]) -> ResolverDecision:
+    """Validate a raw v1 decision payload and return the typed object."""
+
+    if not isinstance(payload, dict):
+        raise ValueError("ResolverDecision payload must be a dict")
+    return ResolverDecision.from_dict(payload)
+
+
+def guard_unknown_taxonomy(resolver_input: ResolverInput) -> ResolverDecision | None:
+    """Return an unresolved decision when the input uses unknown taxonomy.
+
+    The authority resolver is allowed to add new surface/source types only after
+    governance has typed them. Until then, unknown values fail closed instead of
+    receiving guessed precedence.
+    """
+
+    unknown_surfaces = sorted({
+        citation.surface_type
+        for citation in resolver_input.citations
+        if not citation.has_known_surface_type
+    })
+    unknown_roles = sorted({
+        citation.source_role
+        for citation in resolver_input.citations
+        if not citation.has_known_source_role
+    })
+    if not unknown_surfaces and not unknown_roles:
+        return None
+
+    reason_parts: list[str] = []
+    if unknown_surfaces:
+        reason_parts.append(f"unknown surface type(s): {', '.join(unknown_surfaces)}")
+    if unknown_roles:
+        reason_parts.append(f"unknown source role(s): {', '.join(unknown_roles)}")
+
+    evidence_handles = [citation.evidence_handle for citation in resolver_input.citations]
+    source_role_map = {
+        citation.evidence_handle: (
+            citation.source_role
+            if citation.has_known_source_role
+            else "unknown-source-role"
+        )
+        for citation in resolver_input.citations
+    }
+    for citation in resolver_input.citations:
+        if not citation.has_known_surface_type:
+            source_role_map[citation.evidence_handle] = "unknown-surface"
+
+    return ResolverDecision(
+        status="unresolved",
+        confidence=0.0,
+        evidence_handles=evidence_handles,
+        source_role_map=source_role_map,
+        reason="; ".join(reason_parts),
+    )


### PR DESCRIPTION
## Summary

- Starts live wiki PR-139 as a narrow implementation slice: CHILD-4 build-order step 1 only.
- Adds `workflow.resolution` frozen-shape contract primitives for resolver inputs, decisions, taxonomy guard behavior, and v1 schema constants.
- Adds the v1 fixture pack plus a short spec at `docs/specs/2026-05-27-authority-resolver-contract-v1.md`.

## Boundaries

- No permission cutover.
- No live resolver runtime.
- No fantasy schema or tag-matrix retrieval migration.
- PLAN.md intentionally left unchanged in this first slice; this PR freezes the contract that later PLAN/module work can consume.

## Verification

- `python -m pytest tests/test_resolution_contract.py -q`
- `python -m ruff check workflow/resolution tests/test_resolution_contract.py`
- `python scripts/invariants_run.py --check mirror-parity`
- `python -m pytest tests/test_import_graph_smoke.py -q`
- `python -m pytest tests/test_canary_scripts_import_smoke.py -q`
- Pre-commit on `4ab409d4` also passed mirror parity, mojibake, import graph smoke, path-resolver lint, cross-provider drift, and skills validation.

## Live brain

- Source: `pages/patch-requests/pr-139-souled-universe-consolidation-program-finish-the-substrate-s.md`
- Coordination marker: `pages/notes/pr-139-in-flight-slice-1-codex-2026-05-27.md`

Needs opposite-family checker review before merge. Host merge key still required.
