### PR TITLE
PR-139 slice 6: add tag-matrix retrieval filter

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/knowledge/knowledge_graph.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/knowledge/knowledge_graph.py
@@ -19,6 +19,7 @@ from workflow.knowledge.models import (
     GraphEdge,
     GraphEntity,
 )
+from workflow.knowledge.tag_matrix import KnowledgeTags, knowledge_tags_from_mapping
 from workflow.memory.scoping import MemoryScope
 
 # Memory-scope Stage 2b: shared helpers for injecting scope column
@@ -28,6 +29,15 @@ from workflow.memory.scoping import MemoryScope
 # helpers keeps the three write sites in sync.
 _SCOPE_COL_NAMES: tuple[str, ...] = (
     "universe_id", "goal_id", "branch_id", "user_id",
+)
+_TAG_COL_NAMES: tuple[str, ...] = (
+    "tag_universes",
+    "tag_domains",
+    "tag_shapes",
+    "tag_general",
+    "tag_commons",
+    "tag_private_canon",
+    "promotion_record",
 )
 
 
@@ -68,6 +78,51 @@ def _scope_upsert_fragment(scope: MemoryScope | None) -> str:
     )
 
 
+def _tag_insert_fragment(
+    tags: KnowledgeTags | None,
+) -> tuple[str, tuple[Any, ...]]:
+    """Return tag columns/values for INSERT fragments."""
+    if tags is None:
+        return "", ()
+    metadata = tags.as_row_metadata()
+    cols = ", " + ", ".join(_TAG_COL_NAMES)
+    vals = tuple(metadata[col] for col in _TAG_COL_NAMES)
+    return cols, vals
+
+
+def _tag_upsert_fragment(tags: KnowledgeTags | None) -> str:
+    """Return the tag-column UPSERT fragment when tags are supplied."""
+    if tags is None:
+        return ""
+    return "".join(
+        f", {col}=excluded.{col}" for col in _TAG_COL_NAMES
+    )
+
+
+def _attach_row_tags(target: Any, row: sqlite3.Row) -> None:
+    """Attach flat tag metadata from a SQLite row to a result object."""
+    tags = knowledge_tags_from_mapping(dict(row))
+    if isinstance(target, dict):
+        metadata = tags.as_row_metadata()
+        target.update(metadata)
+        return
+    setattr(target, "tag_universes", list(tags.universes))
+    setattr(target, "tag_domains", list(tags.domains))
+    setattr(target, "tag_shapes", list(tags.shapes))
+    setattr(target, "tag_general", tags.general)
+    setattr(target, "tag_commons", tags.commons)
+    setattr(target, "tag_private_canon", tags.private_canon)
+    setattr(
+        target,
+        "promotion_record",
+        (
+            json.dumps(tags.promotion_record.__dict__)
+            if tags.promotion_record is not None
+            else ""
+        ),
+    )
+
+
 class KnowledgeGraph:
     """SQLite-backed knowledge graph with igraph construction.
 
@@ -104,6 +159,15 @@ class KnowledgeGraph:
         ("goal_id", "TEXT"),
         ("branch_id", "TEXT"),
         ("user_id", "TEXT"),
+    )
+    _TAG_COLUMNS: tuple[tuple[str, str], ...] = (
+        ("tag_universes", "TEXT NOT NULL DEFAULT '[]'"),
+        ("tag_domains", "TEXT NOT NULL DEFAULT '[]'"),
+        ("tag_shapes", "TEXT NOT NULL DEFAULT '[]'"),
+        ("tag_general", "INTEGER NOT NULL DEFAULT 0"),
+        ("tag_commons", "INTEGER NOT NULL DEFAULT 0"),
+        ("tag_private_canon", "INTEGER NOT NULL DEFAULT 0"),
+        ("promotion_record", "TEXT NOT NULL DEFAULT ''"),
     )
     _SCOPED_TABLES: tuple[str, ...] = (
         "entities", "edges", "facts", "communities",
@@ -189,6 +253,18 @@ class KnowledgeGraph:
                 self._conn.execute(
                     f"ALTER TABLE {table} ADD COLUMN {col_name} {col_type}"
                 )
+            existing = {
+                row["name"]
+                for row in self._conn.execute(
+                    f"PRAGMA table_info({table})"
+                )
+            }
+            for col_name, col_type in self._TAG_COLUMNS:
+                if col_name in existing:
+                    continue
+                self._conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN {col_name} {col_type}"
+                )
         # Shared index over (universe_id, goal_id, branch_id) per
         # design-note §4 — this is the hot read path.
         for table in self._SCOPED_TABLES:
@@ -234,6 +310,7 @@ class KnowledgeGraph:
         self,
         entity: GraphEntity,
         scope: MemoryScope | None = None,
+        tags: KnowledgeTags | None = None,
     ) -> None:
         """Insert or update an entity.
 
@@ -243,21 +320,26 @@ class KnowledgeGraph:
         legacy/universe-public semantics per design §4). The write is
         a no-op for reads until Stage 2c flips
         ``WORKFLOW_TIERED_SCOPE`` on.
+
+        PR-139 slice 6: optional ``tags`` attach the tag-matrix labels
+        used by retrieval. Tags refine rows after hard MemoryScope
+        filtering; they do not replace scope columns.
         """
         scope_cols, scope_vals = _scope_insert_fragment(scope)
+        tag_cols, tag_vals = _tag_insert_fragment(tags)
         self._conn.execute(
             f"""
             INSERT INTO entities (entity_id, entity_type, access_tier,
                                   public_description, hidden_description,
-                                  secret_description, aliases{scope_cols})
-            VALUES (?, ?, ?, ?, ?, ?, ?{', ?' * len(scope_vals)})
+                                  secret_description, aliases{scope_cols}{tag_cols})
+            VALUES (?, ?, ?, ?, ?, ?, ?{', ?' * (len(scope_vals) + len(tag_vals))})
             ON CONFLICT(entity_id) DO UPDATE SET
                 entity_type=excluded.entity_type,
                 access_tier=excluded.access_tier,
                 public_description=excluded.public_description,
                 hidden_description=excluded.hidden_description,
                 secret_description=excluded.secret_description,
-                aliases=excluded.aliases{_scope_upsert_fragment(scope)}
+                aliases=excluded.aliases{_scope_upsert_fragment(scope)}{_tag_upsert_fragment(tags)}
             """,
             (
                 entity["entity_id"],
@@ -268,6 +350,7 @@ class KnowledgeGraph:
                 entity["secret_description"],
                 json.dumps(entity.get("aliases", [])),
                 *scope_vals,
+                *tag_vals,
             ),
         )
         self._conn.commit()
@@ -325,6 +408,7 @@ class KnowledgeGraph:
         self,
         edge: GraphEdge,
         scope: MemoryScope | None = None,
+        tags: KnowledgeTags | None = None,
     ) -> None:
         """Insert or update an edge.
 
@@ -332,19 +416,20 @@ class KnowledgeGraph:
         contract. Scope tagging is advisory until 2c.
         """
         scope_cols, scope_vals = _scope_insert_fragment(scope)
+        tag_cols, tag_vals = _tag_insert_fragment(tags)
         self._conn.execute(
             f"""
             INSERT INTO edges (source, target, relation_type, access_tier,
                                temporal_scope, pov_characters, weight,
-                               valid_from_chapter, valid_to_chapter{scope_cols})
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?{', ?' * len(scope_vals)})
+                               valid_from_chapter, valid_to_chapter{scope_cols}{tag_cols})
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?{', ?' * (len(scope_vals) + len(tag_vals))})
             ON CONFLICT(source, target, relation_type) DO UPDATE SET
                 access_tier=excluded.access_tier,
                 temporal_scope=excluded.temporal_scope,
                 pov_characters=excluded.pov_characters,
                 weight=excluded.weight,
                 valid_from_chapter=excluded.valid_from_chapter,
