### PR TITLE
PR-139 slice 2: Add domain-neutral universe state

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -36,6 +36,23 @@ Format for future entries:
 
 ---
 
+## 2026-05-27 12:00 - create pr139-universe-state
+
+- Provider: codex-gpt5-desktop
+- Branch: codex/pr139-universe-state
+- Lane state: Active lane
+- Worktree: C:\Users\Jonathan\Projects\wf-pr139-universe-state
+- STATUS/Issue/PR: wiki PR-139; pages/notes/pr-139-in-flight-slice-2-universe-state-codex-2026-05-27.md
+- PLAN refs: Module: Engine & Domains; Reference: State & Artifacts
+- Purpose: PR-139 slice 2, additive domain-neutral universe-state substrate.
+- _PURPOSE.md: C:\Users\Jonathan\Projects\wf-pr139-universe-state\_PURPOSE.md
+- Memory refs: drafts/notes/souled-universe-parent.md; pages/notes/pr-139-in-flight-slice-1-codex-2026-05-27.md
+- Related implications: PR-139 build-order step 2; merged resolver contract PR #1089 at 71c8d5f6
+- Idea feed refs: none
+- Ship/abandon: PR pending; abandon if parent invariants change or another lane owns the same universe-state files
+
+---
+
 ## 2026-05-12 21:08 - create pr828-skill-sync-refactor
 
 - Provider: codex

--- a/domains/fantasy_daemon/state/universe_state.py
+++ b/domains/fantasy_daemon/state/universe_state.py
@@ -12,6 +12,8 @@ from typing import Annotated
 
 from typing_extensions import TypedDict
 
+from workflow.universe_state import DomainNeutralUniverseState
+
 
 class ExecutionEnvelope(TypedDict):
     """Thin live execution cursor for one active target run."""
@@ -26,7 +28,7 @@ class ExecutionEnvelope(TypedDict):
     control_flags: dict
 
 
-class UniverseState(TypedDict):
+class UniverseState(DomainNeutralUniverseState):
     """State for the Universe graph (daemon entry point)."""
 
     # ==================================================================

--- a/tests/test_universe_state.py
+++ b/tests/test_universe_state.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+
+def test_domain_neutral_universe_state_excludes_fantasy_counters() -> None:
+    from workflow.universe_state import (
+        DOMAIN_NEUTRAL_UNIVERSE_STATE_FIELDS,
+        FANTASY_DEFAULT_UNIVERSE_STATE_FIELDS,
+    )
+
+    assert {
+        "universe_id",
+        "universe_path",
+        "domain_name",
+        "progress",
+        "metric_units",
+        "health",
+    } <= DOMAIN_NEUTRAL_UNIVERSE_STATE_FIELDS
+
+    assert FANTASY_DEFAULT_UNIVERSE_STATE_FIELDS.isdisjoint(
+        DOMAIN_NEUTRAL_UNIVERSE_STATE_FIELDS
+    )
+
+
+def test_project_domain_neutral_universe_state_drops_domain_fields() -> None:
+    from workflow.universe_state import project_domain_neutral_universe_state
+
+    projected = project_domain_neutral_universe_state(
+        {
+            "universe_id": "research-alpha",
+            "universe_path": "/tmp/research-alpha",
+            "domain_name": "research_probe",
+            "progress": {"artifacts_reviewed": 3},
+            "metric_units": {"artifacts_reviewed": "count"},
+            "health": {"status": "running"},
+            "total_words": 1500,
+            "total_chapters": 2,
+            "book_number": 1,
+            "chapter_number": 4,
+            "scene_number": 9,
+        }
+    )
+
+    assert projected == {
+        "universe_id": "research-alpha",
+        "universe_path": "/tmp/research-alpha",
+        "domain_name": "research_probe",
+        "progress": {"artifacts_reviewed": 3},
+        "metric_units": {"artifacts_reviewed": "count"},
+        "health": {"status": "running"},
+    }
+
+
+def test_fantasy_universe_state_extends_domain_neutral_base() -> None:
+    from domains.fantasy_daemon.state.universe_state import UniverseState
+    from workflow.universe_state import DOMAIN_NEUTRAL_UNIVERSE_STATE_FIELDS
+
+    fantasy_fields = frozenset(UniverseState.__annotations__)
+
+    assert DOMAIN_NEUTRAL_UNIVERSE_STATE_FIELDS <= fantasy_fields
+    assert {"total_words", "total_chapters"} <= fantasy_fields

