### PR TITLE
PR-139 slice 8: derive action scopes from dispatch registries

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
@@ -231,6 +231,26 @@ ALLOWED_DEPENDENCIES = {
 # ───────────────────────────────────────────────────────────────────────────
 
 
+def _dispatch_scope_error(tool: str, action: str) -> str | None:
+    from workflow.auth.middleware import require_action_scope
+    from workflow.auth.provider import PermissionScope
+
+    try:
+        require_action_scope(
+            tool,
+            action,
+            scope=PermissionScope(resource_type="mcp-tool", resource_id=tool),
+        )
+    except PermissionError as exc:
+        return json.dumps({
+            "error": str(exc),
+            "auth_scope_required": True,
+            "tool": tool,
+            "action": action,
+        })
+    return None
+
+
 def _extensions_impl(
     action: str,
     node_id: str = "",
@@ -355,6 +375,15 @@ def _extensions_impl(
     chatbot-facing docstring. Behavior is identical; the decorator wrapper
     forwards every argument unchanged.
     """
+    if action == "get_action_scope_status":
+        from workflow.auth.provider import action_scope_audit
+
+        return json.dumps(action_scope_audit(), default=str)
+
+    scope_error = _dispatch_scope_error("extensions", action)
+    if scope_error is not None:
+        return scope_error
+
     if action == "register":
         return _ext_register(
             node_id, display_name, description, phase,
@@ -681,6 +710,7 @@ def _extensions_impl(
             "stream_run", "wait_for_run", "cancel_run", "get_run_output",
             "attach_existing_child_run",
             "resume_run", "estimate_run_cost", "query_runs",
+            "get_action_scope_status",
             "judge_run", "list_judgments", "compare_runs",
             "suggest_node_edit", "get_node_output",
             "rollback_node", "list_node_versions",

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
@@ -3132,6 +3132,27 @@ _GATES_ACTIONS: dict[str, Any] = {
 }
 
 
+def _gates_scope_error(action: str) -> str | None:
+    from workflow.auth.middleware import require_action_scope
+    from workflow.auth.provider import PermissionScope
+
+    try:
+        require_action_scope(
+            "gates",
+            action,
+            scope=PermissionScope(resource_type="outcome-gate", resource_id=action),
+        )
+    except PermissionError as exc:
+        return json.dumps({
+            "status": "rejected",
+            "error": str(exc),
+            "auth_scope_required": True,
+            "tool": "gates",
+            "action": action,
+        })
+    return None
+
+
 def gates(
     action: str,
     goal_id: str = "",
@@ -3254,6 +3275,9 @@ def gates(
             "error": f"Unknown action '{action}'.",
             "available_actions": sorted(_GATES_ACTIONS.keys()),
         })
+    scope_error = _gates_scope_error(action)
+    if scope_error is not None:
+        return scope_error
     kwargs: dict[str, Any] = {
         "goal_id": goal_id,
         "branch_def_id": branch_def_id,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -4311,6 +4311,82 @@ def _action_create_universe(
 # ───────────────────────────────────────────────────────────────────────────
 
 
+UNIVERSE_ACTIONS: dict[str, Any] = {
+    "list": _action_list_universes,
+    "inspect": _action_inspect_universe,
+    "read_output": _action_read_output,
+    "query_world": _action_query_world,
+    "get_activity": _action_get_activity,
+    "get_recent_events": _action_get_recent_events,
+    "get_ledger": _action_get_ledger,
+    "submit_request": _action_submit_request,
+    "give_direction": _action_give_direction,
+    "read_premise": _action_read_premise,
+    "set_premise": _action_set_premise,
+    "add_canon": _action_add_canon,
+    "add_canon_from_path": _action_add_canon_from_path,
+    "list_canon": _action_list_canon,
+    "read_canon": _action_read_canon,
+    "list_sources": _action_list_sources,
+    "read_source": _action_read_source,
+    "control_daemon": _action_control_daemon,
+    "switch_universe": _action_switch_universe,
+    "create_universe": _action_create_universe,
+    "queue_list": _action_queue_list,
+    "queue_cancel": _action_queue_cancel,
+    "subscribe_goal": _action_subscribe_goal,
+    "unsubscribe_goal": _action_unsubscribe_goal,
+    "list_subscriptions": _action_list_subscriptions,
+    "post_to_goal_pool": _action_post_to_goal_pool,
+    "submit_node_bid": _action_submit_node_bid,
+    "community_change_context": _action_community_change_context,
+    "daemon_overview": _action_daemon_overview,
+    "daemon_list": _action_daemon_list,
+    "daemon_get": _action_daemon_get,
+    "daemon_create": _action_daemon_create,
+    "daemon_summon": _action_daemon_summon,
+    "daemon_pause": _action_daemon_pause,
+    "daemon_resume": _action_daemon_resume,
+    "daemon_restart": _action_daemon_restart,
+    "daemon_banish": _action_daemon_banish,
+    "daemon_update_behavior": _action_daemon_update_behavior,
+    "daemon_control_status": _action_daemon_control_status,
+    "daemon_memory_capture": _action_daemon_memory_capture,
+    "daemon_memory_search": _action_daemon_memory_search,
+    "daemon_memory_list": _action_daemon_memory_list,
+    "daemon_memory_review": _action_daemon_memory_review,
+    "daemon_memory_promote": _action_daemon_memory_promote,
+    "daemon_memory_status": _action_daemon_memory_status,
+    "treasury_status": _action_treasury_status,
+    "set_tier_config": _action_set_tier_config,
+}
+
+
+def _dispatch_scope_error(
+    tool: str,
+    action: str,
+    *,
+    universe_id: str = "",
+) -> str | None:
+    from workflow.auth.middleware import require_action_scope
+    from workflow.auth.provider import PermissionScope
+
+    try:
+        require_action_scope(
+            tool,
+            action,
+            scope=PermissionScope(universe_id=universe_id),
+        )
+    except PermissionError as exc:
+        return json.dumps({
+            "error": str(exc),
+            "auth_scope_required": True,
+            "tool": tool,
+            "action": action,
+        })
+    return None
+
+
 def _universe_impl(
     action: str,
     universe_id: str = "",
@@ -4345,62 +4421,16 @@ def _universe_impl(
     chatbot-facing docstring. Behavior is identical; the decorator wrapper
     forwards every argument unchanged.
     """
-    dispatch = {
-        "list": _action_list_universes,
-        "inspect": _action_inspect_universe,
-        "read_output": _action_read_output,
-        "query_world": _action_query_world,
-        "get_activity": _action_get_activity,
-        "get_recent_events": _action_get_recent_events,
-        "get_ledger": _action_get_ledger,
-        "submit_request": _action_submit_request,
-        "give_direction": _action_give_direction,
-        "read_premise": _action_read_premise,
-        "set_premise": _action_set_premise,
-        "add_canon": _action_add_canon,
-        "add_canon_from_path": _action_add_canon_from_path,
-        "list_canon": _action_list_canon,
-        "read_canon": _action_read_canon,
-        "list_sources": _action_list_sources,
-        "read_source": _action_read_source,
-        "control_daemon": _action_control_daemon,
-        "switch_universe": _action_switch_universe,
-        "create_universe": _action_create_universe,
-        "queue_list": _action_queue_list,
-        "queue_cancel": _action_queue_cancel,
-        "subscribe_goal": _action_subscribe_goal,
-        "unsubscribe_goal": _action_unsubscribe_goal,
-        "list_subscriptions": _action_list_subscriptions,
-        "post_to_goal_pool": _action_post_to_goal_pool,
-        "submit_node_bid": _action_submit_node_bid,
-        "community_change_context": _action_community_change_context,
-        "daemon_overview": _action_daemon_overview,
-        "daemon_list": _action_daemon_list,
-        "daemon_get": _action_daemon_get,
-        "daemon_create": _action_daemon_create,
-        "daemon_summon": _action_daemon_summon,
-        "daemon_pause": _action_daemon_pause,
-        "daemon_resume": _action_daemon_resume,
-        "daemon_restart": _action_daemon_restart,
-        "daemon_banish": _action_daemon_banish,
-        "daemon_update_behavior": _action_daemon_update_behavior,
-        "daemon_control_status": _action_daemon_control_status,
-        "daemon_memory_capture": _action_daemon_memory_capture,
-        "daemon_memory_search": _action_daemon_memory_search,
-        "daemon_memory_list": _action_daemon_memory_list,
-        "daemon_memory_review": _action_daemon_memory_review,
-        "daemon_memory_promote": _action_daemon_memory_promote,
-        "daemon_memory_status": _action_daemon_memory_status,
-        "treasury_status": _action_treasury_status,
-        "set_tier_config": _action_set_tier_config,
-    }
-
+    dispatch = UNIVERSE_ACTIONS
     handler = dispatch.get(action)
     if handler is None:
         return json.dumps({
             "error": f"Unknown action '{action}'.",
             "available_actions": sorted(dispatch.keys()),
         })
+    scope_error = _dispatch_scope_error("universe", action, universe_id=universe_id)
+    if scope_error is not None:
+        return scope_error
 
     # Build kwargs from all optional params
     kwargs: dict[str, Any] = {

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -2134,6 +2134,57 @@ def _wiki_file_bug(
 # workflow/universe_server.py and delegates here (Pattern A2).
 # ---------------------------------------------------------------------------
 
+WIKI_ACTIONS: dict[str, Any] = {
+    "read": _wiki_read,
+    "search": _wiki_search,
+    "since": _wiki_since,
+    "list": _wiki_list,
+    "lint": _wiki_lint,
+    "write": _wiki_write,
+    "patch": _wiki_patch,
+    "delete": _wiki_delete,
+    "consolidate": _wiki_consolidate,
+    "promote": _wiki_promote,
+    "ingest": _wiki_ingest,
+    "supersede": _wiki_supersede,
+    "sync_projects": _wiki_sync_projects,
+    "file_bug": _wiki_file_bug,
+    "cosign_bug": _wiki_cosign_bug,
+}
+
+WIKI_WRITE_ACTIONS: frozenset[str] = frozenset({
+    "write",
+    "patch",
+    "delete",
+    "consolidate",
+    "promote",
+    "ingest",
+    "supersede",
+    "sync_projects",
+    "file_bug",
+    "cosign_bug",
+})
+
+
+def _dispatch_scope_error(tool: str, action: str) -> str | None:
+    from workflow.auth.middleware import require_action_scope
+    from workflow.auth.provider import PermissionScope
+
+    try:
+        require_action_scope(
+            tool,
+            action,
+            scope=PermissionScope(resource_type="wiki", resource_id=action),
+        )
+    except PermissionError as exc:
+        return json.dumps({
+            "error": str(exc),
+            "auth_scope_required": True,
+            "tool": tool,
+            "action": action,
+        })
+    return None
+
 
 def wiki(
     action: str,
@@ -2210,30 +2261,16 @@ def wiki(
             ),
         })
 
-    dispatch = {
-        "read": _wiki_read,
-        "search": _wiki_search,
-        "since": _wiki_since,
-        "list": _wiki_list,
-        "lint": _wiki_lint,
-        "write": _wiki_write,
-        "patch": _wiki_patch,
-        "delete": _wiki_delete,
-        "consolidate": _wiki_consolidate,
-        "promote": _wiki_promote,
-        "ingest": _wiki_ingest,
-        "supersede": _wiki_supersede,
-        "sync_projects": _wiki_sync_projects,
-        "file_bug": _wiki_file_bug,
-        "cosign_bug": _wiki_cosign_bug,
-    }
-
+    dispatch = WIKI_ACTIONS
     handler = dispatch.get(action)
     if handler is None:
         return json.dumps({
             "error": f"Unknown action '{action}'.",
             "available_actions": sorted(dispatch.keys()),
         })
+    scope_error = _dispatch_scope_error("wiki", action)
+    if scope_error is not None:
+        return scope_error
 
     kwargs: dict[str, Any] = {
         "page": page,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/__init__.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/__init__.py
@@ -15,8 +15,9 @@ Dev mode:
   No auth required. Set UNIVERSE_SERVER_AUTH=false (default).
 """
 
-from workflow.auth.middleware import auth_middleware, require_auth
+from workflow.auth.middleware import auth_middleware, require_action_scope, require_auth
 from workflow.auth.provider import (
+    ActionScopeMetadata,
     AuthProvider,
     DevAuthProvider,
     OAuthProvider,
@@ -24,10 +25,15 @@ from workflow.auth.provider import (
     PermissionContext,
     PermissionScope,
     PermissionVerdict,
+    action_scope_audit,
+    action_scope_for,
+    build_action_scope_registry,
+    supported_oauth_scopes,
 )
 from workflow.auth.wellknown import create_wellknown_routes
 
 __all__ = [
+    "ActionScopeMetadata",
     "AuthProvider",
     "DevAuthProvider",
     "OAuthProvider",
@@ -35,7 +41,12 @@ __all__ = [
     "PermissionContext",
     "PermissionScope",
     "PermissionVerdict",
+    "action_scope_audit",
+    "action_scope_for",
     "auth_middleware",
+    "build_action_scope_registry",
     "require_auth",
+    "require_action_scope",
+    "supported_oauth_scopes",
     "create_wellknown_routes",
 ]

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/middleware.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/middleware.py
@@ -22,6 +22,7 @@ from workflow.auth.provider import (
     PermissionAction,
     PermissionContext,
     PermissionScope,
+    action_scope_for,
     create_provider,
 )
 
@@ -117,4 +118,46 @@ def require_auth(
             f"(user={identity.username}, capabilities={identity.capabilities})"
         )
 
+    return identity
+
+
+def require_action_scope(
+    tool: str,
+    action: str,
+    *,
+    scope: PermissionScope | None = None,
+    context: PermissionContext | None = None,
+) -> Identity:
+    """Authorize one internal dispatch action against its named OAuth scope."""
+
+    identity = current_identity()
+    provider = _get_provider()
+    if not provider.is_auth_required():
+        return identity
+
+    metadata = action_scope_for(tool, action)
+    if metadata is None:
+        raise PermissionError(
+            f"No action-scope metadata for {tool}.{action}; refusing "
+            "authenticated dispatch."
+        )
+
+    if provider.is_auth_required() and identity.user_id == "anonymous":
+        raise PermissionError("Authentication required")
+
+    verdict = identity.can(
+        PermissionAction(
+            name=metadata.action_name,
+            cost_tier=metadata.cost_tier,
+            required_scope=metadata.oauth_scope,
+        ),
+        scope=scope,
+        context=context,
+    )
+    if not verdict.allowed:
+        raise PermissionError(
+            f"Missing OAuth scope: {verdict.required_scope} "
+            f"for action {metadata.action_name} "
+            f"(user={identity.username}, capabilities={identity.capabilities})"
+        )
     return identity

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/provider.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/provider.py
@@ -38,15 +38,48 @@ class PermissionAction:
 
     name: str
     cost_tier: str = "standard"
+    required_scope: str = ""
 
     def __post_init__(self) -> None:
         self.name = self.name.strip()
         self.cost_tier = self.cost_tier.strip() or "standard"
+        self.required_scope = self.required_scope.strip()
         if not self.name:
             raise ValueError("PermissionAction.name is required")
 
     def to_dict(self) -> dict[str, str]:
         return asdict(self)
+
+
+@dataclass(frozen=True)
+class ActionScopeMetadata:
+    """Named OAuth-scope metadata derived from an internal action registry."""
+
+    tool: str
+    action: str
+    oauth_scope: str
+    cost_tier: str
+    effect: str
+    source: str
+    checkpoint: str = "dispatch"
+    caveats: tuple[str, ...] = ()
+
+    @property
+    def action_name(self) -> str:
+        return f"{self.tool}.{self.action}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool": self.tool,
+            "action": self.action,
+            "action_name": self.action_name,
+            "oauth_scope": self.oauth_scope,
+            "cost_tier": self.cost_tier,
+            "effect": self.effect,
+            "source": self.source,
+            "checkpoint": self.checkpoint,
+            "caveats": list(self.caveats),
+        }
 
 
 @dataclass
@@ -97,6 +130,7 @@ class PermissionVerdict:
 
     allowed: bool
     action: str
+    required_scope: str
     scope: dict[str, Any]
     reason: str
     presented_grants: tuple[str, ...]
@@ -111,6 +145,7 @@ class PermissionVerdict:
         return {
             "allowed": self.allowed,
             "action": self.action,
+            "required_scope": self.required_scope,
             "scope": self.scope,
             "reason": self.reason,
             "presented_grants": list(self.presented_grants),
@@ -158,7 +193,8 @@ def resolve_permission(
             permission_context.presented_grants or tuple(grants)
         ) if grant.strip()})
     )
-    allowed = permission_action.name in presented_grants
+    required_scope = permission_action.required_scope or permission_action.name
+    allowed = required_scope in presented_grants
     resolver_decision = permission_context.resolver_decision
     evidence_handles = tuple(permission_context.external_evidence_handles)
     resolver_status = ""
@@ -173,6 +209,7 @@ def resolve_permission(
     return PermissionVerdict(
         allowed=allowed,
         action=permission_action.name,
+        required_scope=required_scope,
         scope=permission_scope.to_dict(),
         reason=reason,
         presented_grants=presented_grants,
@@ -210,6 +247,297 @@ class Identity:
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+
+_EFFECT_TO_SCOPE_SUFFIX: dict[str, str] = {
+    "read": "read",
+    "write": "write",
+    "costly": "costly",
+    "admin": "admin",
+}
+
+_EFFECT_TO_COST_TIER: dict[str, str] = {
+    "read": "free",
+    "write": "standard",
+    "costly": "costly",
+    "admin": "admin",
+}
+
+_EXTENSION_STANDALONE_ACTIONS = frozenset({
+    "register", "list", "inspect", "approve", "disable", "enable", "remove",
+    "get_action_scope_status",
+})
+_EXTENSION_STANDALONE_WRITE_ACTIONS = frozenset({
+    "register", "approve", "disable", "enable", "remove",
+})
+_UNIVERSE_COSTLY_ACTIONS = frozenset({
+    "create_universe",
+    "post_to_goal_pool",
+    "submit_node_bid",
+    "daemon_create",
+    "daemon_summon",
+    "daemon_memory_promote",
+})
+_UNIVERSE_ADMIN_ACTIONS = frozenset({
+    "control_daemon",
+    "set_tier_config",
+    "daemon_banish",
+    "daemon_pause",
+    "daemon_resume",
+    "daemon_restart",
+    "daemon_update_behavior",
+})
+_EXTENSIONS_COSTLY_ACTIONS = frozenset({
+    "run_branch",
+    "run_branch_version",
+    "resume_run",
+    "rollback_merge",
+    "rollback_node",
+    "open_auto_ship_pr",
+    "schedule_branch",
+    "subscribe_branch",
+    "escrow_lock",
+    "escrow_release",
+    "escrow_refund",
+    "record_outcome",
+    "record_remix",
+})
+_EXTENSIONS_ADMIN_ACTIONS = frozenset({
+    "delete_branch",
+    "cancel_run",
+    "grant_effector_consent",
+    "revoke_effector_consent",
+    "pause_schedule",
+    "unpause_schedule",
+    "unschedule_branch",
+})
+_GATES_COSTLY_ACTIONS = frozenset({
+    "claim",
+    "claim_from_branch_run",
+    "stake_bonus",
+    "release_bonus",
+})
+_GATES_ADMIN_ACTIONS = frozenset({
+    "define_ladder",
+    "retract",
+    "unstake_bonus",
+})
+
+
+def _metadata_for_action(
+    *,
+    tool: str,
+    action: str,
+    source: str,
+    write_actions: set[str] | frozenset[str],
+    costly_actions: set[str] | frozenset[str] = frozenset(),
+    admin_actions: set[str] | frozenset[str] = frozenset(),
+) -> ActionScopeMetadata:
+    if action in admin_actions:
+        effect = "admin"
+    elif action in costly_actions:
+        effect = "costly"
+    elif action in write_actions:
+        effect = "write"
+    else:
+        effect = "read"
+    return ActionScopeMetadata(
+        tool=tool,
+        action=action,
+        oauth_scope=f"workflow.{tool}.{_EFFECT_TO_SCOPE_SUFFIX[effect]}",
+        cost_tier=_EFFECT_TO_COST_TIER[effect],
+        effect=effect,
+        source=source,
+    )
+
+
+def _extend_scope_rows(
+    rows: list[ActionScopeMetadata],
+    *,
+    tool: str,
+    actions: set[str] | frozenset[str],
+    source: str,
+    write_actions: set[str] | frozenset[str],
+    costly_actions: set[str] | frozenset[str] = frozenset(),
+    admin_actions: set[str] | frozenset[str] = frozenset(),
+) -> None:
+    for action in sorted(actions):
+        rows.append(_metadata_for_action(
+            tool=tool,
+            action=action,
+            source=source,
+            write_actions=write_actions,
+            costly_actions=costly_actions,
+            admin_actions=admin_actions,
+        ))
+
+
+def build_action_scope_registry() -> dict[str, ActionScopeMetadata]:
+    """Derive action-scope metadata from internal MCP dispatch registries."""
+
+    rows: list[ActionScopeMetadata] = []
+
+    from workflow.api.auto_ship_actions import _AUTO_SHIP_ACTIONS
+    from workflow.api.branches import _BRANCH_ACTIONS, _BRANCH_WRITE_ACTIONS
+    from workflow.api.evaluation import (
+        _BRANCH_VERSION_ACTIONS,
+        _JUDGMENT_ACTIONS,
+        _JUDGMENT_WRITE_ACTIONS,
+    )
+    from workflow.api.extensions_consent_actions import _EFFECTOR_CONSENT_ACTIONS
+    from workflow.api.extensions_leaderboard_actions import _LEADERBOARD_ACTIONS
+    from workflow.api.market import (
+        _ATTRIBUTION_ACTIONS,
+        _ESCROW_ACTIONS,
+        _GATE_EVENT_ACTIONS,
+        _GATES_ACTIONS,
+        _OUTCOME_ACTIONS,
+    )
+    from workflow.api.runs import _RUN_ACTIONS, _RUN_WRITE_ACTIONS
+    from workflow.api.runtime_ops import (
+        _INSPECT_DRY_ACTIONS,
+        _MESSAGING_ACTIONS,
+        _PROJECT_MEMORY_ACTIONS,
+        _PROJECT_MEMORY_WRITE_ACTIONS,
+        _SCHEDULER_ACTIONS,
+    )
+    from workflow.api.universe import UNIVERSE_ACTIONS, WRITE_ACTIONS
+    from workflow.api.wiki import WIKI_ACTIONS, WIKI_WRITE_ACTIONS
+
+    _extend_scope_rows(
+        rows,
+        tool="universe",
+        actions=set(UNIVERSE_ACTIONS),
+        source="workflow.api.universe.UNIVERSE_ACTIONS",
+        write_actions=set(WRITE_ACTIONS),
+        costly_actions=_UNIVERSE_COSTLY_ACTIONS,
+        admin_actions=_UNIVERSE_ADMIN_ACTIONS,
+    )
+    _extend_scope_rows(
+        rows,
+        tool="wiki",
+        actions=set(WIKI_ACTIONS),
+        source="workflow.api.wiki.WIKI_ACTIONS",
+        write_actions=set(WIKI_WRITE_ACTIONS),
+    )
+
+    extension_actions: set[str] = set(_EXTENSION_STANDALONE_ACTIONS)
+    extension_writes: set[str] = set(_EXTENSION_STANDALONE_WRITE_ACTIONS)
+    for action_map in (
+        _BRANCH_ACTIONS,
+        _RUN_ACTIONS,
+        _JUDGMENT_ACTIONS,
+        _BRANCH_VERSION_ACTIONS,
+        _PROJECT_MEMORY_ACTIONS,
+        _MESSAGING_ACTIONS,
+        _ESCROW_ACTIONS,
+        _GATE_EVENT_ACTIONS,
+        _INSPECT_DRY_ACTIONS,
+        _AUTO_SHIP_ACTIONS,
+        _SCHEDULER_ACTIONS,
+        _OUTCOME_ACTIONS,
+        _EFFECTOR_CONSENT_ACTIONS,
+        _ATTRIBUTION_ACTIONS,
+        _LEADERBOARD_ACTIONS,
+    ):
+        extension_actions.update(action_map)
+    extension_writes.update(_BRANCH_WRITE_ACTIONS)
+    extension_writes.update(_RUN_WRITE_ACTIONS)
+    extension_writes.update(_JUDGMENT_WRITE_ACTIONS)
+    extension_writes.update({"publish_version"})
+    extension_writes.update(_PROJECT_MEMORY_WRITE_ACTIONS)
+    extension_writes.update({"messaging_send", "messaging_ack"})
+    extension_writes.update({"escrow_lock", "escrow_release", "escrow_refund"})
+    extension_writes.update({
+        "attest_gate_event", "verify_gate_event", "dispute_gate_event",
+        "retract_gate_event",
+    })
+    extension_writes.update({"open_auto_ship_pr"})
+    extension_writes.update({
+        "schedule_branch", "unschedule_branch", "subscribe_branch",
+        "unsubscribe_branch", "pause_schedule", "unpause_schedule",
+    })
+    extension_writes.update({"record_outcome", "record_remix"})
+    extension_writes.update({
+        "grant_effector_consent", "revoke_effector_consent",
+    })
+    _extend_scope_rows(
+        rows,
+        tool="extensions",
+        actions=extension_actions,
+        source="workflow.api.extensions internal dispatch tables",
+        write_actions=extension_writes,
+        costly_actions=_EXTENSIONS_COSTLY_ACTIONS,
+        admin_actions=_EXTENSIONS_ADMIN_ACTIONS,
+    )
+
+    gates_writes = {
+        "define_ladder",
+        "claim",
+        "claim_from_branch_run",
+        "retract",
+        "stake_bonus",
+        "unstake_bonus",
+        "release_bonus",
+    }
+    _extend_scope_rows(
+        rows,
+        tool="gates",
+        actions=set(_GATES_ACTIONS),
+        source="workflow.api.market._GATES_ACTIONS",
+        write_actions=gates_writes,
+        costly_actions=_GATES_COSTLY_ACTIONS,
+        admin_actions=_GATES_ADMIN_ACTIONS,
+    )
+
+    return {row.action_name: row for row in rows}
+
+
+def action_scope_for(tool: str, action: str) -> ActionScopeMetadata | None:
+    """Return the derived action-scope row for one MCP tool action."""
+
+    return build_action_scope_registry().get(f"{tool}.{action}")
+
+
+def supported_oauth_scopes() -> list[str]:
+    """Advertise named action scopes plus legacy coarse scopes."""
+
+    scopes = {row.oauth_scope for row in build_action_scope_registry().values()}
+    scopes.update({"read", "write", "admin"})
+    return sorted(scopes)
+
+
+def action_scope_audit() -> dict[str, Any]:
+    """Self-auditing read payload for CHILD-3 gradient scopes."""
+
+    registry = build_action_scope_registry()
+    rows = [row.to_dict() for row in registry.values()]
+    rows.sort(key=lambda item: (item["tool"], item["action"]))
+    return {
+        "schema_version": 1,
+        "source": "internal_dispatch_action_registries",
+        "scope_derivation": (
+            "Scopes are derived from server-side action dispatch tables and "
+            "write-action sets, not raw MCP tool schemas."
+        ),
+        "checkpoint_mode": (
+            "Dispatch checkpoints fail closed for missing named scopes when "
+            "auth is enabled; dev/no-auth mode bypasses grant enforcement."
+        ),
+        "oauth_scopes": supported_oauth_scopes(),
+        "actions": rows,
+        "counts": {
+            "actions": len(rows),
+            "oauth_scopes": len({row["oauth_scope"] for row in rows}),
+        },
+        "caveats": [
+            "Read/write/admin legacy OAuth scopes are still advertised for "
+            "older clients but are not the source of the derived table.",
+            "Argument-sensitive actions such as universe control_daemon are "
+            "classified at the action level; finer sub-action scoping can be "
+            "added by attaching metadata to that internal sub-dispatch.",
+        ],
+    }
 
 
 ANONYMOUS = Identity(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/wellknown.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/wellknown.py
@@ -44,6 +44,8 @@ def authorization_server_metadata() -> dict[str, Any]:
       - registration endpoint (for DCR)
     """
     base = _server_url()
+    from workflow.auth.provider import supported_oauth_scopes
+
     return {
         "issuer": base,
         "authorization_endpoint": f"{base}/oauth/authorize",
@@ -53,7 +55,7 @@ def authorization_server_metadata() -> dict[str, Any]:
         "grant_types_supported": ["authorization_code", "refresh_token"],
         "token_endpoint_auth_methods_supported": ["none"],
         "code_challenge_methods_supported": ["S256"],
-        "scopes_supported": ["read", "write", "admin"],
+        "scopes_supported": supported_oauth_scopes(),
         "service_documentation": f"{base}/docs",
     }
 
@@ -67,10 +69,12 @@ def protected_resource_metadata() -> dict[str, Any]:
     this resource, so they know where to start the auth flow.
     """
     base = _server_url()
+    from workflow.auth.provider import supported_oauth_scopes
+
     return {
         "resource": base,
         "authorization_servers": [base],
-        "scopes_supported": ["read", "write", "admin"],
+        "scopes_supported": supported_oauth_scopes(),
         "bearer_methods_supported": ["header"],
     }
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -601,7 +601,8 @@ def extensions(
 
     Core actions include build_branch, patch_branch, list_branches,
     describe_branch, get_branch, run_branch, get_run, wait_for_run,
-    judge_run, publish_version, schedule_branch, fork_tree, and search_nodes.
+    judge_run, publish_version, schedule_branch, fork_tree, search_nodes,
+    and get_action_scope_status for the derived action-to-OAuth-scope audit.
     Pass `action` plus the matching ids or JSON payload fields.
     Use `scope` with list_branches to filter the result:
     `"published"` (default) = only Branches that have a published version

--- a/tests/test_action_scopes.py
+++ b/tests/test_action_scopes.py
@@ -1,0 +1,148 @@
+"""PR-139 slice 8 action-scope registry and checkpoint tests."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from workflow.auth.middleware import auth_middleware, require_action_scope, set_provider
+from workflow.auth.provider import (
+    AuthProvider,
+    DevAuthProvider,
+    Identity,
+    PermissionAction,
+    build_action_scope_registry,
+)
+
+
+class StaticAuthProvider(AuthProvider):
+    def __init__(self, identity: Identity | None) -> None:
+        self.identity = identity
+
+    def resolve_token(self, token: str) -> Identity | None:
+        return self.identity if token == "ok" else None
+
+    def is_auth_required(self) -> bool:
+        return True
+
+    def register_client(self, metadata: dict[str, Any]) -> dict[str, Any]:
+        return {"client_id": "test-client", **metadata}
+
+    def create_authorization(
+        self,
+        client_id: str,
+        redirect_uri: str,
+        scope: str,
+        state: str,
+        code_challenge: str,
+        code_challenge_method: str,
+    ) -> str:
+        return "test-code"
+
+    def exchange_code(
+        self,
+        code: str,
+        client_id: str,
+        redirect_uri: str,
+        code_verifier: str,
+    ) -> dict[str, Any] | None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _reset_auth_provider() -> None:
+    set_provider(DevAuthProvider())
+    auth_middleware(None)
+    yield
+    set_provider(DevAuthProvider())
+    auth_middleware(None)
+
+
+def test_action_scope_registry_is_derived_from_internal_dispatch_tables() -> None:
+    registry = build_action_scope_registry()
+
+    assert registry["universe.inspect"].oauth_scope == "workflow.universe.read"
+    assert registry["universe.inspect"].effect == "read"
+    assert "UNIVERSE_ACTIONS" in registry["universe.inspect"].source
+
+    assert registry["universe.daemon_banish"].oauth_scope == "workflow.universe.admin"
+    assert registry["universe.daemon_banish"].effect == "admin"
+
+    assert registry["wiki.read"].oauth_scope == "workflow.wiki.read"
+    assert registry["wiki.write"].oauth_scope == "workflow.wiki.write"
+
+    assert registry["extensions.run_branch"].oauth_scope == "workflow.extensions.costly"
+    assert registry["gates.list"].oauth_scope == "workflow.gates.read"
+
+    assert all("schema" not in row.source.lower() for row in registry.values())
+
+
+def test_action_scope_status_self_audit_reports_table_and_caveats() -> None:
+    from workflow.api.extensions import _extensions_impl
+
+    payload = json.loads(_extensions_impl(action="get_action_scope_status"))
+
+    assert payload["source"] == "internal_dispatch_action_registries"
+    assert "not raw MCP tool schemas" in payload["scope_derivation"]
+    assert "workflow.universe.admin" in payload["oauth_scopes"]
+    assert payload["counts"]["actions"] >= 80
+    assert any(
+        row["action_name"] == "universe.daemon_banish"
+        and row["oauth_scope"] == "workflow.universe.admin"
+        for row in payload["actions"]
+    )
+    assert payload["caveats"]
+
+
+def test_permission_action_requires_named_scope_when_present() -> None:
+    identity = Identity(
+        user_id="user::operator",
+        username="operator",
+        capabilities=["workflow.universe.write"],
+    )
+
+    verdict = identity.can(
+        PermissionAction(
+            name="universe.submit_request",
+            required_scope="workflow.universe.write",
+        )
+    )
+    assert verdict.allowed is True
+    assert verdict.required_scope == "workflow.universe.write"
+
+    legacy_only = Identity(
+        user_id="user::legacy",
+        username="legacy",
+        capabilities=["universe.submit_request"],
+    )
+    assert legacy_only.can(
+        PermissionAction(
+            name="universe.submit_request",
+            required_scope="workflow.universe.write",
+        )
+    ).allowed is False
+
+
+def test_action_scope_checkpoint_enforces_only_when_auth_is_enabled() -> None:
+    set_provider(StaticAuthProvider(Identity(
+        user_id="user::operator",
+        username="operator",
+        capabilities=["workflow.universe.admin"],
+    )))
+    auth_middleware("ok")
+    require_action_scope("universe", "daemon_banish")
+
+    set_provider(StaticAuthProvider(Identity(
+        user_id="user::reader",
+        username="reader",
+        capabilities=["workflow.universe.read"],
+    )))
+    auth_middleware("ok")
+    with pytest.raises(PermissionError, match="workflow.universe.admin"):
+        require_action_scope("universe", "daemon_banish")
+
+    set_provider(DevAuthProvider())
+    auth_middleware(None)
+    require_action_scope("universe", "daemon_banish")

--- a/workflow/api/extensions.py
+++ b/workflow/api/extensions.py
@@ -231,6 +231,26 @@ ALLOWED_DEPENDENCIES = {
 # ───────────────────────────────────────────────────────────────────────────
 
 
+def _dispatch_scope_error(tool: str, action: str) -> str | None:
+    from workflow.auth.middleware import require_action_scope
+    from workflow.auth.provider import PermissionScope
+
+    try:
+        require_action_scope(
+            tool,
+            action,
+            scope=PermissionScope(resource_type="mcp-tool", resource_id=tool),
+        )
+    except PermissionError as exc:
+        return json.dumps({
+            "error": str(exc),
+            "auth_scope_required": True,
+            "tool": tool,
+            "action": action,
+        })
+    return None
+
+
 def _extensions_impl(
     action: str,
     node_id: str = "",
@@ -355,6 +375,15 @@ def _extensions_impl(
     chatbot-facing docstring. Behavior is identical; the decorator wrapper
     forwards every argument unchanged.
     """
+    if action == "get_action_scope_status":
+        from workflow.auth.provider import action_scope_audit
+
+        return json.dumps(action_scope_audit(), default=str)
+
+    scope_error = _dispatch_scope_error("extensions", action)
+    if scope_error is not None:
+        return scope_error
+
     if action == "register":
         return _ext_register(
             node_id, display_name, description, phase,
@@ -681,6 +710,7 @@ def _extensions_impl(
             "stream_run", "wait_for_run", "cancel_run", "get_run_output",
             "attach_existing_child_run",
             "resume_run", "estimate_run_cost", "query_runs",
+            "get_action_scope_status",
             "judge_run", "list_judgments", "compare_runs",
             "suggest_node_edit", "get_node_output",
             "rollback_node", "list_node_versions",

--- a/workflow/api/market.py
+++ b/workflow/api/market.py
@@ -3132,6 +3132,27 @@ _GATES_ACTIONS: dict[str, Any] = {
 }
 
 
+def _gates_scope_error(action: str) -> str | None:
+    from workflow.auth.middleware import require_action_scope
+    from workflow.auth.provider import PermissionScope
+
+    try:
+        require_action_scope(
+            "gates",
+            action,
+            scope=PermissionScope(resource_type="outcome-gate", resource_id=action),
+        )
+    except PermissionError as exc:
+        return json.dumps({
+            "status": "rejected",
+            "error": str(exc),
+            "auth_scope_required": True,
+            "tool": "gates",
+            "action": action,
+        })
+    return None
+
+
 def gates(
     action: str,
     goal_id: str = "",
@@ -3254,6 +3275,9 @@ def gates(
             "error": f"Unknown action '{action}'.",
             "available_actions": sorted(_GATES_ACTIONS.keys()),
         })
+    scope_error = _gates_scope_error(action)
+    if scope_error is not None:
+        return scope_error
     kwargs: dict[str, Any] = {
         "goal_id": goal_id,
         "branch_def_id": branch_def_id,

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -4311,6 +4311,82 @@ def _action_create_universe(
 # ───────────────────────────────────────────────────────────────────────────
 
 
+UNIVERSE_ACTIONS: dict[str, Any] = {
+    "list": _action_list_universes,
+    "inspect": _action_inspect_universe,
+    "read_output": _action_read_output,
+    "query_world": _action_query_world,
+    "get_activity": _action_get_activity,
+    "get_recent_events": _action_get_recent_events,
+    "get_ledger": _action_get_ledger,
+    "submit_request": _action_submit_request,
+    "give_direction": _action_give_direction,
+    "read_premise": _action_read_premise,
+    "set_premise": _action_set_premise,
+    "add_canon": _action_add_canon,
+    "add_canon_from_path": _action_add_canon_from_path,
+    "list_canon": _action_list_canon,
+    "read_canon": _action_read_canon,
+    "list_sources": _action_list_sources,
+    "read_source": _action_read_source,
+    "control_daemon": _action_control_daemon,
+    "switch_universe": _action_switch_universe,
+    "create_universe": _action_create_universe,
+    "queue_list": _action_queue_list,
+    "queue_cancel": _action_queue_cancel,
+    "subscribe_goal": _action_subscribe_goal,
+    "unsubscribe_goal": _action_unsubscribe_goal,
+    "list_subscriptions": _action_list_subscriptions,
+    "post_to_goal_pool": _action_post_to_goal_pool,
+    "submit_node_bid": _action_submit_node_bid,
+    "community_change_context": _action_community_change_context,
+    "daemon_overview": _action_daemon_overview,
+    "daemon_list": _action_daemon_list,
+    "daemon_get": _action_daemon_get,
+    "daemon_create": _action_daemon_create,
+    "daemon_summon": _action_daemon_summon,
+    "daemon_pause": _action_daemon_pause,
+    "daemon_resume": _action_daemon_resume,
+    "daemon_restart": _action_daemon_restart,
+    "daemon_banish": _action_daemon_banish,
+    "daemon_update_behavior": _action_daemon_update_behavior,
+    "daemon_control_status": _action_daemon_control_status,
+    "daemon_memory_capture": _action_daemon_memory_capture,
+    "daemon_memory_search": _action_daemon_memory_search,
+    "daemon_memory_list": _action_daemon_memory_list,
+    "daemon_memory_review": _action_daemon_memory_review,
+    "daemon_memory_promote": _action_daemon_memory_promote,
+    "daemon_memory_status": _action_daemon_memory_status,
+    "treasury_status": _action_treasury_status,
+    "set_tier_config": _action_set_tier_config,
+}
+
+
+def _dispatch_scope_error(
+    tool: str,
+    action: str,
+    *,
+    universe_id: str = "",
+) -> str | None:
+    from workflow.auth.middleware import require_action_scope
+    from workflow.auth.provider import PermissionScope
+
+    try:
+        require_action_scope(
+            tool,
+            action,
+            scope=PermissionScope(universe_id=universe_id),
+        )
+    except PermissionError as exc:
+        return json.dumps({
+            "error": str(exc),
+            "auth_scope_required": True,
+            "tool": tool,
+            "action": action,
+        })
+    return None
+
+
 def _universe_impl(
     action: str,
     universe_id: str = "",
@@ -4345,62 +4421,16 @@ def _universe_impl(
     chatbot-facing docstring. Behavior is identical; the decorator wrapper
     forwards every argument unchanged.
     """
-    dispatch = {
-        "list": _action_list_universes,
-        "inspect": _action_inspect_universe,
-        "read_output": _action_read_output,
-        "query_world": _action_query_world,
-        "get_activity": _action_get_activity,
-        "get_recent_events": _action_get_recent_events,
-        "get_ledger": _action_get_ledger,
-        "submit_request": _action_submit_request,
-        "give_direction": _action_give_direction,
-        "read_premise": _action_read_premise,
-        "set_premise": _action_set_premise,
-        "add_canon": _action_add_canon,
-        "add_canon_from_path": _action_add_canon_from_path,
-        "list_canon": _action_list_canon,
-        "read_canon": _action_read_canon,
-        "list_sources": _action_list_sources,
-        "read_source": _action_read_source,
-        "control_daemon": _action_control_daemon,
-        "switch_universe": _action_switch_universe,
-        "create_universe": _action_create_universe,
-        "queue_list": _action_queue_list,
-        "queue_cancel": _action_queue_cancel,
-        "subscribe_goal": _action_subscribe_goal,
-        "unsubscribe_goal": _action_unsubscribe_goal,
-        "list_subscriptions": _action_list_subscriptions,
-        "post_to_goal_pool": _action_post_to_goal_pool,
-        "submit_node_bid": _action_submit_node_bid,
-        "community_change_context": _action_community_change_context,
-        "daemon_overview": _action_daemon_overview,
-        "daemon_list": _action_daemon_list,
-        "daemon_get": _action_daemon_get,
-        "daemon_create": _action_daemon_create,
-        "daemon_summon": _action_daemon_summon,
-        "daemon_pause": _action_daemon_pause,
-        "daemon_resume": _action_daemon_resume,
-        "daemon_restart": _action_daemon_restart,
-        "daemon_banish": _action_daemon_banish,
-        "daemon_update_behavior": _action_daemon_update_behavior,
-        "daemon_control_status": _action_daemon_control_status,
-        "daemon_memory_capture": _action_daemon_memory_capture,
-        "daemon_memory_search": _action_daemon_memory_search,
-        "daemon_memory_list": _action_daemon_memory_list,
-        "daemon_memory_review": _action_daemon_memory_review,
-        "daemon_memory_promote": _action_daemon_memory_promote,
-        "daemon_memory_status": _action_daemon_memory_status,
-        "treasury_status": _action_treasury_status,
-        "set_tier_config": _action_set_tier_config,
-    }
-
+    dispatch = UNIVERSE_ACTIONS
     handler = dispatch.get(action)
     if handler is None:
         return json.dumps({
             "error": f"Unknown action '{action}'.",
             "available_actions": sorted(dispatch.keys()),
         })
+    scope_error = _dispatch_scope_error("universe", action, universe_id=universe_id)
+    if scope_error is not None:
+        return scope_error
 
     # Build kwargs from all optional params
     kwargs: dict[str, Any] = {

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -2134,6 +2134,57 @@ def _wiki_file_bug(
 # workflow/universe_server.py and delegates here (Pattern A2).
 # ---------------------------------------------------------------------------
 
+WIKI_ACTIONS: dict[str, Any] = {
+    "read": _wiki_read,
+    "search": _wiki_search,
+    "since": _wiki_since,
+    "list": _wiki_list,
+    "lint": _wiki_lint,
+    "write": _wiki_write,
+    "patch": _wiki_patch,
+    "delete": _wiki_delete,
+    "consolidate": _wiki_consolidate,
+    "promote": _wiki_promote,
+    "ingest": _wiki_ingest,
+    "supersede": _wiki_supersede,
+    "sync_projects": _wiki_sync_projects,
+    "file_bug": _wiki_file_bug,
+    "cosign_bug": _wiki_cosign_bug,
+}
+
+WIKI_WRITE_ACTIONS: frozenset[str] = frozenset({
+    "write",
+    "patch",
+    "delete",
+    "consolidate",
+    "promote",
+    "ingest",
+    "supersede",
+    "sync_projects",
+    "file_bug",
+    "cosign_bug",
+})
+
+
+def _dispatch_scope_error(tool: str, action: str) -> str | None:
+    from workflow.auth.middleware import require_action_scope
+    from workflow.auth.provider import PermissionScope
+
+    try:
+        require_action_scope(
+            tool,
+            action,
+            scope=PermissionScope(resource_type="wiki", resource_id=action),
+        )
+    except PermissionError as exc:
+        return json.dumps({
+            "error": str(exc),
+            "auth_scope_required": True,
+            "tool": tool,
+            "action": action,
+        })
+    return None
+
 
 def wiki(
     action: str,
@@ -2210,30 +2261,16 @@ def wiki(
             ),
         })
 
-    dispatch = {
-        "read": _wiki_read,
-        "search": _wiki_search,
-        "since": _wiki_since,
-        "list": _wiki_list,
-        "lint": _wiki_lint,
-        "write": _wiki_write,
-        "patch": _wiki_patch,
-        "delete": _wiki_delete,
-        "consolidate": _wiki_consolidate,
-        "promote": _wiki_promote,
-        "ingest": _wiki_ingest,
-        "supersede": _wiki_supersede,
-        "sync_projects": _wiki_sync_projects,
-        "file_bug": _wiki_file_bug,
-        "cosign_bug": _wiki_cosign_bug,
-    }
-
+    dispatch = WIKI_ACTIONS
     handler = dispatch.get(action)
     if handler is None:
         return json.dumps({
             "error": f"Unknown action '{action}'.",
             "available_actions": sorted(dispatch.keys()),
         })
+    scope_error = _dispatch_scope_error("wiki", action)
+    if scope_error is not None:
+        return scope_error
 
     kwargs: dict[str, Any] = {
         "page": page,

--- a/workflow/auth/__init__.py
+++ b/workflow/auth/__init__.py
@@ -15,8 +15,9 @@ Dev mode:
   No auth required. Set UNIVERSE_SERVER_AUTH=false (default).
 """
 
-from workflow.auth.middleware import auth_middleware, require_auth
+from workflow.auth.middleware import auth_middleware, require_action_scope, require_auth
 from workflow.auth.provider import (
+    ActionScopeMetadata,
     AuthProvider,
     DevAuthProvider,
     OAuthProvider,
@@ -24,10 +25,15 @@ from workflow.auth.provider import (
     PermissionContext,
     PermissionScope,
     PermissionVerdict,
+    action_scope_audit,
+    action_scope_for,
+    build_action_scope_registry,
+    supported_oauth_scopes,
 )
 from workflow.auth.wellknown import create_wellknown_routes
 
 __all__ = [
+    "ActionScopeMetadata",
     "AuthProvider",
     "DevAuthProvider",
     "OAuthProvider",
@@ -35,7 +41,12 @@ __all__ = [
     "PermissionContext",
     "PermissionScope",
     "PermissionVerdict",
+    "action_scope_audit",
+    "action_scope_for",
     "auth_middleware",
+    "build_action_scope_registry",
     "require_auth",
+    "require_action_scope",
+    "supported_oauth_scopes",
     "create_wellknown_routes",
 ]

--- a/workflow/auth/middleware.py
+++ b/workflow/auth/middleware.py
@@ -22,6 +22,7 @@ from workflow.auth.provider import (
     PermissionAction,
     PermissionContext,
     PermissionScope,
+    action_scope_for,
     create_provider,
 )
 
@@ -117,4 +118,46 @@ def require_auth(
             f"(user={identity.username}, capabilities={identity.capabilities})"
         )
 
+    return identity
+
+
+def require_action_scope(
+    tool: str,
+    action: str,
+    *,
+    scope: PermissionScope | None = None,
+    context: PermissionContext | None = None,
+) -> Identity:
+    """Authorize one internal dispatch action against its named OAuth scope."""
+
+    identity = current_identity()
+    provider = _get_provider()
+    if not provider.is_auth_required():
+        return identity
+
+    metadata = action_scope_for(tool, action)
+    if metadata is None:
+        raise PermissionError(
+            f"No action-scope metadata for {tool}.{action}; refusing "
+            "authenticated dispatch."
+        )
+
+    if provider.is_auth_required() and identity.user_id == "anonymous":
+        raise PermissionError("Authentication required")
+
+    verdict = identity.can(
+        PermissionAction(
+            name=metadata.action_name,
+            cost_tier=metadata.cost_tier,
+            required_scope=metadata.oauth_scope,
+        ),
+        scope=scope,
+        context=context,
+    )
+    if not verdict.allowed:
+        raise PermissionError(
+            f"Missing OAuth scope: {verdict.required_scope} "
+            f"for action {metadata.action_name} "
+            f"(user={identity.username}, capabilities={identity.capabilities})"
+        )
     return identity

--- a/workflow/auth/provider.py
+++ b/workflow/auth/provider.py
@@ -38,15 +38,48 @@ class PermissionAction:
 
     name: str
     cost_tier: str = "standard"
+    required_scope: str = ""
 
     def __post_init__(self) -> None:
         self.name = self.name.strip()
         self.cost_tier = self.cost_tier.strip() or "standard"
+        self.required_scope = self.required_scope.strip()
         if not self.name:
             raise ValueError("PermissionAction.name is required")
 
     def to_dict(self) -> dict[str, str]:
         return asdict(self)
+
+
+@dataclass(frozen=True)
+class ActionScopeMetadata:
+    """Named OAuth-scope metadata derived from an internal action registry."""
+
+    tool: str
+    action: str
+    oauth_scope: str
+    cost_tier: str
+    effect: str
+    source: str
+    checkpoint: str = "dispatch"
+    caveats: tuple[str, ...] = ()
+
+    @property
+    def action_name(self) -> str:
+        return f"{self.tool}.{self.action}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool": self.tool,
+            "action": self.action,
+            "action_name": self.action_name,
+            "oauth_scope": self.oauth_scope,
+            "cost_tier": self.cost_tier,
+            "effect": self.effect,
+            "source": self.source,
+            "checkpoint": self.checkpoint,
+            "caveats": list(self.caveats),
+        }
 
 
 @dataclass
@@ -97,6 +130,7 @@ class PermissionVerdict:
 
     allowed: bool
     action: str
+    required_scope: str
     scope: dict[str, Any]
     reason: str
     presented_grants: tuple[str, ...]
@@ -111,6 +145,7 @@ class PermissionVerdict:
         return {
             "allowed": self.allowed,
             "action": self.action,
+            "required_scope": self.required_scope,
             "scope": self.scope,
             "reason": self.reason,
             "presented_grants": list(self.presented_grants),
@@ -158,7 +193,8 @@ def resolve_permission(
             permission_context.presented_grants or tuple(grants)
         ) if grant.strip()})
     )
-    allowed = permission_action.name in presented_grants
+    required_scope = permission_action.required_scope or permission_action.name
+    allowed = required_scope in presented_grants
     resolver_decision = permission_context.resolver_decision
     evidence_handles = tuple(permission_context.external_evidence_handles)
     resolver_status = ""
@@ -173,6 +209,7 @@ def resolve_permission(
     return PermissionVerdict(
         allowed=allowed,
         action=permission_action.name,
+        required_scope=required_scope,
         scope=permission_scope.to_dict(),
         reason=reason,
         presented_grants=presented_grants,
@@ -210,6 +247,297 @@ class Identity:
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+
+_EFFECT_TO_SCOPE_SUFFIX: dict[str, str] = {
+    "read": "read",
+    "write": "write",
+    "costly": "costly",
+    "admin": "admin",
+}
+
+_EFFECT_TO_COST_TIER: dict[str, str] = {
+    "read": "free",
+    "write": "standard",
+    "costly": "costly",
+    "admin": "admin",
+}
+
+_EXTENSION_STANDALONE_ACTIONS = frozenset({
+    "register", "list", "inspect", "approve", "disable", "enable", "remove",
+    "get_action_scope_status",
+})
+_EXTENSION_STANDALONE_WRITE_ACTIONS = frozenset({
+    "register", "approve", "disable", "enable", "remove",
+})
+_UNIVERSE_COSTLY_ACTIONS = frozenset({
+    "create_universe",
+    "post_to_goal_pool",
+    "submit_node_bid",
+    "daemon_create",
+    "daemon_summon",
+    "daemon_memory_promote",
+})
+_UNIVERSE_ADMIN_ACTIONS = frozenset({
+    "control_daemon",
+    "set_tier_config",
+    "daemon_banish",
+    "daemon_pause",
+    "daemon_resume",
+    "daemon_restart",
+    "daemon_update_behavior",
+})
+_EXTENSIONS_COSTLY_ACTIONS = frozenset({
+    "run_branch",
+    "run_branch_version",
+    "resume_run",
+    "rollback_merge",
+    "rollback_node",
+    "open_auto_ship_pr",
+    "schedule_branch",
+    "subscribe_branch",
+    "escrow_lock",
+    "escrow_release",
+    "escrow_refund",
+    "record_outcome",
+    "record_remix",
+})
+_EXTENSIONS_ADMIN_ACTIONS = frozenset({
+    "delete_branch",
+    "cancel_run",
+    "grant_effector_consent",
+    "revoke_effector_consent",
+    "pause_schedule",
+    "unpause_schedule",
+    "unschedule_branch",
+})
+_GATES_COSTLY_ACTIONS = frozenset({
+    "claim",
+    "claim_from_branch_run",
+    "stake_bonus",
+    "release_bonus",
+})
+_GATES_ADMIN_ACTIONS = frozenset({
+    "define_ladder",
+    "retract",
+    "unstake_bonus",
+})
+
+
+def _metadata_for_action(
+    *,
+    tool: str,
+    action: str,
+    source: str,
+    write_actions: set[str] | frozenset[str],
+    costly_actions: set[str] | frozenset[str] = frozenset(),
+    admin_actions: set[str] | frozenset[str] = frozenset(),
+) -> ActionScopeMetadata:
+    if action in admin_actions:
+        effect = "admin"
+    elif action in costly_actions:
+        effect = "costly"
+    elif action in write_actions:
+        effect = "write"
+    else:
+        effect = "read"
+    return ActionScopeMetadata(
+        tool=tool,
+        action=action,
+        oauth_scope=f"workflow.{tool}.{_EFFECT_TO_SCOPE_SUFFIX[effect]}",
+        cost_tier=_EFFECT_TO_COST_TIER[effect],
+        effect=effect,
+        source=source,
+    )
+
+
+def _extend_scope_rows(
+    rows: list[ActionScopeMetadata],
+    *,
+    tool: str,
+    actions: set[str] | frozenset[str],
+    source: str,
+    write_actions: set[str] | frozenset[str],
+    costly_actions: set[str] | frozenset[str] = frozenset(),
+    admin_actions: set[str] | frozenset[str] = frozenset(),
+) -> None:
+    for action in sorted(actions):
+        rows.append(_metadata_for_action(
+            tool=tool,
+            action=action,
+            source=source,
+            write_actions=write_actions,
+            costly_actions=costly_actions,
+            admin_actions=admin_actions,
+        ))
+
+
+def build_action_scope_registry() -> dict[str, ActionScopeMetadata]:
+    """Derive action-scope metadata from internal MCP dispatch registries."""
+
+    rows: list[ActionScopeMetadata] = []
+
+    from workflow.api.auto_ship_actions import _AUTO_SHIP_ACTIONS
+    from workflow.api.branches import _BRANCH_ACTIONS, _BRANCH_WRITE_ACTIONS
+    from workflow.api.evaluation import (
+        _BRANCH_VERSION_ACTIONS,
+        _JUDGMENT_ACTIONS,
+        _JUDGMENT_WRITE_ACTIONS,
+    )
+    from workflow.api.extensions_consent_actions import _EFFECTOR_CONSENT_ACTIONS
+    from workflow.api.extensions_leaderboard_actions import _LEADERBOARD_ACTIONS
+    from workflow.api.market import (
+        _ATTRIBUTION_ACTIONS,
+        _ESCROW_ACTIONS,
+        _GATE_EVENT_ACTIONS,
+        _GATES_ACTIONS,
+        _OUTCOME_ACTIONS,
+    )
+    from workflow.api.runs import _RUN_ACTIONS, _RUN_WRITE_ACTIONS
+    from workflow.api.runtime_ops import (
+        _INSPECT_DRY_ACTIONS,
+        _MESSAGING_ACTIONS,
+        _PROJECT_MEMORY_ACTIONS,
+        _PROJECT_MEMORY_WRITE_ACTIONS,
+        _SCHEDULER_ACTIONS,
+    )
+    from workflow.api.universe import UNIVERSE_ACTIONS, WRITE_ACTIONS
+    from workflow.api.wiki import WIKI_ACTIONS, WIKI_WRITE_ACTIONS
+
+    _extend_scope_rows(
+        rows,
+        tool="universe",
+        actions=set(UNIVERSE_ACTIONS),
+        source="workflow.api.universe.UNIVERSE_ACTIONS",
+        write_actions=set(WRITE_ACTIONS),
+        costly_actions=_UNIVERSE_COSTLY_ACTIONS,
+        admin_actions=_UNIVERSE_ADMIN_ACTIONS,
+    )
+    _extend_scope_rows(
+        rows,
+        tool="wiki",
+        actions=set(WIKI_ACTIONS),
+        source="workflow.api.wiki.WIKI_ACTIONS",
+        write_actions=set(WIKI_WRITE_ACTIONS),
+    )
+
+    extension_actions: set[str] = set(_EXTENSION_STANDALONE_ACTIONS)
+    extension_writes: set[str] = set(_EXTENSION_STANDALONE_WRITE_ACTIONS)
+    for action_map in (
+        _BRANCH_ACTIONS,
+        _RUN_ACTIONS,
+        _JUDGMENT_ACTIONS,
+        _BRANCH_VERSION_ACTIONS,
+        _PROJECT_MEMORY_ACTIONS,
+        _MESSAGING_ACTIONS,
+        _ESCROW_ACTIONS,
+        _GATE_EVENT_ACTIONS,
+        _INSPECT_DRY_ACTIONS,
+        _AUTO_SHIP_ACTIONS,
+        _SCHEDULER_ACTIONS,
+        _OUTCOME_ACTIONS,
+        _EFFECTOR_CONSENT_ACTIONS,
+        _ATTRIBUTION_ACTIONS,
+        _LEADERBOARD_ACTIONS,
+    ):
+        extension_actions.update(action_map)
+    extension_writes.update(_BRANCH_WRITE_ACTIONS)
+    extension_writes.update(_RUN_WRITE_ACTIONS)
+    extension_writes.update(_JUDGMENT_WRITE_ACTIONS)
+    extension_writes.update({"publish_version"})
+    extension_writes.update(_PROJECT_MEMORY_WRITE_ACTIONS)
+    extension_writes.update({"messaging_send", "messaging_ack"})
+    extension_writes.update({"escrow_lock", "escrow_release", "escrow_refund"})
+    extension_writes.update({
+        "attest_gate_event", "verify_gate_event", "dispute_gate_event",
+        "retract_gate_event",
+    })
+    extension_writes.update({"open_auto_ship_pr"})
+    extension_writes.update({
+        "schedule_branch", "unschedule_branch", "subscribe_branch",
+        "unsubscribe_branch", "pause_schedule", "unpause_schedule",
+    })
+    extension_writes.update({"record_outcome", "record_remix"})
+    extension_writes.update({
+        "grant_effector_consent", "revoke_effector_consent",
+    })
+    _extend_scope_rows(
+        rows,
+        tool="extensions",
+        actions=extension_actions,
+        source="workflow.api.extensions internal dispatch tables",
+        write_actions=extension_writes,
+        costly_actions=_EXTENSIONS_COSTLY_ACTIONS,
+        admin_actions=_EXTENSIONS_ADMIN_ACTIONS,
+    )
+
+    gates_writes = {
+        "define_ladder",
+        "claim",
+        "claim_from_branch_run",
+        "retract",
+        "stake_bonus",
+        "unstake_bonus",
+        "release_bonus",
+    }
+    _extend_scope_rows(
+        rows,
+        tool="gates",
+        actions=set(_GATES_ACTIONS),
+        source="workflow.api.market._GATES_ACTIONS",
+        write_actions=gates_writes,
+        costly_actions=_GATES_COSTLY_ACTIONS,
+        admin_actions=_GATES_ADMIN_ACTIONS,
+    )
+
+    return {row.action_name: row for row in rows}
+
+
+def action_scope_for(tool: str, action: str) -> ActionScopeMetadata | None:
+    """Return the derived action-scope row for one MCP tool action."""
+
+    return build_action_scope_registry().get(f"{tool}.{action}")
+
+
+def supported_oauth_scopes() -> list[str]:
+    """Advertise named action scopes plus legacy coarse scopes."""
+
+    scopes = {row.oauth_scope for row in build_action_scope_registry().values()}
+    scopes.update({"read", "write", "admin"})
+    return sorted(scopes)
+
+
+def action_scope_audit() -> dict[str, Any]:
+    """Self-auditing read payload for CHILD-3 gradient scopes."""
+
+    registry = build_action_scope_registry()
+    rows = [row.to_dict() for row in registry.values()]
+    rows.sort(key=lambda item: (item["tool"], item["action"]))
+    return {
+        "schema_version": 1,
+        "source": "internal_dispatch_action_registries",
+        "scope_derivation": (
+            "Scopes are derived from server-side action dispatch tables and "
+            "write-action sets, not raw MCP tool schemas."
+        ),
+        "checkpoint_mode": (
+            "Dispatch checkpoints fail closed for missing named scopes when "
+            "auth is enabled; dev/no-auth mode bypasses grant enforcement."
+        ),
+        "oauth_scopes": supported_oauth_scopes(),
+        "actions": rows,
+        "counts": {
+            "actions": len(rows),
+            "oauth_scopes": len({row["oauth_scope"] for row in rows}),
+        },
+        "caveats": [
+            "Read/write/admin legacy OAuth scopes are still advertised for "
+            "older clients but are not the source of the derived table.",
+            "Argument-sensitive actions such as universe control_daemon are "
+            "classified at the action level; finer sub-action scoping can be "
+            "added by attaching metadata to that internal sub-dispatch.",
+        ],
+    }
 
 
 ANONYMOUS = Identity(

--- a/workflow/auth/wellknown.py
+++ b/workflow/auth/wellknown.py
@@ -44,6 +44,8 @@ def authorization_server_metadata() -> dict[str, Any]:
       - registration endpoint (for DCR)
     """
     base = _server_url()
+    from workflow.auth.provider import supported_oauth_scopes
+
     return {
         "issuer": base,
         "authorization_endpoint": f"{base}/oauth/authorize",
@@ -53,7 +55,7 @@ def authorization_server_metadata() -> dict[str, Any]:
         "grant_types_supported": ["authorization_code", "refresh_token"],
         "token_endpoint_auth_methods_supported": ["none"],
         "code_challenge_methods_supported": ["S256"],
-        "scopes_supported": ["read", "write", "admin"],
+        "scopes_supported": supported_oauth_scopes(),
         "service_documentation": f"{base}/docs",
     }
 
@@ -67,10 +69,12 @@ def protected_resource_metadata() -> dict[str, Any]:
     this resource, so they know where to start the auth flow.
     """
     base = _server_url()
+    from workflow.auth.provider import supported_oauth_scopes
+
     return {
         "resource": base,
         "authorization_servers": [base],
-        "scopes_supported": ["read", "write", "admin"],
+        "scopes_supported": supported_oauth_scopes(),
         "bearer_methods_supported": ["header"],
     }
 

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -601,7 +601,8 @@ def extensions(
 
     Core actions include build_branch, patch_branch, list_branches,
     describe_branch, get_branch, run_branch, get_run, wait_for_run,
-    judge_run, publish_version, schedule_branch, fork_tree, and search_nodes.
+    judge_run, publish_version, schedule_branch, fork_tree, search_nodes,
+    and get_action_scope_status for the derived action-to-OAuth-scope audit.
     Pass `action` plus the matching ids or JSON payload fields.
     Use `scope` with list_branches to filter the result:
     `"published"` (default) = only Branches that have a published version


### PR DESCRIPTION
## Summary
- derives named OAuth/action scopes from internal dispatch registries instead of raw MCP schemas
- adds dispatch-time scope checkpoints for universe, extensions, wiki, and gates that enforce named scopes only when auth is enabled
- exposes `extensions action=get_action_scope_status` as the self-auditing read action with table/caveats and mirrors the changes into the Claude plugin package

## Stack / merge note
- PR-139 slice 8 is stacked on slice 7 / PR #1098 (`codex/pr139-resolver-build`) while #1098 waits for the Cowork checker key
- after #1098 lands, rebase/retarget this PR to `main` before final merge

## Verification
- python -m pytest tests/test_action_scopes.py tests/test_permission_decisions.py tests/test_mcp_server.py tests/test_mcp_tool_canary.py tests/test_wiki_canary.py tests/test_api_universe.py -q
- python -m pytest tests/test_action_scopes.py tests/test_permission_decisions.py tests/test_mcp_server.py tests/test_mcp_tool_canary.py tests/test_wiki_canary.py tests/test_api_universe.py tests/test_api.py tests/test_api_edge_cases.py -q
- python -m ruff check workflow/auth workflow/api/extensions.py workflow/api/universe.py workflow/api/wiki.py workflow/api/market.py workflow/universe_server.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py tests/test_action_scopes.py
- python -m scripts.invariants.mirror_parity
- python packaging\\claude-plugin\\build_plugin.py
- git diff --check