### PR TITLE
Add PR-139 universe soul premise substrate

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -567,3 +567,14 @@ Notes:
   fixture shape, and tests.
 - Ship condition: focused resolution contract tests pass, branch pushed, PR
   opened for opposite-family checker review.
+
+## PR-139 Soul From Premise - 2026-05-27
+
+- 2026-05-27 create `../wf-pr139-soul` on `codex/pr139-soul` by
+  codex-gpt5-desktop.
+- Source: live wiki PR-139 souled-universe consolidation program; host key
+  now approved for all PR-139 slices.
+- Purpose: implement build-order step 3 only: generalize `soul.md` from the
+  current premise mechanism.
+- Ship condition: focused soul/premise tests pass, branch pushed, PR opened
+  for opposite-family checker review.

--- a/domains/fantasy_daemon/phases/reflect.py
+++ b/domains/fantasy_daemon/phases/reflect.py
@@ -22,6 +22,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from workflow.universe_soul import premise_from_soul, read_legacy_premise
 from workflow.utils.json_parsing import parse_llm_json
 
 logger = logging.getLogger(__name__)
@@ -190,15 +191,13 @@ def _review_canon_quality(state: dict[str, Any]) -> dict[str, Any]:
 
 
 def _read_premise(universe_dir: Path, state: dict[str, Any]) -> str:
-    """Read the story premise from PROGRAM.md or state."""
-    program_path = universe_dir / "PROGRAM.md"
-    if program_path.exists():
-        try:
-            content = program_path.read_text(encoding="utf-8").strip()
-            if content:
-                return content
-        except OSError:
-            logger.debug("Failed to read PROGRAM.md", exc_info=True)
+    """Read the story premise from PROGRAM.md, soul.md, or state."""
+    content = read_legacy_premise(universe_dir).strip()
+    if content:
+        return content
+    content = premise_from_soul(universe_dir).strip()
+    if content:
+        return content
     return state.get("premise_kernel", "")
 
 

--- a/domains/fantasy_daemon/phases/worldbuild.py
+++ b/domains/fantasy_daemon/phases/worldbuild.py
@@ -8,6 +8,11 @@ from pathlib import Path
 from typing import Any
 
 from domains.fantasy_daemon.phases.world_state_db import connect, get_all_facts, init_db