-                valid_to_chapter=excluded.valid_to_chapter{_scope_upsert_fragment(scope)}
+                valid_to_chapter=excluded.valid_to_chapter{_scope_upsert_fragment(scope)}{_tag_upsert_fragment(tags)}
             """,
             (
                 edge["source"],
@@ -357,6 +442,7 @@ class KnowledgeGraph:
                 edge.get("valid_from_chapter"),
                 edge.get("valid_to_chapter"),
                 *scope_vals,
+                *tag_vals,
             ),
         )
         self._conn.commit()
@@ -387,8 +473,9 @@ class KnowledgeGraph:
             sql += " AND access_tier <= ?"
             params.append(access_tier)
         rows = self._conn.execute(sql, params).fetchall()
-        return [
-            GraphEdge(
+        edges: list[GraphEdge] = []
+        for r in rows:
+            edge = GraphEdge(
                 source=r["source"],
                 target=r["target"],
                 relation_type=r["relation_type"],
@@ -399,8 +486,9 @@ class KnowledgeGraph:
                 valid_from_chapter=r["valid_from_chapter"],
                 valid_to_chapter=r["valid_to_chapter"],
             )
-            for r in rows
-        ]
+            _attach_row_tags(edge, r)
+            edges.append(edge)
+        return edges
 
     # ------------------------------------------------------------------
     # Fact CRUD
@@ -410,6 +498,7 @@ class KnowledgeGraph:
         self,
         facts: Sequence[FactWithContext],
         scope: MemoryScope | None = None,
+        tags: KnowledgeTags | None = None,
     ) -> None:
         """Insert or update a batch of facts.
 
@@ -417,7 +506,10 @@ class KnowledgeGraph:
         contract.
         """
         scope_cols, scope_vals = _scope_insert_fragment(scope)
-        placeholders = ",".join(["?"] * (21 + len(scope_vals)))
+        tag_cols, tag_vals = _tag_insert_fragment(tags)
+        placeholders = ",".join(
+            ["?"] * (21 + len(scope_vals) + len(tag_vals))
+        )
         for f in facts:
             self._conn.execute(
                 f"""
@@ -426,7 +518,7 @@ class KnowledgeGraph:
                     truth_value_initial, truth_value_final, truth_value_revealed,
                     language_type, narrative_function, importance, weight,
                     hardness, horizon, provenance, confidence, seeded_scene,
-                    access_tier, pov_characters{scope_cols})
+                    access_tier, pov_characters{scope_cols}{tag_cols})
                 VALUES ({placeholders})
                 ON CONFLICT(fact_id) DO UPDATE SET
                     text=excluded.text,
@@ -448,7 +540,7 @@ class KnowledgeGraph:
                     confidence=excluded.confidence,
                     seeded_scene=excluded.seeded_scene,
                     access_tier=excluded.access_tier,
