### PR TITLE
PR-139 slice 5: add pinned soul lens to context assembly

### DIFF
--- a/domains/fantasy_daemon/phases/writer_tools.py
+++ b/domains/fantasy_daemon/phases/writer_tools.py
@@ -198,6 +198,10 @@ def _render_story_search(state: dict[str, Any]) -> str:
     if sources:
         parts.append("Routed sources: " + ", ".join(sources[:8]))
 
+    soul_section = _render_universe_soul_from_context(search.get("universe_soul", {}))
+    if soul_section:
+        parts.append(soul_section)
+
     world_section = _render_world_state_from_context(search.get("world_state", {}))
     if world_section:
         parts.append(world_section)
@@ -221,6 +225,51 @@ def _render_story_search(state: dict[str, Any]) -> str:
         parts.append("Canon Files:\n\n" + canon_section)
 
     return "\n\n".join(parts)
+
+
+def _render_universe_soul_from_context(soul_ctx: dict[str, Any]) -> str:
+    if not soul_ctx:
+        return ""
+
+    parts: list[str] = []
+    version_id = str(soul_ctx.get("version_id") or "")
+    digest = str(soul_ctx.get("content_sha256") or "")
+    if version_id or digest:
+        label = version_id or "soul.md"
+        hash_part = f", sha256={digest[:12]}" if digest else ""
+        parts.append(f"Universe soul lens pinned to {label}{hash_part}.")
+
+    content = str(soul_ctx.get("content") or "").strip()
+    if content:
+        parts.append("Pinned soul.md:\n" + content)
+    else:
+        purpose = str(soul_ctx.get("purpose") or "").strip()
+        if purpose:
+            parts.append(f"Purpose: {purpose}")
+
+        why = str(soul_ctx.get("why") or "").strip()
+        if why:
+            parts.append(f"Why: {why}")
+
+        hard_lines = _string_list(soul_ctx.get("hard_lines"))
+        if hard_lines:
+            parts.append(
+                "Hard lines:\n"
+                + "\n".join(f"- {item}" for item in hard_lines[:5])
+            )
+
+        soft_preferences = _string_list(soul_ctx.get("soft_preferences"))
+        if soft_preferences:
+            parts.append(
+                "Soft preferences:\n"
+                + "\n".join(f"- {item}" for item in soft_preferences[:5])
+            )
+
+    boundary = str(soul_ctx.get("identity_boundary") or "").strip()
+    if boundary:
+        parts.append(boundary)
+
+    return "\n".join(parts)
 
 
 def _render_world_state(state: dict[str, Any]) -> str:
@@ -420,6 +469,12 @@ def _render_retrieval_context_from_context(retrieved: dict[str, Any]) -> str:
             parts.append("World summaries:\n" + "\n\n".join(summary_lines))
 
     return "\n\n".join(parts)
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
 
 
 def _get_search_context(state: dict[str, Any], phase: str) -> dict[str, Any]:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/retrieval/agentic_search.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/retrieval/agentic_search.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import asdict
+from pathlib import Path
 from typing import Any, Callable
 
 from workflow.memory.scoping import MemoryScope
@@ -41,6 +42,7 @@ def assemble_phase_search_context(
 ) -> dict[str, Any]:
     """Build the unified search surface for a graph phase."""
     memory_context = assemble_memory_context(state, phase)