--- a/workflow/universe_state.py
+++ b/workflow/universe_state.py
@@ -1,0 +1,100 @@
+"""Domain-neutral universe state contract.
+
+This module defines the substrate-level fields that every universe can share
+without inheriting the fantasy daemon's book/chapter/scene shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from typing_extensions import TypedDict
+
+from workflow.protocols import WorkflowState
+
+
+class UniverseIdentity(TypedDict, total=False):
+    """Identity fields that name a universe independently of its domain."""
+
+    universe_id: str
+    universe_version: str
+    soul_ref: str | None
+
+
+class UniverseScope(TypedDict, total=False):
+    """Resource boundary fields for a universe."""
+
+    universe_path: str
+    goal_id: str | None
+    branch_id: str | None
+    workspace_ref: str | None
+    hard_priorities_ref: str | None
+    timeline_ref: str | None
+
+
+class UniverseMetrics(TypedDict, total=False):
+    """Generic metric envelope.
+
+    Domain metrics live under named keys so the substrate does not grow
+    domain-specific counters such as chapters, scenes, or words.
+    """
+
+    progress: dict[str, int | float]
+    metric_units: dict[str, str]
+    last_activity_at: str | None
+
+
+class DomainNeutralUniverseState(
+    WorkflowState,
+    UniverseIdentity,
+    UniverseScope,
+    UniverseMetrics,
+    total=False,
+):
+    """Base state for all universe domains."""
+
+    workflow_instructions: dict[str, Any]
+
+
+FANTASY_DEFAULT_UNIVERSE_STATE_FIELDS = frozenset({
+    "active_series",
+    "series_completed",
+    "world_state_version",
+    "canon_facts_count",
+    "total_words",
+    "total_chapters",
+    "book_number",
+    "chapter_number",
+    "scene_number",
+    "premise_kernel",
+    "worldbuild_signals",
+    "universal_style_rules",
+    "cross_series_facts",
+})
+
+DOMAIN_NEUTRAL_UNIVERSE_STATE_FIELDS = frozenset(
+    DomainNeutralUniverseState.__annotations__
+)
+
+
+def project_domain_neutral_universe_state(
+    state: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return only the domain-neutral universe-state view."""
+
+    return {
+        field: state[field]
+        for field in DOMAIN_NEUTRAL_UNIVERSE_STATE_FIELDS
+        if field in state
+    }
+
+
+__all__ = [
+    "DOMAIN_NEUTRAL_UNIVERSE_STATE_FIELDS",
+    "FANTASY_DEFAULT_UNIVERSE_STATE_FIELDS",
+    "DomainNeutralUniverseState",
+    "UniverseIdentity",
+    "UniverseMetrics",
+    "UniverseScope",
+    "project_domain_neutral_universe_state",
+]


### PR DESCRIPTION
## Summary

PR-139 slice 2 / CHILD-1 Part A. This adds the additive domain-neutral universe-state substrate after slice 1 (#1089) landed.

- Adds `workflow.universe_state` with base TypedDict fragments for universe identity, scope, and generic metrics.
- Adds a projection helper that strips domain-specific fields from a mixed runtime state.
- Makes the existing fantasy daemon `UniverseState` extend the new base while preserving current fantasy counters/runtime fields for compatibility.
- Adds focused tests proving the base shape excludes fantasy defaults like `total_words`, `total_chapters`, and book/chapter/scene fields.

Out of scope: episodic schema migration, universe-cycle de-default, soul.md creation, permission cutover, tag-matrix retrieval, live resolver runtime, and removal of existing fantasy runtime counters.

## Verification

- `python -m pytest tests/test_universe_state.py -q` (red first, then green)
- `python -m pytest tests/test_universe_state.py tests/test_worldbuild_noop_integration.py tests/test_workflow_runtime.py -q`
- `python -m ruff check workflow/universe_state.py domains/fantasy_daemon/state/universe_state.py tests/test_universe_state.py`
- `python scripts/invariants_run.py --check mirror-parity`
- `python -m pytest tests/test_import_graph_smoke.py -q`
- `python -m pytest tests/test_canary_scripts_import_smoke.py -q`

## Gate notes

Canonical coordination record: `pages/notes/pr-139-in-flight-slice-2-universe-state-codex-2026-05-27.md`.

This is ready for an opposite-family checker key. Do not merge until the PR-139 triple-key gate for this slice is complete on the wiki position-record surface.