-                    pov_characters=excluded.pov_characters{_scope_upsert_fragment(scope)}
+                    pov_characters=excluded.pov_characters{_scope_upsert_fragment(scope)}{_tag_upsert_fragment(tags)}
                 """,
                 (
                     f.fact_id, f.text, f.source_type.value, f.narrator,
@@ -458,6 +550,7 @@ class KnowledgeGraph:
                     f.weight, f.hardness, f.horizon, f.provenance, f.confidence,
                     f.seeded_scene, f.access_tier, json.dumps(f.pov_characters),
                     *scope_vals,
+                    *tag_vals,
                 ),
             )
         self._conn.commit()
@@ -526,6 +619,7 @@ class KnowledgeGraph:
             if character_id is not None:
                 if fact.pov_characters and character_id not in fact.pov_characters:
                     continue
+            _attach_row_tags(fact, r)
             results.append(fact)
         return results
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/knowledge/models.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/knowledge/models.py
@@ -132,6 +132,16 @@ class FactWithContext:
     access_tier: int = 0
     pov_characters: list[str] = field(default_factory=list)
 
+    # Tag-matrix retrieval metadata. Hard scope is enforced separately by
+    # MemoryScope; these tags refine eligible rows by universe/domain/shape.
+    tag_universes: list[str] = field(default_factory=list)
+    tag_domains: list[str] = field(default_factory=list)
+    tag_shapes: list[str] = field(default_factory=list)
+    tag_general: bool = False
+    tag_commons: bool = False
+    tag_private_canon: bool = False
+    promotion_record: str = ""
+
     def is_accessible_to(self, character_id: str, character_knowledge_level: int) -> bool:
         """Check if a character should be able to know this fact."""
         if character_knowledge_level >= self.access_tier:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/knowledge/tag_matrix.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/knowledge/tag_matrix.py
@@ -1,0 +1,311 @@
+"""Tag-matrix filtering for knowledge and retrieval rows.
+
+The tag matrix is a refinement layer above hard memory scope. Scope decides
+which universe/user/branch a caller may see; tags decide which eligible
+documents are relevant to the current universe/domain/shape/commons query.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from workflow.memory.scoping import MemoryScope
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CommonsPromotionRecord:
+    """INV-5 promotion evidence for a private-canon shape entering commons."""
+
+    source_universe: str
+    shape_tag: str
+    promoter_identity: str
+    declassification_reason: str
+    resolver_decision: str
+    timestamp: str
+
+    def is_complete(self) -> bool:
+        return all(
+            str(value).strip()
+            for value in (
+                self.source_universe,
+                self.shape_tag,
+                self.promoter_identity,
+                self.declassification_reason,
+                self.resolver_decision,
+                self.timestamp,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class KnowledgeTags:
+    """Tag-matrix labels attached to one knowledge/retrieval row."""
+
+    universes: tuple[str, ...] = ()
+    domains: tuple[str, ...] = ()
+    shapes: tuple[str, ...] = ()
+    general: bool = False
+    commons: bool = False
+    private_canon: bool = False
+    promotion_record: CommonsPromotionRecord | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "universes", _normalize_values(self.universes))
+        object.__setattr__(self, "domains", _normalize_values(self.domains))
+        object.__setattr__(self, "shapes", _normalize_values(self.shapes))
+
+    @property
+    def is_tagged(self) -> bool:
+        return bool(
+            self.universes
+            or self.domains
+            or self.shapes
+            or self.general
+            or self.commons
+            or self.private_canon
+        )
+
+    def commons_promotion_complete(self) -> bool:
+        if not (self.commons and self.private_canon):
+            return True
+        return (
+            self.promotion_record is not None
+            and self.promotion_record.is_complete()
+        )
+
+    def as_row_metadata(self) -> dict[str, Any]:
+        """Serialize tags into flat row metadata columns."""
+        return {
+            "tag_universes": json.dumps(list(self.universes)),
+            "tag_domains": json.dumps(list(self.domains)),
+            "tag_shapes": json.dumps(list(self.shapes)),
+            "tag_general": int(self.general),
+            "tag_commons": int(self.commons),
+            "tag_private_canon": int(self.private_canon),
+            "promotion_record": (
+                json.dumps(self.promotion_record.__dict__)
+                if self.promotion_record is not None
+                else ""
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class TagMatrixQuery:
+    """Tag filter requested by a retrieval caller."""
+
+    domain_tags: tuple[str, ...] = ()
+    shape_tags: tuple[str, ...] = ()
+    include_general: bool = True
+    include_commons: bool = True
+    include_untagged: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "domain_tags", _normalize_values(self.domain_tags)
+        )
+        object.__setattr__(
+            self, "shape_tags", _normalize_values(self.shape_tags)
+        )
+
+
+def knowledge_tags_from_mapping(value: Any) -> KnowledgeTags:
+    """Build ``KnowledgeTags`` from flat or nested row metadata."""
+    if isinstance(value, KnowledgeTags):
+        return value
+    if value is None:
+        return KnowledgeTags()
+
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return KnowledgeTags()
+    if not isinstance(value, dict):
+        return KnowledgeTags()
+
+    nested = value.get("tag_matrix")
+    if isinstance(nested, dict):
+        value = {**value, **nested}
+
+    record = _promotion_record_from_value(
+        value.get("promotion_record")
+        or value.get("commons_promotion_record")
+    )
+    return KnowledgeTags(
+        universes=_read_values(value, "tag_universes", "universes"),
+        domains=_read_values(value, "tag_domains", "domains"),
+        shapes=_read_values(value, "tag_shapes", "shapes"),
+        general=_read_bool(value, "tag_general", "general"),
+        commons=_read_bool(value, "tag_commons", "commons"),
+        private_canon=_read_bool(value, "tag_private_canon", "private_canon"),
+        promotion_record=record,
+    )
+
+
+def knowledge_tags_from_row(row: Any) -> KnowledgeTags:
+    """Extract tag metadata from a dict/dataclass/object row."""
+    if isinstance(row, str):
+        return KnowledgeTags()
+    if isinstance(row, dict):
+        return knowledge_tags_from_mapping(row)
+
+    data: dict[str, Any] = {}
+    for key in (
+        "tag_matrix",
+        "tag_universes",
+        "tag_domains",
+        "tag_shapes",
+        "tag_general",
+        "tag_commons",
+        "tag_private_canon",
+        "promotion_record",
+        "commons_promotion_record",
+    ):
+        if hasattr(row, key):
+            data[key] = getattr(row, key)
+    return knowledge_tags_from_mapping(data)
+
+
+def row_visible_for_tag_matrix(
+    row: Any,
+    *,
+    scope: MemoryScope,
+    query: TagMatrixQuery,
+) -> bool:
+    """Return True when a row's tags are visible for ``scope`` and ``query``."""
+    tags = knowledge_tags_from_row(row)
+    if not tags.is_tagged:
+        return query.include_untagged
+
+    if not tags.commons_promotion_complete():
+        logger.warning(
+            "tag_matrix.inv5_block: dropped row without complete "
+            "commons promotion record (scope=%s, tags=%s)",
+            scope.compose_predicate(),
+            tags,
+        )
+        return False
+
+    if tags.universes and scope.universe_id not in tags.universes:
+        if not (tags.general or (tags.commons and query.include_commons)):
+            return False
+
+    if tags.general and not query.include_general:
+        return False
+    if tags.commons and not query.include_commons:
+        return False
+
+    if query.domain_tags:
+        if tags.domains:
+            if not _intersects(tags.domains, query.domain_tags) and not tags.general:
+                return False
+        elif not tags.general:
+            return False
+
+    if query.shape_tags:
+        if tags.shapes:
+            if not _intersects(tags.shapes, query.shape_tags) and not tags.general:
+                return False
+        elif not tags.general:
+            return False
+
+    return True
+
+
+def filter_rows_by_tag_matrix(
+    rows: Iterable[Any],
+    *,
+    scope: MemoryScope,
+    query: TagMatrixQuery | None,
+) -> list[Any]:
+    """Filter rows by tag matrix after hard scope filtering."""
+    if query is None:
+        return list(rows)
+    return [
+        row
+        for row in rows
+        if row_visible_for_tag_matrix(row, scope=scope, query=query)
+    ]
+
+
+def _normalize_values(values: Iterable[Any] | None) -> tuple[str, ...]:
+    if isinstance(values, str):
+        values = (values,)
+    output: list[str] = []
+    seen: set[str] = set()
+    for value in values or ():
+        text = str(value).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        output.append(text)
+    return tuple(output)
+
+
+def _intersects(left: tuple[str, ...], right: tuple[str, ...]) -> bool:
+    return bool(set(left) & set(right))
+
+
+def _read_values(data: dict[str, Any], *keys: str) -> tuple[str, ...]:
+    for key in keys:
+        if key not in data:
+            continue
+        value = data[key]
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return ()
+            try:
+                decoded = json.loads(stripped)
+            except json.JSONDecodeError:
+                decoded = [part.strip() for part in stripped.split(",")]
+            value = decoded
+        if isinstance(value, Iterable) and not isinstance(value, (bytes, str)):
+            return _normalize_values(value)
+        return _normalize_values([value])
+    return ()
+
+
+def _read_bool(data: dict[str, Any], *keys: str) -> bool:
+    for key in keys:
+        if key not in data:
+            continue
+        value = data[key]
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int):
+            return value != 0
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def _promotion_record_from_value(value: Any) -> CommonsPromotionRecord | None:
+    if isinstance(value, CommonsPromotionRecord):
+        return value
+    if value is None or value == "":
+        return None
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(value, dict):
+        return None
+    return CommonsPromotionRecord(
+        source_universe=str(value.get("source_universe", "") or ""),
+        shape_tag=str(value.get("shape_tag", "") or ""),
+        promoter_identity=str(value.get("promoter_identity", "") or ""),
+        declassification_reason=str(
+            value.get("declassification_reason", "") or ""
+        ),
+        resolver_decision=str(value.get("resolver_decision", "") or ""),
+        timestamp=str(value.get("timestamp", "") or ""),
+    )

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/retrieval/agentic_search.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/retrieval/agentic_search.py
@@ -13,6 +13,7 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Callable
 
+from workflow.knowledge.tag_matrix import TagMatrixQuery
 from workflow.memory.scoping import MemoryScope
 
 logger = logging.getLogger(__name__)
@@ -168,6 +169,7 @@ def run_phase_retrieval(
             phase,
         )
         return {}
+    tag_query = _tag_query_from_state(state)
 
     kg = None
     owns_kg = False
@@ -206,6 +208,7 @@ def run_phase_retrieval(
             access_tier=int(orient_result.get("access_tier", 0) or 0),
             pov_character=orient_result.get("pov_character"),
             chapter_number=state.get("chapter_number"),
+            tag_query=tag_query,
         )
 
         try:
@@ -245,6 +248,28 @@ def run_phase_retrieval(
                 kg.close()
             except Exception:
                 logger.debug("Failed to close temporary knowledge graph", exc_info=True)
+
+
+def _tag_query_from_state(state: dict[str, Any]) -> TagMatrixQuery | None:
+    """Derive an optional tag-matrix filter from graph state."""
+    raw = (
+        state.get("tag_matrix")
+        or state.get("tag_filter")
+        or state.get("knowledge_tags")
+    )
+    if raw is None:
+        return None
+    if isinstance(raw, TagMatrixQuery):
+        return raw
+    if not isinstance(raw, dict):
+        return None
+    return TagMatrixQuery(
+        domain_tags=raw.get("domain_tags") or raw.get("domains") or (),
+        shape_tags=raw.get("shape_tags") or raw.get("shapes") or (),
+        include_general=bool(raw.get("include_general", True)),
+        include_commons=bool(raw.get("include_commons", True)),
+        include_untagged=bool(raw.get("include_untagged", False)),
+    )
 
 
 def build_phase_query(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/retrieval/router.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/retrieval/router.py
@@ -22,6 +22,11 @@ from workflow.knowledge.models import (
     SubQuery,
 )
 from workflow.knowledge.raptor import RaptorTree, query_raptor_tree
+from workflow.knowledge.tag_matrix import (
+    TagMatrixQuery,
+    filter_rows_by_tag_matrix,
+    row_visible_for_tag_matrix,
+)
 from workflow.memory.scoping import MemoryScope
 from workflow.retrieval.phase_context import should_use_backend
 from workflow.retrieval.vector_store import VectorStore
@@ -174,6 +179,7 @@ class RetrievalRouter:
         access_tier: int = 0,
         pov_character: str | None = None,
         chapter_number: int | None = None,
+        tag_query: TagMatrixQuery | None = None,
         token_budget: int = 4000,
     ) -> RetrievalResult:
         """Route a query to the appropriate retrieval backends.
@@ -195,6 +201,9 @@ class RetrievalRouter:
             POV character for epistemic filtering.
         chapter_number
             Current chapter for temporal filtering.
+        tag_query
+            Optional tag-matrix filter. Applied after hard
+            ``MemoryScope`` filtering; tags never replace scope.
         token_budget
             Maximum tokens for the assembled context.
 
@@ -228,7 +237,7 @@ class RetrievalRouter:
             elif sq.query_type == QueryType.TONE_SIMILARITY:
                 if not should_use_backend(phase, "voice_examples"):
                     continue
-                self._route_to_vector(sq, result)
+                self._route_to_vector(sq, result, scope, tag_query)
                 result.sources.append("vector")
 
         # Defense-in-depth: drop rows whose declared universe_id
@@ -236,6 +245,9 @@ class RetrievalRouter:
         # attribute pass through (Stage 1 — interface only; KG/vector
         # rows are path-tagged, not row-tagged, today).
         result = _drop_cross_universe_rows(result, scope)
+        if tag_query is not None:
+            result = _filter_by_tag_matrix(result, scope, tag_query)
+            result.sources.append("tag_matrix")
 
         # Cluster similar results to reduce redundancy
         result = self._cluster_results(result)
@@ -293,7 +305,13 @@ class RetrievalRouter:
         )
         result.community_summaries.extend(summaries)
 
-    def _route_to_vector(self, sq: SubQuery, result: RetrievalResult) -> None:
+    def _route_to_vector(
+        self,
+        sq: SubQuery,
+        result: RetrievalResult,
+        scope: MemoryScope,
+        tag_query: TagMatrixQuery | None,
+    ) -> None:
         """Route a tone/similarity query to LanceDB vectors."""
         if self._vector_store is None or self._embed_fn is None:
             return
@@ -304,6 +322,10 @@ class RetrievalRouter:
 
         matches = self._vector_store.search(query_emb, limit=5)
         for match in matches:
+            if tag_query is not None and not row_visible_for_tag_matrix(
+                match, scope=scope, query=tag_query,
+            ):
+                continue
             result.prose_chunks.append(match.get("text", ""))
 
     def _cluster_results(self, result: RetrievalResult) -> RetrievalResult:
@@ -490,6 +512,44 @@ def _drop_cross_universe_rows(
             "on" if flag_on else "off",
         )
 
+    return result
+
+
+def _filter_by_tag_matrix(
+    result: RetrievalResult,
+    scope: MemoryScope,
+    tag_query: TagMatrixQuery,
+) -> RetrievalResult:
+    """Apply CHILD-2 tag-matrix filtering after hard scope checks."""
+    before = (
+        len(result.facts),
+        len(result.relationships),
+        len(result.community_summaries),
+    )
+    result.facts = filter_rows_by_tag_matrix(
+        result.facts, scope=scope, query=tag_query,
+    )
+    result.relationships = filter_rows_by_tag_matrix(
+        result.relationships, scope=scope, query=tag_query,
+    )
+    result.community_summaries = filter_rows_by_tag_matrix(
+        result.community_summaries, scope=scope, query=tag_query,
+    )
+    after = (
+        len(result.facts),
+        len(result.relationships),
+        len(result.community_summaries),
+    )
+    dropped = sum(before) - sum(after)
+    if dropped:
+        logger.info(
+            "tag_matrix.filter: dropped %d rows after scope filtering "
+            "(caller_scope=%r, domain_tags=%r, shape_tags=%r)",
+            dropped,
+            scope.compose_predicate(),
+            tag_query.domain_tags,
+            tag_query.shape_tags,
+        )
     return result
 
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/retrieval/vector_store.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/retrieval/vector_store.py
@@ -15,6 +15,7 @@ import lancedb
 import numpy as np
 
 if TYPE_CHECKING:
+    from workflow.knowledge.tag_matrix import KnowledgeTags
     from workflow.memory.scoping import MemoryScope
 
 # ---------------------------------------------------------------------------
@@ -123,6 +124,13 @@ class VectorStore:
                 "goal_id": "",
                 "branch_id": "",
                 "user_id": "",
+                "tag_universes": "[]",
+                "tag_domains": "[]",
+                "tag_shapes": "[]",
+                "tag_general": 0,
+                "tag_commons": 0,
+                "tag_private_canon": 0,
+                "promotion_record": "",
                 "embedding": np.zeros(self._embedding_dim, dtype=np.float32).tolist(),
             }]
             self._table = self._db.create_table(self._table_name, data=seed)
@@ -132,6 +140,7 @@ class VectorStore:
         self,
         chunks: Sequence[dict],
         scope: "MemoryScope | None" = None,
+        tags: "KnowledgeTags | None" = None,
     ) -> int:
         """Index prose chunks with pre-computed embeddings.
 
@@ -172,6 +181,15 @@ class VectorStore:
                 "universe_id": "", "goal_id": "",
                 "branch_id": "", "user_id": "",
             }
+        tag_defaults = tags.as_row_metadata() if tags is not None else {
+            "tag_universes": "[]",
+            "tag_domains": "[]",
+            "tag_shapes": "[]",
+            "tag_general": 0,
+            "tag_commons": 0,
+            "tag_private_canon": 0,
+            "promotion_record": "",
+        }
 
         rows = []
         for chunk in chunks:
@@ -192,6 +210,27 @@ class VectorStore:
                 "goal_id": chunk.get("goal_id", scope_defaults["goal_id"]),
                 "branch_id": chunk.get("branch_id", scope_defaults["branch_id"]),
                 "user_id": chunk.get("user_id", scope_defaults["user_id"]),
+                "tag_universes": chunk.get(
+                    "tag_universes", tag_defaults["tag_universes"],
+                ),
+                "tag_domains": chunk.get(
+                    "tag_domains", tag_defaults["tag_domains"],
+                ),
+                "tag_shapes": chunk.get(
+                    "tag_shapes", tag_defaults["tag_shapes"],
+                ),
+                "tag_general": chunk.get(
+                    "tag_general", tag_defaults["tag_general"],
+                ),
+                "tag_commons": chunk.get(
+                    "tag_commons", tag_defaults["tag_commons"],
+                ),
+                "tag_private_canon": chunk.get(
+                    "tag_private_canon", tag_defaults["tag_private_canon"],
+                ),
+                "promotion_record": chunk.get(
+                    "promotion_record", tag_defaults["promotion_record"],
+                ),
                 "embedding": emb,
             })
 

