### PR TITLE
PR-139 slice 7: add authority resolver runtime

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/resolution/__init__.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/resolution/__init__.py
@@ -18,6 +18,7 @@ from workflow.resolution.contracts import (
     guard_unknown_taxonomy,
     validate_decision_payload,
 )
+from workflow.resolution.resolver import resolve_authority
 
 __all__ = [
     "FIXTURE_LOCATION",
@@ -31,5 +32,6 @@ __all__ = [
     "ResolverDecision",
     "ResolverInput",
     "guard_unknown_taxonomy",
+    "resolve_authority",
     "validate_decision_payload",
 ]

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/resolution/resolver.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/resolution/resolver.py
@@ -1,0 +1,101 @@
+"""Deterministic authority resolver runtime.
+
+The runtime is intentionally small: it turns typed resolver inputs into the
+frozen ``ResolverDecision`` contract without becoming a policy VM. Unknown
+taxonomy fails closed, surface mismatches are reframed with all claims kept,
+and direct claim conflicts remain structurally unresolved.
+"""
+
+from __future__ import annotations
+
+from workflow.resolution.contracts import (
+    ResolverDecision,
+    ResolverInput,
+    guard_unknown_taxonomy,
+)
+
+
+def resolve_authority(resolver_input: ResolverInput) -> ResolverDecision:
+    """Resolve a conflict input into the frozen authority-decision shape."""
+
+    taxonomy_guard = guard_unknown_taxonomy(resolver_input)
+    if taxonomy_guard is not None:
+        return taxonomy_guard
+
+    if resolver_input.conflict_type == "surface-mismatch":
+        return _resolve_surface_mismatch(resolver_input)
+
+    normalized_claims = {
+        _normalize_claim(citation.claim)
+        for citation in resolver_input.citations
+        if _normalize_claim(citation.claim)
+    }
+    if not normalized_claims:
+        return _needs_human_decision(
+            resolver_input,
+            "No cited claim text is available for deterministic comparison.",
+        )
+    if len(normalized_claims) == 1:
+        return ResolverDecision(
+            status="resolved",
+            confidence=0.9,
+            evidence_handles=_evidence_handles(resolver_input),
+            source_role_map=_source_role_map(resolver_input),
+            reason="All cited claims agree under the typed resolver input.",
+        )
+
+    return ResolverDecision(
+        status="unresolved",
+        confidence=0.0,
+        evidence_handles=_evidence_handles(resolver_input),
+        source_role_map=_source_role_map(resolver_input),
+        reason="Claims conflict and no resolver rule may force a winner.",
+    )
+
+
+def _resolve_surface_mismatch(resolver_input: ResolverInput) -> ResolverDecision:
+    surface_labels = ", ".join(
+        f"{citation.evidence_handle}={citation.surface_type}"
+        for citation in resolver_input.citations
+    )
+    return ResolverDecision(
+        status="resolved",
+        confidence=0.82,
+        evidence_handles=_evidence_handles(resolver_input),
+        source_role_map=_source_role_map(resolver_input),
+        reason=(
+            "Surface mismatch reframed; all claims preserved under typed "
+            f"surface labels: {surface_labels}."
+        ),
+    )
+
+
+def _needs_human_decision(
+    resolver_input: ResolverInput,
+    reason: str,
+) -> ResolverDecision:
+    return ResolverDecision(
+        status="needs-human-decision",
+        confidence=0.0,
+        evidence_handles=_evidence_handles(resolver_input),
+        source_role_map=_source_role_map(resolver_input),
+        reason=reason,
+    )
+
+
+def _evidence_handles(resolver_input: ResolverInput) -> list[str]:
+    return [citation.evidence_handle for citation in resolver_input.citations]
+
+
+def _source_role_map(resolver_input: ResolverInput) -> dict[str, str]:
+    return {
+        citation.evidence_handle: citation.source_role
+        for citation in resolver_input.citations
+    }
+
+
+def _normalize_claim(claim: str) -> str:
+    return " ".join(claim.casefold().split())
+
+
+__all__ = ["resolve_authority"]

--- a/tests/test_resolution_runtime.py
+++ b/tests/test_resolution_runtime.py
@@ -1,0 +1,142 @@
+"""Tests for the PR-139 authority resolver runtime."""
+
+from __future__ import annotations
+
+from workflow.resolution import (
+    EvidenceCitation,
+    ResolutionScope,
+    ResolverInput,
+    resolve_authority,
+)
+
+
+def _scope() -> ResolutionScope:
+    return ResolutionScope(
+        universe_id="u-1",
+        resource_type="code",
+        resource_id="authority-resolver",
+    )
+
+
+def test_real_conflict_returns_unresolved_without_forcing_winner() -> None:
+    decision = resolve_authority(
+        ResolverInput(
+            question="Does the code exist on the merged surface?",
+            scope=_scope(),
+            conflict_type="direct-conflict",
+            citations=[
+                EvidenceCitation(
+                    evidence_handle="evidence:main-a",
+                    source_role="merged-code",
+                    surface_type="merged",
+                    reference="git:abc123",
+                    claim="The resolver runtime exists.",
+                ),
+                EvidenceCitation(
+                    evidence_handle="evidence:main-b",
+                    source_role="merged-code",
+                    surface_type="merged",
+                    reference="git:def456",
+                    claim="The resolver runtime does not exist.",
+                ),
+            ],
+        )
+    )
+
+    assert decision.status == "unresolved"
+    assert decision.confidence == 0.0
+    assert decision.evidence_handles == ["evidence:main-a", "evidence:main-b"]
+    assert "no resolver rule may force a winner" in decision.reason
+
+
+def test_surface_mismatch_reframes_and_preserves_all_claims() -> None:
+    decision = resolve_authority(
+        ResolverInput(
+            question="Which surface is being cited?",
+            scope=_scope(),
+            conflict_type="surface-mismatch",
+            citations=[
+                EvidenceCitation(
+                    evidence_handle="evidence:github-commit",
+                    source_role="merged-code",
+                    surface_type="merged",
+                    reference="git:abc123",
+                    claim="The code is merged.",
+                ),
+                EvidenceCitation(
+                    evidence_handle="evidence:local-worktree",
+                    source_role="worktree-snapshot",
+                    surface_type="worktree-snapshot",
+                    reference="C:/worktree",
+                    claim="The local checkout still lacks the code.",
+                ),
+            ],
+        )
+    )
+
+    assert decision.status == "resolved"
+    assert decision.evidence_handles == [
+        "evidence:github-commit",
+        "evidence:local-worktree",
+    ]
+    assert decision.source_role_map == {
+        "evidence:github-commit": "merged-code",
+        "evidence:local-worktree": "worktree-snapshot",
+    }
+    assert "evidence:github-commit=merged" in decision.reason
+    assert "evidence:local-worktree=worktree-snapshot" in decision.reason
+
+
+def test_unknown_surface_still_fails_closed_through_runtime() -> None:
+    decision = resolve_authority(
+        ResolverInput(
+            question="Can an untyped dashboard surface decide authority?",
+            scope=_scope(),
+            conflict_type="surface-mismatch",
+            citations=[
+                EvidenceCitation(
+                    evidence_handle="evidence:dashboard",
+                    source_role="claimant",
+                    surface_type="dashboard-screenshot",
+                    reference="https://example.invalid/dashboard",
+                    claim="The dashboard says this is deployed.",
+                )
+            ],
+        )
+    )
+
+    assert decision.status == "unresolved"
+    assert decision.source_role_map == {
+        "evidence:dashboard": "unknown-surface",
+    }
+    assert "unknown surface type" in decision.reason
+
+
+def test_matching_claims_resolve_deterministically() -> None:
+    decision = resolve_authority(
+        ResolverInput(
+            question="Do the cited surfaces agree?",
+            scope=_scope(),
+            conflict_type="direct-conflict",
+            citations=[
+                EvidenceCitation(
+                    evidence_handle="evidence:main",
+                    source_role="merged-code",
+                    surface_type="merged",
+                    reference="git:abc123",
+                    claim="The resolver contract is present.",
+                ),
+                EvidenceCitation(
+                    evidence_handle="evidence:release",
+                    source_role="released-artifact",
+                    surface_type="released",
+                    reference="release:v1",
+                    claim="The resolver contract is present.",
+                ),
+            ],
+        )
+    )
+
+    assert decision.status == "resolved"
+    assert decision.confidence == 0.9
+    assert decision.reason == "All cited claims agree under the typed resolver input."

--- a/workflow/resolution/__init__.py
+++ b/workflow/resolution/__init__.py
@@ -18,6 +18,7 @@ from workflow.resolution.contracts import (
     guard_unknown_taxonomy,
     validate_decision_payload,
 )
+from workflow.resolution.resolver import resolve_authority
 
 __all__ = [
     "FIXTURE_LOCATION",
@@ -31,5 +32,6 @@ __all__ = [
     "ResolverDecision",
     "ResolverInput",
     "guard_unknown_taxonomy",
+    "resolve_authority",
     "validate_decision_payload",
 ]

--- a/workflow/resolution/resolver.py
+++ b/workflow/resolution/resolver.py
@@ -1,0 +1,101 @@
+"""Deterministic authority resolver runtime.
+
+The runtime is intentionally small: it turns typed resolver inputs into the
+frozen ``ResolverDecision`` contract without becoming a policy VM. Unknown
+taxonomy fails closed, surface mismatches are reframed with all claims kept,
+and direct claim conflicts remain structurally unresolved.
+"""
+
+from __future__ import annotations
+
+from workflow.resolution.contracts import (
+    ResolverDecision,
+    ResolverInput,
+    guard_unknown_taxonomy,
+)
+
+
+def resolve_authority(resolver_input: ResolverInput) -> ResolverDecision:
+    """Resolve a conflict input into the frozen authority-decision shape."""
+
+    taxonomy_guard = guard_unknown_taxonomy(resolver_input)
+    if taxonomy_guard is not None:
+        return taxonomy_guard
+
+    if resolver_input.conflict_type == "surface-mismatch":
+        return _resolve_surface_mismatch(resolver_input)
+
+    normalized_claims = {
+        _normalize_claim(citation.claim)
+        for citation in resolver_input.citations
+        if _normalize_claim(citation.claim)
+    }
+    if not normalized_claims:
+        return _needs_human_decision(
+            resolver_input,
+            "No cited claim text is available for deterministic comparison.",
+        )
+    if len(normalized_claims) == 1:
+        return ResolverDecision(
+            status="resolved",
+            confidence=0.9,
+            evidence_handles=_evidence_handles(resolver_input),
+            source_role_map=_source_role_map(resolver_input),
+            reason="All cited claims agree under the typed resolver input.",
+        )
+
+    return ResolverDecision(
+        status="unresolved",
+        confidence=0.0,
+        evidence_handles=_evidence_handles(resolver_input),
+        source_role_map=_source_role_map(resolver_input),
+        reason="Claims conflict and no resolver rule may force a winner.",
+    )
+
+
+def _resolve_surface_mismatch(resolver_input: ResolverInput) -> ResolverDecision:
+    surface_labels = ", ".join(
+        f"{citation.evidence_handle}={citation.surface_type}"
+        for citation in resolver_input.citations
+    )
+    return ResolverDecision(
+        status="resolved",
+        confidence=0.82,
+        evidence_handles=_evidence_handles(resolver_input),
+        source_role_map=_source_role_map(resolver_input),
+        reason=(
+            "Surface mismatch reframed; all claims preserved under typed "
+            f"surface labels: {surface_labels}."
+        ),
+    )
+
+
+def _needs_human_decision(
+    resolver_input: ResolverInput,
+    reason: str,
+) -> ResolverDecision:
+    return ResolverDecision(
+        status="needs-human-decision",
+        confidence=0.0,
+        evidence_handles=_evidence_handles(resolver_input),
+        source_role_map=_source_role_map(resolver_input),
+        reason=reason,
+    )
+
+
+def _evidence_handles(resolver_input: ResolverInput) -> list[str]:
+    return [citation.evidence_handle for citation in resolver_input.citations]
+
+
+def _source_role_map(resolver_input: ResolverInput) -> dict[str, str]:
+    return {
+        citation.evidence_handle: citation.source_role
+        for citation in resolver_input.citations
+    }
+
+
+def _normalize_claim(claim: str) -> str:
+    return " ".join(claim.casefold().split())
+
+
+__all__ = ["resolve_authority"]


### PR DESCRIPTION
## Summary
- adds the deterministic authority resolver runtime on top of the frozen resolver-decision contract
- preserves INV-1 by returning unresolved for constructed real conflicts instead of forcing a winner
- reframes typed surface mismatches while preserving all evidence handles and claim surfaces; unknown taxonomy still fails closed
- mirrors the runtime into the Claude plugin package

## Verification
- python -m pytest tests/test_resolution_contract.py tests/test_resolution_runtime.py tests/test_permission_decisions.py tests/test_knowledge_tag_matrix.py tests/test_retrieval.py tests/test_memory_scoping.py -q
- python -m ruff check workflow/resolution packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/resolution tests/test_resolution_runtime.py tests/test_resolution_contract.py tests/test_permission_decisions.py
- python -m scripts.invariants.mirror_parity
- python packaging\\claude-plugin\\build_plugin.py
- git diff --check HEAD~1..HEAD

## PR-139 gate
- Build-order step 7: CHILD-4 live authority resolver runtime
- Depends on slice 6, which is now merged/deployed as #1097 / 2212bee62a824ffeb69a022136b23665b2121150
- Standing host key applies; merge still requires Cowork/Claude-family checker key and green GitHub checks