+    universe_soul = assemble_soul_lens_context(state)
     prior_retrieved = state.get("retrieved_context", {}) or {}
     phase_retrieved = run_phase_retrieval(
         state,
@@ -67,6 +69,7 @@ def assemble_phase_search_context(
 
     sources = _dedupe_strings(
         [
+            _soul_source(universe_soul),
             *(retrieved_context.get("sources", []) or []),
             f"memory:{phase}" if memory_context else "",
             "world_state" if world_state else "",
@@ -75,6 +78,7 @@ def assemble_phase_search_context(
 
     return {
         "phase": phase,
+        "universe_soul": universe_soul,
         "memory_context": memory_context,
         "retrieved_context": retrieved_context,
         "world_state": world_state,
@@ -95,6 +99,25 @@ def assemble_phase_search_context(
     }
 
 
+def assemble_soul_lens_context(state: dict[str, Any]) -> dict[str, Any]:
+    """Read the universe's pinned soul profile for prompt/context assembly."""
+    universe_dir = _universe_dir_from_state(state)
+    if universe_dir is None:
+        return {}
+
+    try:
+        from workflow.universe_soul import read_pinned_universe_soul
+
+        pinned = read_pinned_universe_soul(universe_dir)
+    except Exception as exc:
+        logger.warning("Failed to read universe soul lens: %s", exc)
+        return {}
+
+    if pinned is None:
+        return {}
+    return dict(pinned.context())
+
+
 def assemble_memory_context(state: dict[str, Any], phase: str) -> dict[str, Any]:
     """Call MemoryManager.assemble_context if available."""
     from workflow import runtime_singletons as runtime
@@ -107,6 +130,23 @@ def assemble_memory_context(state: dict[str, Any], phase: str) -> dict[str, Any]
     except Exception as exc:
         logger.warning("MemoryManager.assemble_context(%s) failed: %s", phase, exc)
         return state.get("memory_context", {})
+
+
+def _universe_dir_from_state(state: dict[str, Any]) -> Path | None:
+    explicit_path = state.get("_universe_path") or state.get("universe_path")
+    if explicit_path:
+        return Path(str(explicit_path))
+
+    base_path = state.get("_base_path") or state.get("base_path")
+    universe_id = state.get("universe_id") or state.get("_universe_id")
+    if base_path and universe_id:
+        return Path(str(base_path)) / str(universe_id)
+    return None
+
+
+def _soul_source(universe_soul: dict[str, Any]) -> str:
+    version_id = str(universe_soul.get("version_id", "") or "")
+    return f"soul:{version_id}" if version_id else ""
 
 
 def run_phase_retrieval(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_soul.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_soul.py
@@ -6,6 +6,7 @@ mirror while introducing ``soul.md`` as the durable universe-intent artifact.
 
 from __future__ import annotations
 
+import hashlib
 import re
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -39,6 +40,38 @@ class UniverseSoul:
             "lineage": self.lineage,
             "edit_authority": self.edit_authority,
             "versions_dir": SOUL_VERSIONS_DIR,
+        }
+
+
+@dataclass(frozen=True)
+class PinnedUniverseSoul:
+    soul: UniverseSoul
+    content: str
+    version_id: str
+    content_sha256: str
+
+    def context(self, *, max_chars: int = 4000) -> dict[str, object]:
+        content = self.content[:max_chars].rstrip()
+        truncated = len(self.content) > max_chars
+        return {
+            "path": SOUL_FILENAME,
+            "version_id": self.version_id,
+            "content_sha256": self.content_sha256,
+            "schema_version": self.soul.schema_version,
+            "purpose": self.soul.purpose,
+            "why": self.soul.why,
+            "hard_lines": list(self.soul.hard_lines),
+            "soft_preferences": list(self.soul.soft_preferences),
+            "open_to_contributors": list(self.soul.open_to_contributors),
+            "domain_shape": self.soul.domain_shape,
+            "lineage": self.soul.lineage,
+            "edit_authority": self.soul.edit_authority,
+            "identity_boundary": (
+                "Universe soul guides this context only; it does not change "
+                "the actor identity or user memory scope."
+            ),
+            "content": content,
+            "truncated": truncated,
         }
 
 
@@ -112,6 +145,29 @@ def read_universe_soul(universe_dir: Path) -> UniverseSoul | None:
             _read_section(text, "Edit Authority")
             or _read_meta(text, "Edit authority", DEFAULT_EDIT_AUTHORITY)
         ),
+    )
+
+
+def read_pinned_universe_soul(universe_dir: Path) -> PinnedUniverseSoul | None:
+    soul = read_universe_soul(universe_dir)
+    if soul is None:
+        return None
+
+    try:
+        content = soul_path(universe_dir).read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    version_id = _matching_soul_version_id(universe_dir, content)
+    if version_id is None:
+        digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        version_id = f"{SOUL_FILENAME}@sha256:{digest[:12]}"
+
+    return PinnedUniverseSoul(
+        soul=soul,
+        content=content,
+        version_id=version_id,
+        content_sha256=hashlib.sha256(content.encode("utf-8")).hexdigest(),
     )
 
 
@@ -220,6 +276,19 @@ def _write_soul_version(universe_dir: Path, rendered: str) -> None:
         except ValueError:
             next_number = len(versions) + 1
     (versions_dir / f"{next_number:04d}.md").write_text(rendered, encoding="utf-8")
+
+
+def _matching_soul_version_id(universe_dir: Path, content: str) -> str | None:
+    versions_dir = universe_dir / SOUL_VERSIONS_DIR
+    if not versions_dir.is_dir():
+        return None
+    for path in sorted(versions_dir.glob("[0-9][0-9][0-9][0-9].md"), reverse=True):
+        try:
+            if path.read_text(encoding="utf-8") == content:
+                return f"{SOUL_VERSIONS_DIR}/{path.name}"
+        except OSError:
+            continue
+    return None
 
 
 def _read_meta(text: str, key: str, default: str) -> str:

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -605,3 +605,37 @@ class TestAgenticSearchPolicy:
         assert search["retrieved_context"]["prose_chunks"] == [
             "Cold rain needled the harbor."
         ]
+
+    def test_assemble_phase_search_context_adds_pinned_soul_lens(
+        self, tmp_path, monkeypatch,
+    ):
+        from workflow.universe_soul import write_universe_soul
+
+        write_universe_soul(
+            tmp_path,
+            purpose="A lab studies civic memory with auditable sources.",
+            why="Keep research claims reusable.",
+            hard_lines=("Cite uncertainty.",),
+            soft_preferences=("Prefer compact steps.",),
+        )
+        monkeypatch.setattr(
+            "workflow.retrieval.agentic_search.assemble_memory_context",
+            lambda state, phase: {},
+        )
+        monkeypatch.setattr(
+            "workflow.retrieval.agentic_search.run_phase_retrieval",
+            lambda state, phase, memory_context=None: {},
+        )
+
+        search = assemble_phase_search_context({
+            "universe_id": "u1",
+            "_universe_path": str(tmp_path),
+        }, "plan")
+
+        soul = search["universe_soul"]
+        assert soul["version_id"] == "soul_versions/0001.md"
+        assert soul["purpose"] == "A lab studies civic memory with auditable sources."
+        assert soul["hard_lines"] == ["Cite uncertainty."]
+        assert soul["soft_preferences"] == ["Prefer compact steps."]
+        assert soul["identity_boundary"].startswith("Universe soul guides")
+        assert "soul:soul_versions/0001.md" in search["sources"]

--- a/tests/test_universe_soul.py
+++ b/tests/test_universe_soul.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from workflow.universe_soul import read_pinned_universe_soul
+
 
 @pytest.fixture
 def us(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -60,6 +62,28 @@ def test_read_premise_falls_back_to_soul_purpose(us):
     assert result["premise"] == "A solar archive wakes up."
     assert result["source"] == "soul.md"
     assert result["soul"]["schema_version"] == 1
+
+
+def test_read_pinned_universe_soul_reports_version_hash(us):
+    base = Path(us._base_path())
+    _mkuniverse(base, "u1")
+    us._action_set_premise(
+        universe_id="u1",
+        text="A civic-memory workflow checks every source.",
+    )
+
+    pinned = read_pinned_universe_soul(base / "u1")
+
+    assert pinned is not None
+    assert pinned.version_id == "soul_versions/0001.md"
+    assert len(pinned.content_sha256) == 64
+    context = pinned.context()
+    assert context["purpose"] == "A civic-memory workflow checks every source."
+    assert context["version_id"] == "soul_versions/0001.md"
+    assert context["identity_boundary"] == (
+        "Universe soul guides this context only; it does not change "
+        "the actor identity or user memory scope."
+    )
 
 
 def test_create_universe_always_writes_soul_profile(us):

--- a/tests/test_writer_tools.py
+++ b/tests/test_writer_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from domains.fantasy_daemon.phases.orient import orient
 from domains.fantasy_daemon.phases.writer_tools import select_and_run_writer_tools
 from workflow.notes import add_note, list_notes
+from workflow.universe_soul import write_universe_soul
 
 
 def _state_with_context(tmp_path) -> dict:
@@ -51,6 +52,11 @@ def _state_with_context(tmp_path) -> dict:
 class TestWriterTools:
     def test_plan_tools_render_context_and_mark_notes_read(self, tmp_path):
         state = _state_with_context(tmp_path)
+        write_universe_soul(
+            tmp_path,
+            purpose="A civic-memory lens checks every source.",
+            hard_lines=("Never invent citations.",),
+        )
         add_note(
             tmp_path,
             source="user",
@@ -64,6 +70,9 @@ class TestWriterTools:
         assert "Story Search" in context
         assert "Routed sources" in context
         assert "Unread Notes" in context
+        assert "Universe soul lens pinned to soul_versions/0001.md" in context
+        assert "A civic-memory lens checks every source." in context
+        assert "Never invent citations." in context
         assert "Keep the pressure on the harbor gate." in context
         assert "stormglass towers" in context
         assert "harbor watch" in context

--- a/workflow/retrieval/agentic_search.py
+++ b/workflow/retrieval/agentic_search.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import asdict
+from pathlib import Path
 from typing import Any, Callable
 
 from workflow.memory.scoping import MemoryScope
@@ -41,6 +42,7 @@ def assemble_phase_search_context(
 ) -> dict[str, Any]:
     """Build the unified search surface for a graph phase."""
     memory_context = assemble_memory_context(state, phase)
+    universe_soul = assemble_soul_lens_context(state)
     prior_retrieved = state.get("retrieved_context", {}) or {}
     phase_retrieved = run_phase_retrieval(
         state,
@@ -67,6 +69,7 @@ def assemble_phase_search_context(
 
     sources = _dedupe_strings(
         [
+            _soul_source(universe_soul),
             *(retrieved_context.get("sources", []) or []),
             f"memory:{phase}" if memory_context else "",
             "world_state" if world_state else "",
@@ -75,6 +78,7 @@ def assemble_phase_search_context(
 
     return {
         "phase": phase,
+        "universe_soul": universe_soul,
         "memory_context": memory_context,
         "retrieved_context": retrieved_context,
         "world_state": world_state,
@@ -95,6 +99,25 @@ def assemble_phase_search_context(
     }
 
 
+def assemble_soul_lens_context(state: dict[str, Any]) -> dict[str, Any]:
+    """Read the universe's pinned soul profile for prompt/context assembly."""
+    universe_dir = _universe_dir_from_state(state)
+    if universe_dir is None:
+        return {}
+
+    try:
+        from workflow.universe_soul import read_pinned_universe_soul
+
+        pinned = read_pinned_universe_soul(universe_dir)
+    except Exception as exc:
+        logger.warning("Failed to read universe soul lens: %s", exc)
+        return {}
+
+    if pinned is None:
+        return {}
+    return dict(pinned.context())
+
+
 def assemble_memory_context(state: dict[str, Any], phase: str) -> dict[str, Any]:
     """Call MemoryManager.assemble_context if available."""
     from workflow import runtime_singletons as runtime
@@ -107,6 +130,23 @@ def assemble_memory_context(state: dict[str, Any], phase: str) -> dict[str, Any]
     except Exception as exc:
         logger.warning("MemoryManager.assemble_context(%s) failed: %s", phase, exc)
         return state.get("memory_context", {})
+
+
+def _universe_dir_from_state(state: dict[str, Any]) -> Path | None:
+    explicit_path = state.get("_universe_path") or state.get("universe_path")
+    if explicit_path:
+        return Path(str(explicit_path))
+
+    base_path = state.get("_base_path") or state.get("base_path")
+    universe_id = state.get("universe_id") or state.get("_universe_id")
+    if base_path and universe_id:
+        return Path(str(base_path)) / str(universe_id)
+    return None
+
+
+def _soul_source(universe_soul: dict[str, Any]) -> str:
+    version_id = str(universe_soul.get("version_id", "") or "")
+    return f"soul:{version_id}" if version_id else ""
 
 
 def run_phase_retrieval(

--- a/workflow/universe_soul.py
+++ b/workflow/universe_soul.py
@@ -6,6 +6,7 @@ mirror while introducing ``soul.md`` as the durable universe-intent artifact.
 
 from __future__ import annotations
 
+import hashlib
 import re
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -39,6 +40,38 @@ class UniverseSoul:
             "lineage": self.lineage,
             "edit_authority": self.edit_authority,
             "versions_dir": SOUL_VERSIONS_DIR,
+        }
+
+
+@dataclass(frozen=True)
+class PinnedUniverseSoul:
+    soul: UniverseSoul
+    content: str
+    version_id: str
+    content_sha256: str
+
+    def context(self, *, max_chars: int = 4000) -> dict[str, object]:
+        content = self.content[:max_chars].rstrip()
+        truncated = len(self.content) > max_chars
+        return {
+            "path": SOUL_FILENAME,
+            "version_id": self.version_id,
+            "content_sha256": self.content_sha256,
+            "schema_version": self.soul.schema_version,
+            "purpose": self.soul.purpose,
+            "why": self.soul.why,
+            "hard_lines": list(self.soul.hard_lines),
+            "soft_preferences": list(self.soul.soft_preferences),
+            "open_to_contributors": list(self.soul.open_to_contributors),
+            "domain_shape": self.soul.domain_shape,
+            "lineage": self.soul.lineage,
+            "edit_authority": self.soul.edit_authority,
+            "identity_boundary": (
+                "Universe soul guides this context only; it does not change "
+                "the actor identity or user memory scope."
+            ),
+            "content": content,
+            "truncated": truncated,
         }
 
 
@@ -112,6 +145,29 @@ def read_universe_soul(universe_dir: Path) -> UniverseSoul | None:
             _read_section(text, "Edit Authority")
             or _read_meta(text, "Edit authority", DEFAULT_EDIT_AUTHORITY)
         ),
+    )
+
+
+def read_pinned_universe_soul(universe_dir: Path) -> PinnedUniverseSoul | None:
+    soul = read_universe_soul(universe_dir)
+    if soul is None:
+        return None
+
+    try:
+        content = soul_path(universe_dir).read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    version_id = _matching_soul_version_id(universe_dir, content)
+    if version_id is None:
+        digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        version_id = f"{SOUL_FILENAME}@sha256:{digest[:12]}"
+
+    return PinnedUniverseSoul(
+        soul=soul,
+        content=content,
+        version_id=version_id,
+        content_sha256=hashlib.sha256(content.encode("utf-8")).hexdigest(),
     )
 
 
@@ -220,6 +276,19 @@ def _write_soul_version(universe_dir: Path, rendered: str) -> None:
         except ValueError:
             next_number = len(versions) + 1
     (versions_dir / f"{next_number:04d}.md").write_text(rendered, encoding="utf-8")
+
+
+def _matching_soul_version_id(universe_dir: Path, content: str) -> str | None:
+    versions_dir = universe_dir / SOUL_VERSIONS_DIR
+    if not versions_dir.is_dir():
+        return None
+    for path in sorted(versions_dir.glob("[0-9][0-9][0-9][0-9].md"), reverse=True):
+        try:
+            if path.read_text(encoding="utf-8") == content:
+                return f"{SOUL_VERSIONS_DIR}/{path.name}"
+        except OSError:
+            continue
+    return None
 
 
 def _read_meta(text: str, key: str, default: str) -> str:


### PR DESCRIPTION
## Summary
- adds a pinned universe-soul context object from soul.md / soul_versions into phase search context
- renders that pinned soul.md into plan/draft writer context with an explicit identity/memory boundary
- keeps this to CHILD-2 §2.3 only: no tag-matrix brain, resolver runtime, cycle de-defaulting, or episodic migration

## Verification
- python -m pytest tests/test_universe_soul.py tests/test_retrieval.py tests/test_writer_tools.py -q
- python -m pytest tests/test_universe_soul.py tests/test_retrieval.py tests/test_writer_tools.py tests/test_api_universe.py tests/test_universe_nodes.py tests/test_import_graph_smoke.py tests/test_pre_commit_mirror_parity.py -q
- python -m ruff check workflow/universe_soul.py workflow/retrieval/agentic_search.py domains/fantasy_daemon/phases/writer_tools.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_soul.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/retrieval/agentic_search.py tests/test_universe_soul.py tests/test_retrieval.py tests/test_writer_tools.py
- python packaging\\claude-plugin\\build_plugin.py
- python -m scripts.invariants.mirror_parity
- git diff --check

## PR-139 gates
- Writer key: Codex, commit 5c3ab4c9
- Host key: standing approval for PR-139 all slices applies unless checker finds a substantive deviation
- Waiting on Cowork/Claude-family checker key before merge