--- a/tests/test_knowledge_tag_matrix.py
+++ b/tests/test_knowledge_tag_matrix.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import logging
+
+from workflow.knowledge.knowledge_graph import KnowledgeGraph
+from workflow.knowledge.models import FactWithContext, RetrievalResult, SourceType
+from workflow.knowledge.tag_matrix import (
+    CommonsPromotionRecord,
+    KnowledgeTags,
+    TagMatrixQuery,
+    filter_rows_by_tag_matrix,
+    row_visible_for_tag_matrix,
+)
+from workflow.memory.scoping import MemoryScope
+from workflow.retrieval.router import _drop_cross_universe_rows, _filter_by_tag_matrix
+
+
+def _promotion_record() -> CommonsPromotionRecord:
+    return CommonsPromotionRecord(
+        source_universe="u-private",
+        shape_tag="protocol",
+        promoter_identity="user-123",
+        declassification_reason="Reusable protocol shape, no private canon.",
+        resolver_decision="resolved",
+        timestamp="2026-05-27T22:16:00Z",
+    )
+
+
+def test_tag_matrix_includes_same_scope_and_promoted_commons(caplog):
+    scope = MemoryScope(universe_id="u1")
+    query = TagMatrixQuery(domain_tags=("research",), shape_tags=("protocol",))
+    promoted = _promotion_record()
+
+    rows = [
+        {
+            "id": "same-universe",
+            "tag_universes": json.dumps(["u1"]),
+            "tag_domains": json.dumps(["research"]),
+            "tag_shapes": json.dumps(["protocol"]),
+        },
+        {
+            "id": "other-universe",
+            "tag_universes": json.dumps(["u2"]),
+            "tag_domains": json.dumps(["research"]),
+            "tag_shapes": json.dumps(["protocol"]),
+        },
+        {
+            "id": "promoted-commons",
+            "tag_commons": 1,
+            "tag_private_canon": 1,
+            "tag_domains": json.dumps(["research"]),
+            "tag_shapes": json.dumps(["protocol"]),
+            "promotion_record": json.dumps(promoted.__dict__),
+        },
+        {
+            "id": "wrong-domain-commons",
+            "tag_commons": 1,
+            "tag_domains": json.dumps(["fiction"]),
+            "tag_shapes": json.dumps(["protocol"]),
+        },
+        {
+            "id": "unpromoted-private",
+            "tag_commons": 1,
+            "tag_private_canon": 1,
+            "tag_domains": json.dumps(["research"]),
+            "tag_shapes": json.dumps(["protocol"]),
+        },
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="workflow.knowledge.tag_matrix"):
+        filtered = filter_rows_by_tag_matrix(rows, scope=scope, query=query)
+
+    assert [row["id"] for row in filtered] == [
+        "same-universe",
+        "promoted-commons",
+    ]
+    assert any("tag_matrix.inv5_block" in rec.message for rec in caplog.records)
+
+
+def test_tag_matrix_does_not_override_hard_memory_scope():
+    scope = MemoryScope(universe_id="u1")
+    tag_query = TagMatrixQuery(domain_tags=("research",))
+    result = RetrievalResult(
+        relationships=[
+            {
+                "source": "bad",
+                "target": "leak",
+                "universe_id": "u2",
+                "tag_universes": json.dumps(["u1"]),
+                "tag_domains": json.dumps(["research"]),
+            },
+            {
+                "source": "ok",
+                "target": "local",
+                "universe_id": "u1",
+                "tag_universes": json.dumps(["u1"]),
+                "tag_domains": json.dumps(["research"]),
+            },
+        ],
+    )
+
+    scoped = _drop_cross_universe_rows(result, scope)
+    filtered = _filter_by_tag_matrix(scoped, scope, tag_query)
+
+    assert filtered.relationships == [
+        {
+            "source": "ok",
+            "target": "local",
+            "universe_id": "u1",
+            "tag_universes": json.dumps(["u1"]),
+            "tag_domains": json.dumps(["research"]),
+        },
+    ]
+
+
+def test_unpromoted_private_commons_fails_closed():
+    scope = MemoryScope(universe_id="u1")
+    row = {
+        "tag_commons": 1,
+        "tag_private_canon": 1,
+        "tag_shapes": json.dumps(["protocol"]),
+    }
+
+    assert not row_visible_for_tag_matrix(
+        row,
+        scope=scope,
+        query=TagMatrixQuery(shape_tags=("protocol",)),
+    )
+
+
+def test_manual_tag_construction_accepts_single_string():
+    tags = KnowledgeTags(universes="u1", domains="research", shapes="protocol")  # type: ignore[arg-type]
+    query = TagMatrixQuery(domain_tags="research", shape_tags="protocol")  # type: ignore[arg-type]
+
+    assert tags.universes == ("u1",)
+    assert tags.domains == ("research",)
+    assert tags.shapes == ("protocol",)
+    assert query.domain_tags == ("research",)
+    assert query.shape_tags == ("protocol",)
+
+
+def test_knowledge_graph_persists_fact_tags(tmp_path):
+    kg = KnowledgeGraph(tmp_path / "kg.db")
+    try:
+        scope = MemoryScope(universe_id="u1")
+        tags = KnowledgeTags(
+            universes=("u1",),
+            domains=("research",),
+            shapes=("protocol",),
+        )
+        kg.add_facts(
+            [
+                FactWithContext(
+                    fact_id="f1",
+                    text="Ryn keeps a cited research protocol.",
+                    source_type=SourceType.AUTHOR_FACT,
+                )
+            ],
+            scope=scope,
+            tags=tags,
+        )
+
+        facts = kg.query_facts()
+        assert len(facts) == 1
+        assert facts[0].tag_universes == ["u1"]
+        assert facts[0].tag_domains == ["research"]
+        assert facts[0].tag_shapes == ["protocol"]
+    finally:
+        kg.close()

