### PR TITLE
PR-139 slice 9: derive universe loop dispatch from soul

### DIFF
--- a/fantasy_daemon/api.py
+++ b/fantasy_daemon/api.py
@@ -284,6 +284,10 @@ class CreateUniverseBody(BaseModel):
         None,
         description="Human-readable display name (auto-generated if omitted)",
     )
+    branch_def_id: str | None = Field(
+        None,
+        description="Optional workflow loop branch declared in the new universe soul.",
+    )
 
 
 class UpdateUniverseBody(BaseModel):
@@ -781,7 +785,12 @@ def create_universe(
 
     try:
         udir.mkdir(parents=True, exist_ok=True)
-        soul = ensure_universe_soul(udir)
+        soul = ensure_universe_soul(
+            udir,
+            loop_branch_def_id=(
+                body.branch_def_id if body and body.branch_def_id else ""
+            ),
+        )
         (udir / "canon").mkdir(exist_ok=True)
         (udir / "output").mkdir(exist_ok=True)
         (udir / "universe.json").write_text(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -71,6 +71,7 @@ from workflow.api.helpers import (
 )
 from workflow.catalog import list_unreconciled_writes
 from workflow.universe_soul import (
+    NO_LOOP_DECLARED,
     SOUL_FILENAME,
     ensure_universe_soul,
     has_soul,
@@ -87,6 +88,7 @@ ENV_CAPABILITIES_VAR = "UNIVERSE_SERVER_CAPABILITIES"
 ACTION_SUBMIT_PRIORITY_REQUEST = "submit_priority_request"
 ACTION_CANCEL_BRANCH_TASK = "cancel_branch_task"
 ACTION_POST_PRIORITY_GOAL_POOL = "post_priority_goal_pool"
+LEGACY_FANTASY_LOOP_BRANCH_DEF_ID = "fantasy_author:universe_cycle_wrapper"
 
 
 def _env_actor_grants() -> tuple[str, ...]:
@@ -134,6 +136,7 @@ def _extract_submit_request(
             "pickup_incentive": kwargs.get("pickup_incentive", "") or None,
             "directed_daemon_id": kwargs.get("directed_daemon_id", "") or None,
             "request_classification": result.get("request_classification"),
+            "loop_dispatch": result.get("loop_dispatch"),
         },
     )
 
@@ -233,6 +236,7 @@ def _extract_create_universe(
         "has_premise": bool(text.strip()),
         "has_soul": True,
         "soul_path": SOUL_FILENAME,
+        "loop_branch_def_id": str(kwargs.get("branch_def_id") or "").strip(),
     })
 
 
@@ -279,6 +283,37 @@ def _synthesis_first_run_checklist(has_premise: bool) -> dict[str, Any]:
         ),
         "steps": steps,
         "next_action": next_action,
+    }
+
+
+def _universe_loop_dispatch(udir: Path) -> tuple[str, dict[str, Any]]:
+    soul = read_universe_soul(udir)
+    if soul is None:
+        return LEGACY_FANTASY_LOOP_BRANCH_DEF_ID, {
+            "source": "legacy_no_soul_compat",
+            "has_soul": False,
+            "branch_def_id": LEGACY_FANTASY_LOOP_BRANCH_DEF_ID,
+            "caveat": (
+                "Legacy universe has no soul.md; keeping the existing fantasy "
+                "loop only until the universe is migrated to a soul-declared loop."
+            ),
+        }
+    branch_def_id = soul.loop_branch_def_id.strip()
+    if not branch_def_id:
+        return NO_LOOP_DECLARED, {
+            "source": SOUL_FILENAME,
+            "has_soul": True,
+            "branch_def_id": "",
+            "error": "universe_loop_not_declared",
+            "note": (
+                "This universe has a soul.md but no Loop branch declaration; "
+                "new souled universes do not silently attach the fantasy loop."
+            ),
+        }
+    return branch_def_id, {
+        "source": SOUL_FILENAME,
+        "has_soul": True,
+        "branch_def_id": branch_def_id,
     }
 
 