+from workflow.universe_soul import (
+    premise_from_soul,
+    read_legacy_premise,
+    write_universe_soul,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -251,10 +256,8 @@ def _maybe_generate_premise(state: dict[str, Any]) -> str:
         return ""
 
     universe_dir = Path(universe_path)
-    program_path = universe_dir / "PROGRAM.md"
-
     # Skip if premise already exists (on disk or in state)
-    if program_path.exists():
+    if read_legacy_premise(universe_dir).strip() or premise_from_soul(universe_dir).strip():
         return ""
     existing_premise = state.get("premise_kernel", "")
     if existing_premise and existing_premise.strip():
@@ -311,9 +314,12 @@ def _maybe_generate_premise(state: dict[str, Any]) -> str:
 
     premise = premise.strip()
 
-    # Write to PROGRAM.md
+    # Write to PROGRAM.md as compatibility mirror and soul.md as intent profile.
     try:
-        program_path.write_text(premise, encoding="utf-8")
+        (universe_dir / "PROGRAM.md").write_text(premise, encoding="utf-8")
+        write_universe_soul(
+            universe_dir, purpose=premise, lineage="auto-generated-from-canon",
+        )
         logger.info(
             "Auto-premise: generated from %d canon files (%d chars)",
             len(canon_files), len(premise),
@@ -885,18 +891,16 @@ def _generate_canon_documents(state: dict[str, Any]) -> list[str]:
 
 
 def _read_premise(universe_dir: Path, state: dict[str, Any]) -> str:
-    """Read the story premise from PROGRAM.md or state.
+    """Read the story premise from PROGRAM.md, soul.md, or state.
 
     Falls back to ``premise_kernel`` in state if the file is missing.
     """
-    program_path = universe_dir / "PROGRAM.md"
-    if program_path.exists():
-        try:
-            content = program_path.read_text(encoding="utf-8").strip()
-            if content:
-                return content
-        except OSError:
-            logger.debug("Failed to read PROGRAM.md", exc_info=True)
+    content = read_legacy_premise(universe_dir).strip()
+    if content:
+        return content
+    content = premise_from_soul(universe_dir).strip()
+    if content:
+        return content
 
     # Fallback to state
     return state.get("premise_kernel", "")

--- a/domains/fantasy_daemon/producers.py
+++ b/domains/fantasy_daemon/producers.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from workflow.universe_soul import premise_from_soul, read_legacy_premise
 from workflow.work_targets import (
     WorkTarget,
     ensure_seed_targets,
@@ -28,12 +29,9 @@ logger = logging.getLogger(__name__)
 
 
 def _read_premise(universe_path: Path) -> str:
-    """Read premise from ``PROGRAM.md`` (fantasy on-disk convention)."""
-    program = Path(universe_path) / "PROGRAM.md"
-    try:
-        return program.read_text(encoding="utf-8")
-    except OSError:
-        return ""
+    """Read premise from compatibility file or soul.md purpose."""
+    path = Path(universe_path)
+    return read_legacy_premise(path) or premise_from_soul(path)
 
 
 class SeedProducer:

--- a/fantasy_daemon/__main__.py
+++ b/fantasy_daemon/__main__.py
@@ -25,6 +25,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
+from workflow.universe_soul import premise_from_soul, read_legacy_premise
+
 # Suppress langchain-core Pydantic V1 deprecation warning on Python 3.14+
 warnings.filterwarnings(
     "ignore",
@@ -1309,15 +1311,13 @@ class DaemonController:
         with SqliteSaver.from_conn_string(self._checkpoint_path) as checkpointer:
             compiled = graph_builder.compile(checkpointer=checkpointer)
 
-            # Resolve premise: explicit value > PROGRAM.md fallback
+            # Resolve premise: explicit value > compatibility file > soul.md.
             premise = self._premise
             if not premise:
-                program_md = output_dir / "PROGRAM.md"
-                if program_md.exists():
-                    try:
-                        premise = program_md.read_text(encoding="utf-8").strip()
-                    except OSError:
-                        logger.warning("Could not read %s", program_md)
+                premise = (
+                    read_legacy_premise(output_dir).strip()
+                    or premise_from_soul(output_dir).strip()
+                )
 
             # Workflow configuration
             workflow = {"premise": premise}
@@ -2478,7 +2478,13 @@ def _run_tray_mode(args: argparse.Namespace) -> None:
     if not universe_path:
         try:
             for entry in sorted(Path(base_path).iterdir()):
-                if entry.is_dir() and (entry / "PROGRAM.md").exists():
+                if (
+                    entry.is_dir()
+                    and (
+                        (entry / "PROGRAM.md").exists()
+                        or (entry / "soul.md").exists()
+                    )
+                ):
                     universe_path = str(entry)
                     break
         except OSError:
@@ -2642,7 +2648,7 @@ def main() -> None:
     parser.add_argument(
         "--premise",
         default="",
-        help="Story premise / prompt (overrides PROGRAM.md in universe dir)",
+        help="Story premise / prompt (overrides PROGRAM.md or soul.md in universe dir)",
     )
     parser.add_argument(
         "--verbose", "-v",
@@ -2790,7 +2796,7 @@ def main() -> None:
 
         # Resolve which universe to write in.  Priority:
         # 1. .active_universe file (persisted from last session)
-        # 2. First universe subdir that has a PROGRAM.md
+        # 2. First universe subdir that has a PROGRAM.md or soul.md
         # 3. Don't start a daemon — let the API handle it on demand
         active_file = Path(base_path) / ".active_universe"
         universe_path = ""
@@ -2808,7 +2814,13 @@ def main() -> None:
             # Scan for a universe with a premise
             try:
                 for entry in sorted(Path(base_path).iterdir()):
-                    if entry.is_dir() and (entry / "PROGRAM.md").exists():
+                    if (
+                        entry.is_dir()
+                        and (
+                            (entry / "PROGRAM.md").exists()
+                            or (entry / "soul.md").exists()
+                        )
+                    ):
                         universe_path = str(entry)
                         logger.info("Auto-selected universe with premise: %s", entry.name)
                         break

--- a/fantasy_daemon/api.py
+++ b/fantasy_daemon/api.py
@@ -27,6 +27,16 @@ from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel, Field
 
+from workflow.universe_soul import (
+    ensure_universe_soul,
+    has_soul,
+    legacy_premise_path,
+    premise_from_soul,
+    read_legacy_premise,
+    read_universe_soul,
+    write_universe_soul,
+)
+
 logger = logging.getLogger("fantasy_daemon.api")
 
 # ---------------------------------------------------------------------------
@@ -409,7 +419,10 @@ def _read_universe_info(udir: Path, uid: str) -> dict[str, Any]:
         info["word_count"] = 0
         info["daemon_state"] = "idle"
 
-    info["has_premise"] = (udir / "PROGRAM.md").exists()
+    info["has_premise"] = bool(
+        read_legacy_premise(udir).strip() or premise_from_soul(udir).strip()
+    )
+    info["has_soul"] = has_soul(udir)
     return info
 
 
@@ -764,6 +777,7 @@ def create_universe(
 
     try:
         udir.mkdir(parents=True, exist_ok=True)
+        soul = ensure_universe_soul(udir)
         (udir / "canon").mkdir(exist_ok=True)
         (udir / "output").mkdir(exist_ok=True)
         (udir / "universe.json").write_text(
@@ -774,7 +788,7 @@ def create_universe(
             status_code=500, detail=f"Failed to create universe: {e}",
         )
 
-    return {"id": slug, "name": name}
+    return {"id": slug, "name": name, "has_soul": True, "soul": soul.summary()}
 
 
 @app.patch("/v1/universes/{uid}")
@@ -838,34 +852,42 @@ def delete_universe(
 
 
 @app.get("/v1/universes/{uid}/premise")
-def get_premise(uid: str, _user: str = Depends(_require_auth)) -> dict[str, str]:
-    """Read the current story premise from PROGRAM.md."""
+def get_premise(uid: str, _user: str = Depends(_require_auth)) -> dict[str, Any]:
+    """Read the current premise, falling back to soul.md purpose."""
     udir = _validate_universe_id(uid)
-    program_path = udir / "PROGRAM.md"
-    if not program_path.exists():
+    text = read_legacy_premise(udir)
+    source = "PROGRAM.md"
+    soul = read_universe_soul(udir)
+    if not text.strip() and soul is not None:
+        text = soul.purpose
+        source = "soul.md"
+    if not text.strip():
         raise HTTPException(
             status_code=404,
             detail="No premise set yet. Use the set premise endpoint to create one.",
         )
-    try:
-        text = program_path.read_text(encoding="utf-8")
-    except OSError as e:
-        raise HTTPException(status_code=500, detail=f"Failed to read premise: {e}")
-    return {"text": text}
+    return {
+        "text": text,
+        "source": source,
+        "has_soul": soul is not None,
+        "soul": soul.summary() if soul is not None else None,
+    }
 
 
 @app.post("/v1/universes/{uid}/premise", status_code=200)
 def set_premise(
     uid: str, body: PremiseBody, _user: str = Depends(_require_auth),
-) -> dict[str, str]:
-    """Write or overwrite the story premise in PROGRAM.md."""
+) -> dict[str, Any]:
+    """Write or overwrite the premise as soul.md purpose plus legacy mirror."""
     udir = _validate_universe_id(uid)
-    program_path = udir / "PROGRAM.md"
     try:
-        program_path.write_text(body.text, encoding="utf-8")
+        soul = write_universe_soul(
+            udir, purpose=body.text, lineage="created-from-premise",
+        )
+        legacy_premise_path(udir).write_text(body.text, encoding="utf-8")
     except OSError as e:
         raise HTTPException(status_code=500, detail=f"Failed to write premise: {e}")
-    return {"status": "ok"}
+    return {"status": "ok", "has_soul": True, "soul": soul.summary()}
 
 
 # -- Notes -----------------------------------------------------------------
@@ -1148,7 +1170,9 @@ def get_overview(uid: str, _user: str = Depends(_require_auth)) -> dict[str, Any
         except OSError:
             pass
 
-    premise_set = (udir / "PROGRAM.md").exists()
+    premise_set = bool(
+        read_legacy_premise(udir).strip() or premise_from_soul(udir).strip()
+    )
     daemon_state = status.get("daemon_state", "idle")
 
     # Check if daemon is actually on this universe

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -70,6 +70,16 @@ from workflow.api.helpers import (
     _universe_dir,
 )
 from workflow.catalog import list_unreconciled_writes
+from workflow.universe_soul import (
+    SOUL_FILENAME,
+    ensure_universe_soul,
+    has_soul,
+    legacy_premise_path,
+    premise_from_soul,
+    read_legacy_premise,
+    read_universe_soul,
+    write_universe_soul,
+)
 
 logger = logging.getLogger("universe_server.universe")
 
@@ -126,9 +136,12 @@ def _extract_set_premise(
     from workflow.api.engine_helpers import _truncate
     text = kwargs.get("text", "")
     return (
-        "PROGRAM.md",
+        SOUL_FILENAME,
         _truncate(text),
-        {"bytes": len(text.encode("utf-8"))},
+        {
+            "bytes": len(text.encode("utf-8")),
+            "legacy_program_mirror": "PROGRAM.md",
+        },
     )
 
 
@@ -193,7 +206,11 @@ def _extract_create_universe(
     uid = kwargs.get("universe_id", "")
     text = kwargs.get("text", "")
     summary = _truncate(text) if text.strip() else f"created {uid}"
-    return (uid, summary, {"has_premise": bool(text.strip())})
+    return (uid, summary, {
+        "has_premise": bool(text.strip()),
+        "has_soul": True,
+        "soul_path": SOUL_FILENAME,
+    })
 
 
 def _synthesis_first_run_checklist(has_premise: bool) -> dict[str, Any]:
@@ -201,7 +218,7 @@ def _synthesis_first_run_checklist(has_premise: bool) -> dict[str, Any]:
     steps = [
         {
             "id": "premise",
-            "label": "Save a premise with create_universe text or set_premise.",
+            "label": "Save a soul purpose with create_universe text or set_premise.",
             "complete": has_premise,
         },
         {
@@ -830,7 +847,9 @@ def _daemon_liveness(udir: Path, status: dict[str, Any] | None) -> dict[str, Any
     same interpreted fields, so legibility fixes in one place land
     everywhere at once.
     """
-    has_premise = (udir / "PROGRAM.md").exists()
+    has_premise = bool(
+        read_legacy_premise(udir).strip() or premise_from_soul(udir).strip()
+    )
     targets = _read_json(udir / "work_targets.json")
     has_work = isinstance(targets, list) and any(
         t.get("lifecycle") == "active" for t in targets if isinstance(t, dict)
@@ -858,6 +877,7 @@ def _daemon_liveness(udir: Path, status: dict[str, Any] | None) -> dict[str, Any
         ),
         "is_paused": is_paused,
         "has_premise": has_premise,
+        "has_soul": has_soul(udir),
         "has_work": has_work,
         "last_activity_at": last_activity,
         "staleness": staleness,
@@ -895,6 +915,7 @@ def _action_list_universes(**_kwargs: Any) -> str:
         info: dict[str, Any] = {
             "id": child.name,
             "has_premise": liveness["has_premise"],
+            "has_soul": liveness["has_soul"],
             "word_count": liveness["word_count"],
             "phase": liveness["phase"],
             "phase_human": liveness["phase_human"],
@@ -941,6 +962,7 @@ def _action_inspect_universe(universe_id: str = "", **_kwargs: Any) -> str:
         "phase_human": liveness["phase_human"],
         "is_paused": liveness["is_paused"],
         "has_premise": liveness["has_premise"],
+        "has_soul": liveness["has_soul"],
         "has_work": liveness["has_work"],
         "last_activity_at": liveness["last_activity_at"],
         "staleness": liveness["staleness"],
@@ -950,12 +972,21 @@ def _action_inspect_universe(universe_id: str = "", **_kwargs: Any) -> str:
         "accept_rate_sample": liveness["accept_rate_sample"],
     }
 
-    # Premise — always present as a boolean so callers can't silently miss
-    # the "no premise set" case. Full text included only when non-empty.
-    program = _read_text(udir / "PROGRAM.md")
-    result["has_premise"] = bool(program)
-    if program:
-        result["premise"] = program[:500] + ("..." if len(program) > 500 else "")
+    soul = read_universe_soul(udir)
+    if soul is not None:
+        result["has_soul"] = True
+        result["soul"] = soul.summary()
+
+    # Premise remains the public compatibility field. The durable source is
+    # now soul.md when PROGRAM.md is absent or empty.
+    program = _normalize_escaped_text(read_legacy_premise(udir))
+    premise = program.strip() or (soul.purpose if soul is not None else "")
+    result["has_premise"] = bool(premise)
+    if premise:
+        result["premise"] = premise[:500] + ("..." if len(premise) > 500 else "")
+        result["premise_source"] = (
+            "PROGRAM.md" if program.strip() else SOUL_FILENAME
+        )
 
     # Notes summary
     notes = _read_json(udir / "notes.json")
@@ -3329,20 +3360,29 @@ def _query_world_db(
 def _action_read_premise(universe_id: str = "", **_kwargs: Any) -> str:
     uid = universe_id or _default_universe()
     udir = _universe_dir(uid)
-    program_path = udir / "PROGRAM.md"
+    content = _normalize_escaped_text(read_legacy_premise(udir))
+    source = "PROGRAM.md"
+    if not content.strip():
+        soul = read_universe_soul(udir)
+        content = soul.purpose if soul is not None else ""
+        source = SOUL_FILENAME
+    else:
+        soul = read_universe_soul(udir)
 
-    content = _read_text(program_path)
-    if not content:
+    if not content.strip():
         return json.dumps({
             "universe_id": uid,
             "premise": None,
+            "has_soul": soul is not None,
+            "soul": soul.summary() if soul is not None else None,
             "note": "No premise set. Use action='set_premise' to create one.",
         })
-    # Read-time fallback: decode any pre-existing files that were written
-    # with literal \n sequences by a buggy client before the write-side fix.
     return json.dumps({
         "universe_id": uid,
-        "premise": _normalize_escaped_text(content),
+        "premise": content,
+        "source": source,
+        "has_soul": soul is not None,
+        "soul": soul.summary() if soul is not None else None,
     })
 
 
@@ -3375,17 +3415,21 @@ def _normalize_escaped_text(text: str) -> str:
 def _action_set_premise(universe_id: str = "", text: str = "", **_kwargs: Any) -> str:
     uid = universe_id or _default_universe()
     udir = _universe_dir(uid)
-    program_path = udir / "PROGRAM.md"
 
     if not text.strip():
         return json.dumps({"error": "Premise text cannot be empty."})
     text = _normalize_escaped_text(text)
     try:
         udir.mkdir(parents=True, exist_ok=True)
-        program_path.write_text(text, encoding="utf-8")
+        soul = write_universe_soul(
+            udir, purpose=text, lineage="created-from-premise",
+        )
+        legacy_premise_path(udir).write_text(text, encoding="utf-8")
         return json.dumps({
             "universe_id": uid,
             "status": "updated",
+            "has_soul": True,
+            "soul": soul.summary(),
             "note": "Premise saved. The daemon will read it at next startup.",
         })
     except OSError as exc:
@@ -4200,11 +4244,11 @@ def _action_create_universe(
 
     try:
         udir.mkdir(parents=True, exist_ok=True)
+        normalized_text = _normalize_escaped_text(text) if text.strip() else ""
+        soul = ensure_universe_soul(udir, purpose=normalized_text)
         # Write premise if provided
-        if text.strip():
-            (udir / "PROGRAM.md").write_text(
-                _normalize_escaped_text(text), encoding="utf-8",
-            )
+        if normalized_text.strip():
+            legacy_premise_path(udir).write_text(normalized_text, encoding="utf-8")
 
         # Initialize empty state files
         (udir / "notes.json").write_text("[]", encoding="utf-8")
@@ -4213,9 +4257,11 @@ def _action_create_universe(
         result: dict[str, Any] = {
             "universe_id": uid,
             "status": "created",
-            "has_premise": bool(text.strip()),
+            "has_premise": bool(normalized_text.strip()),
+            "has_soul": True,
+            "soul": soul.summary(),
             "first_run_checklist": _synthesis_first_run_checklist(
-                has_premise=bool(text.strip()),
+                has_premise=bool(normalized_text.strip()),
             ),
         }
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker.py
@@ -96,7 +96,7 @@ def _resolve_universe_path() -> Path:
       1. ``WORKFLOW_UNIVERSE`` env var (explicit override).
       2. ``$WORKFLOW_DATA_DIR/$UNIVERSE_SERVER_DEFAULT_UNIVERSE``.
       3. First directory under ``WORKFLOW_DATA_DIR`` that has a
-         ``PROGRAM.md`` (auto-selects the active universe in the common
+         ``PROGRAM.md`` or ``soul.md`` (auto-selects the active universe in the common
          "one universe" droplet deployment).
       4. ``$WORKFLOW_DATA_DIR/default-universe`` as a last-resort fallback.
     """
@@ -119,7 +119,10 @@ def _resolve_universe_path() -> Path:
 
     if base.is_dir():
         for entry in sorted(base.iterdir()):
-            if entry.is_dir() and (entry / "PROGRAM.md").exists():
+            if (
+                entry.is_dir()
+                and ((entry / "PROGRAM.md").exists() or (entry / "soul.md").exists())
+            ):
                 return entry
 
     return base / "default-universe"
@@ -528,7 +531,7 @@ def main(argv: list[str] | None = None) -> int:
         "--universe",
         default="",
         help="Explicit universe path. Default: WORKFLOW_UNIVERSE / "
-             "first-PROGRAM.md / WORKFLOW_DATA_DIR/default-universe.",
+             "first PROGRAM.md or soul.md / WORKFLOW_DATA_DIR/default-universe.",
     )
     parser.add_argument(
         "--idle-backoff", type=float, default=DEFAULT_IDLE_BACKOFF_S,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/desktop/launcher.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/desktop/launcher.py
@@ -25,6 +25,8 @@ import threading
 from pathlib import Path
 from typing import Any, Callable
 
+from workflow.universe_soul import premise_from_soul, read_legacy_premise
+
 # tkinter requires libtk (system lib). Headless Docker containers
 # don't ship it; the cloud_worker's fantasy_daemon subprocess imports
 # the desktop tree at load time before --no-tray is parsed. Tolerate
@@ -653,14 +655,13 @@ class LauncherApp:
         if self._daemon is None:
             return
 
-        # Re-read premise from PROGRAM.md
-        program_md = Path(self.universe_path) / "PROGRAM.md"
-        if program_md.exists():
-            try:
-                premise = program_md.read_text(encoding="utf-8").strip()
-                self._daemon._premise = premise
-            except OSError:
-                pass
+        # Re-read premise from the compatibility file or soul.md purpose.
+        universe_dir = Path(self.universe_path)
+        premise = read_legacy_premise(universe_dir).strip()
+        if not premise:
+            premise = premise_from_soul(universe_dir).strip()
+        if premise:
+            self._daemon._premise = premise
 
     def _reimport_modules(self) -> None:
         """Reimport workflow submodules to pick up code changes."""

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/evaluation/structural.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/evaluation/structural.py
@@ -887,16 +887,17 @@ def _check_premise_grounding(state: dict[str, Any]) -> CheckResult:
     if not premise:
         premise = state.get("premise_kernel", "")
     if not premise:
-        # Fallback: read PROGRAM.md from universe directory
+        # Fallback: read PROGRAM.md or soul.md from universe directory.
         uni_path = state.get("_universe_path", "")
         if uni_path:
             from pathlib import Path as _P
-            program_md = _P(uni_path) / "PROGRAM.md"
-            try:
-                if program_md.exists():
-                    premise = program_md.read_text(encoding="utf-8").strip()
-            except OSError:
-                pass
+
+            from workflow.universe_soul import premise_from_soul, read_legacy_premise
+            universe_dir = _P(uni_path)
+            premise = (
+                read_legacy_premise(universe_dir).strip()
+                or premise_from_soul(universe_dir).strip()
+            )
 
     if not premise:
         return CheckResult(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/mcp_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/mcp_server.py
@@ -22,6 +22,13 @@ from pathlib import Path
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
+from workflow.universe_soul import (
+    legacy_premise_path,
+    premise_from_soul,
+    read_legacy_premise,
+    write_universe_soul,
+)
+
 mcp = FastMCP(
     "workflow",
     instructions=(
@@ -176,17 +183,18 @@ def steer(directive: str, category: str = "direction") -> str:
 
 
 def get_premise() -> str:
-    """Read the current story premise from PROGRAM.md.
+    """Read the current story premise from PROGRAM.md or soul.md.
 
     The premise seeds the daemon's creative direction.
     """
-    program_path = _universe_dir() / "PROGRAM.md"
-    if not program_path.exists():
-        return "No PROGRAM.md found. Use set_premise() to create one."
-    try:
-        return program_path.read_text(encoding="utf-8")
-    except OSError as e:
-        return f"Error reading PROGRAM.md: {e}"
+    universe_dir = _universe_dir()
+    premise = read_legacy_premise(universe_dir).strip()
+    if premise:
+        return premise
+    premise = premise_from_soul(universe_dir).strip()
+    if premise:
+        return premise
+    return "No premise found. Use set_premise() to create one."
 
 
 _mcp_get_premise = _register_structured_tool(
@@ -198,19 +206,22 @@ _mcp_get_premise = _register_structured_tool(
 
 
 def set_premise(text: str) -> str:
-    """Write or overwrite the story premise in PROGRAM.md.
+    """Write or overwrite the story premise as soul.md plus PROGRAM.md.
 
     The daemon reads this at startup to seed the story direction.
     Overwrites any existing premise — use get_premise first if you want to
     edit rather than replace.
     """
-    program_path = _universe_dir() / "PROGRAM.md"
+    universe_dir = _universe_dir()
     try:
-        _universe_dir().mkdir(parents=True, exist_ok=True)
-        program_path.write_text(text, encoding="utf-8")
-        return "PROGRAM.md updated."
+        universe_dir.mkdir(parents=True, exist_ok=True)
+        write_universe_soul(
+            universe_dir, purpose=text, lineage="created-from-premise",
+        )
+        legacy_premise_path(universe_dir).write_text(text, encoding="utf-8")
+        return "soul.md updated."
     except OSError as e:
-        return f"Error writing PROGRAM.md: {e}"
+        return f"Error writing premise: {e}"
 
 
 _mcp_set_premise = _register_structured_tool(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/resolution/__init__.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/resolution/__init__.py
@@ -1,0 +1,35 @@
+"""Authority resolver contract primitives.
+
+PR-139 build-order step 1 freezes the resolver decision shape before any
+permission cutover or resolver runtime work consumes it.
+"""
+
+from workflow.resolution.contracts import (
+    FIXTURE_LOCATION,
+    KNOWN_SOURCE_ROLES,
+    KNOWN_SURFACE_TYPES,
+    RESOLVER_CONTRACT_VERSION,
+    RESOLVER_DECISION_SCHEMA_VERSION,
+    VALID_DECISION_STATUSES,
+    EvidenceCitation,
+    ResolutionScope,
+    ResolverDecision,
+    ResolverInput,
+    guard_unknown_taxonomy,
+    validate_decision_payload,
+)
+
+__all__ = [
+    "FIXTURE_LOCATION",
+    "KNOWN_SOURCE_ROLES",
+    "KNOWN_SURFACE_TYPES",
+    "RESOLVER_CONTRACT_VERSION",
+    "RESOLVER_DECISION_SCHEMA_VERSION",
+    "VALID_DECISION_STATUSES",
+    "EvidenceCitation",
+    "ResolutionScope",
+    "ResolverDecision",
+    "ResolverInput",
+    "guard_unknown_taxonomy",
+    "validate_decision_payload",
+]

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/resolution/contracts.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/resolution/contracts.py
@@ -1,0 +1,233 @@
+"""Frozen-shape contract for authority-resolution decisions.
+
+This module intentionally does not implement resolver policy. It defines the
+stable data shape that later PR-139 slices can consume for permission checks,
+tag-matrix conflict surfacing, and surface-precedence review.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+RESOLVER_DECISION_SCHEMA_VERSION = "resolver-decision-v1"
+RESOLVER_CONTRACT_VERSION = "authority-resolver-contract-v1"
+FIXTURE_LOCATION = "tests/fixtures/resolution/resolver_decision_v1.json"
+
+VALID_DECISION_STATUSES = frozenset({
+    "resolved",
+    "unresolved",
+    "needs-human-decision",
+})
+
+KNOWN_SURFACE_TYPES = frozenset({
+    "merged",
+    "running",
+    "proposed",
+    "compiled",
+    "released",
+    "worktree-head",
+    "worktree-snapshot",
+    "local-snapshot",
+})
+
+KNOWN_SOURCE_ROLES = frozenset({
+    "claimant",
+    "reviewer",
+    "operator",
+    "runtime-observation",
+    "evidence-source",
+    "merged-code",
+    "running-system",
+    "proposed-change",
+    "compiled-artifact",
+    "released-artifact",
+    "worktree-snapshot",
+})
+
+
+@dataclass(frozen=True)
+class ResolutionScope:
+    """The resource boundary a resolver input is about."""
+
+    universe_id: str
+    goal_id: str | None = None
+    branch_id: str | None = None
+    resource_type: str = ""
+    resource_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.universe_id:
+            raise ValueError("ResolutionScope.universe_id is required")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class EvidenceCitation:
+    """One cited claim and the surface it came from.
+
+    Unknown ``source_role`` or ``surface_type`` values are allowed at this
+    boundary so the contract guard can fail closed with an auditable decision
+    instead of raising before a resolver can report the issue.
+    """
+
+    evidence_handle: str
+    source_role: str
+    surface_type: str
+    reference: str
+    claim: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.evidence_handle:
+            raise ValueError("EvidenceCitation.evidence_handle is required")
+        if not self.source_role:
+            raise ValueError("EvidenceCitation.source_role is required")
+        if not self.surface_type:
+            raise ValueError("EvidenceCitation.surface_type is required")
+        if not self.reference:
+            raise ValueError("EvidenceCitation.reference is required")
+
+    @property
+    def has_known_surface_type(self) -> bool:
+        return self.surface_type in KNOWN_SURFACE_TYPES
+
+    @property
+    def has_known_source_role(self) -> bool:
+        return self.source_role in KNOWN_SOURCE_ROLES
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ResolverInput:
+    """Inputs accepted by a future authority resolver runtime."""
+
+    question: str
+    scope: ResolutionScope
+    conflict_type: str
+    citations: list[EvidenceCitation]
+
+    def __post_init__(self) -> None:
+        if not self.question:
+            raise ValueError("ResolverInput.question is required")
+        if not self.conflict_type:
+            raise ValueError("ResolverInput.conflict_type is required")
+        if not self.citations:
+            raise ValueError("ResolverInput.citations must not be empty")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "question": self.question,
+            "scope": self.scope.to_dict(),
+            "conflict_type": self.conflict_type,
+            "citations": [citation.to_dict() for citation in self.citations],
+        }
+
+
+@dataclass(frozen=True)
+class ResolverDecision:
+    """Stable decision payload produced by authority-resolution logic."""
+
+    status: str
+    confidence: float
+    evidence_handles: list[str]
+    source_role_map: dict[str, str]
+    reason: str
+    resolver_version: str = RESOLVER_CONTRACT_VERSION
+    schema_version: str = RESOLVER_DECISION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != RESOLVER_DECISION_SCHEMA_VERSION:
+            raise ValueError(
+                "schema_version must be "
+                f"{RESOLVER_DECISION_SCHEMA_VERSION!r}, got {self.schema_version!r}"
+            )
+        if self.status not in VALID_DECISION_STATUSES:
+            raise ValueError(
+                f"status must be one of {sorted(VALID_DECISION_STATUSES)}, "
+                f"got {self.status!r}"
+            )
+        if not 0.0 <= float(self.confidence) <= 1.0:
+            raise ValueError("confidence must be between 0.0 and 1.0")
+        if not self.evidence_handles:
+            raise ValueError("evidence_handles must not be empty")
+        missing = set(self.evidence_handles) - set(self.source_role_map)
+        if missing:
+            raise ValueError(
+                "source_role_map must include every evidence handle; "
+                f"missing {sorted(missing)!r}"
+            )
+        if not self.resolver_version:
+            raise ValueError("resolver_version is required")
+        if not self.reason:
+            raise ValueError("reason is required")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ResolverDecision":
+        unknown = set(data) - set(cls.__dataclass_fields__)
+        if unknown:
+            raise ValueError(f"Unknown ResolverDecision fields: {sorted(unknown)!r}")
+        return cls(**data)
+
+
+def validate_decision_payload(payload: dict[str, Any]) -> ResolverDecision:
+    """Validate a raw v1 decision payload and return the typed object."""
+
+    if not isinstance(payload, dict):
+        raise ValueError("ResolverDecision payload must be a dict")
+    return ResolverDecision.from_dict(payload)
+
+
+def guard_unknown_taxonomy(resolver_input: ResolverInput) -> ResolverDecision | None:
+    """Return an unresolved decision when the input uses unknown taxonomy.
+
+    The authority resolver is allowed to add new surface/source types only after
+    governance has typed them. Until then, unknown values fail closed instead of
+    receiving guessed precedence.
+    """
+
+    unknown_surfaces = sorted({
+        citation.surface_type
+        for citation in resolver_input.citations
+        if not citation.has_known_surface_type
+    })
+    unknown_roles = sorted({
+        citation.source_role
+        for citation in resolver_input.citations
+        if not citation.has_known_source_role
+    })
+    if not unknown_surfaces and not unknown_roles:
+        return None
+
+    reason_parts: list[str] = []
+    if unknown_surfaces:
+        reason_parts.append(f"unknown surface type(s): {', '.join(unknown_surfaces)}")
+    if unknown_roles:
+        reason_parts.append(f"unknown source role(s): {', '.join(unknown_roles)}")
+
+    evidence_handles = [citation.evidence_handle for citation in resolver_input.citations]
+    source_role_map = {
+        citation.evidence_handle: (
+            citation.source_role
+            if citation.has_known_source_role
+            else "unknown-source-role"
+        )
+        for citation in resolver_input.citations
+    }
+    for citation in resolver_input.citations:
+        if not citation.has_known_surface_type:
+            source_role_map[citation.evidence_handle] = "unknown-surface"
+
+    return ResolverDecision(
+        status="unresolved",
+        confidence=0.0,
+        evidence_handles=evidence_handles,
+        source_role_map=source_role_map,
+        reason="; ".join(reason_parts),
+    )

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_soul.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_soul.py
@@ -1,0 +1,263 @@
+"""Domain-neutral universe soul profile helpers.
+
+PR-139 slice 3 keeps the old ``PROGRAM.md`` premise file as a compatibility
+mirror while introducing ``soul.md`` as the durable universe-intent artifact.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+SOUL_FILENAME = "soul.md"
+SOUL_VERSIONS_DIR = "soul_versions"
+LEGACY_PREMISE_FILENAME = "PROGRAM.md"
+SOUL_SCHEMA_VERSION = 1
+DEFAULT_DOMAIN_SHAPE = "general"
+DEFAULT_EDIT_AUTHORITY = "soul.edit"
+
+
+@dataclass(frozen=True)
+class UniverseSoul:
+    schema_version: int = SOUL_SCHEMA_VERSION
+    purpose: str = ""
+    why: str = ""
+    hard_lines: tuple[str, ...] = ()
+    soft_preferences: tuple[str, ...] = ()
+    open_to_contributors: tuple[str, ...] = ()
+    domain_shape: str = DEFAULT_DOMAIN_SHAPE
+    lineage: str = "template"
+    edit_authority: str = DEFAULT_EDIT_AUTHORITY
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "path": SOUL_FILENAME,
+            "schema_version": self.schema_version,
+            "purpose": self.purpose,
+            "domain_shape": self.domain_shape,
+            "lineage": self.lineage,
+            "edit_authority": self.edit_authority,
+            "versions_dir": SOUL_VERSIONS_DIR,
+        }
+
+
+def soul_path(universe_dir: Path) -> Path:
+    return universe_dir / SOUL_FILENAME
+
+
+def legacy_premise_path(universe_dir: Path) -> Path:
+    return universe_dir / LEGACY_PREMISE_FILENAME
+
+
+def has_soul(universe_dir: Path) -> bool:
+    return soul_path(universe_dir).is_file()
+
+
+def render_soul_markdown(soul: UniverseSoul) -> str:
+    return "\n".join([
+        "# Universe Soul",
+        "",
+        f"- Schema version: {soul.schema_version}",
+        f"- Domain shape: {soul.domain_shape}",
+        f"- Lineage: {soul.lineage}",
+        f"- Edit authority: {soul.edit_authority}",
+        "",
+        "## Purpose",
+        "",
+        soul.purpose.strip(),
+        "",
+        "## Why",
+        "",
+        soul.why.strip(),
+        "",
+        "## Hard Lines",
+        "",
+        _render_list(soul.hard_lines),
+        "",
+        "## Soft Preferences",
+        "",
+        _render_list(soul.soft_preferences),
+        "",
+        "## Open To Contributors",
+        "",
+        _render_list(soul.open_to_contributors),
+        "",
+        "## Edit Authority",
+        "",
+        soul.edit_authority.strip() or DEFAULT_EDIT_AUTHORITY,
+        "",
+    ])
+
+
+def read_universe_soul(universe_dir: Path) -> UniverseSoul | None:
+    path = soul_path(universe_dir)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+
+    return UniverseSoul(
+        schema_version=_read_int_meta(text, "Schema version", SOUL_SCHEMA_VERSION),
+        purpose=_read_section(text, "Purpose"),
+        why=_read_section(text, "Why"),
+        hard_lines=_read_list_section(text, "Hard Lines"),
+        soft_preferences=_read_list_section(text, "Soft Preferences"),
+        open_to_contributors=_read_list_section(text, "Open To Contributors"),
+        domain_shape=_read_meta(text, "Domain shape", DEFAULT_DOMAIN_SHAPE),
+        lineage=_read_meta(text, "Lineage", "unknown"),
+        edit_authority=(
+            _read_section(text, "Edit Authority")
+            or _read_meta(text, "Edit authority", DEFAULT_EDIT_AUTHORITY)
+        ),
+    )
+
+
+def write_universe_soul(
+    universe_dir: Path,
+    *,
+    purpose: str = "",
+    why: str = "",
+    hard_lines: tuple[str, ...] = (),
+    soft_preferences: tuple[str, ...] = (),
+    open_to_contributors: tuple[str, ...] = (),
+    domain_shape: str = DEFAULT_DOMAIN_SHAPE,
+    lineage: str = "template",
+    edit_authority: str = DEFAULT_EDIT_AUTHORITY,
+) -> UniverseSoul:
+    universe_dir.mkdir(parents=True, exist_ok=True)
+    existing = read_universe_soul(universe_dir)
+    if existing is None:
+        soul = UniverseSoul(
+            purpose=purpose.strip(),
+            why=why.strip(),
+            hard_lines=tuple(item.strip() for item in hard_lines if item.strip()),
+            soft_preferences=tuple(
+                item.strip() for item in soft_preferences if item.strip()
+            ),
+            open_to_contributors=tuple(
+                item.strip() for item in open_to_contributors if item.strip()
+            ),
+            domain_shape=domain_shape.strip() or DEFAULT_DOMAIN_SHAPE,
+            lineage=lineage.strip() or "template",
+            edit_authority=edit_authority.strip() or DEFAULT_EDIT_AUTHORITY,
+        )
+    else:
+        soul = replace(
+            existing,
+            purpose=purpose.strip() if purpose.strip() else existing.purpose,
+            why=why.strip() if why.strip() else existing.why,
+            hard_lines=(
+                tuple(item.strip() for item in hard_lines if item.strip())
+                or existing.hard_lines
+            ),
+            soft_preferences=(
+                tuple(item.strip() for item in soft_preferences if item.strip())
+                or existing.soft_preferences
+            ),
+            open_to_contributors=(
+                tuple(item.strip() for item in open_to_contributors if item.strip())
+                or existing.open_to_contributors
+            ),
+            domain_shape=domain_shape.strip() or existing.domain_shape,
+            lineage=lineage.strip() or existing.lineage,
+            edit_authority=edit_authority.strip() or existing.edit_authority,
+        )
+
+    rendered = render_soul_markdown(soul)
+    soul_path(universe_dir).write_text(rendered, encoding="utf-8")
+    _write_soul_version(universe_dir, rendered)
+    return soul
+
+
+def ensure_universe_soul(universe_dir: Path, *, purpose: str = "") -> UniverseSoul:
+    existing = read_universe_soul(universe_dir)
+    if existing is not None and (existing.purpose or not purpose.strip()):
+        return existing
+    return write_universe_soul(
+        universe_dir,
+        purpose=purpose,
+        lineage="created-from-premise" if purpose.strip() else "template",
+    )
+
+
+def read_legacy_premise(universe_dir: Path) -> str:
+    try:
+        return legacy_premise_path(universe_dir).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ""
+    except OSError:
+        return ""
+
+
+def premise_from_soul(universe_dir: Path) -> str:
+    soul = read_universe_soul(universe_dir)
+    return soul.purpose if soul is not None else ""
+
+
+def _render_list(items: tuple[str, ...]) -> str:
+    if not items:
+        return "_None recorded._"
+    return "\n".join(f"- {item}" for item in items)
+
+
+def _write_soul_version(universe_dir: Path, rendered: str) -> None:
+    versions_dir = universe_dir / SOUL_VERSIONS_DIR
+    versions_dir.mkdir(parents=True, exist_ok=True)
+    versions = sorted(versions_dir.glob("[0-9][0-9][0-9][0-9].md"))
+    if versions:
+        try:
+            if versions[-1].read_text(encoding="utf-8") == rendered:
+                return
+        except OSError:
+            pass
+    next_number = 1
+    if versions:
+        try:
+            next_number = int(versions[-1].stem) + 1
+        except ValueError:
+            next_number = len(versions) + 1
+    (versions_dir / f"{next_number:04d}.md").write_text(rendered, encoding="utf-8")
+
+
+def _read_meta(text: str, key: str, default: str) -> str:
+    pattern = rf"(?im)^-\s*{re.escape(key)}:\s*(.+?)\s*$"
+    match = re.search(pattern, text)
+    if not match:
+        return default
+    return match.group(1).strip() or default
+
+
+def _read_int_meta(text: str, key: str, default: int) -> int:
+    raw = _read_meta(text, key, str(default))
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _read_section(text: str, heading: str) -> str:
+    pattern = rf"(?ims)^##\s+{re.escape(heading)}\s*$\n(?P<body>.*?)(?=^##\s+|\Z)"
+    match = re.search(pattern, text)
+    if not match:
+        return ""
+    body = match.group("body").strip()
+    return "" if body == "_None recorded._" else body
+
+
+def _read_list_section(text: str, heading: str) -> tuple[str, ...]:
+    body = _read_section(text, heading)
+    if not body:
+        return ()
+    items: list[str] = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped == "_None recorded._":
+            continue
+        if stripped.startswith("- "):
+            items.append(stripped[2:].strip())
+        else:
+            items.append(stripped)
+    return tuple(item for item in items if item)

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_state.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_state.py
@@ -1,0 +1,100 @@
+"""Domain-neutral universe state contract.
+
+This module defines the substrate-level fields that every universe can share
+without inheriting the fantasy daemon's book/chapter/scene shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from typing_extensions import TypedDict
+
+from workflow.protocols import WorkflowState
+
+
+class UniverseIdentity(TypedDict, total=False):
+    """Identity fields that name a universe independently of its domain."""
+
+    universe_id: str
+    universe_version: str
+    soul_ref: str | None
+
+
+class UniverseScope(TypedDict, total=False):
+    """Resource boundary fields for a universe."""
+
+    universe_path: str
+    goal_id: str | None
+    branch_id: str | None
+    workspace_ref: str | None
+    hard_priorities_ref: str | None
+    timeline_ref: str | None
+
+
+class UniverseMetrics(TypedDict, total=False):
+    """Generic metric envelope.
+
+    Domain metrics live under named keys so the substrate does not grow
+    domain-specific counters such as chapters, scenes, or words.
+    """
+
+    progress: dict[str, int | float]
+    metric_units: dict[str, str]
+    last_activity_at: str | None
+
+
+class DomainNeutralUniverseState(
+    WorkflowState,
+    UniverseIdentity,
+    UniverseScope,
+    UniverseMetrics,
+    total=False,
+):
+    """Base state for all universe domains."""
+
+    workflow_instructions: dict[str, Any]
+
+
+FANTASY_DEFAULT_UNIVERSE_STATE_FIELDS = frozenset({
+    "active_series",
+    "series_completed",
+    "world_state_version",
+    "canon_facts_count",
+    "total_words",
+    "total_chapters",
+    "book_number",
+    "chapter_number",
+    "scene_number",
+    "premise_kernel",
+    "worldbuild_signals",
+    "universal_style_rules",
+    "cross_series_facts",
+})
+
+DOMAIN_NEUTRAL_UNIVERSE_STATE_FIELDS = frozenset(
+    DomainNeutralUniverseState.__annotations__
+)
+
+
+def project_domain_neutral_universe_state(
+    state: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return only the domain-neutral universe-state view."""
+
+    return {
+        field: state[field]
+        for field in DOMAIN_NEUTRAL_UNIVERSE_STATE_FIELDS
+        if field in state
+    }
+
+
+__all__ = [
+    "DOMAIN_NEUTRAL_UNIVERSE_STATE_FIELDS",
+    "FANTASY_DEFAULT_UNIVERSE_STATE_FIELDS",
+    "DomainNeutralUniverseState",
+    "UniverseIdentity",
+    "UniverseMetrics",
+    "UniverseScope",
+    "project_domain_neutral_universe_state",
+]

--- a/packaging/claude-plugin/plugins/workflow-universe-server/skills/premise/SKILL.md
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/skills/premise/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Premise
 
-Read or update the story premise (PROGRAM.md) that seeds the daemon's creative direction.
+Read or update the universe purpose/premise that seeds the daemon's creative direction.
 
 ## Usage
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -420,6 +420,20 @@ class TestPremise:
         resp = client.get("/v1/universes/test-universe/premise")
         assert resp.status_code == 200
         assert "dragons" in resp.json()["text"]
+        assert resp.json()["source"] == "PROGRAM.md"
+
+    def test_get_premise_falls_back_to_soul(self, client, universe_dir):
+        from workflow.universe_soul import write_universe_soul
+
+        write_universe_soul(
+            universe_dir,
+            purpose="A civic lab studies memory.",
+            lineage="test",
+        )
+        resp = client.get("/v1/universes/test-universe/premise")
+        assert resp.status_code == 200
+        assert resp.json()["text"] == "A civic lab studies memory."
+        assert resp.json()["source"] == "soul.md"
 
     def test_get_premise_missing(self, client):
         resp = client.get("/v1/universes/test-universe/premise")
@@ -433,6 +447,8 @@ class TestPremise:
         assert resp.status_code == 200
         content = (universe_dir / "PROGRAM.md").read_text(encoding="utf-8")
         assert "wandering knight" in content
+        soul = (universe_dir / "soul.md").read_text(encoding="utf-8")
+        assert "wandering knight" in soul
 
     def test_set_premise_overwrites(self, client, universe_dir):
         client.post(
@@ -1720,13 +1736,15 @@ class TestServeFlag:
 class TestEdgeCaseUniverseCreation:
     """Edge cases a GPT might trigger when creating universes."""
 
-    def test_create_universe_no_name(self, client):
+    def test_create_universe_no_name(self, client, base_dir):
         """Empty body should auto-generate a name."""
         resp = client.post("/v1/universes", json={})
         assert resp.status_code == 201
         data = resp.json()
         assert data["id"]
         assert data["name"]
+        assert data["has_soul"] is True
+        assert (base_dir / data["id"] / "soul.md").exists()
 
     def test_create_universe_empty_name(self, client):
         """Explicit empty string name should auto-generate."""

--- a/tests/test_cloud_worker.py
+++ b/tests/test_cloud_worker.py
@@ -586,6 +586,20 @@ def test_resolve_universe_auto_picks_first_with_program_md(tmp_path, monkeypatch
     assert resolved == with_premise
 
 
+def test_resolve_universe_auto_picks_first_with_soul_md(tmp_path, monkeypatch):
+    empty = tmp_path / "empty-candidate"
+    empty.mkdir()
+    with_soul = tmp_path / "has-soul"
+    with_soul.mkdir()
+    (with_soul / "soul.md").write_text("# Universe Soul\n", encoding="utf-8")
+
+    monkeypatch.delenv("WORKFLOW_UNIVERSE", raising=False)
+    monkeypatch.delenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", raising=False)
+    with patch("workflow.storage.data_dir", return_value=tmp_path):
+        resolved = cw._resolve_universe_path()
+    assert resolved == with_soul
+
+
 def test_resolve_universe_falls_back_to_default_universe_name(tmp_path, monkeypatch):
     """Empty data dir with nothing — falls back to 'default-universe'
     under data_dir so fantasy_daemon creates it on first run."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -183,13 +183,15 @@ class TestPremise:
 
     def test_get_premise_missing(self, universe_dir):
         result = get_premise()
-        assert "No PROGRAM.md" in result
+        assert "No premise found" in result
 
     def test_set_premise_writes(self, universe_dir):
         result = set_premise("A story about a wandering knight.")
         assert "updated" in result.lower()
         content = (universe_dir / "PROGRAM.md").read_text(encoding="utf-8")
         assert "wandering knight" in content
+        soul = (universe_dir / "soul.md").read_text(encoding="utf-8")
+        assert "wandering knight" in soul
 
     def test_set_overwrites_existing(self, universe_dir):
         set_premise("Old premise")
@@ -197,6 +199,18 @@ class TestPremise:
         content = (universe_dir / "PROGRAM.md").read_text(encoding="utf-8")
         assert "New premise" in content
         assert "Old premise" not in content
+
+    def test_get_premise_falls_back_to_soul(self, universe_dir):
+        from workflow.universe_soul import write_universe_soul
+
+        write_universe_soul(
+            universe_dir,
+            purpose="A city remembers every repair.",
+            lineage="test",
+        )
+
+        result = get_premise()
+        assert result == "A city remembers every repair."
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_universe_nodes.py
+++ b/tests/test_universe_nodes.py
@@ -270,6 +270,7 @@ class TestWorldbuildAutoPremise:
         assert result == "A story of Ryn navigating the shattered glass realm."
         assert (universe_dir / "PROGRAM.md").exists()
         assert "Ryn" in (universe_dir / "PROGRAM.md").read_text(encoding="utf-8")
+        assert "Ryn" in (universe_dir / "soul.md").read_text(encoding="utf-8")
 
     def test_skips_when_program_md_exists(self, tmp_path):
         """Should not generate if PROGRAM.md already exists."""

--- a/tests/test_universe_server_ledger.py
+++ b/tests/test_universe_server_ledger.py
@@ -113,10 +113,11 @@ def test_set_premise_appends_ledger(universe: str) -> None:
     entry = entries[0]
     assert entry["action"] == "set_premise"
     assert entry["actor"] == "test-user"
-    assert entry["target"] == "PROGRAM.md"
+    assert entry["target"] == "soul.md"
     assert entry["summary"] == "A tower of bones."
     assert "timestamp" in entry
     assert entry["payload"]["bytes"] == len("A tower of bones.".encode("utf-8"))
+    assert entry["payload"]["legacy_program_mirror"] == "PROGRAM.md"
 
 
 def test_set_premise_empty_does_not_append(universe: str) -> None:
@@ -217,6 +218,7 @@ def test_create_universe_appends_ledger_to_new_universe(universe: str) -> None:
     assert entries[0]["action"] == "create_universe"
     assert entries[0]["summary"] == "A seedling kingdom."
     assert entries[0]["payload"]["has_premise"] is True
+    assert entries[0]["payload"]["has_soul"] is True
 
 
 def test_create_universe_surfaces_synthesis_first_run_checklist(

--- a/tests/test_universe_soul.py
+++ b/tests/test_universe_soul.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def us(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    base = tmp_path / "output"
+    base.mkdir()
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(base))
+    import workflow.api.universe as module
+
+    importlib.reload(module)
+    yield module
+    importlib.reload(module)
+
+
+def _mkuniverse(base: Path, uid: str) -> Path:
+    udir = base / uid
+    udir.mkdir(parents=True, exist_ok=True)
+    return udir
+
+
+def test_set_premise_writes_versioned_soul_profile(us):
+    base = Path(us._base_path())
+    _mkuniverse(base, "u1")
+
+    result = json.loads(us._action_set_premise(
+        universe_id="u1",
+        text="A wandering lab studies civic memory.",
+    ))
+
+    assert result["status"] == "updated"
+    assert result["soul"]["path"] == "soul.md"
+    assert result["soul"]["schema_version"] == 1
+    assert result["soul"]["versions_dir"] == "soul_versions"
+    soul_md = (base / "u1" / "soul.md").read_text(encoding="utf-8")
+    assert "# Universe Soul" in soul_md
+    assert "## Purpose" in soul_md
+    assert "A wandering lab studies civic memory." in soul_md
+    assert "## Edit Authority" in soul_md
+    assert "soul.edit" in soul_md
+    version = base / "u1" / "soul_versions" / "0001.md"
+    assert version.exists()
+    assert version.read_text(encoding="utf-8") == soul_md
+
+
+def test_read_premise_falls_back_to_soul_purpose(us):
+    base = Path(us._base_path())
+    udir = _mkuniverse(base, "u1")
+    us._action_set_premise(universe_id="u1", text="A solar archive wakes up.")
+    (udir / "PROGRAM.md").unlink()
+
+    result = json.loads(us._action_read_premise(universe_id="u1"))
+
+    assert result["premise"] == "A solar archive wakes up."
+    assert result["source"] == "soul.md"
+    assert result["soul"]["schema_version"] == 1
+
+
+def test_create_universe_always_writes_soul_profile(us):
+    base = Path(us._base_path())
+
+    result = json.loads(us._action_create_universe(
+        universe_id="fresh-uni",
+        text="A seedling kingdom.",
+    ))
+
+    assert result["status"] == "created"
+    assert result["has_soul"] is True
+    assert result["soul"]["path"] == "soul.md"
+    assert (base / "fresh-uni" / "soul.md").exists()
+    assert (base / "fresh-uni" / "PROGRAM.md").read_text(
+        encoding="utf-8",
+    ) == "A seedling kingdom."
+
+
+def test_create_universe_without_premise_still_has_thin_soul(us):
+    base = Path(us._base_path())
+
+    result = json.loads(us._action_create_universe(universe_id="thin-uni"))
+
+    assert result["status"] == "created"
+    assert result["has_premise"] is False
+    assert result["has_soul"] is True
+    soul_md = (base / "thin-uni" / "soul.md").read_text(encoding="utf-8")
+    assert "# Universe Soul" in soul_md
+    assert "## Purpose" in soul_md
+    assert not (base / "thin-uni" / "PROGRAM.md").exists()

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -70,6 +70,16 @@ from workflow.api.helpers import (
     _universe_dir,
 )
 from workflow.catalog import list_unreconciled_writes
+from workflow.universe_soul import (
+    SOUL_FILENAME,
+    ensure_universe_soul,
+    has_soul,
+    legacy_premise_path,
+    premise_from_soul,
+    read_legacy_premise,
+    read_universe_soul,
+    write_universe_soul,
+)
 
 logger = logging.getLogger("universe_server.universe")
 
@@ -126,9 +136,12 @@ def _extract_set_premise(
     from workflow.api.engine_helpers import _truncate
     text = kwargs.get("text", "")
     return (
-        "PROGRAM.md",
+        SOUL_FILENAME,
         _truncate(text),
-        {"bytes": len(text.encode("utf-8"))},
+        {
+            "bytes": len(text.encode("utf-8")),
+            "legacy_program_mirror": "PROGRAM.md",
+        },
     )
 
 
@@ -193,7 +206,11 @@ def _extract_create_universe(
     uid = kwargs.get("universe_id", "")
     text = kwargs.get("text", "")
     summary = _truncate(text) if text.strip() else f"created {uid}"
-    return (uid, summary, {"has_premise": bool(text.strip())})
+    return (uid, summary, {
+        "has_premise": bool(text.strip()),
+        "has_soul": True,
+        "soul_path": SOUL_FILENAME,
+    })
 
 
 def _synthesis_first_run_checklist(has_premise: bool) -> dict[str, Any]:
@@ -201,7 +218,7 @@ def _synthesis_first_run_checklist(has_premise: bool) -> dict[str, Any]:
     steps = [
         {
             "id": "premise",
-            "label": "Save a premise with create_universe text or set_premise.",
+            "label": "Save a soul purpose with create_universe text or set_premise.",
             "complete": has_premise,
         },
         {
@@ -830,7 +847,9 @@ def _daemon_liveness(udir: Path, status: dict[str, Any] | None) -> dict[str, Any
     same interpreted fields, so legibility fixes in one place land
     everywhere at once.
     """
-    has_premise = (udir / "PROGRAM.md").exists()
+    has_premise = bool(
+        read_legacy_premise(udir).strip() or premise_from_soul(udir).strip()
+    )
     targets = _read_json(udir / "work_targets.json")
     has_work = isinstance(targets, list) and any(
         t.get("lifecycle") == "active" for t in targets if isinstance(t, dict)
@@ -858,6 +877,7 @@ def _daemon_liveness(udir: Path, status: dict[str, Any] | None) -> dict[str, Any
         ),
         "is_paused": is_paused,
         "has_premise": has_premise,
+        "has_soul": has_soul(udir),
         "has_work": has_work,
         "last_activity_at": last_activity,
         "staleness": staleness,
@@ -895,6 +915,7 @@ def _action_list_universes(**_kwargs: Any) -> str:
         info: dict[str, Any] = {
             "id": child.name,
             "has_premise": liveness["has_premise"],
+            "has_soul": liveness["has_soul"],
             "word_count": liveness["word_count"],
             "phase": liveness["phase"],
             "phase_human": liveness["phase_human"],
@@ -941,6 +962,7 @@ def _action_inspect_universe(universe_id: str = "", **_kwargs: Any) -> str:
         "phase_human": liveness["phase_human"],
         "is_paused": liveness["is_paused"],
         "has_premise": liveness["has_premise"],
+        "has_soul": liveness["has_soul"],
         "has_work": liveness["has_work"],
         "last_activity_at": liveness["last_activity_at"],
         "staleness": liveness["staleness"],
@@ -950,12 +972,21 @@ def _action_inspect_universe(universe_id: str = "", **_kwargs: Any) -> str:
         "accept_rate_sample": liveness["accept_rate_sample"],
     }
 
-    # Premise — always present as a boolean so callers can't silently miss
-    # the "no premise set" case. Full text included only when non-empty.
-    program = _read_text(udir / "PROGRAM.md")
-    result["has_premise"] = bool(program)
-    if program:
-        result["premise"] = program[:500] + ("..." if len(program) > 500 else "")
+    soul = read_universe_soul(udir)
+    if soul is not None:
+        result["has_soul"] = True
+        result["soul"] = soul.summary()
+
+    # Premise remains the public compatibility field. The durable source is
+    # now soul.md when PROGRAM.md is absent or empty.
+    program = _normalize_escaped_text(read_legacy_premise(udir))
+    premise = program.strip() or (soul.purpose if soul is not None else "")
+    result["has_premise"] = bool(premise)
+    if premise:
+        result["premise"] = premise[:500] + ("..." if len(premise) > 500 else "")
+        result["premise_source"] = (
+            "PROGRAM.md" if program.strip() else SOUL_FILENAME
+        )
 
     # Notes summary
     notes = _read_json(udir / "notes.json")
@@ -3329,20 +3360,29 @@ def _query_world_db(
 def _action_read_premise(universe_id: str = "", **_kwargs: Any) -> str:
     uid = universe_id or _default_universe()
     udir = _universe_dir(uid)
-    program_path = udir / "PROGRAM.md"
+    content = _normalize_escaped_text(read_legacy_premise(udir))
+    source = "PROGRAM.md"
+    if not content.strip():
+        soul = read_universe_soul(udir)
+        content = soul.purpose if soul is not None else ""
+        source = SOUL_FILENAME
+    else:
+        soul = read_universe_soul(udir)
 
-    content = _read_text(program_path)
-    if not content:
+    if not content.strip():
         return json.dumps({
             "universe_id": uid,
             "premise": None,
+            "has_soul": soul is not None,
+            "soul": soul.summary() if soul is not None else None,
             "note": "No premise set. Use action='set_premise' to create one.",
         })
-    # Read-time fallback: decode any pre-existing files that were written
-    # with literal \n sequences by a buggy client before the write-side fix.
     return json.dumps({
         "universe_id": uid,
-        "premise": _normalize_escaped_text(content),
+        "premise": content,
+        "source": source,
+        "has_soul": soul is not None,
+        "soul": soul.summary() if soul is not None else None,
     })
 
 
@@ -3375,17 +3415,21 @@ def _normalize_escaped_text(text: str) -> str:
 def _action_set_premise(universe_id: str = "", text: str = "", **_kwargs: Any) -> str:
     uid = universe_id or _default_universe()
     udir = _universe_dir(uid)
-    program_path = udir / "PROGRAM.md"
 
     if not text.strip():
         return json.dumps({"error": "Premise text cannot be empty."})
     text = _normalize_escaped_text(text)
     try:
         udir.mkdir(parents=True, exist_ok=True)
-        program_path.write_text(text, encoding="utf-8")
+        soul = write_universe_soul(
+            udir, purpose=text, lineage="created-from-premise",
+        )
+        legacy_premise_path(udir).write_text(text, encoding="utf-8")
         return json.dumps({
             "universe_id": uid,
             "status": "updated",
+            "has_soul": True,
+            "soul": soul.summary(),
             "note": "Premise saved. The daemon will read it at next startup.",
         })
     except OSError as exc:
@@ -4200,11 +4244,11 @@ def _action_create_universe(
 
     try:
         udir.mkdir(parents=True, exist_ok=True)
+        normalized_text = _normalize_escaped_text(text) if text.strip() else ""
+        soul = ensure_universe_soul(udir, purpose=normalized_text)
         # Write premise if provided
-        if text.strip():
-            (udir / "PROGRAM.md").write_text(
-                _normalize_escaped_text(text), encoding="utf-8",
-            )
+        if normalized_text.strip():
+            legacy_premise_path(udir).write_text(normalized_text, encoding="utf-8")
 
         # Initialize empty state files
         (udir / "notes.json").write_text("[]", encoding="utf-8")
@@ -4213,9 +4257,11 @@ def _action_create_universe(
         result: dict[str, Any] = {
             "universe_id": uid,
             "status": "created",
-            "has_premise": bool(text.strip()),
+            "has_premise": bool(normalized_text.strip()),
+            "has_soul": True,
+            "soul": soul.summary(),
             "first_run_checklist": _synthesis_first_run_checklist(
-                has_premise=bool(text.strip()),
+                has_premise=bool(normalized_text.strip()),
             ),
         }
 

--- a/workflow/cloud_worker.py
+++ b/workflow/cloud_worker.py
@@ -96,7 +96,7 @@ def _resolve_universe_path() -> Path:
       1. ``WORKFLOW_UNIVERSE`` env var (explicit override).
       2. ``$WORKFLOW_DATA_DIR/$UNIVERSE_SERVER_DEFAULT_UNIVERSE``.
       3. First directory under ``WORKFLOW_DATA_DIR`` that has a
-         ``PROGRAM.md`` (auto-selects the active universe in the common
+         ``PROGRAM.md`` or ``soul.md`` (auto-selects the active universe in the common
          "one universe" droplet deployment).
       4. ``$WORKFLOW_DATA_DIR/default-universe`` as a last-resort fallback.
     """
@@ -119,7 +119,10 @@ def _resolve_universe_path() -> Path:
 
     if base.is_dir():
         for entry in sorted(base.iterdir()):
-            if entry.is_dir() and (entry / "PROGRAM.md").exists():
+            if (
+                entry.is_dir()
+                and ((entry / "PROGRAM.md").exists() or (entry / "soul.md").exists())
+            ):
                 return entry
 
     return base / "default-universe"
@@ -528,7 +531,7 @@ def main(argv: list[str] | None = None) -> int:
         "--universe",
         default="",
         help="Explicit universe path. Default: WORKFLOW_UNIVERSE / "
-             "first-PROGRAM.md / WORKFLOW_DATA_DIR/default-universe.",
+             "first PROGRAM.md or soul.md / WORKFLOW_DATA_DIR/default-universe.",
     )
     parser.add_argument(
         "--idle-backoff", type=float, default=DEFAULT_IDLE_BACKOFF_S,

--- a/workflow/desktop/launcher.py
+++ b/workflow/desktop/launcher.py
@@ -25,6 +25,8 @@ import threading
 from pathlib import Path
 from typing import Any, Callable
 
+from workflow.universe_soul import premise_from_soul, read_legacy_premise
+
 # tkinter requires libtk (system lib). Headless Docker containers
 # don't ship it; the cloud_worker's fantasy_daemon subprocess imports
 # the desktop tree at load time before --no-tray is parsed. Tolerate
@@ -653,14 +655,13 @@ class LauncherApp:
         if self._daemon is None:
             return
 
-        # Re-read premise from PROGRAM.md
-        program_md = Path(self.universe_path) / "PROGRAM.md"
-        if program_md.exists():
-            try:
-                premise = program_md.read_text(encoding="utf-8").strip()
-                self._daemon._premise = premise
-            except OSError:
-                pass
+        # Re-read premise from the compatibility file or soul.md purpose.
+        universe_dir = Path(self.universe_path)
+        premise = read_legacy_premise(universe_dir).strip()
+        if not premise:
+            premise = premise_from_soul(universe_dir).strip()
+        if premise:
+            self._daemon._premise = premise
 
     def _reimport_modules(self) -> None:
         """Reimport workflow submodules to pick up code changes."""

--- a/workflow/evaluation/structural.py
+++ b/workflow/evaluation/structural.py
@@ -887,16 +887,17 @@ def _check_premise_grounding(state: dict[str, Any]) -> CheckResult:
     if not premise:
         premise = state.get("premise_kernel", "")
     if not premise:
-        # Fallback: read PROGRAM.md from universe directory
+        # Fallback: read PROGRAM.md or soul.md from universe directory.
         uni_path = state.get("_universe_path", "")
         if uni_path:
             from pathlib import Path as _P
-            program_md = _P(uni_path) / "PROGRAM.md"
-            try:
-                if program_md.exists():
-                    premise = program_md.read_text(encoding="utf-8").strip()
-            except OSError:
-                pass
+
+            from workflow.universe_soul import premise_from_soul, read_legacy_premise
+            universe_dir = _P(uni_path)
+            premise = (
+                read_legacy_premise(universe_dir).strip()
+                or premise_from_soul(universe_dir).strip()
+            )
 
     if not premise:
         return CheckResult(

--- a/workflow/mcp_server.py
+++ b/workflow/mcp_server.py
@@ -22,6 +22,13 @@ from pathlib import Path
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
+from workflow.universe_soul import (
+    legacy_premise_path,
+    premise_from_soul,
+    read_legacy_premise,
+    write_universe_soul,
+)
+
 mcp = FastMCP(
     "workflow",
     instructions=(
@@ -176,17 +183,18 @@ def steer(directive: str, category: str = "direction") -> str:
 
 
 def get_premise() -> str:
-    """Read the current story premise from PROGRAM.md.
+    """Read the current story premise from PROGRAM.md or soul.md.
 
     The premise seeds the daemon's creative direction.
     """
-    program_path = _universe_dir() / "PROGRAM.md"
-    if not program_path.exists():
-        return "No PROGRAM.md found. Use set_premise() to create one."
-    try:
-        return program_path.read_text(encoding="utf-8")
-    except OSError as e:
-        return f"Error reading PROGRAM.md: {e}"
+    universe_dir = _universe_dir()
+    premise = read_legacy_premise(universe_dir).strip()
+    if premise:
+        return premise
+    premise = premise_from_soul(universe_dir).strip()
+    if premise:
+        return premise
+    return "No premise found. Use set_premise() to create one."
 
 
 _mcp_get_premise = _register_structured_tool(
@@ -198,19 +206,22 @@ _mcp_get_premise = _register_structured_tool(
 
 
 def set_premise(text: str) -> str:
-    """Write or overwrite the story premise in PROGRAM.md.
+    """Write or overwrite the story premise as soul.md plus PROGRAM.md.
 
     The daemon reads this at startup to seed the story direction.
     Overwrites any existing premise — use get_premise first if you want to
     edit rather than replace.
     """
-    program_path = _universe_dir() / "PROGRAM.md"
+    universe_dir = _universe_dir()
     try:
-        _universe_dir().mkdir(parents=True, exist_ok=True)
-        program_path.write_text(text, encoding="utf-8")
-        return "PROGRAM.md updated."
+        universe_dir.mkdir(parents=True, exist_ok=True)
+        write_universe_soul(
+            universe_dir, purpose=text, lineage="created-from-premise",
+        )
+        legacy_premise_path(universe_dir).write_text(text, encoding="utf-8")
+        return "soul.md updated."
     except OSError as e:
-        return f"Error writing PROGRAM.md: {e}"
+        return f"Error writing premise: {e}"
 
 
 _mcp_set_premise = _register_structured_tool(

--- a/workflow/universe_soul.py
+++ b/workflow/universe_soul.py
@@ -1,0 +1,263 @@
+"""Domain-neutral universe soul profile helpers.
+
+PR-139 slice 3 keeps the old ``PROGRAM.md`` premise file as a compatibility
+mirror while introducing ``soul.md`` as the durable universe-intent artifact.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+SOUL_FILENAME = "soul.md"
+SOUL_VERSIONS_DIR = "soul_versions"
+LEGACY_PREMISE_FILENAME = "PROGRAM.md"
+SOUL_SCHEMA_VERSION = 1
+DEFAULT_DOMAIN_SHAPE = "general"
+DEFAULT_EDIT_AUTHORITY = "soul.edit"
+
+
+@dataclass(frozen=True)
+class UniverseSoul:
+    schema_version: int = SOUL_SCHEMA_VERSION
+    purpose: str = ""
+    why: str = ""
+    hard_lines: tuple[str, ...] = ()
+    soft_preferences: tuple[str, ...] = ()
+    open_to_contributors: tuple[str, ...] = ()
+    domain_shape: str = DEFAULT_DOMAIN_SHAPE
+    lineage: str = "template"
+    edit_authority: str = DEFAULT_EDIT_AUTHORITY
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "path": SOUL_FILENAME,
+            "schema_version": self.schema_version,
+            "purpose": self.purpose,
+            "domain_shape": self.domain_shape,
+            "lineage": self.lineage,
+            "edit_authority": self.edit_authority,
+            "versions_dir": SOUL_VERSIONS_DIR,
+        }
+
+
+def soul_path(universe_dir: Path) -> Path:
+    return universe_dir / SOUL_FILENAME
+
+
+def legacy_premise_path(universe_dir: Path) -> Path:
+    return universe_dir / LEGACY_PREMISE_FILENAME
+
+
+def has_soul(universe_dir: Path) -> bool:
+    return soul_path(universe_dir).is_file()
+
+
+def render_soul_markdown(soul: UniverseSoul) -> str:
+    return "\n".join([
+        "# Universe Soul",
+        "",
+        f"- Schema version: {soul.schema_version}",
+        f"- Domain shape: {soul.domain_shape}",
+        f"- Lineage: {soul.lineage}",
+        f"- Edit authority: {soul.edit_authority}",
+        "",
+        "## Purpose",
+        "",
+        soul.purpose.strip(),
+        "",
+        "## Why",
+        "",
+        soul.why.strip(),
+        "",
+        "## Hard Lines",
+        "",
+        _render_list(soul.hard_lines),
+        "",
+        "## Soft Preferences",
+        "",
+        _render_list(soul.soft_preferences),
+        "",
+        "## Open To Contributors",
+        "",
+        _render_list(soul.open_to_contributors),
+        "",
+        "## Edit Authority",
+        "",
+        soul.edit_authority.strip() or DEFAULT_EDIT_AUTHORITY,
+        "",
+    ])
+
+
+def read_universe_soul(universe_dir: Path) -> UniverseSoul | None:
+    path = soul_path(universe_dir)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+
+    return UniverseSoul(
+        schema_version=_read_int_meta(text, "Schema version", SOUL_SCHEMA_VERSION),
+        purpose=_read_section(text, "Purpose"),
+        why=_read_section(text, "Why"),
+        hard_lines=_read_list_section(text, "Hard Lines"),
+        soft_preferences=_read_list_section(text, "Soft Preferences"),
+        open_to_contributors=_read_list_section(text, "Open To Contributors"),
+        domain_shape=_read_meta(text, "Domain shape", DEFAULT_DOMAIN_SHAPE),
+        lineage=_read_meta(text, "Lineage", "unknown"),
+        edit_authority=(
+            _read_section(text, "Edit Authority")
+            or _read_meta(text, "Edit authority", DEFAULT_EDIT_AUTHORITY)
+        ),
+    )
+
+
+def write_universe_soul(
+    universe_dir: Path,
+    *,
+    purpose: str = "",
+    why: str = "",
+    hard_lines: tuple[str, ...] = (),
+    soft_preferences: tuple[str, ...] = (),
+    open_to_contributors: tuple[str, ...] = (),
+    domain_shape: str = DEFAULT_DOMAIN_SHAPE,
+    lineage: str = "template",
+    edit_authority: str = DEFAULT_EDIT_AUTHORITY,
+) -> UniverseSoul:
+    universe_dir.mkdir(parents=True, exist_ok=True)
+    existing = read_universe_soul(universe_dir)
+    if existing is None:
+        soul = UniverseSoul(
+            purpose=purpose.strip(),
+            why=why.strip(),
+            hard_lines=tuple(item.strip() for item in hard_lines if item.strip()),
+            soft_preferences=tuple(
+                item.strip() for item in soft_preferences if item.strip()
+            ),
+            open_to_contributors=tuple(
+                item.strip() for item in open_to_contributors if item.strip()
+            ),
+            domain_shape=domain_shape.strip() or DEFAULT_DOMAIN_SHAPE,
+            lineage=lineage.strip() or "template",
+            edit_authority=edit_authority.strip() or DEFAULT_EDIT_AUTHORITY,
+        )
+    else:
+        soul = replace(
+            existing,
+            purpose=purpose.strip() if purpose.strip() else existing.purpose,
+            why=why.strip() if why.strip() else existing.why,
+            hard_lines=(
+                tuple(item.strip() for item in hard_lines if item.strip())
+                or existing.hard_lines
+            ),
+            soft_preferences=(
+                tuple(item.strip() for item in soft_preferences if item.strip())
+                or existing.soft_preferences
+            ),
+            open_to_contributors=(
+                tuple(item.strip() for item in open_to_contributors if item.strip())
+                or existing.open_to_contributors
+            ),
+            domain_shape=domain_shape.strip() or existing.domain_shape,
+            lineage=lineage.strip() or existing.lineage,
+            edit_authority=edit_authority.strip() or existing.edit_authority,
+        )
+
+    rendered = render_soul_markdown(soul)
+    soul_path(universe_dir).write_text(rendered, encoding="utf-8")
+    _write_soul_version(universe_dir, rendered)
+    return soul
+
+
+def ensure_universe_soul(universe_dir: Path, *, purpose: str = "") -> UniverseSoul:
+    existing = read_universe_soul(universe_dir)
+    if existing is not None and (existing.purpose or not purpose.strip()):
+        return existing
+    return write_universe_soul(
+        universe_dir,
+        purpose=purpose,
+        lineage="created-from-premise" if purpose.strip() else "template",
+    )
+
+
+def read_legacy_premise(universe_dir: Path) -> str:
+    try:
+        return legacy_premise_path(universe_dir).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ""
+    except OSError:
+        return ""
+
+
+def premise_from_soul(universe_dir: Path) -> str:
+    soul = read_universe_soul(universe_dir)
+    return soul.purpose if soul is not None else ""
+
+
+def _render_list(items: tuple[str, ...]) -> str:
+    if not items:
+        return "_None recorded._"
+    return "\n".join(f"- {item}" for item in items)
+
+
+def _write_soul_version(universe_dir: Path, rendered: str) -> None:
+    versions_dir = universe_dir / SOUL_VERSIONS_DIR
+    versions_dir.mkdir(parents=True, exist_ok=True)
+    versions = sorted(versions_dir.glob("[0-9][0-9][0-9][0-9].md"))
+    if versions:
+        try:
+            if versions[-1].read_text(encoding="utf-8") == rendered:
+                return
+        except OSError:
+            pass
+    next_number = 1
+    if versions:
+        try:
+            next_number = int(versions[-1].stem) + 1
+        except ValueError:
+            next_number = len(versions) + 1
+    (versions_dir / f"{next_number:04d}.md").write_text(rendered, encoding="utf-8")
+
+
+def _read_meta(text: str, key: str, default: str) -> str:
+    pattern = rf"(?im)^-\s*{re.escape(key)}:\s*(.+?)\s*$"
+    match = re.search(pattern, text)
+    if not match:
+        return default
+    return match.group(1).strip() or default
+
+
+def _read_int_meta(text: str, key: str, default: int) -> int:
+    raw = _read_meta(text, key, str(default))
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _read_section(text: str, heading: str) -> str:
+    pattern = rf"(?ims)^##\s+{re.escape(heading)}\s*$\n(?P<body>.*?)(?=^##\s+|\Z)"
+    match = re.search(pattern, text)
+    if not match:
+        return ""
+    body = match.group("body").strip()
+    return "" if body == "_None recorded._" else body
+
+
+def _read_list_section(text: str, heading: str) -> tuple[str, ...]:
+    body = _read_section(text, heading)
+    if not body:
+        return ()
+    items: list[str] = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped == "_None recorded._":
+            continue
+        if stripped.startswith("- "):
+            items.append(stripped[2:].strip())
+        else:
+            items.append(stripped)
+    return tuple(item for item in items if item)


### PR DESCRIPTION
PR-139 slice 3 / CHILD-2 Part D.

Adds the domain-neutral universe soul profile substrate and adapts the existing premise surfaces so `soul.md` becomes the durable intent artifact while `PROGRAM.md` remains a compatibility mirror for existing fantasy-domain readers.

Scope:
- Add `workflow.universe_soul` with `soul.md` rendering/parsing and `soul_versions/NNNN.md` snapshots.
- Wire MCP `universe` read/set/create premise paths to write/read soul metadata.
- Wire REST/legacy premise paths, cloud/desktop selection, and fantasy-domain premise readers to fall back to `soul.md` purpose.
- Keep permission cutover, tag-matrix retrieval, soul-as-lens context assembly, universe-cycle de-default, and episodic migration out of this slice.
- Refresh Claude plugin runtime mirror; includes missing mirror files for already-landed PR-139 slice 1/2 modules required by mirror parity.

Gate state:
- Host key for all PR-139 slices recorded at `pages/notes/pr139-program-host-key-all-slices-approved-2026-05-27.md`.
- Needs Cowork/Claude-family checker key before merge.

Verification:
- `python -m pytest tests/test_api.py tests/test_api_edge_cases.py tests/test_mcp_server.py tests/test_universe_server_premise_escaping.py tests/test_universe_server_ledger.py tests/test_universe_server_isolation.py tests/test_universe_server_telemetry.py tests/test_universe_soul.py -q` -> 363 passed.
- `python -m pytest tests/test_cloud_worker.py tests/test_task_producers.py tests/test_universe_nodes.py::TestWorldbuildAutoPremise tests/test_evaluation.py -q` -> 152 passed, 1 skipped.
- `python -m ruff check ...` on changed canonical/test files -> passed.
- `python scripts/invariants_run.py --check mirror-parity` -> passed.
- `python -m pytest tests/test_import_graph_smoke.py tests/test_canary_scripts_import_smoke.py -q` -> 52 passed.