--- a/workflow/knowledge/knowledge_graph.py
+++ b/workflow/knowledge/knowledge_graph.py
@@ -19,6 +19,7 @@ from workflow.knowledge.models import (
     GraphEdge,
     GraphEntity,
 )
+from workflow.knowledge.tag_matrix import KnowledgeTags, knowledge_tags_from_mapping
 from workflow.memory.scoping import MemoryScope
 
 # Memory-scope Stage 2b: shared helpers for injecting scope column
@@ -28,6 +29,15 @@ from workflow.memory.scoping import MemoryScope
 # helpers keeps the three write sites in sync.
 _SCOPE_COL_NAMES: tuple[str, ...] = (
     "universe_id", "goal_id", "branch_id", "user_id",
+)
+_TAG_COL_NAMES: tuple[str, ...] = (
+    "tag_universes",
+    "tag_domains",
+    "tag_shapes",
+    "tag_general",
+    "tag_commons",
+    "tag_private_canon",
+    "promotion_record",
 )
 
 
@@ -68,6 +78,51 @@ def _scope_upsert_fragment(scope: MemoryScope | None) -> str:
     )
 
 
+def _tag_insert_fragment(
+    tags: KnowledgeTags | None,
+) -> tuple[str, tuple[Any, ...]]:
+    """Return tag columns/values for INSERT fragments."""
+    if tags is None:
+        return "", ()
+    metadata = tags.as_row_metadata()
+    cols = ", " + ", ".join(_TAG_COL_NAMES)
+    vals = tuple(metadata[col] for col in _TAG_COL_NAMES)
+    return cols, vals
+
+
+def _tag_upsert_fragment(tags: KnowledgeTags | None) -> str:
+    """Return the tag-column UPSERT fragment when tags are supplied."""
+    if tags is None:
+        return ""
+    return "".join(
+        f", {col}=excluded.{col}" for col in _TAG_COL_NAMES
+    )
+
+
+def _attach_row_tags(target: Any, row: sqlite3.Row) -> None:
+    """Attach flat tag metadata from a SQLite row to a result object."""
+    tags = knowledge_tags_from_mapping(dict(row))
+    if isinstance(target, dict):
+        metadata = tags.as_row_metadata()
+        target.update(metadata)
+        return
+    setattr(target, "tag_universes", list(tags.universes))
+    setattr(target, "tag_domains", list(tags.domains))
+    setattr(target, "tag_shapes", list(tags.shapes))
+    setattr(target, "tag_general", tags.general)
+    setattr(target, "tag_commons", tags.commons)
+    setattr(target, "tag_private_canon", tags.private_canon)
+    setattr(
+        target,
+        "promotion_record",
+        (
+            json.dumps(tags.promotion_record.__dict__)
+            if tags.promotion_record is not None
+            else ""
+        ),
+    )
+
+
 class KnowledgeGraph:
     """SQLite-backed knowledge graph with igraph construction.
 
@@ -104,6 +159,15 @@ class KnowledgeGraph:
         ("goal_id", "TEXT"),
         ("branch_id", "TEXT"),
         ("user_id", "TEXT"),
+    )
+    _TAG_COLUMNS: tuple[tuple[str, str], ...] = (
+        ("tag_universes", "TEXT NOT NULL DEFAULT '[]'"),
+        ("tag_domains", "TEXT NOT NULL DEFAULT '[]'"),
+        ("tag_shapes", "TEXT NOT NULL DEFAULT '[]'"),
+        ("tag_general", "INTEGER NOT NULL DEFAULT 0"),
+        ("tag_commons", "INTEGER NOT NULL DEFAULT 0"),
+        ("tag_private_canon", "INTEGER NOT NULL DEFAULT 0"),
+        ("promotion_record", "TEXT NOT NULL DEFAULT ''"),
     )
     _SCOPED_TABLES: tuple[str, ...] = (
         "entities", "edges", "facts", "communities",
@@ -189,6 +253,18 @@ class KnowledgeGraph:
                 self._conn.execute(
                     f"ALTER TABLE {table} ADD COLUMN {col_name} {col_type}"
                 )
+            existing = {
+                row["name"]
+                for row in self._conn.execute(
+                    f"PRAGMA table_info({table})"
+                )
+            }
+            for col_name, col_type in self._TAG_COLUMNS:
+                if col_name in existing:
+                    continue
+                self._conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN {col_name} {col_type}"
+                )
         # Shared index over (universe_id, goal_id, branch_id) per
         # design-note §4 — this is the hot read path.
         for table in self._SCOPED_TABLES:
@@ -234,6 +310,7 @@ class KnowledgeGraph:
         self,
         entity: GraphEntity,
         scope: MemoryScope | None = None,
+        tags: KnowledgeTags | None = None,
     ) -> None:
         """Insert or update an entity.
 
@@ -243,21 +320,26 @@ class KnowledgeGraph:
         legacy/universe-public semantics per design §4). The write is
         a no-op for reads until Stage 2c flips
         ``WORKFLOW_TIERED_SCOPE`` on.
+
+        PR-139 slice 6: optional ``tags`` attach the tag-matrix labels
+        used by retrieval. Tags refine rows after hard MemoryScope
+        filtering; they do not replace scope columns.
         """
         scope_cols, scope_vals = _scope_insert_fragment(scope)
+        tag_cols, tag_vals = _tag_insert_fragment(tags)
         self._conn.execute(
             f"""
             INSERT INTO entities (entity_id, entity_type, access_tier,
                                   public_description, hidden_description,
-                                  secret_description, aliases{scope_cols})
-            VALUES (?, ?, ?, ?, ?, ?, ?{', ?' * len(scope_vals)})
+                                  secret_description, aliases{scope_cols}{tag_cols})
+            VALUES (?, ?, ?, ?, ?, ?, ?{', ?' * (len(scope_vals) + len(tag_vals))})
             ON CONFLICT(entity_id) DO UPDATE SET
                 entity_type=excluded.entity_type,
                 access_tier=excluded.access_tier,
                 public_description=excluded.public_description,
                 hidden_description=excluded.hidden_description,
                 secret_description=excluded.secret_description,
-                aliases=excluded.aliases{_scope_upsert_fragment(scope)}
+                aliases=excluded.aliases{_scope_upsert_fragment(scope)}{_tag_upsert_fragment(tags)}
             """,
             (
                 entity["entity_id"],
@@ -268,6 +350,7 @@ class KnowledgeGraph:
                 entity["secret_description"],
                 json.dumps(entity.get("aliases", [])),
                 *scope_vals,
+                *tag_vals,
             ),
         )
         self._conn.commit()
@@ -325,6 +408,7 @@ class KnowledgeGraph:
         self,
         edge: GraphEdge,
         scope: MemoryScope | None = None,
+        tags: KnowledgeTags | None = None,
     ) -> None:
         """Insert or update an edge.
 