@@ -1163,6 +1198,14 @@ def _action_submit_request(
     if not udir.is_dir():
         return json.dumps({"error": f"Universe '{uid}' not found."})
 
+    loop_branch_def_id, loop_dispatch = _universe_loop_dispatch(udir)
+    if not loop_branch_def_id:
+        return json.dumps({
+            "error": "universe_loop_not_declared",
+            "universe_id": uid,
+            "loop_dispatch": loop_dispatch,
+        })
+
     # 8 KiB cap keeps requests.json bounded and discourages pasting
     # entire drafts into the request channel (add_canon is the right
     # tool for that). UTF-8 byte length, not char count.
@@ -1244,6 +1287,7 @@ def _action_submit_request(
         "pickup_incentive": incentive,
         "authority_boundary": authority_boundary,
         "request_classification": request_classification,
+        "loop_dispatch": loop_dispatch,
     }
     if requester_directed_daemon is not None:
         request_obj["requester_directed_daemon"] = requester_directed_daemon
@@ -1272,7 +1316,7 @@ def _action_submit_request(
     try:
         task = BranchTask(
             branch_task_id=new_task_id(),
-            branch_def_id="fantasy_author:universe_cycle_wrapper",
+            branch_def_id=loop_branch_def_id,
             universe_id=uid,
             inputs={
                 "work_target_ref": None,
@@ -1283,6 +1327,7 @@ def _action_submit_request(
                 "authority_boundary": authority_boundary,
                 "request_classification": request_classification,
                 "requester_directed_daemon": requester_directed_daemon,
+                "loop_dispatch": loop_dispatch,
             },
             trigger_source=(
                 "owner_queued"
@@ -1323,6 +1368,7 @@ def _action_submit_request(
         "authority_boundary": authority_boundary,
         "request_classification": request_classification,
         "requester_directed_daemon": requester_directed_daemon,
+        "loop_dispatch": loop_dispatch,
         "queue_position": pending_count,
         "ahead_of_yours": ahead,
         "what_happens_next": (
@@ -4252,6 +4298,7 @@ def _action_switch_universe(universe_id: str = "", **_kwargs: Any) -> str:
 def _action_create_universe(
     universe_id: str = "",
     text: str = "",
+    branch_def_id: str = "",
     **_kwargs: Any,
 ) -> str:
     if not universe_id:
@@ -4270,7 +4317,12 @@ def _action_create_universe(
     try:
         udir.mkdir(parents=True, exist_ok=True)
         normalized_text = _normalize_escaped_text(text) if text.strip() else ""
-        soul = ensure_universe_soul(udir, purpose=normalized_text)
+        loop_branch_def_id = str(branch_def_id or "").strip()
+        soul = ensure_universe_soul(
+            udir,
+            purpose=normalized_text,
+            loop_branch_def_id=loop_branch_def_id,
+        )
         # Write premise if provided
         if normalized_text.strip():
             legacy_premise_path(udir).write_text(normalized_text, encoding="utf-8")
@@ -4285,6 +4337,11 @@ def _action_create_universe(
             "has_premise": bool(normalized_text.strip()),
             "has_soul": True,
             "soul": soul.summary(),
+            "loop_dispatch": {
+                "source": SOUL_FILENAME,
+                "branch_def_id": soul.loop_branch_def_id,
+                "declared": bool(soul.loop_branch_def_id),
+            },
             "first_run_checklist": _synthesis_first_run_checklist(
                 has_premise=bool(normalized_text.strip()),
             ),

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/desktop/launcher.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/desktop/launcher.py
@@ -25,7 +25,11 @@ import threading
 from pathlib import Path
 from typing import Any, Callable
 
-from workflow.universe_soul import premise_from_soul, read_legacy_premise
+from workflow.universe_soul import (
+    ensure_universe_soul,
+    premise_from_soul,
+    read_legacy_premise,
+)
 
 # tkinter requires libtk (system lib). Headless Docker containers
 # don't ship it; the cloud_worker's fantasy_daemon subprocess imports
@@ -359,6 +363,7 @@ class LauncherApp:
         path = Path(self._universe_var.get())
         canon_path = path / "canon"
         try:
+            ensure_universe_soul(path)
             canon_path.mkdir(parents=True, exist_ok=True)
             self.set_status(f"Created: {path}")
             logger.info("Created universe directory: %s", path)

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_soul.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_soul.py
@@ -17,6 +17,8 @@ LEGACY_PREMISE_FILENAME = "PROGRAM.md"
 SOUL_SCHEMA_VERSION = 1
 DEFAULT_DOMAIN_SHAPE = "general"
 DEFAULT_EDIT_AUTHORITY = "soul.edit"
+NO_LOOP_DECLARED = ""
+NO_LOOP_MARKER = "_None recorded._"
 
 
 @dataclass(frozen=True)
@@ -30,6 +32,7 @@ class UniverseSoul:
     domain_shape: str = DEFAULT_DOMAIN_SHAPE
     lineage: str = "template"
     edit_authority: str = DEFAULT_EDIT_AUTHORITY
+    loop_branch_def_id: str = NO_LOOP_DECLARED
 
     def summary(self) -> dict[str, object]:
         return {
@@ -39,6 +42,7 @@ class UniverseSoul:
             "domain_shape": self.domain_shape,
             "lineage": self.lineage,
             "edit_authority": self.edit_authority,
+            "loop_branch_def_id": self.loop_branch_def_id,
             "versions_dir": SOUL_VERSIONS_DIR,
         }
 
@@ -66,6 +70,7 @@ class PinnedUniverseSoul:
             "domain_shape": self.soul.domain_shape,
             "lineage": self.soul.lineage,
             "edit_authority": self.soul.edit_authority,
+            "loop_branch_def_id": self.soul.loop_branch_def_id,
             "identity_boundary": (
                 "Universe soul guides this context only; it does not change "
                 "the actor identity or user memory scope."
@@ -95,6 +100,7 @@ def render_soul_markdown(soul: UniverseSoul) -> str:
         f"- Domain shape: {soul.domain_shape}",
         f"- Lineage: {soul.lineage}",
         f"- Edit authority: {soul.edit_authority}",
+        f"- Loop branch: {soul.loop_branch_def_id or NO_LOOP_MARKER}",
         "",
         "## Purpose",
         "",
@@ -145,6 +151,7 @@ def read_universe_soul(universe_dir: Path) -> UniverseSoul | None:
             _read_section(text, "Edit Authority")
             or _read_meta(text, "Edit authority", DEFAULT_EDIT_AUTHORITY)
         ),
+        loop_branch_def_id=_read_loop_branch_meta(text),
     )
 
 
@@ -182,6 +189,7 @@ def write_universe_soul(
     domain_shape: str = DEFAULT_DOMAIN_SHAPE,
     lineage: str = "template",
     edit_authority: str = DEFAULT_EDIT_AUTHORITY,
+    loop_branch_def_id: str = NO_LOOP_DECLARED,
 ) -> UniverseSoul:
     universe_dir.mkdir(parents=True, exist_ok=True)
     existing = read_universe_soul(universe_dir)
@@ -199,6 +207,7 @@ def write_universe_soul(
             domain_shape=domain_shape.strip() or DEFAULT_DOMAIN_SHAPE,
             lineage=lineage.strip() or "template",
             edit_authority=edit_authority.strip() or DEFAULT_EDIT_AUTHORITY,
+            loop_branch_def_id=loop_branch_def_id.strip(),
         )
     else:
         soul = replace(
@@ -220,6 +229,9 @@ def write_universe_soul(
             domain_shape=domain_shape.strip() or existing.domain_shape,
             lineage=lineage.strip() or existing.lineage,
             edit_authority=edit_authority.strip() or existing.edit_authority,
+            loop_branch_def_id=(
+                loop_branch_def_id.strip() or existing.loop_branch_def_id
+            ),
         )
 
     rendered = render_soul_markdown(soul)
@@ -228,14 +240,23 @@ def write_universe_soul(
     return soul
 
 
-def ensure_universe_soul(universe_dir: Path, *, purpose: str = "") -> UniverseSoul:
+def ensure_universe_soul(
+    universe_dir: Path,
+    *,
+    purpose: str = "",
+    loop_branch_def_id: str = NO_LOOP_DECLARED,
+) -> UniverseSoul:
     existing = read_universe_soul(universe_dir)
-    if existing is not None and (existing.purpose or not purpose.strip()):
+    if existing is not None and (
+        (existing.purpose or not purpose.strip())
+        and (existing.loop_branch_def_id or not loop_branch_def_id.strip())
+    ):
         return existing
     return write_universe_soul(
         universe_dir,
         purpose=purpose,
         lineage="created-from-premise" if purpose.strip() else "template",
+        loop_branch_def_id=loop_branch_def_id,
     )
 
 
@@ -251,6 +272,11 @@ def read_legacy_premise(universe_dir: Path) -> str:
 def premise_from_soul(universe_dir: Path) -> str:
     soul = read_universe_soul(universe_dir)
     return soul.purpose if soul is not None else ""
+
+
+def loop_branch_from_soul(universe_dir: Path) -> str:
+    soul = read_universe_soul(universe_dir)
+    return soul.loop_branch_def_id if soul is not None else NO_LOOP_DECLARED
 
 
 def _render_list(items: tuple[str, ...]) -> str:
@@ -305,6 +331,13 @@ def _read_int_meta(text: str, key: str, default: int) -> int:
         return int(raw)
     except ValueError:
         return default
+
+
+def _read_loop_branch_meta(text: str) -> str:
+    raw = _read_meta(text, "Loop branch", NO_LOOP_DECLARED)
+    if raw in {NO_LOOP_MARKER, "none", "None", "NONE"}:
+        return NO_LOOP_DECLARED
+    return raw
 
 
 def _read_section(text: str, heading: str) -> str:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1746,6 +1746,17 @@ class TestEdgeCaseUniverseCreation:
         assert data["has_soul"] is True
         assert (base_dir / data["id"] / "soul.md").exists()
 
+    def test_create_universe_declares_loop_branch_in_soul(self, client, base_dir):
+        resp = client.post(
+            "/v1/universes",
+            json={"name": "Workflow Lab", "branch_def_id": "workflow:review_loop"},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["soul"]["loop_branch_def_id"] == "workflow:review_loop"
+        soul_md = (base_dir / data["id"] / "soul.md").read_text(encoding="utf-8")
+        assert "- Loop branch: workflow:review_loop" in soul_md
+
     def test_create_universe_empty_name(self, client):
         """Explicit empty string name should auto-generate."""
         resp = client.post("/v1/universes", json={"name": ""})

--- a/tests/test_universe_server_ledger.py
+++ b/tests/test_universe_server_ledger.py
@@ -164,6 +164,7 @@ def test_submit_request_appends_ledger(universe: str) -> None:
     assert entries[0]["action"] == "submit_request"
     assert entries[0]["target"] == out["request_id"]
     assert entries[0]["payload"]["request_type"] == "scene_direction"
+    assert entries[0]["payload"]["loop_dispatch"]["source"] == "legacy_no_soul_compat"
 
 
 def test_add_canon_appends_ledger(universe: str) -> None:
@@ -261,6 +262,10 @@ def test_get_ledger_returns_appended_entries(universe: str) -> None:
 def test_ledger_survives_across_mixed_writes(universe: str) -> None:
     _call("set_premise", text="Premise.")
     _call("give_direction", text="Direction.")
+    us.ensure_universe_soul(
+        us._base_path() / universe,
+        loop_branch_def_id="fantasy_author:universe_cycle_wrapper",
+    )
     _call("submit_request", text="Request.")
     _call("add_canon", filename="a.md", text="x", provenance_tag="test")
 

--- a/tests/test_universe_soul.py
+++ b/tests/test_universe_soul.py
@@ -46,6 +46,7 @@ def test_set_premise_writes_versioned_soul_profile(us):
     assert "A wandering lab studies civic memory." in soul_md
     assert "## Edit Authority" in soul_md
     assert "soul.edit" in soul_md
+    assert "- Loop branch: _None recorded._" in soul_md
     version = base / "u1" / "soul_versions" / "0001.md"
     assert version.exists()
     assert version.read_text(encoding="utf-8") == soul_md
@@ -111,7 +112,96 @@ def test_create_universe_without_premise_still_has_thin_soul(us):
     assert result["status"] == "created"
     assert result["has_premise"] is False
     assert result["has_soul"] is True
+    assert result["loop_dispatch"] == {
+        "source": "soul.md",
+        "branch_def_id": "",
+        "declared": False,
+    }
     soul_md = (base / "thin-uni" / "soul.md").read_text(encoding="utf-8")
     assert "# Universe Soul" in soul_md
     assert "## Purpose" in soul_md
+    assert "- Loop branch: _None recorded._" in soul_md
     assert not (base / "thin-uni" / "PROGRAM.md").exists()
+
+
+def test_create_universe_records_declared_loop_branch(us):
+    base = Path(us._base_path())
+
+    result = json.loads(us._action_create_universe(
+        universe_id="workflow-uni",
+        text="A civic workflow lab.",
+        branch_def_id="workflow:review_loop",
+    ))
+
+    assert result["status"] == "created"
+    assert result["soul"]["loop_branch_def_id"] == "workflow:review_loop"
+    assert result["loop_dispatch"] == {
+        "source": "soul.md",
+        "branch_def_id": "workflow:review_loop",
+        "declared": True,
+    }
+    soul_md = (base / "workflow-uni" / "soul.md").read_text(encoding="utf-8")
+    assert "- Loop branch: workflow:review_loop" in soul_md
+    pinned = read_pinned_universe_soul(base / "workflow-uni")
+    assert pinned is not None
+    assert pinned.context()["loop_branch_def_id"] == "workflow:review_loop"
+
+
+def test_submit_request_uses_soul_declared_loop_branch(us):
+    base = Path(us._base_path())
+    us._action_create_universe(
+        universe_id="loop-uni",
+        text="A civic workflow lab.",
+        branch_def_id="workflow:review_loop",
+    )
+
+    result = json.loads(us._action_submit_request(
+        universe_id="loop-uni",
+        text="Review this packet.",
+        request_type="general",
+    ))
+
+    assert result["status"] == "pending"
+    assert result["loop_dispatch"] == {
+        "source": "soul.md",
+        "has_soul": True,
+        "branch_def_id": "workflow:review_loop",
+    }
+    queue = json.loads((base / "loop-uni" / "branch_tasks.json").read_text(
+        encoding="utf-8",
+    ))
+    assert queue[0]["branch_def_id"] == "workflow:review_loop"
+    assert queue[0]["inputs"]["loop_dispatch"]["source"] == "soul.md"
+
+
+def test_submit_request_rejects_souled_universe_without_declared_loop(us):
+    base = Path(us._base_path())
+    us._action_create_universe(universe_id="thin-uni")
+
+    result = json.loads(us._action_submit_request(
+        universe_id="thin-uni",
+        text="Do work.",
+        request_type="general",
+    ))
+
+    assert result["error"] == "universe_loop_not_declared"
+    assert result["loop_dispatch"]["source"] == "soul.md"
+    assert not (base / "thin-uni" / "requests.json").exists()
+    assert not (base / "thin-uni" / "branch_tasks.json").exists()
+
+
+def test_submit_request_legacy_no_soul_keeps_named_compat_loop(us):
+    base = Path(us._base_path())
+    legacy = _mkuniverse(base, "legacy-uni")
+    assert not (legacy / "soul.md").exists()
+
+    result = json.loads(us._action_submit_request(
+        universe_id="legacy-uni",
+        text="Do legacy work.",
+        request_type="general",
+    ))
+
+    assert result["status"] == "pending"
+    assert result["loop_dispatch"]["source"] == "legacy_no_soul_compat"
+    queue = json.loads((legacy / "branch_tasks.json").read_text(encoding="utf-8"))
+    assert queue[0]["branch_def_id"] == "fantasy_author:universe_cycle_wrapper"

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -71,6 +71,7 @@ from workflow.api.helpers import (
 )
 from workflow.catalog import list_unreconciled_writes
 from workflow.universe_soul import (
+    NO_LOOP_DECLARED,
     SOUL_FILENAME,
     ensure_universe_soul,
     has_soul,
@@ -87,6 +88,7 @@ ENV_CAPABILITIES_VAR = "UNIVERSE_SERVER_CAPABILITIES"
 ACTION_SUBMIT_PRIORITY_REQUEST = "submit_priority_request"
 ACTION_CANCEL_BRANCH_TASK = "cancel_branch_task"
 ACTION_POST_PRIORITY_GOAL_POOL = "post_priority_goal_pool"
+LEGACY_FANTASY_LOOP_BRANCH_DEF_ID = "fantasy_author:universe_cycle_wrapper"
 
 
 def _env_actor_grants() -> tuple[str, ...]:
@@ -134,6 +136,7 @@ def _extract_submit_request(
             "pickup_incentive": kwargs.get("pickup_incentive", "") or None,
             "directed_daemon_id": kwargs.get("directed_daemon_id", "") or None,
             "request_classification": result.get("request_classification"),
+            "loop_dispatch": result.get("loop_dispatch"),
         },
     )
 
@@ -233,6 +236,7 @@ def _extract_create_universe(
         "has_premise": bool(text.strip()),
         "has_soul": True,
         "soul_path": SOUL_FILENAME,
+        "loop_branch_def_id": str(kwargs.get("branch_def_id") or "").strip(),
     })
 
 
@@ -279,6 +283,37 @@ def _synthesis_first_run_checklist(has_premise: bool) -> dict[str, Any]:
         ),
         "steps": steps,
         "next_action": next_action,
+    }
+
+
+def _universe_loop_dispatch(udir: Path) -> tuple[str, dict[str, Any]]:
+    soul = read_universe_soul(udir)
+    if soul is None:
+        return LEGACY_FANTASY_LOOP_BRANCH_DEF_ID, {
+            "source": "legacy_no_soul_compat",
+            "has_soul": False,
+            "branch_def_id": LEGACY_FANTASY_LOOP_BRANCH_DEF_ID,
+            "caveat": (
+                "Legacy universe has no soul.md; keeping the existing fantasy "
+                "loop only until the universe is migrated to a soul-declared loop."
+            ),
+        }
+    branch_def_id = soul.loop_branch_def_id.strip()
+    if not branch_def_id:
+        return NO_LOOP_DECLARED, {
+            "source": SOUL_FILENAME,
+            "has_soul": True,
+            "branch_def_id": "",
+            "error": "universe_loop_not_declared",
+            "note": (
+                "This universe has a soul.md but no Loop branch declaration; "
+                "new souled universes do not silently attach the fantasy loop."
+            ),
+        }
+    return branch_def_id, {
+        "source": SOUL_FILENAME,
+        "has_soul": True,
+        "branch_def_id": branch_def_id,
     }
 
 
@@ -1163,6 +1198,14 @@ def _action_submit_request(
     if not udir.is_dir():
         return json.dumps({"error": f"Universe '{uid}' not found."})
 
+    loop_branch_def_id, loop_dispatch = _universe_loop_dispatch(udir)
+    if not loop_branch_def_id:
+        return json.dumps({
+            "error": "universe_loop_not_declared",
+            "universe_id": uid,
+            "loop_dispatch": loop_dispatch,
+        })
+
     # 8 KiB cap keeps requests.json bounded and discourages pasting
     # entire drafts into the request channel (add_canon is the right
     # tool for that). UTF-8 byte length, not char count.
@@ -1244,6 +1287,7 @@ def _action_submit_request(
         "pickup_incentive": incentive,
         "authority_boundary": authority_boundary,
         "request_classification": request_classification,
+        "loop_dispatch": loop_dispatch,
     }
     if requester_directed_daemon is not None:
         request_obj["requester_directed_daemon"] = requester_directed_daemon
@@ -1272,7 +1316,7 @@ def _action_submit_request(
     try:
         task = BranchTask(
             branch_task_id=new_task_id(),
-            branch_def_id="fantasy_author:universe_cycle_wrapper",
+            branch_def_id=loop_branch_def_id,
             universe_id=uid,
             inputs={
                 "work_target_ref": None,
@@ -1283,6 +1327,7 @@ def _action_submit_request(
                 "authority_boundary": authority_boundary,
                 "request_classification": request_classification,
                 "requester_directed_daemon": requester_directed_daemon,
+                "loop_dispatch": loop_dispatch,
             },
             trigger_source=(
                 "owner_queued"
@@ -1323,6 +1368,7 @@ def _action_submit_request(
         "authority_boundary": authority_boundary,
         "request_classification": request_classification,
         "requester_directed_daemon": requester_directed_daemon,
+        "loop_dispatch": loop_dispatch,
         "queue_position": pending_count,
         "ahead_of_yours": ahead,
         "what_happens_next": (
@@ -4252,6 +4298,7 @@ def _action_switch_universe(universe_id: str = "", **_kwargs: Any) -> str:
 def _action_create_universe(
     universe_id: str = "",
     text: str = "",
+    branch_def_id: str = "",
     **_kwargs: Any,
 ) -> str:
     if not universe_id:
@@ -4270,7 +4317,12 @@ def _action_create_universe(
     try:
         udir.mkdir(parents=True, exist_ok=True)
         normalized_text = _normalize_escaped_text(text) if text.strip() else ""
-        soul = ensure_universe_soul(udir, purpose=normalized_text)
+        loop_branch_def_id = str(branch_def_id or "").strip()
+        soul = ensure_universe_soul(
+            udir,
+            purpose=normalized_text,
+            loop_branch_def_id=loop_branch_def_id,
+        )
         # Write premise if provided
         if normalized_text.strip():
             legacy_premise_path(udir).write_text(normalized_text, encoding="utf-8")
@@ -4285,6 +4337,11 @@ def _action_create_universe(
             "has_premise": bool(normalized_text.strip()),
             "has_soul": True,
             "soul": soul.summary(),
+            "loop_dispatch": {
+                "source": SOUL_FILENAME,
+                "branch_def_id": soul.loop_branch_def_id,
+                "declared": bool(soul.loop_branch_def_id),
+            },
             "first_run_checklist": _synthesis_first_run_checklist(
                 has_premise=bool(normalized_text.strip()),
             ),

--- a/workflow/desktop/launcher.py
+++ b/workflow/desktop/launcher.py
@@ -25,7 +25,11 @@ import threading
 from pathlib import Path
 from typing import Any, Callable
 
-from workflow.universe_soul import premise_from_soul, read_legacy_premise
+from workflow.universe_soul import (
+    ensure_universe_soul,
+    premise_from_soul,
+    read_legacy_premise,
+)
 
 # tkinter requires libtk (system lib). Headless Docker containers
 # don't ship it; the cloud_worker's fantasy_daemon subprocess imports
@@ -359,6 +363,7 @@ class LauncherApp:
         path = Path(self._universe_var.get())
         canon_path = path / "canon"
         try:
+            ensure_universe_soul(path)
             canon_path.mkdir(parents=True, exist_ok=True)
             self.set_status(f"Created: {path}")
             logger.info("Created universe directory: %s", path)

--- a/workflow/universe_soul.py
+++ b/workflow/universe_soul.py
@@ -17,6 +17,8 @@ LEGACY_PREMISE_FILENAME = "PROGRAM.md"
 SOUL_SCHEMA_VERSION = 1
 DEFAULT_DOMAIN_SHAPE = "general"
 DEFAULT_EDIT_AUTHORITY = "soul.edit"
+NO_LOOP_DECLARED = ""
+NO_LOOP_MARKER = "_None recorded._"
 
 
 @dataclass(frozen=True)
@@ -30,6 +32,7 @@ class UniverseSoul:
     domain_shape: str = DEFAULT_DOMAIN_SHAPE
     lineage: str = "template"
     edit_authority: str = DEFAULT_EDIT_AUTHORITY
+    loop_branch_def_id: str = NO_LOOP_DECLARED
 
     def summary(self) -> dict[str, object]:
         return {
@@ -39,6 +42,7 @@ class UniverseSoul:
             "domain_shape": self.domain_shape,
             "lineage": self.lineage,
             "edit_authority": self.edit_authority,
+            "loop_branch_def_id": self.loop_branch_def_id,
             "versions_dir": SOUL_VERSIONS_DIR,
         }
 
@@ -66,6 +70,7 @@ class PinnedUniverseSoul:
             "domain_shape": self.soul.domain_shape,
             "lineage": self.soul.lineage,
             "edit_authority": self.soul.edit_authority,
+            "loop_branch_def_id": self.soul.loop_branch_def_id,
             "identity_boundary": (
                 "Universe soul guides this context only; it does not change "
                 "the actor identity or user memory scope."
@@ -95,6 +100,7 @@ def render_soul_markdown(soul: UniverseSoul) -> str:
         f"- Domain shape: {soul.domain_shape}",
         f"- Lineage: {soul.lineage}",
         f"- Edit authority: {soul.edit_authority}",
+        f"- Loop branch: {soul.loop_branch_def_id or NO_LOOP_MARKER}",
         "",
         "## Purpose",
         "",
@@ -145,6 +151,7 @@ def read_universe_soul(universe_dir: Path) -> UniverseSoul | None:
             _read_section(text, "Edit Authority")
             or _read_meta(text, "Edit authority", DEFAULT_EDIT_AUTHORITY)
         ),
+        loop_branch_def_id=_read_loop_branch_meta(text),
     )
 
 
@@ -182,6 +189,7 @@ def write_universe_soul(
     domain_shape: str = DEFAULT_DOMAIN_SHAPE,
     lineage: str = "template",
     edit_authority: str = DEFAULT_EDIT_AUTHORITY,
+    loop_branch_def_id: str = NO_LOOP_DECLARED,
 ) -> UniverseSoul:
     universe_dir.mkdir(parents=True, exist_ok=True)
     existing = read_universe_soul(universe_dir)
@@ -199,6 +207,7 @@ def write_universe_soul(
             domain_shape=domain_shape.strip() or DEFAULT_DOMAIN_SHAPE,
             lineage=lineage.strip() or "template",
             edit_authority=edit_authority.strip() or DEFAULT_EDIT_AUTHORITY,
+            loop_branch_def_id=loop_branch_def_id.strip(),
         )
     else:
         soul = replace(
@@ -220,6 +229,9 @@ def write_universe_soul(
             domain_shape=domain_shape.strip() or existing.domain_shape,
             lineage=lineage.strip() or existing.lineage,
             edit_authority=edit_authority.strip() or existing.edit_authority,
+            loop_branch_def_id=(
+                loop_branch_def_id.strip() or existing.loop_branch_def_id
+            ),
         )
 
     rendered = render_soul_markdown(soul)
@@ -228,14 +240,23 @@ def write_universe_soul(
     return soul
 
 
-def ensure_universe_soul(universe_dir: Path, *, purpose: str = "") -> UniverseSoul:
+def ensure_universe_soul(
+    universe_dir: Path,
+    *,
+    purpose: str = "",
+    loop_branch_def_id: str = NO_LOOP_DECLARED,
+) -> UniverseSoul:
     existing = read_universe_soul(universe_dir)
-    if existing is not None and (existing.purpose or not purpose.strip()):
+    if existing is not None and (
+        (existing.purpose or not purpose.strip())
+        and (existing.loop_branch_def_id or not loop_branch_def_id.strip())
+    ):
         return existing
     return write_universe_soul(
         universe_dir,
         purpose=purpose,
         lineage="created-from-premise" if purpose.strip() else "template",
+        loop_branch_def_id=loop_branch_def_id,
     )
 
 
@@ -251,6 +272,11 @@ def read_legacy_premise(universe_dir: Path) -> str:
 def premise_from_soul(universe_dir: Path) -> str:
     soul = read_universe_soul(universe_dir)
     return soul.purpose if soul is not None else ""
+
+
+def loop_branch_from_soul(universe_dir: Path) -> str:
+    soul = read_universe_soul(universe_dir)
+    return soul.loop_branch_def_id if soul is not None else NO_LOOP_DECLARED
 
 
 def _render_list(items: tuple[str, ...]) -> str:
@@ -305,6 +331,13 @@ def _read_int_meta(text: str, key: str, default: int) -> int:
         return int(raw)
     except ValueError:
         return default
+
+
+def _read_loop_branch_meta(text: str) -> str:
+    raw = _read_meta(text, "Loop branch", NO_LOOP_DECLARED)
+    if raw in {NO_LOOP_MARKER, "none", "None", "NONE"}:
+        return NO_LOOP_DECLARED
+    return raw
 
 
 def _read_section(text: str, heading: str) -> str:


### PR DESCRIPTION
## Summary
- adds an explicit `Loop branch` declaration to universe `soul.md` metadata and exposes it in soul summaries/context
- makes MCP, REST, and desktop new-universe paths create the soul first, with optional loop branch declaration
- queues `submit_request` work from the soul-declared loop when present and fails closed for souled universes with no loop instead of silently attaching the fantasy wrapper
- keeps existing no-soul legacy universes on a named compatibility dispatch path until they are migrated

## Verification
- `python -m pytest tests/test_universe_soul.py tests/test_universe_server_ledger.py tests/test_api.py::TestEdgeCaseUniverseCreation -q`
- `python -m pytest tests/test_universe_soul.py tests/test_universe_server_ledger.py tests/test_api_universe.py tests/test_api.py tests/test_api_edge_cases.py tests/test_universe_server_telemetry.py -q`
- `python -m pytest tests/test_mcp_server.py tests/test_mcp_tool_canary.py tests/test_wiki_canary.py -q`
- `python -m ruff check workflow/universe_soul.py workflow/api/universe.py workflow/desktop/launcher.py fantasy_daemon/api.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_soul.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/desktop/launcher.py tests/test_universe_soul.py tests/test_universe_server_ledger.py tests/test_api.py`
- `python -m scripts.invariants.mirror_parity`
- `python packaging\claude-plugin\build_plugin.py`
- `git diff --check`

## Gate notes
- PR-139 slice 9, stacked behind #1098 and #1099.
- Keep draft until prior slices land/retarget, checks are green against main, Cowork checker key is present, and the standing host key is revalidated.