@@ -332,19 +416,20 @@ class KnowledgeGraph:
         contract. Scope tagging is advisory until 2c.
         """
         scope_cols, scope_vals = _scope_insert_fragment(scope)
+        tag_cols, tag_vals = _tag_insert_fragment(tags)
         self._conn.execute(
             f"""
             INSERT INTO edges (source, target, relation_type, access_tier,
                                temporal_scope, pov_characters, weight,
-                               valid_from_chapter, valid_to_chapter{scope_cols})
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?{', ?' * len(scope_vals)})
+                               valid_from_chapter, valid_to_chapter{scope_cols}{tag_cols})
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?{', ?' * (len(scope_vals) + len(tag_vals))})
             ON CONFLICT(source, target, relation_type) DO UPDATE SET
                 access_tier=excluded.access_tier,
                 temporal_scope=excluded.temporal_scope,
                 pov_characters=excluded.pov_characters,
                 weight=excluded.weight,
                 valid_from_chapter=excluded.valid_from_chapter,
-                valid_to_chapter=excluded.valid_to_chapter{_scope_upsert_fragment(scope)}
+                valid_to_chapter=excluded.valid_to_chapter{_scope_upsert_fragment(scope)}{_tag_upsert_fragment(tags)}
             """,
             (
                 edge["source"],
@@ -357,6 +442,7 @@ class KnowledgeGraph:
                 edge.get("valid_from_chapter"),
                 edge.get("valid_to_chapter"),
                 *scope_vals,
+                *tag_vals,
             ),
         )
         self._conn.commit()
@@ -387,8 +473,9 @@ class KnowledgeGraph:
             sql += " AND access_tier <= ?"
             params.append(access_tier)
         rows = self._conn.execute(sql, params).fetchall()
-        return [
-            GraphEdge(
+        edges: list[GraphEdge] = []
+        for r in rows:
+            edge = GraphEdge(
                 source=r["source"],
                 target=r["target"],
                 relation_type=r["relation_type"],
@@ -399,8 +486,9 @@ class KnowledgeGraph:
                 valid_from_chapter=r["valid_from_chapter"],
                 valid_to_chapter=r["valid_to_chapter"],
             )
-            for r in rows
-        ]
+            _attach_row_tags(edge, r)
+            edges.append(edge)
+        return edges
 
     # ------------------------------------------------------------------
     # Fact CRUD
@@ -410,6 +498,7 @@ class KnowledgeGraph:
         self,
         facts: Sequence[FactWithContext],
         scope: MemoryScope | None = None,
+        tags: KnowledgeTags | None = None,
     ) -> None:
         """Insert or update a batch of facts.
 
@@ -417,7 +506,10 @@ class KnowledgeGraph:
         contract.
         """
         scope_cols, scope_vals = _scope_insert_fragment(scope)
-        placeholders = ",".join(["?"] * (21 + len(scope_vals)))
+        tag_cols, tag_vals = _tag_insert_fragment(tags)
+        placeholders = ",".join(
+            ["?"] * (21 + len(scope_vals) + len(tag_vals))
+        )
         for f in facts:
             self._conn.execute(
                 f"""
@@ -426,7 +518,7 @@ class KnowledgeGraph:
                     truth_value_initial, truth_value_final, truth_value_revealed,
                     language_type, narrative_function, importance, weight,
                     hardness, horizon, provenance, confidence, seeded_scene,
-                    access_tier, pov_characters{scope_cols})
+                    access_tier, pov_characters{scope_cols}{tag_cols})
                 VALUES ({placeholders})
                 ON CONFLICT(fact_id) DO UPDATE SET
                     text=excluded.text,
@@ -448,7 +540,7 @@ class KnowledgeGraph:
                     confidence=excluded.confidence,
                     seeded_scene=excluded.seeded_scene,
                     access_tier=excluded.access_tier,
-                    pov_characters=excluded.pov_characters{_scope_upsert_fragment(scope)}
+                    pov_characters=excluded.pov_characters{_scope_upsert_fragment(scope)}{_tag_upsert_fragment(tags)}
                 """,
                 (
                     f.fact_id, f.text, f.source_type.value, f.narrator,
@@ -458,6 +550,7 @@ class KnowledgeGraph:
                     f.weight, f.hardness, f.horizon, f.provenance, f.confidence,
                     f.seeded_scene, f.access_tier, json.dumps(f.pov_characters),
                     *scope_vals,
+                    *tag_vals,
                 ),
             )
         self._conn.commit()
@@ -526,6 +619,7 @@ class KnowledgeGraph:
             if character_id is not None:
                 if fact.pov_characters and character_id not in fact.pov_characters:
                     continue
+            _attach_row_tags(fact, r)
             results.append(fact)
         return results
 

--- a/workflow/knowledge/models.py
+++ b/workflow/knowledge/models.py
@@ -132,6 +132,16 @@ class FactWithContext:
     access_tier: int = 0
     pov_characters: list[str] = field(default_factory=list)
 
+    # Tag-matrix retrieval metadata. Hard scope is enforced separately by
+    # MemoryScope; these tags refine eligible rows by universe/domain/shape.
+    tag_universes: list[str] = field(default_factory=list)
+    tag_domains: list[str] = field(default_factory=list)
+    tag_shapes: list[str] = field(default_factory=list)
+    tag_general: bool = False
+    tag_commons: bool = False
+    tag_private_canon: bool = False
+    promotion_record: str = ""
+
     def is_accessible_to(self, character_id: str, character_knowledge_level: int) -> bool:
         """Check if a character should be able to know this fact."""
         if character_knowledge_level >= self.access_tier:

--- a/workflow/knowledge/tag_matrix.py
+++ b/workflow/knowledge/tag_matrix.py
@@ -1,0 +1,311 @@
+"""Tag-matrix filtering for knowledge and retrieval rows.
+
+The tag matrix is a refinement layer above hard memory scope. Scope decides
+which universe/user/branch a caller may see; tags decide which eligible
+documents are relevant to the current universe/domain/shape/commons query.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from workflow.memory.scoping import MemoryScope
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CommonsPromotionRecord:
+    """INV-5 promotion evidence for a private-canon shape entering commons."""
+
+    source_universe: str
+    shape_tag: str
+    promoter_identity: str
+    declassification_reason: str
+    resolver_decision: str
+    timestamp: str
+
+    def is_complete(self) -> bool:
+        return all(
+            str(value).strip()
+            for value in (
+                self.source_universe,
+                self.shape_tag,
+                self.promoter_identity,
+                self.declassification_reason,
+                self.resolver_decision,
+                self.timestamp,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class KnowledgeTags:
+    """Tag-matrix labels attached to one knowledge/retrieval row."""
+
+    universes: tuple[str, ...] = ()
+    domains: tuple[str, ...] = ()
+    shapes: tuple[str, ...] = ()
+    general: bool = False
+    commons: bool = False
+    private_canon: bool = False
+    promotion_record: CommonsPromotionRecord | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "universes", _normalize_values(self.universes))
+        object.__setattr__(self, "domains", _normalize_values(self.domains))
+        object.__setattr__(self, "shapes", _normalize_values(self.shapes))
+
+    @property
+    def is_tagged(self) -> bool:
+        return bool(
+            self.universes
+            or self.domains
+            or self.shapes
+            or self.general
+            or self.commons
+            or self.private_canon
+        )
+
+    def commons_promotion_complete(self) -> bool:
+        if not (self.commons and self.private_canon):
+            return True
+        return (
+            self.promotion_record is not None
+            and self.promotion_record.is_complete()
+        )
+
+    def as_row_metadata(self) -> dict[str, Any]:
+        """Serialize tags into flat row metadata columns."""
+        return {
+            "tag_universes": json.dumps(list(self.universes)),
+            "tag_domains": json.dumps(list(self.domains)),
+            "tag_shapes": json.dumps(list(self.shapes)),
+            "tag_general": int(self.general),
+            "tag_commons": int(self.commons),
+            "tag_private_canon": int(self.private_canon),
+            "promotion_record": (
+                json.dumps(self.promotion_record.__dict__)
+                if self.promotion_record is not None
+                else ""
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class TagMatrixQuery:
+    """Tag filter requested by a retrieval caller."""
+
+    domain_tags: tuple[str, ...] = ()
+    shape_tags: tuple[str, ...] = ()
+    include_general: bool = True
+    include_commons: bool = True
+    include_untagged: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "domain_tags", _normalize_values(self.domain_tags)
+        )
+        object.__setattr__(
+            self, "shape_tags", _normalize_values(self.shape_tags)
+        )
+
+
+def knowledge_tags_from_mapping(value: Any) -> KnowledgeTags:
+    """Build ``KnowledgeTags`` from flat or nested row metadata."""
+    if isinstance(value, KnowledgeTags):
+        return value
+    if value is None:
+        return KnowledgeTags()
+
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return KnowledgeTags()
+    if not isinstance(value, dict):
+        return KnowledgeTags()
+
+    nested = value.get("tag_matrix")
+    if isinstance(nested, dict):
+        value = {**value, **nested}
+
+    record = _promotion_record_from_value(
+        value.get("promotion_record")
+        or value.get("commons_promotion_record")
+    )
+    return KnowledgeTags(
+        universes=_read_values(value, "tag_universes", "universes"),
+        domains=_read_values(value, "tag_domains", "domains"),
+        shapes=_read_values(value, "tag_shapes", "shapes"),
+        general=_read_bool(value, "tag_general", "general"),
+        commons=_read_bool(value, "tag_commons", "commons"),
+        private_canon=_read_bool(value, "tag_private_canon", "private_canon"),
+        promotion_record=record,
+    )
+
+
+def knowledge_tags_from_row(row: Any) -> KnowledgeTags:
+    """Extract tag metadata from a dict/dataclass/object row."""
+    if isinstance(row, str):
+        return KnowledgeTags()
+    if isinstance(row, dict):
+        return knowledge_tags_from_mapping(row)
+
+    data: dict[str, Any] = {}
+    for key in (
+        "tag_matrix",
+        "tag_universes",
+        "tag_domains",
+        "tag_shapes",
+        "tag_general",
+        "tag_commons",
+        "tag_private_canon",
+        "promotion_record",
+        "commons_promotion_record",
+    ):
+        if hasattr(row, key):
+            data[key] = getattr(row, key)
+    return knowledge_tags_from_mapping(data)
+
+
+def row_visible_for_tag_matrix(
+    row: Any,
+    *,
+    scope: MemoryScope,
+    query: TagMatrixQuery,
+) -> bool:
+    """Return True when a row's tags are visible for ``scope`` and ``query``."""
+    tags = knowledge_tags_from_row(row)
+    if not tags.is_tagged:
+        return query.include_untagged
+
+    if not tags.commons_promotion_complete():
+        logger.warning(
+            "tag_matrix.inv5_block: dropped row without complete "
+            "commons promotion record (scope=%s, tags=%s)",
+            scope.compose_predicate(),
+            tags,
+        )
+        return False
+
+    if tags.universes and scope.universe_id not in tags.universes:
+        if not (tags.general or (tags.commons and query.include_commons)):
+            return False
+
+    if tags.general and not query.include_general:
+        return False
+    if tags.commons and not query.include_commons:
+        return False
+
+    if query.domain_tags:
+        if tags.domains:
+            if not _intersects(tags.domains, query.domain_tags) and not tags.general:
+                return False
+        elif not tags.general:
+            return False
+
+    if query.shape_tags:
+        if tags.shapes:
+            if not _intersects(tags.shapes, query.shape_tags) and not tags.general:
+                return False
+        elif not tags.general:
+            return False
+
+    return True
+
+
+def filter_rows_by_tag_matrix(
+    rows: Iterable[Any],
+    *,
+    scope: MemoryScope,
+    query: TagMatrixQuery | None,
+) -> list[Any]:
+    """Filter rows by tag matrix after hard scope filtering."""
+    if query is None:
+        return list(rows)
+    return [
+        row
+        for row in rows
+        if row_visible_for_tag_matrix(row, scope=scope, query=query)
+    ]
+
+
+def _normalize_values(values: Iterable[Any] | None) -> tuple[str, ...]:
+    if isinstance(values, str):
+        values = (values,)
+    output: list[str] = []
+    seen: set[str] = set()
+    for value in values or ():
+        text = str(value).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        output.append(text)
+    return tuple(output)
+
+
+def _intersects(left: tuple[str, ...], right: tuple[str, ...]) -> bool:
+    return bool(set(left) & set(right))
+
+
+def _read_values(data: dict[str, Any], *keys: str) -> tuple[str, ...]:
+    for key in keys:
+        if key not in data:
+            continue
+        value = data[key]
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return ()
+            try:
+                decoded = json.loads(stripped)
+            except json.JSONDecodeError:
+                decoded = [part.strip() for part in stripped.split(",")]
+            value = decoded
+        if isinstance(value, Iterable) and not isinstance(value, (bytes, str)):
+            return _normalize_values(value)
+        return _normalize_values([value])
+    return ()
+
+
+def _read_bool(data: dict[str, Any], *keys: str) -> bool:
+    for key in keys:
+        if key not in data:
+            continue
+        value = data[key]
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int):
+            return value != 0
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def _promotion_record_from_value(value: Any) -> CommonsPromotionRecord | None:
+    if isinstance(value, CommonsPromotionRecord):
+        return value
+    if value is None or value == "":
+        return None
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(value, dict):
+        return None
+    return CommonsPromotionRecord(
+        source_universe=str(value.get("source_universe", "") or ""),
+        shape_tag=str(value.get("shape_tag", "") or ""),
+        promoter_identity=str(value.get("promoter_identity", "") or ""),
+        declassification_reason=str(
+            value.get("declassification_reason", "") or ""
+        ),
+        resolver_decision=str(value.get("resolver_decision", "") or ""),
+        timestamp=str(value.get("timestamp", "") or ""),
+    )

--- a/workflow/retrieval/agentic_search.py
+++ b/workflow/retrieval/agentic_search.py
@@ -13,6 +13,7 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Callable
 
+from workflow.knowledge.tag_matrix import TagMatrixQuery
 from workflow.memory.scoping import MemoryScope
 
 logger = logging.getLogger(__name__)
@@ -168,6 +169,7 @@ def run_phase_retrieval(
             phase,
         )
         return {}
+    tag_query = _tag_query_from_state(state)
 
     kg = None
     owns_kg = False
@@ -206,6 +208,7 @@ def run_phase_retrieval(
             access_tier=int(orient_result.get("access_tier", 0) or 0),
             pov_character=orient_result.get("pov_character"),
             chapter_number=state.get("chapter_number"),
+            tag_query=tag_query,
         )
 
         try:
@@ -245,6 +248,28 @@ def run_phase_retrieval(
                 kg.close()
             except Exception:
                 logger.debug("Failed to close temporary knowledge graph", exc_info=True)
+
+
+def _tag_query_from_state(state: dict[str, Any]) -> TagMatrixQuery | None:
+    """Derive an optional tag-matrix filter from graph state."""
+    raw = (
+        state.get("tag_matrix")
+        or state.get("tag_filter")
+        or state.get("knowledge_tags")
+    )
+    if raw is None:
+        return None
+    if isinstance(raw, TagMatrixQuery):
+        return raw
+    if not isinstance(raw, dict):
+        return None
+    return TagMatrixQuery(
+        domain_tags=raw.get("domain_tags") or raw.get("domains") or (),
+        shape_tags=raw.get("shape_tags") or raw.get("shapes") or (),
+        include_general=bool(raw.get("include_general", True)),
+        include_commons=bool(raw.get("include_commons", True)),
+        include_untagged=bool(raw.get("include_untagged", False)),
+    )
 
 
 def build_phase_query(

--- a/workflow/retrieval/router.py
+++ b/workflow/retrieval/router.py
@@ -22,6 +22,11 @@ from workflow.knowledge.models import (
     SubQuery,
 )
 from workflow.knowledge.raptor import RaptorTree, query_raptor_tree
+from workflow.knowledge.tag_matrix import (
+    TagMatrixQuery,
+    filter_rows_by_tag_matrix,
+    row_visible_for_tag_matrix,
+)
 from workflow.memory.scoping import MemoryScope
 from workflow.retrieval.phase_context import should_use_backend
 from workflow.retrieval.vector_store import VectorStore
@@ -174,6 +179,7 @@ class RetrievalRouter:
         access_tier: int = 0,
         pov_character: str | None = None,
         chapter_number: int | None = None,
+        tag_query: TagMatrixQuery | None = None,
         token_budget: int = 4000,
     ) -> RetrievalResult:
         """Route a query to the appropriate retrieval backends.
@@ -195,6 +201,9 @@ class RetrievalRouter:
             POV character for epistemic filtering.
         chapter_number
             Current chapter for temporal filtering.
+        tag_query
+            Optional tag-matrix filter. Applied after hard
+            ``MemoryScope`` filtering; tags never replace scope.
         token_budget
             Maximum tokens for the assembled context.
 
@@ -228,7 +237,7 @@ class RetrievalRouter:
             elif sq.query_type == QueryType.TONE_SIMILARITY:
                 if not should_use_backend(phase, "voice_examples"):
                     continue
-                self._route_to_vector(sq, result)
+                self._route_to_vector(sq, result, scope, tag_query)
                 result.sources.append("vector")
 
         # Defense-in-depth: drop rows whose declared universe_id
@@ -236,6 +245,9 @@ class RetrievalRouter:
         # attribute pass through (Stage 1 — interface only; KG/vector
         # rows are path-tagged, not row-tagged, today).
         result = _drop_cross_universe_rows(result, scope)
+        if tag_query is not None:
+            result = _filter_by_tag_matrix(result, scope, tag_query)
+            result.sources.append("tag_matrix")
 
         # Cluster similar results to reduce redundancy
         result = self._cluster_results(result)
@@ -293,7 +305,13 @@ class RetrievalRouter:
         )
         result.community_summaries.extend(summaries)
 
-    def _route_to_vector(self, sq: SubQuery, result: RetrievalResult) -> None:
+    def _route_to_vector(
+        self,
+        sq: SubQuery,
+        result: RetrievalResult,
+        scope: MemoryScope,
+        tag_query: TagMatrixQuery | None,
+    ) -> None:
         """Route a tone/similarity query to LanceDB vectors."""
         if self._vector_store is None or self._embed_fn is None:
             return
@@ -304,6 +322,10 @@ class RetrievalRouter:
 
         matches = self._vector_store.search(query_emb, limit=5)
         for match in matches:
+            if tag_query is not None and not row_visible_for_tag_matrix(
+                match, scope=scope, query=tag_query,
+            ):
+                continue
             result.prose_chunks.append(match.get("text", ""))
 
     def _cluster_results(self, result: RetrievalResult) -> RetrievalResult:
@@ -490,6 +512,44 @@ def _drop_cross_universe_rows(
             "on" if flag_on else "off",
         )
 
+    return result
+
+
+def _filter_by_tag_matrix(
+    result: RetrievalResult,
+    scope: MemoryScope,
+    tag_query: TagMatrixQuery,
+) -> RetrievalResult:
+    """Apply CHILD-2 tag-matrix filtering after hard scope checks."""
+    before = (
+        len(result.facts),
+        len(result.relationships),
+        len(result.community_summaries),
+    )
+    result.facts = filter_rows_by_tag_matrix(
+        result.facts, scope=scope, query=tag_query,
+    )
+    result.relationships = filter_rows_by_tag_matrix(
+        result.relationships, scope=scope, query=tag_query,
+    )
+    result.community_summaries = filter_rows_by_tag_matrix(
+        result.community_summaries, scope=scope, query=tag_query,
+    )
+    after = (
+        len(result.facts),
+        len(result.relationships),
+        len(result.community_summaries),
+    )
+    dropped = sum(before) - sum(after)
+    if dropped:
+        logger.info(
+            "tag_matrix.filter: dropped %d rows after scope filtering "
+            "(caller_scope=%r, domain_tags=%r, shape_tags=%r)",
+            dropped,
+            scope.compose_predicate(),
+            tag_query.domain_tags,
+            tag_query.shape_tags,
+        )
     return result
 
 

--- a/workflow/retrieval/vector_store.py
+++ b/workflow/retrieval/vector_store.py
@@ -15,6 +15,7 @@ import lancedb
 import numpy as np
 
 if TYPE_CHECKING:
+    from workflow.knowledge.tag_matrix import KnowledgeTags
     from workflow.memory.scoping import MemoryScope
 
 # ---------------------------------------------------------------------------
@@ -123,6 +124,13 @@ class VectorStore:
                 "goal_id": "",
                 "branch_id": "",
                 "user_id": "",
+                "tag_universes": "[]",
+                "tag_domains": "[]",
+                "tag_shapes": "[]",
+                "tag_general": 0,
+                "tag_commons": 0,
+                "tag_private_canon": 0,
+                "promotion_record": "",
                 "embedding": np.zeros(self._embedding_dim, dtype=np.float32).tolist(),
             }]
             self._table = self._db.create_table(self._table_name, data=seed)
@@ -132,6 +140,7 @@ class VectorStore:
         self,
         chunks: Sequence[dict],
         scope: "MemoryScope | None" = None,
+        tags: "KnowledgeTags | None" = None,
     ) -> int:
         """Index prose chunks with pre-computed embeddings.
 
@@ -172,6 +181,15 @@ class VectorStore:
                 "universe_id": "", "goal_id": "",
                 "branch_id": "", "user_id": "",
             }
+        tag_defaults = tags.as_row_metadata() if tags is not None else {
+            "tag_universes": "[]",
+            "tag_domains": "[]",
+            "tag_shapes": "[]",
+            "tag_general": 0,
+            "tag_commons": 0,
+            "tag_private_canon": 0,
+            "promotion_record": "",
+        }
 
         rows = []
         for chunk in chunks:
@@ -192,6 +210,27 @@ class VectorStore:
                 "goal_id": chunk.get("goal_id", scope_defaults["goal_id"]),
                 "branch_id": chunk.get("branch_id", scope_defaults["branch_id"]),
                 "user_id": chunk.get("user_id", scope_defaults["user_id"]),
+                "tag_universes": chunk.get(
+                    "tag_universes", tag_defaults["tag_universes"],
+                ),
+                "tag_domains": chunk.get(
+                    "tag_domains", tag_defaults["tag_domains"],
+                ),
+                "tag_shapes": chunk.get(
+                    "tag_shapes", tag_defaults["tag_shapes"],
+                ),
+                "tag_general": chunk.get(
+                    "tag_general", tag_defaults["tag_general"],
+                ),
+                "tag_commons": chunk.get(
+                    "tag_commons", tag_defaults["tag_commons"],
+                ),
+                "tag_private_canon": chunk.get(
+                    "tag_private_canon", tag_defaults["tag_private_canon"],
+                ),
+                "promotion_record": chunk.get(
+                    "promotion_record", tag_defaults["promotion_record"],
+                ),
                 "embedding": emb,
             })
 


### PR DESCRIPTION
## Summary

PR-139 slice 6 (CHILD-2 tag-matrix brain): adds a reusable tag-matrix layer over the existing hard MemoryScope boundary.

- adds `workflow.knowledge.tag_matrix` with `KnowledgeTags`, `TagMatrixQuery`, commons-promotion records, and INV-5 fail-closed filtering
- persists tag metadata on knowledge graph and vector rows without replacing existing scope columns
- applies tag filtering in retrieval after `_drop_cross_universe_rows`, so tags refine allowed rows but cannot override hard universe/scope isolation
- wires optional tag filters from graph state via `tag_matrix` / `tag_filter` / `knowledge_tags`
- updates the Claude plugin runtime mirror

## PR-139 boundaries

This is build-order step 6 only. It does not build the live resolver runtime (step 7), gradient scopes/checkpoints (step 8), universe-cycle de-defaulting (step 9), or episodic schema migration (step 10).

## Verification

- `python -m pytest tests/test_knowledge_tag_matrix.py tests/test_retrieval.py tests/test_memory_scoping.py tests/test_knowledge_graph.py tests/test_api_universe.py tests/test_universe_nodes.py -q` -> 343 passed, 8 warnings
- `python -m ruff check workflow/knowledge/tag_matrix.py workflow/knowledge/models.py workflow/knowledge/knowledge_graph.py workflow/retrieval/router.py workflow/retrieval/agentic_search.py workflow/retrieval/vector_store.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/knowledge/tag_matrix.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/knowledge/models.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/knowledge/knowledge_graph.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/retrieval/router.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/retrieval/agentic_search.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/retrieval/vector_store.py tests/test_knowledge_tag_matrix.py tests/test_retrieval.py` -> pass
- `python packaging\claude-plugin\build_plugin.py` -> Import probe: probe-ok
- `python -m scripts.invariants.mirror_parity` -> pass
- `git diff --check` -> pass

## Gate

Standing host key applies to PR-139 slices. Merge still waits for Cowork/Claude-family checker key and green GitHub checks.