### PR TITLE
PR-139 slice 10: add host-gated episodic neutral migration

### DIFF
--- a/domains/fantasy_daemon/memory/schemas.py
+++ b/domains/fantasy_daemon/memory/schemas.py
@@ -17,7 +17,14 @@ domain-specific storage patterns Workflow uses.
 
 from __future__ import annotations
 
+from workflow.domain_registry import register_episodic_coordinate_shape
 from workflow.protocols import MemorySchema
+
+register_episodic_coordinate_shape(
+    "fantasy_author",
+    ("book_number", "chapter_number", "scene_number"),
+    sequence_field="chapter_number",
+)
 
 
 def get_fantasy_memory_schemas() -> list[MemorySchema]:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/domain_registry.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/domain_registry.py
@@ -20,6 +20,7 @@ the footprint for investigation.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
@@ -28,6 +29,18 @@ logger = logging.getLogger(__name__)
 _DomainCallable = Callable[[dict[str, Any]], dict[str, Any]]
 
 _REGISTRY: dict[tuple[str, str], _DomainCallable] = {}
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodicCoordinateShape:
+    """Domain-owned coordinate fields for episodic memory rows."""
+
+    domain_id: str
+    coordinate_fields: tuple[str, ...]
+    sequence_field: str | None = None
+
+
+_EPISODIC_COORDINATE_SHAPES: dict[str, EpisodicCoordinateShape] = {}
 
 
 def register_domain_callable(
@@ -62,3 +75,30 @@ def resolve_domain_callable(
 def clear_registry() -> None:
     """Testing-only helper; drops all registrations."""
     _REGISTRY.clear()
+    _EPISODIC_COORDINATE_SHAPES.clear()
+
+
+def register_episodic_coordinate_shape(
+    domain_id: str,
+    coordinate_fields: tuple[str, ...] | list[str],
+    *,
+    sequence_field: str | None = None,
+) -> None:
+    """Register the domain-owned coordinate fields for episodic rows.
+
+    The shared episodic tables stay domain-neutral; this registry names
+    which optional payload fields a domain uses to interpret row order and
+    identity.
+    """
+    _EPISODIC_COORDINATE_SHAPES[domain_id] = EpisodicCoordinateShape(
+        domain_id=domain_id,
+        coordinate_fields=tuple(coordinate_fields),
+        sequence_field=sequence_field,
+    )
+
+
+def resolve_episodic_coordinate_shape(
+    domain_id: str,
+) -> EpisodicCoordinateShape | None:
+    """Return a registered episodic coordinate shape, if any."""
+    return _EPISODIC_COORDINATE_SHAPES.get(domain_id)

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/memory/episodic.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/memory/episodic.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import shutil
 import sqlite3
+import tempfile
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -19,6 +23,49 @@ if TYPE_CHECKING:
     from workflow.memory.scoping import MemoryScope
 
 logger = logging.getLogger(__name__)
+
+FANTASY_DOMAIN_ID = "fantasy_author"
+EPISODIC_NEUTRAL_MIGRATION_FLAG = "WORKFLOW_EPISODIC_SCHEMA_MIGRATION"
+
+
+def _json_dumps(value: dict[str, Any]) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _json_loads(value: str | None) -> dict[str, Any]:
+    if not value:
+        return {}
+    try:
+        loaded = json.loads(value)
+    except json.JSONDecodeError:
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _fantasy_episode_id(
+    book_number: int,
+    chapter_number: int,
+    scene_number: int,
+) -> str:
+    return (
+        f"book:{book_number}/chapter:{chapter_number}/scene:{scene_number}"
+    )
+
+
+def _fantasy_summary_payload(
+    book_number: int,
+    chapter_number: int,
+    scene_number: int,
+) -> dict[str, int]:
+    return {
+        "book_number": book_number,
+        "chapter_number": chapter_number,
+        "scene_number": scene_number,
+    }
+
+
+def _fantasy_reflection_id(chapter_number: int, scene_number: int) -> str:
+    return f"chapter:{chapter_number}/scene:{scene_number}"
 
 
 def _scope_tiers(
@@ -39,12 +86,17 @@ _SCHEMA = """
 CREATE TABLE IF NOT EXISTS scene_summaries (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
     universe_id   TEXT    NOT NULL,
-    book_number   INTEGER NOT NULL,
-    chapter_number INTEGER NOT NULL,
-    scene_number  INTEGER NOT NULL,
+    domain_id     TEXT    NOT NULL DEFAULT '',
+    episode_id    TEXT    NOT NULL DEFAULT '',
+    sequence_number INTEGER NOT NULL DEFAULT 0,
+    domain_payload TEXT   NOT NULL DEFAULT '{}',
+    book_number   INTEGER,
+    chapter_number INTEGER,
+    scene_number  INTEGER,
     summary       TEXT    NOT NULL,
     word_count    INTEGER NOT NULL DEFAULT 0,
     created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(universe_id, domain_id, episode_id),
     UNIQUE(universe_id, book_number, chapter_number, scene_number)
 );
 
@@ -73,8 +125,12 @@ CREATE TABLE IF NOT EXISTS style_observations (
 CREATE TABLE IF NOT EXISTS reflections (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
     universe_id   TEXT    NOT NULL,
-    chapter_number INTEGER NOT NULL,
-    scene_number  INTEGER NOT NULL,
+    domain_id     TEXT    NOT NULL DEFAULT '',
+    episode_id    TEXT    NOT NULL DEFAULT '',
+    sequence_number INTEGER NOT NULL DEFAULT 0,
+    domain_payload TEXT   NOT NULL DEFAULT '{}',
+    chapter_number INTEGER,
+    scene_number  INTEGER,
     critique      TEXT    NOT NULL,
     reflection    TEXT    NOT NULL,
     created_at    TEXT    NOT NULL DEFAULT (datetime('now'))
@@ -91,6 +147,31 @@ class SceneSummary:
     scene_number: int
     summary: str
     word_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodeSummary:
+    """A domain-neutral episodic summary."""
+
+    domain_id: str
+    episode_id: str
+    sequence_number: int
+    domain_payload: dict[str, Any]
+    summary: str
+    word_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodicSchemaMigrationResult:
+    """Report for the host-gated episodic schema migration."""
+
+    db_path: Path
+    dry_run: bool
+    schema_changed: bool
+    backup_path: Path | None
+    row_counts: dict[str, int]
+    no_bleed_ok: bool
+    no_bleed_violations: list[str]
 
 
 class EpisodicMemory:
@@ -120,6 +201,7 @@ class EpisodicMemory:
         self._conn.execute("PRAGMA busy_timeout=30000")
         self._conn.executescript(_SCHEMA)
         self._migrate_scope_columns()
+        self._migrate_domain_neutral_columns()
 
     # -----------------------------------------------------------------
     # Memory-scope Stage 2b schema migration
@@ -134,6 +216,20 @@ class EpisodicMemory:
         "scene_summaries", "episodic_facts",
         "style_observations", "reflections",
     )
+    _DOMAIN_NEUTRAL_COLUMNS: dict[str, tuple[tuple[str, str], ...]] = {
+        "scene_summaries": (
+            ("domain_id", "TEXT"),
+            ("episode_id", "TEXT"),
+            ("sequence_number", "INTEGER"),
+            ("domain_payload", "TEXT"),
+        ),
+        "reflections": (
+            ("domain_id", "TEXT"),
+            ("episode_id", "TEXT"),
+            ("sequence_number", "INTEGER"),
+            ("domain_payload", "TEXT"),
+        ),
+    }
 
     def _migrate_scope_columns(self) -> None:
         """Add ``goal_id`` / ``branch_id`` / ``user_id`` columns if missing.
@@ -162,6 +258,37 @@ class EpisodicMemory:
                 f"CREATE INDEX IF NOT EXISTS idx_{table}_scope "
                 f"ON {table}(universe_id, goal_id, branch_id)"
             )
+        self._conn.commit()
+
+    def _migrate_domain_neutral_columns(self) -> None:
+        """Add neutral episodic columns without rebuilding live tables.
+
+        This is the normal-startup compatibility path. It lets old DBs keep
+        serving while the host-gated rebuild migration remains explicit.
+        """
+        for table, columns in self._DOMAIN_NEUTRAL_COLUMNS.items():
+            existing = {
+                row[1]
+                for row in self._conn.execute(f"PRAGMA table_info({table})")
+            }
+            for col_name, col_type in columns:
+                if col_name in existing:
+                    continue
+                self._conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN {col_name} {col_type}"
+                )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_scene_summaries_episode "
+            "ON scene_summaries(universe_id, domain_id, episode_id)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_scene_summaries_sequence "
+            "ON scene_summaries(universe_id, domain_id, sequence_number)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_reflections_sequence "
+            "ON reflections(universe_id, domain_id, sequence_number)"
+        )
         self._conn.commit()
 
     def close(self) -> None:
@@ -195,23 +322,130 @@ class EpisodicMemory:
         hard-invariant tier). Scope tagging is advisory until 2c.
         """
         goal_id, branch_id, user_id = self._scope_tiers(scope)
+        domain_payload = _fantasy_summary_payload(
+            book_number, chapter_number, scene_number
+        )
         self._conn.execute(
             """
             INSERT INTO scene_summaries
-                (universe_id, book_number, chapter_number, scene_number,
+                (universe_id, domain_id, episode_id, sequence_number,
+                 domain_payload, book_number, chapter_number, scene_number,
                  summary, word_count, goal_id, branch_id, user_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(universe_id, book_number, chapter_number, scene_number)
             DO UPDATE SET summary=excluded.summary,
                           word_count=excluded.word_count,
+                          domain_id=excluded.domain_id,
+                          episode_id=excluded.episode_id,
+                          sequence_number=excluded.sequence_number,
+                          domain_payload=excluded.domain_payload,
                           goal_id=COALESCE(excluded.goal_id, scene_summaries.goal_id),
                           branch_id=COALESCE(excluded.branch_id, scene_summaries.branch_id),
                           user_id=COALESCE(excluded.user_id, scene_summaries.user_id)
             """,
-            (self._universe_id, book_number, chapter_number,
-             scene_number, summary, word_count,
-             goal_id, branch_id, user_id),
+            (
+                self._universe_id,
+                FANTASY_DOMAIN_ID,
+                _fantasy_episode_id(book_number, chapter_number, scene_number),
+                chapter_number,
+                _json_dumps(domain_payload),
+                book_number,
+                chapter_number,
+                scene_number,
+                summary,
+                word_count,
+                goal_id,
+                branch_id,
+                user_id,
+            ),
         )
+        self._conn.commit()
+
+    def store_episode_summary(
+        self,
+        episode_id: str,
+        sequence_number: int,
+        summary: str,
+        word_count: int = 0,
+        *,
+        domain_id: str = "workflow",
+        domain_payload: dict[str, Any] | None = None,
+        scope: "MemoryScope | None" = None,
+    ) -> None:
+        """Persist a domain-neutral episode summary.
+
+        Domain-specific coordinates stay in ``domain_payload`` and the
+        optional domain registry. Shared substrate columns never require
+        book/chapter/scene for non-fantasy domains.
+        """
+        goal_id, branch_id, user_id = self._scope_tiers(scope)
+        payload = dict(domain_payload or {})
+        book_number = payload.get("book_number")
+        chapter_number = payload.get("chapter_number")
+        scene_number = payload.get("scene_number")
+        if domain_id != FANTASY_DOMAIN_ID:
+            book_number = chapter_number = scene_number = None
+
+        existing = self._conn.execute(
+            "SELECT id FROM scene_summaries "
+            "WHERE universe_id = ? AND domain_id = ? AND episode_id = ?",
+            (self._universe_id, domain_id, episode_id),
+        ).fetchone()
+        if existing is None:
+            self._conn.execute(
+                """
+                INSERT INTO scene_summaries
+                    (universe_id, domain_id, episode_id, sequence_number,
+                     domain_payload, book_number, chapter_number, scene_number,
+                     summary, word_count, goal_id, branch_id, user_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    self._universe_id,
+                    domain_id,
+                    episode_id,
+                    sequence_number,
+                    _json_dumps(payload),
+                    book_number,
+                    chapter_number,
+                    scene_number,
+                    summary,
+                    word_count,
+                    goal_id,
+                    branch_id,
+                    user_id,
+                ),
+            )
+        else:
+            self._conn.execute(
+                """
+                UPDATE scene_summaries
+                SET sequence_number = ?,
+                    domain_payload = ?,
+                    book_number = ?,
+                    chapter_number = ?,
+                    scene_number = ?,
+                    summary = ?,
+                    word_count = ?,
+                    goal_id = COALESCE(?, goal_id),
+                    branch_id = COALESCE(?, branch_id),
+                    user_id = COALESCE(?, user_id)
+                WHERE id = ?
+                """,
+                (
+                    sequence_number,
+                    _json_dumps(payload),
+                    book_number,
+                    chapter_number,
+                    scene_number,
+                    summary,
+                    word_count,
+                    goal_id,
+                    branch_id,
+                    user_id,
+                    existing[0],
+                ),
+            )
         self._conn.commit()
 
     def get_recent(
@@ -241,6 +475,45 @@ class EpisodicMemory:
                 scene_number=r[2],
                 summary=r[3],
                 word_count=r[4],
+            )
+            for r in rows
+        ]
+
+    def get_recent_episodes(
+        self,
+        max_sequence: int,
+        k: int = 5,
+        *,
+        domain_id: str | None = None,
+    ) -> list[EpisodeSummary]:
+        """Return recent domain-neutral episode summaries."""
+        params: list[Any] = [self._universe_id, max_sequence]
+        domain_filter = ""
+        if domain_id is not None:
+            domain_filter = " AND domain_id = ?"
+            params.append(domain_id)
+        params.append(k)
+        rows = self._conn.execute(
+            f"""
+            SELECT domain_id, episode_id, sequence_number,
+                   domain_payload, summary, word_count
+            FROM scene_summaries
+            WHERE universe_id = ?
+              AND sequence_number <= ?
+              {domain_filter}
+            ORDER BY sequence_number DESC, id DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+        return [
+            EpisodeSummary(
+                domain_id=r[0] or "",
+                episode_id=r[1] or "",
+                sequence_number=r[2] or 0,
+                domain_payload=_json_loads(r[3]),
+                summary=r[4],
+                word_count=r[5],
             )
             for r in rows
         ]
@@ -417,14 +690,30 @@ class EpisodicMemory:
         Memory-scope Stage 2b: optional ``scope`` tags the row.
         """
         goal_id, branch_id, user_id = self._scope_tiers(scope)
+        domain_payload = {
+            "chapter_number": chapter_number,
+            "scene_number": scene_number,
+        }
         self._conn.execute(
             "INSERT INTO reflections "
-            "(universe_id, chapter_number, scene_number, "
+            "(universe_id, domain_id, episode_id, sequence_number, "
+            " domain_payload, chapter_number, scene_number, "
             " critique, reflection, goal_id, branch_id, user_id) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (self._universe_id, chapter_number, scene_number,
-             critique, reflection,
-             goal_id, branch_id, user_id),
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                self._universe_id,
+                FANTASY_DOMAIN_ID,
+                _fantasy_reflection_id(chapter_number, scene_number),
+                chapter_number,
+                _json_dumps(domain_payload),
+                chapter_number,
+                scene_number,
+                critique,
+                reflection,
+                goal_id,
+                branch_id,
+                user_id,
+            ),
         )
         self._conn.commit()
 
@@ -472,3 +761,430 @@ class EpisodicMemory:
         )
         self._conn.commit()
         return cur.rowcount
+
+
+def check_episodic_no_bleed(
+    conn_or_path: sqlite3.Connection | str | Path,
+    *,
+    fantasy_domain_id: str = FANTASY_DOMAIN_ID,
+) -> list[str]:
+    """Return non-fantasy rows that still carry fantasy coordinates."""
+    conn, should_close = _coerce_connection(conn_or_path)
+    try:
+        violations: list[str] = []
+        if _has_columns(
+            conn,
+            "scene_summaries",
+            ("domain_id", "book_number", "chapter_number", "scene_number"),
+        ):
+            rows = conn.execute(
+                """
+                SELECT id, universe_id, COALESCE(domain_id, '') AS domain_id
+                FROM scene_summaries
+                WHERE COALESCE(domain_id, '') != ?
+                  AND (
+                    book_number IS NOT NULL
+                    OR chapter_number IS NOT NULL
+                    OR scene_number IS NOT NULL
+                  )
+                """,
+                (fantasy_domain_id,),
+            ).fetchall()
+            violations.extend(
+                "scene_summaries id={id} universe={universe} domain={domain} "
+                "carries book/chapter/scene coordinates".format(
+                    id=row[0], universe=row[1], domain=row[2]
+                )
+                for row in rows
+            )
+        if _has_columns(
+            conn,
+            "reflections",
+            ("domain_id", "chapter_number", "scene_number"),
+        ):
+            rows = conn.execute(
+                """
+                SELECT id, universe_id, COALESCE(domain_id, '') AS domain_id
+                FROM reflections
+                WHERE COALESCE(domain_id, '') != ?
+                  AND (chapter_number IS NOT NULL OR scene_number IS NOT NULL)
+                """,
+                (fantasy_domain_id,),
+            ).fetchall()
+            violations.extend(
+                "reflections id={id} universe={universe} domain={domain} "
+                "carries chapter/scene coordinates".format(
+                    id=row[0], universe=row[1], domain=row[2]
+                )
+                for row in rows
+            )
+        return violations
+    finally:
+        if should_close:
+            conn.close()
+
+
+def migrate_episodic_schema_to_domain_neutral(
+    db_path: str | Path,
+    *,
+    dry_run: bool = True,
+    backup_dir: str | Path | None = None,
+    legacy_domain_id: str = FANTASY_DOMAIN_ID,
+) -> EpisodicSchemaMigrationResult:
+    """Host-gated migration that loosens fantasy coordinates.
+
+    ``dry_run=True`` copies the database, performs the rebuild on the copy,
+    and reports the result without modifying the source. ``dry_run=False``
+    creates a SQLite backup before touching the source; callers can restore
+    it with :func:`rollback_episodic_schema_migration`.
+    """
+    source = Path(db_path)
+    if str(source) == ":memory:":
+        raise ValueError("episodic schema migration requires a filesystem DB")
+    if not source.exists():
+        raise FileNotFoundError(source)
+
+    if dry_run:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            candidate = Path(temp_dir) / source.name
+            _backup_sqlite_database(source, candidate)
+            report = _migrate_episodic_database_in_place(
+                candidate,
+                dry_run=True,
+                backup_path=None,
+                legacy_domain_id=legacy_domain_id,
+            )
+            return EpisodicSchemaMigrationResult(
+                db_path=source,
+                dry_run=True,
+                schema_changed=report.schema_changed,
+                backup_path=None,
+                row_counts=report.row_counts,
+                no_bleed_ok=report.no_bleed_ok,
+                no_bleed_violations=report.no_bleed_violations,
+            )
+
+    if os.environ.get(EPISODIC_NEUTRAL_MIGRATION_FLAG) != "1":
+        raise PermissionError(
+            f"Set {EPISODIC_NEUTRAL_MIGRATION_FLAG}=1 to run the "
+            "host-gated episodic schema rebuild; dry_run=True does not "
+            "require the flag."
+        )
+
+    backup_root = Path(backup_dir) if backup_dir is not None else source.parent
+    backup_root.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_path = backup_root / f"{source.stem}.episodic-neutral.{stamp}.bak"
+    _backup_sqlite_database(source, backup_path)
+    try:
+        return _migrate_episodic_database_in_place(
+            source,
+            dry_run=False,
+            backup_path=backup_path,
+            legacy_domain_id=legacy_domain_id,
+        )
+    except Exception:
+        rollback_episodic_schema_migration(source, backup_path)
+        raise
+
+
+def rollback_episodic_schema_migration(
+    db_path: str | Path,
+    backup_path: str | Path,
+) -> None:
+    """Restore an episodic DB from a migration backup."""
+    target = Path(db_path)
+    shutil.copy2(Path(backup_path), target)
+    _remove_sqlite_sidecars(target)
+
+
+def _migrate_episodic_database_in_place(
+    db_path: Path,
+    *,
+    dry_run: bool,
+    backup_path: Path | None,
+    legacy_domain_id: str,
+) -> EpisodicSchemaMigrationResult:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        _ensure_scope_columns(conn)
+        _ensure_domain_neutral_columns(conn)
+        _rewrite_scene_summaries(conn, legacy_domain_id=legacy_domain_id)
+        _rewrite_reflections(conn, legacy_domain_id=legacy_domain_id)
+        conn.commit()
+        violations = check_episodic_no_bleed(conn)
+        return EpisodicSchemaMigrationResult(
+            db_path=db_path,
+            dry_run=dry_run,
+            schema_changed=True,
+            backup_path=backup_path,
+            row_counts=_row_counts(conn),
+            no_bleed_ok=not violations,
+            no_bleed_violations=violations,
+        )
+    finally:
+        conn.close()
+
+
+def _rewrite_scene_summaries(
+    conn: sqlite3.Connection,
+    *,
+    legacy_domain_id: str,
+) -> None:
+    if not _table_exists(conn, "scene_summaries"):
+        return
+    rows = conn.execute("SELECT * FROM scene_summaries ORDER BY id").fetchall()
+    conn.execute("ALTER TABLE scene_summaries RENAME TO scene_summaries__old")
+    conn.execute(
+        """
+        CREATE TABLE scene_summaries (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            universe_id   TEXT    NOT NULL,
+            domain_id     TEXT    NOT NULL DEFAULT '',
+            episode_id    TEXT    NOT NULL DEFAULT '',
+            sequence_number INTEGER NOT NULL DEFAULT 0,
+            domain_payload TEXT   NOT NULL DEFAULT '{}',
+            book_number   INTEGER,
+            chapter_number INTEGER,
+            scene_number  INTEGER,
+            summary       TEXT    NOT NULL,
+            word_count    INTEGER NOT NULL DEFAULT 0,
+            created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+            goal_id       TEXT,
+            branch_id     TEXT,
+            user_id       TEXT,
+            UNIQUE(universe_id, domain_id, episode_id),
+            UNIQUE(universe_id, book_number, chapter_number, scene_number)
+        )
+        """
+    )
+    for row in rows:
+        domain_id = row["domain_id"] or legacy_domain_id
+        book = row["book_number"]
+        chapter = row["chapter_number"]
+        scene = row["scene_number"]
+        payload = _json_loads(row["domain_payload"])
+        if not payload:
+            payload = {
+                "book_number": book,
+                "chapter_number": chapter,
+                "scene_number": scene,
+            }
+        episode_id = row["episode_id"] or _fantasy_episode_id(book, chapter, scene)
+        sequence_number = row["sequence_number"]
+        if sequence_number is None:
+            sequence_number = chapter or 0
+        if domain_id != FANTASY_DOMAIN_ID:
+            book = chapter = scene = None
+        conn.execute(
+            """
+            INSERT INTO scene_summaries
+                (id, universe_id, domain_id, episode_id, sequence_number,
+                 domain_payload, book_number, chapter_number, scene_number,
+                 summary, word_count, created_at, goal_id, branch_id, user_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                row["id"],
+                row["universe_id"],
+                domain_id,
+                episode_id,
+                sequence_number,
+                _json_dumps(payload),
+                book,
+                chapter,
+                scene,
+                row["summary"],
+                row["word_count"],
+                row["created_at"],
+                row["goal_id"],
+                row["branch_id"],
+                row["user_id"],
+            ),
+        )
+    conn.execute("DROP TABLE scene_summaries__old")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_scene_summaries_scope "
+        "ON scene_summaries(universe_id, goal_id, branch_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_scene_summaries_episode "
+        "ON scene_summaries(universe_id, domain_id, episode_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_scene_summaries_sequence "
+        "ON scene_summaries(universe_id, domain_id, sequence_number)"
+    )
+
+
+def _rewrite_reflections(
+    conn: sqlite3.Connection,
+    *,
+    legacy_domain_id: str,
+) -> None:
+    if not _table_exists(conn, "reflections"):
+        return
+    rows = conn.execute("SELECT * FROM reflections ORDER BY id").fetchall()
+    conn.execute("ALTER TABLE reflections RENAME TO reflections__old")
+    conn.execute(
+        """
+        CREATE TABLE reflections (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            universe_id   TEXT    NOT NULL,
+            domain_id     TEXT    NOT NULL DEFAULT '',
+            episode_id    TEXT    NOT NULL DEFAULT '',
+            sequence_number INTEGER NOT NULL DEFAULT 0,
+            domain_payload TEXT   NOT NULL DEFAULT '{}',
+            chapter_number INTEGER,
+            scene_number  INTEGER,
+            critique      TEXT    NOT NULL,
+            reflection    TEXT    NOT NULL,
+            created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+            goal_id       TEXT,
+            branch_id     TEXT,
+            user_id       TEXT
+        )
+        """
+    )
+    for row in rows:
+        domain_id = row["domain_id"] or legacy_domain_id
+        chapter = row["chapter_number"]
+        scene = row["scene_number"]
+        payload = _json_loads(row["domain_payload"])
+        if not payload:
+            payload = {
+                "chapter_number": chapter,
+                "scene_number": scene,
+            }
+        episode_id = row["episode_id"] or _fantasy_reflection_id(chapter, scene)
+        sequence_number = row["sequence_number"]
+        if sequence_number is None:
+            sequence_number = chapter or 0
+        if domain_id != FANTASY_DOMAIN_ID:
+            chapter = scene = None
+        conn.execute(
+            """
+            INSERT INTO reflections
+                (id, universe_id, domain_id, episode_id, sequence_number,
+                 domain_payload, chapter_number, scene_number, critique,
+                 reflection, created_at, goal_id, branch_id, user_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                row["id"],
+                row["universe_id"],
+                domain_id,
+                episode_id,
+                sequence_number,
+                _json_dumps(payload),
+                chapter,
+                scene,
+                row["critique"],
+                row["reflection"],
+                row["created_at"],
+                row["goal_id"],
+                row["branch_id"],
+                row["user_id"],
+            ),
+        )
+    conn.execute("DROP TABLE reflections__old")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_reflections_scope "
+        "ON reflections(universe_id, goal_id, branch_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_reflections_sequence "
+        "ON reflections(universe_id, domain_id, sequence_number)"
+    )
+
+
+def _ensure_scope_columns(conn: sqlite3.Connection) -> None:
+    for table in EpisodicMemory._SCOPED_TABLES:
+        if not _table_exists(conn, table):
+            continue
+        existing = _columns(conn, table)
+        for col_name, col_type in EpisodicMemory._SCOPE_COLUMNS:
+            if col_name not in existing:
+                conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN {col_name} {col_type}"
+                )
+
+
+def _ensure_domain_neutral_columns(conn: sqlite3.Connection) -> None:
+    for table, columns in EpisodicMemory._DOMAIN_NEUTRAL_COLUMNS.items():
+        if not _table_exists(conn, table):
+            continue
+        existing = _columns(conn, table)
+        for col_name, col_type in columns:
+            if col_name not in existing:
+                conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN {col_name} {col_type}"
+                )
+
+
+def _backup_sqlite_database(source: Path, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    src = sqlite3.connect(source)
+    try:
+        dst = sqlite3.connect(target)
+        try:
+            src.backup(dst)
+        finally:
+            dst.close()
+    finally:
+        src.close()
+
+
+def _remove_sqlite_sidecars(db_path: Path) -> None:
+    for suffix in ("-wal", "-shm"):
+        sidecar = db_path.with_name(f"{db_path.name}{suffix}")
+        if sidecar.exists():
+            sidecar.unlink()
+
+
+def _coerce_connection(
+    conn_or_path: sqlite3.Connection | str | Path,
+) -> tuple[sqlite3.Connection, bool]:
+    if isinstance(conn_or_path, sqlite3.Connection):
+        return conn_or_path, False
+    conn = sqlite3.connect(conn_or_path)
+    return conn, True
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _has_columns(
+    conn: sqlite3.Connection,
+    table: str,
+    columns: tuple[str, ...],
+) -> bool:
+    if not _table_exists(conn, table):
+        return False
+    existing = _columns(conn, table)
+    return all(column in existing for column in columns)
+
+
+def _row_counts(conn: sqlite3.Connection) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for table in (
+        "scene_summaries",
+        "episodic_facts",
+        "style_observations",
+        "reflections",
+    ):
+        if not _table_exists(conn, table):
+            continue
+        row = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+        counts[table] = int(row[0]) if row is not None else 0
+    return counts

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from workflow.memory.core import CoreMemory
 from workflow.memory.episodic import EpisodicMemory
 from workflow.memory.manager import DRAFT, EVALUATE, ORIENT, PLAN, MemoryManager
@@ -175,6 +177,48 @@ class TestEpisodicMemory:
         recent = ep.get_recent(chapter=1, k=5)
         assert len(recent) == 1
         assert recent[0].summary == "Version 2"
+
+    def test_store_episode_summary_keeps_generic_rows_domain_neutral(self):
+        ep = self._make_episodic()
+        ep.store_episode_summary(
+            episode_id="research-session-1",
+            sequence_number=7,
+            summary="Synthesized current standards evidence.",
+            word_count=120,
+            domain_id="research_probe",
+            domain_payload={"query": "data rules"},
+        )
+
+        recent = ep.get_recent_episodes(max_sequence=7, k=5, domain_id="research_probe")
+        assert len(recent) == 1
+        assert recent[0].episode_id == "research-session-1"
+        assert recent[0].sequence_number == 7
+        assert recent[0].domain_payload == {"query": "data rules"}
+
+        row = ep._conn.execute(
+            "SELECT book_number, chapter_number, scene_number "
+            "FROM scene_summaries WHERE domain_id = ?",
+            ("research_probe",),
+        ).fetchone()
+        assert row == (None, None, None)
+
+    def test_legacy_summary_call_records_fantasy_domain_payload(self):
+        ep = self._make_episodic()
+        ep.store_summary(1, 2, 3, "Fantasy scene summary.", 90)
+
+        row = ep._conn.execute(
+            "SELECT domain_id, episode_id, sequence_number, domain_payload "
+            "FROM scene_summaries WHERE universe_id = ?",
+            ("test",),
+        ).fetchone()
+        assert row[0] == "fantasy_author"
+        assert row[1] == "book:1/chapter:2/scene:3"
+        assert row[2] == 2
+        assert json.loads(row[3]) == {
+            "book_number": 1,
+            "chapter_number": 2,
+            "scene_number": 3,
+        }
 
 
 # =====================================================================

--- a/tests/test_memory_scope_stage_2b.py
+++ b/tests/test_memory_scope_stage_2b.py
@@ -22,6 +22,7 @@ Stage 2b ships three guarantees tests here pin down:
 
 from __future__ import annotations
 
+import json
 import sqlite3
 
 import pytest
@@ -35,7 +36,12 @@ from workflow.knowledge.models import (
     NarrativeFunction,
     SourceType,
 )
-from workflow.memory.episodic import EpisodicMemory
+from workflow.memory.episodic import (
+    EpisodicMemory,
+    check_episodic_no_bleed,
+    migrate_episodic_schema_to_domain_neutral,
+    rollback_episodic_schema_migration,
+)
 from workflow.memory.scoping import MemoryScope
 
 # ─── KG write-site threading ────────────────────────────────────────────
@@ -226,6 +232,27 @@ def _legacy_episodic_schema() -> str:
     """
 
 
+def _seed_legacy_episodic_db(db) -> None:
+    raw = sqlite3.connect(db)
+    try:
+        raw.executescript(_legacy_episodic_schema())
+        raw.execute(
+            "INSERT INTO scene_summaries "
+            "(universe_id, book_number, chapter_number, scene_number, summary, word_count) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("world", 1, 2, 3, "Legacy summary.", 100),
+        )
+        raw.execute(
+            "INSERT INTO reflections "
+            "(universe_id, chapter_number, scene_number, critique, reflection) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("world", 2, 3, "Too sparse.", "Add sensory detail."),
+        )
+        raw.commit()
+    finally:
+        raw.close()
+
+
 def test_episodic_migration_non_destructive_on_legacy_rows(tmp_path):
     """Simulate a pre-2b universe with populated rows, then open with
     the 2b code. Legacy rows must survive with NULL sub-scope tiers.
@@ -332,6 +359,144 @@ def test_episodic_migration_is_idempotent(tmp_path):
         assert row[1] == 42
     finally:
         second.close()
+
+
+def test_episodic_neutral_migration_dry_run_leaves_source_db_unchanged(tmp_path):
+    db = tmp_path / "episodic.db"
+    _seed_legacy_episodic_db(db)
+
+    before = sqlite3.connect(db)
+    try:
+        before_notnull = {
+            row[1]: row[3]
+            for row in before.execute("PRAGMA table_info(scene_summaries)")
+        }
+    finally:
+        before.close()
+
+    report = migrate_episodic_schema_to_domain_neutral(
+        db,
+        dry_run=True,
+        backup_dir=tmp_path / "backups",
+        legacy_domain_id="fantasy_author",
+    )
+
+    assert report.dry_run is True
+    assert report.backup_path is None
+    assert report.schema_changed is True
+    assert report.no_bleed_ok is True
+    assert report.row_counts["scene_summaries"] == 1
+
+    after = sqlite3.connect(db)
+    try:
+        after_notnull = {
+            row[1]: row[3]
+            for row in after.execute("PRAGMA table_info(scene_summaries)")
+        }
+    finally:
+        after.close()
+    assert after_notnull == before_notnull
+    assert after_notnull["book_number"] == 1
+
+
+def test_episodic_neutral_migration_requires_operator_flag(tmp_path):
+    db = tmp_path / "episodic.db"
+    _seed_legacy_episodic_db(db)
+
+    with pytest.raises(PermissionError):
+        migrate_episodic_schema_to_domain_neutral(
+            db,
+            dry_run=False,
+            backup_dir=tmp_path / "backups",
+            legacy_domain_id="fantasy_author",
+        )
+
+
+def test_episodic_neutral_migration_backup_and_rollback(tmp_path, monkeypatch):
+    db = tmp_path / "episodic.db"
+    _seed_legacy_episodic_db(db)
+    monkeypatch.setenv("WORKFLOW_EPISODIC_SCHEMA_MIGRATION", "1")
+
+    report = migrate_episodic_schema_to_domain_neutral(
+        db,
+        dry_run=False,
+        backup_dir=tmp_path / "backups",
+        legacy_domain_id="fantasy_author",
+    )
+
+    assert report.dry_run is False
+    assert report.backup_path is not None
+    assert report.backup_path.exists()
+    assert report.no_bleed_ok is True
+
+    migrated = sqlite3.connect(db)
+    try:
+        scene_cols = {
+            row[1]: row[3]
+            for row in migrated.execute("PRAGMA table_info(scene_summaries)")
+        }
+        assert scene_cols["book_number"] == 0
+        assert scene_cols["chapter_number"] == 0
+        assert scene_cols["scene_number"] == 0
+
+        row = migrated.execute(
+            "SELECT domain_id, episode_id, sequence_number, domain_payload, "
+            "summary FROM scene_summaries"
+        ).fetchone()
+        assert row[0] == "fantasy_author"
+        assert row[1] == "book:1/chapter:2/scene:3"
+        assert row[2] == 2
+        assert json.loads(row[3]) == {
+            "book_number": 1,
+            "chapter_number": 2,
+            "scene_number": 3,
+        }
+        assert row[4] == "Legacy summary."
+    finally:
+        migrated.close()
+
+    db.with_name(f"{db.name}-wal").write_text("stale wal")
+    db.with_name(f"{db.name}-shm").write_text("stale shm")
+    rollback_episodic_schema_migration(db, report.backup_path)
+    assert not db.with_name(f"{db.name}-wal").exists()
+    assert not db.with_name(f"{db.name}-shm").exists()
+
+    restored = sqlite3.connect(db)
+    try:
+        restored_cols = {
+            row[1]: row[3]
+            for row in restored.execute("PRAGMA table_info(scene_summaries)")
+        }
+        assert "domain_id" not in restored_cols
+        assert restored_cols["book_number"] == 1
+        restored_row = restored.execute(
+            "SELECT summary FROM scene_summaries"
+        ).fetchone()
+        assert restored_row[0] == "Legacy summary."
+    finally:
+        restored.close()
+
+
+def test_episodic_no_bleed_check_flags_non_fantasy_coordinates(tmp_path):
+    store = EpisodicMemory(db_path=str(tmp_path / "e.db"), universe_id="world")
+    try:
+        store.store_episode_summary(
+            episode_id="research-session-1",
+            sequence_number=1,
+            summary="Generic research summary.",
+            domain_id="research_probe",
+        )
+        store._conn.execute(
+            "UPDATE scene_summaries SET book_number = 1 WHERE domain_id = ?",
+            ("research_probe",),
+        )
+        store._conn.commit()
+
+        violations = check_episodic_no_bleed(store._conn)
+        assert any("scene_summaries" in violation for violation in violations)
+        assert any("research_probe" in violation for violation in violations)
+    finally:
+        store.close()
 
 
 def test_episodic_store_summary_with_scope(tmp_path):

--- a/workflow/domain_registry.py
+++ b/workflow/domain_registry.py
@@ -20,6 +20,7 @@ the footprint for investigation.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
@@ -28,6 +29,18 @@ logger = logging.getLogger(__name__)
 _DomainCallable = Callable[[dict[str, Any]], dict[str, Any]]
 
 _REGISTRY: dict[tuple[str, str], _DomainCallable] = {}
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodicCoordinateShape:
+    """Domain-owned coordinate fields for episodic memory rows."""
+
+    domain_id: str
+    coordinate_fields: tuple[str, ...]
+    sequence_field: str | None = None
+
+
+_EPISODIC_COORDINATE_SHAPES: dict[str, EpisodicCoordinateShape] = {}
 
 
 def register_domain_callable(
@@ -62,3 +75,30 @@ def resolve_domain_callable(
 def clear_registry() -> None:
     """Testing-only helper; drops all registrations."""
     _REGISTRY.clear()
+    _EPISODIC_COORDINATE_SHAPES.clear()
+
+
+def register_episodic_coordinate_shape(
+    domain_id: str,
+    coordinate_fields: tuple[str, ...] | list[str],
+    *,
+    sequence_field: str | None = None,
+) -> None:
+    """Register the domain-owned coordinate fields for episodic rows.
+
+    The shared episodic tables stay domain-neutral; this registry names
+    which optional payload fields a domain uses to interpret row order and
+    identity.
+    """
+    _EPISODIC_COORDINATE_SHAPES[domain_id] = EpisodicCoordinateShape(
+        domain_id=domain_id,
+        coordinate_fields=tuple(coordinate_fields),
+        sequence_field=sequence_field,
+    )
+
+
+def resolve_episodic_coordinate_shape(
+    domain_id: str,
+) -> EpisodicCoordinateShape | None:
+    """Return a registered episodic coordinate shape, if any."""
+    return _EPISODIC_COORDINATE_SHAPES.get(domain_id)

--- a/workflow/memory/episodic.py
+++ b/workflow/memory/episodic.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import shutil
 import sqlite3
+import tempfile
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -19,6 +23,49 @@ if TYPE_CHECKING:
     from workflow.memory.scoping import MemoryScope
 
 logger = logging.getLogger(__name__)
+
+FANTASY_DOMAIN_ID = "fantasy_author"
+EPISODIC_NEUTRAL_MIGRATION_FLAG = "WORKFLOW_EPISODIC_SCHEMA_MIGRATION"
+
+
+def _json_dumps(value: dict[str, Any]) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _json_loads(value: str | None) -> dict[str, Any]:
+    if not value:
+        return {}
+    try:
+        loaded = json.loads(value)
+    except json.JSONDecodeError:
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _fantasy_episode_id(
+    book_number: int,
+    chapter_number: int,
+    scene_number: int,
+) -> str:
+    return (
+        f"book:{book_number}/chapter:{chapter_number}/scene:{scene_number}"
+    )
+
+
+def _fantasy_summary_payload(
+    book_number: int,
+    chapter_number: int,
+    scene_number: int,
+) -> dict[str, int]:
+    return {
+        "book_number": book_number,
+        "chapter_number": chapter_number,
+        "scene_number": scene_number,
+    }
+
+
+def _fantasy_reflection_id(chapter_number: int, scene_number: int) -> str:
+    return f"chapter:{chapter_number}/scene:{scene_number}"
 
 
 def _scope_tiers(
@@ -39,12 +86,17 @@ _SCHEMA = """
 CREATE TABLE IF NOT EXISTS scene_summaries (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
     universe_id   TEXT    NOT NULL,
-    book_number   INTEGER NOT NULL,
-    chapter_number INTEGER NOT NULL,
-    scene_number  INTEGER NOT NULL,
+    domain_id     TEXT    NOT NULL DEFAULT '',
+    episode_id    TEXT    NOT NULL DEFAULT '',
+    sequence_number INTEGER NOT NULL DEFAULT 0,
+    domain_payload TEXT   NOT NULL DEFAULT '{}',
+    book_number   INTEGER,
+    chapter_number INTEGER,
+    scene_number  INTEGER,
     summary       TEXT    NOT NULL,
     word_count    INTEGER NOT NULL DEFAULT 0,
     created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(universe_id, domain_id, episode_id),
     UNIQUE(universe_id, book_number, chapter_number, scene_number)
 );
 
@@ -73,8 +125,12 @@ CREATE TABLE IF NOT EXISTS style_observations (
 CREATE TABLE IF NOT EXISTS reflections (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
     universe_id   TEXT    NOT NULL,
-    chapter_number INTEGER NOT NULL,
-    scene_number  INTEGER NOT NULL,
+    domain_id     TEXT    NOT NULL DEFAULT '',
+    episode_id    TEXT    NOT NULL DEFAULT '',
+    sequence_number INTEGER NOT NULL DEFAULT 0,
+    domain_payload TEXT   NOT NULL DEFAULT '{}',
+    chapter_number INTEGER,
+    scene_number  INTEGER,
     critique      TEXT    NOT NULL,
     reflection    TEXT    NOT NULL,
     created_at    TEXT    NOT NULL DEFAULT (datetime('now'))
@@ -91,6 +147,31 @@ class SceneSummary:
     scene_number: int
     summary: str
     word_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodeSummary:
+    """A domain-neutral episodic summary."""
+
+    domain_id: str
+    episode_id: str
+    sequence_number: int
+    domain_payload: dict[str, Any]
+    summary: str
+    word_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodicSchemaMigrationResult:
+    """Report for the host-gated episodic schema migration."""
+
+    db_path: Path
+    dry_run: bool
+    schema_changed: bool
+    backup_path: Path | None
+    row_counts: dict[str, int]
+    no_bleed_ok: bool
+    no_bleed_violations: list[str]
 
 
 class EpisodicMemory:
@@ -120,6 +201,7 @@ class EpisodicMemory:
         self._conn.execute("PRAGMA busy_timeout=30000")
         self._conn.executescript(_SCHEMA)
         self._migrate_scope_columns()
+        self._migrate_domain_neutral_columns()
 
     # -----------------------------------------------------------------
     # Memory-scope Stage 2b schema migration
@@ -134,6 +216,20 @@ class EpisodicMemory:
         "scene_summaries", "episodic_facts",
         "style_observations", "reflections",
     )
+    _DOMAIN_NEUTRAL_COLUMNS: dict[str, tuple[tuple[str, str], ...]] = {
+        "scene_summaries": (
+            ("domain_id", "TEXT"),
+            ("episode_id", "TEXT"),
+            ("sequence_number", "INTEGER"),
+            ("domain_payload", "TEXT"),
+        ),
+        "reflections": (
+            ("domain_id", "TEXT"),
+            ("episode_id", "TEXT"),
+            ("sequence_number", "INTEGER"),
+            ("domain_payload", "TEXT"),
+        ),
+    }
 
     def _migrate_scope_columns(self) -> None:
         """Add ``goal_id`` / ``branch_id`` / ``user_id`` columns if missing.
@@ -162,6 +258,37 @@ class EpisodicMemory:
                 f"CREATE INDEX IF NOT EXISTS idx_{table}_scope "
                 f"ON {table}(universe_id, goal_id, branch_id)"
             )
+        self._conn.commit()
+
+    def _migrate_domain_neutral_columns(self) -> None:
+        """Add neutral episodic columns without rebuilding live tables.
+
+        This is the normal-startup compatibility path. It lets old DBs keep
+        serving while the host-gated rebuild migration remains explicit.
+        """
+        for table, columns in self._DOMAIN_NEUTRAL_COLUMNS.items():
+            existing = {
+                row[1]
+                for row in self._conn.execute(f"PRAGMA table_info({table})")
+            }
+            for col_name, col_type in columns:
+                if col_name in existing:
+                    continue
+                self._conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN {col_name} {col_type}"
+                )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_scene_summaries_episode "
+            "ON scene_summaries(universe_id, domain_id, episode_id)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_scene_summaries_sequence "
+            "ON scene_summaries(universe_id, domain_id, sequence_number)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_reflections_sequence "
+            "ON reflections(universe_id, domain_id, sequence_number)"
+        )
         self._conn.commit()
 
     def close(self) -> None:
@@ -195,23 +322,130 @@ class EpisodicMemory:
         hard-invariant tier). Scope tagging is advisory until 2c.
         """
         goal_id, branch_id, user_id = self._scope_tiers(scope)
+        domain_payload = _fantasy_summary_payload(
+            book_number, chapter_number, scene_number
+        )
         self._conn.execute(
             """
             INSERT INTO scene_summaries
-                (universe_id, book_number, chapter_number, scene_number,
+                (universe_id, domain_id, episode_id, sequence_number,
+                 domain_payload, book_number, chapter_number, scene_number,
                  summary, word_count, goal_id, branch_id, user_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(universe_id, book_number, chapter_number, scene_number)
             DO UPDATE SET summary=excluded.summary,
                           word_count=excluded.word_count,
+                          domain_id=excluded.domain_id,
+                          episode_id=excluded.episode_id,
+                          sequence_number=excluded.sequence_number,
+                          domain_payload=excluded.domain_payload,
                           goal_id=COALESCE(excluded.goal_id, scene_summaries.goal_id),
                           branch_id=COALESCE(excluded.branch_id, scene_summaries.branch_id),
                           user_id=COALESCE(excluded.user_id, scene_summaries.user_id)
             """,
-            (self._universe_id, book_number, chapter_number,
-             scene_number, summary, word_count,
-             goal_id, branch_id, user_id),
+            (
+                self._universe_id,
+                FANTASY_DOMAIN_ID,
+                _fantasy_episode_id(book_number, chapter_number, scene_number),
+                chapter_number,
+                _json_dumps(domain_payload),
+                book_number,
+                chapter_number,
+                scene_number,
+                summary,
+                word_count,
+                goal_id,
+                branch_id,
+                user_id,
+            ),
         )
+        self._conn.commit()
+
+    def store_episode_summary(
+        self,
+        episode_id: str,
+        sequence_number: int,
+        summary: str,
+        word_count: int = 0,
+        *,
+        domain_id: str = "workflow",
+        domain_payload: dict[str, Any] | None = None,
+        scope: "MemoryScope | None" = None,
+    ) -> None:
+        """Persist a domain-neutral episode summary.
+
+        Domain-specific coordinates stay in ``domain_payload`` and the
+        optional domain registry. Shared substrate columns never require
+        book/chapter/scene for non-fantasy domains.
+        """
+        goal_id, branch_id, user_id = self._scope_tiers(scope)
+        payload = dict(domain_payload or {})
+        book_number = payload.get("book_number")
+        chapter_number = payload.get("chapter_number")
+        scene_number = payload.get("scene_number")
+        if domain_id != FANTASY_DOMAIN_ID:
+            book_number = chapter_number = scene_number = None
+
+        existing = self._conn.execute(
+            "SELECT id FROM scene_summaries "
+            "WHERE universe_id = ? AND domain_id = ? AND episode_id = ?",
+            (self._universe_id, domain_id, episode_id),
+        ).fetchone()
+        if existing is None:
+            self._conn.execute(
+                """
+                INSERT INTO scene_summaries
+                    (universe_id, domain_id, episode_id, sequence_number,
+                     domain_payload, book_number, chapter_number, scene_number,
+                     summary, word_count, goal_id, branch_id, user_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    self._universe_id,
+                    domain_id,
+                    episode_id,
+                    sequence_number,
+                    _json_dumps(payload),
+                    book_number,
+                    chapter_number,
+                    scene_number,
+                    summary,
+                    word_count,
+                    goal_id,
+                    branch_id,
+                    user_id,
+                ),
+            )
+        else:
+            self._conn.execute(
+                """
+                UPDATE scene_summaries
+                SET sequence_number = ?,
+                    domain_payload = ?,
+                    book_number = ?,
+                    chapter_number = ?,
+                    scene_number = ?,
+                    summary = ?,
+                    word_count = ?,
+                    goal_id = COALESCE(?, goal_id),
+                    branch_id = COALESCE(?, branch_id),
+                    user_id = COALESCE(?, user_id)
+                WHERE id = ?
+                """,
+                (
+                    sequence_number,
+                    _json_dumps(payload),
+                    book_number,
+                    chapter_number,
+                    scene_number,
+                    summary,
+                    word_count,
+                    goal_id,
+                    branch_id,
+                    user_id,
+                    existing[0],
+                ),
+            )
         self._conn.commit()
 
     def get_recent(
@@ -241,6 +475,45 @@ class EpisodicMemory:
                 scene_number=r[2],
                 summary=r[3],
                 word_count=r[4],
+            )
+            for r in rows
+        ]
+
+    def get_recent_episodes(
+        self,
+        max_sequence: int,
+        k: int = 5,
+        *,
+        domain_id: str | None = None,
+    ) -> list[EpisodeSummary]:
+        """Return recent domain-neutral episode summaries."""
+        params: list[Any] = [self._universe_id, max_sequence]
+        domain_filter = ""
+        if domain_id is not None:
+            domain_filter = " AND domain_id = ?"
+            params.append(domain_id)
+        params.append(k)
+        rows = self._conn.execute(
+            f"""
+            SELECT domain_id, episode_id, sequence_number,
+                   domain_payload, summary, word_count
+            FROM scene_summaries
+            WHERE universe_id = ?
+              AND sequence_number <= ?
+              {domain_filter}
+            ORDER BY sequence_number DESC, id DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+        return [
+            EpisodeSummary(
+                domain_id=r[0] or "",
+                episode_id=r[1] or "",
+                sequence_number=r[2] or 0,
+                domain_payload=_json_loads(r[3]),
+                summary=r[4],
+                word_count=r[5],
             )
             for r in rows
         ]
@@ -417,14 +690,30 @@ class EpisodicMemory:
         Memory-scope Stage 2b: optional ``scope`` tags the row.
         """
         goal_id, branch_id, user_id = self._scope_tiers(scope)
+        domain_payload = {
+            "chapter_number": chapter_number,
+            "scene_number": scene_number,
+        }
         self._conn.execute(
             "INSERT INTO reflections "
-            "(universe_id, chapter_number, scene_number, "
+            "(universe_id, domain_id, episode_id, sequence_number, "
+            " domain_payload, chapter_number, scene_number, "
             " critique, reflection, goal_id, branch_id, user_id) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (self._universe_id, chapter_number, scene_number,
-             critique, reflection,
-             goal_id, branch_id, user_id),
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                self._universe_id,
+                FANTASY_DOMAIN_ID,
+                _fantasy_reflection_id(chapter_number, scene_number),
+                chapter_number,
+                _json_dumps(domain_payload),
+                chapter_number,
+                scene_number,
+                critique,
+                reflection,
+                goal_id,
+                branch_id,
+                user_id,
+            ),
         )
         self._conn.commit()
 
@@ -472,3 +761,430 @@ class EpisodicMemory:
         )
         self._conn.commit()
         return cur.rowcount
+
+
+def check_episodic_no_bleed(
+    conn_or_path: sqlite3.Connection | str | Path,
+    *,
+    fantasy_domain_id: str = FANTASY_DOMAIN_ID,
+) -> list[str]:
+    """Return non-fantasy rows that still carry fantasy coordinates."""
+    conn, should_close = _coerce_connection(conn_or_path)
+    try:
+        violations: list[str] = []
+        if _has_columns(
+            conn,
+            "scene_summaries",
+            ("domain_id", "book_number", "chapter_number", "scene_number"),
+        ):
+            rows = conn.execute(
+                """
+                SELECT id, universe_id, COALESCE(domain_id, '') AS domain_id
+                FROM scene_summaries
+                WHERE COALESCE(domain_id, '') != ?
+                  AND (
+                    book_number IS NOT NULL
+                    OR chapter_number IS NOT NULL
+                    OR scene_number IS NOT NULL
+                  )
+                """,
+                (fantasy_domain_id,),
+            ).fetchall()
+            violations.extend(
+                "scene_summaries id={id} universe={universe} domain={domain} "
+                "carries book/chapter/scene coordinates".format(
+                    id=row[0], universe=row[1], domain=row[2]
+                )
+                for row in rows
+            )
+        if _has_columns(
+            conn,
+            "reflections",
+            ("domain_id", "chapter_number", "scene_number"),
+        ):
+            rows = conn.execute(
+                """
+                SELECT id, universe_id, COALESCE(domain_id, '') AS domain_id
+                FROM reflections
+                WHERE COALESCE(domain_id, '') != ?
+                  AND (chapter_number IS NOT NULL OR scene_number IS NOT NULL)
+                """,
+                (fantasy_domain_id,),
+            ).fetchall()
+            violations.extend(
+                "reflections id={id} universe={universe} domain={domain} "
+                "carries chapter/scene coordinates".format(
+                    id=row[0], universe=row[1], domain=row[2]
+                )
+                for row in rows
+            )
+        return violations
+    finally:
+        if should_close:
+            conn.close()
+
+
+def migrate_episodic_schema_to_domain_neutral(
+    db_path: str | Path,
+    *,
+    dry_run: bool = True,
+    backup_dir: str | Path | None = None,
+    legacy_domain_id: str = FANTASY_DOMAIN_ID,
+) -> EpisodicSchemaMigrationResult:
+    """Host-gated migration that loosens fantasy coordinates.
+
+    ``dry_run=True`` copies the database, performs the rebuild on the copy,
+    and reports the result without modifying the source. ``dry_run=False``
+    creates a SQLite backup before touching the source; callers can restore
+    it with :func:`rollback_episodic_schema_migration`.
+    """
+    source = Path(db_path)
+    if str(source) == ":memory:":
+        raise ValueError("episodic schema migration requires a filesystem DB")
+    if not source.exists():
+        raise FileNotFoundError(source)
+
+    if dry_run:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            candidate = Path(temp_dir) / source.name
+            _backup_sqlite_database(source, candidate)
+            report = _migrate_episodic_database_in_place(
+                candidate,
+                dry_run=True,
+                backup_path=None,
+                legacy_domain_id=legacy_domain_id,
+            )
+            return EpisodicSchemaMigrationResult(
+                db_path=source,
+                dry_run=True,
+                schema_changed=report.schema_changed,
+                backup_path=None,
+                row_counts=report.row_counts,
+                no_bleed_ok=report.no_bleed_ok,
+                no_bleed_violations=report.no_bleed_violations,
+            )
+
+    if os.environ.get(EPISODIC_NEUTRAL_MIGRATION_FLAG) != "1":
+        raise PermissionError(
+            f"Set {EPISODIC_NEUTRAL_MIGRATION_FLAG}=1 to run the "
+            "host-gated episodic schema rebuild; dry_run=True does not "
+            "require the flag."
+        )
+
+    backup_root = Path(backup_dir) if backup_dir is not None else source.parent
+    backup_root.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_path = backup_root / f"{source.stem}.episodic-neutral.{stamp}.bak"
+    _backup_sqlite_database(source, backup_path)
+    try:
+        return _migrate_episodic_database_in_place(
+            source,
+            dry_run=False,
+            backup_path=backup_path,
+            legacy_domain_id=legacy_domain_id,
+        )
+    except Exception:
+        rollback_episodic_schema_migration(source, backup_path)
+        raise
+
+
+def rollback_episodic_schema_migration(
+    db_path: str | Path,
+    backup_path: str | Path,
+) -> None:
+    """Restore an episodic DB from a migration backup."""
+    target = Path(db_path)
+    shutil.copy2(Path(backup_path), target)
+    _remove_sqlite_sidecars(target)
+
+
+def _migrate_episodic_database_in_place(
+    db_path: Path,
+    *,
+    dry_run: bool,
+    backup_path: Path | None,
+    legacy_domain_id: str,
+) -> EpisodicSchemaMigrationResult:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        _ensure_scope_columns(conn)
+        _ensure_domain_neutral_columns(conn)
+        _rewrite_scene_summaries(conn, legacy_domain_id=legacy_domain_id)
+        _rewrite_reflections(conn, legacy_domain_id=legacy_domain_id)
+        conn.commit()
+        violations = check_episodic_no_bleed(conn)
+        return EpisodicSchemaMigrationResult(
+            db_path=db_path,
+            dry_run=dry_run,
+            schema_changed=True,
+            backup_path=backup_path,
+            row_counts=_row_counts(conn),
+            no_bleed_ok=not violations,
+            no_bleed_violations=violations,
+        )
+    finally:
+        conn.close()
+
+
+def _rewrite_scene_summaries(
+    conn: sqlite3.Connection,
+    *,
+    legacy_domain_id: str,
+) -> None:
+    if not _table_exists(conn, "scene_summaries"):
+        return
+    rows = conn.execute("SELECT * FROM scene_summaries ORDER BY id").fetchall()
+    conn.execute("ALTER TABLE scene_summaries RENAME TO scene_summaries__old")
+    conn.execute(
+        """
+        CREATE TABLE scene_summaries (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            universe_id   TEXT    NOT NULL,
+            domain_id     TEXT    NOT NULL DEFAULT '',
+            episode_id    TEXT    NOT NULL DEFAULT '',
+            sequence_number INTEGER NOT NULL DEFAULT 0,
+            domain_payload TEXT   NOT NULL DEFAULT '{}',
+            book_number   INTEGER,
+            chapter_number INTEGER,
+            scene_number  INTEGER,
+            summary       TEXT    NOT NULL,
+            word_count    INTEGER NOT NULL DEFAULT 0,
+            created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+            goal_id       TEXT,
+            branch_id     TEXT,
+            user_id       TEXT,
+            UNIQUE(universe_id, domain_id, episode_id),
+            UNIQUE(universe_id, book_number, chapter_number, scene_number)
+        )
+        """
+    )
+    for row in rows:
+        domain_id = row["domain_id"] or legacy_domain_id
+        book = row["book_number"]
+        chapter = row["chapter_number"]
+        scene = row["scene_number"]
+        payload = _json_loads(row["domain_payload"])
+        if not payload:
+            payload = {
+                "book_number": book,
+                "chapter_number": chapter,
+                "scene_number": scene,
+            }
+        episode_id = row["episode_id"] or _fantasy_episode_id(book, chapter, scene)
+        sequence_number = row["sequence_number"]
+        if sequence_number is None:
+            sequence_number = chapter or 0
+        if domain_id != FANTASY_DOMAIN_ID:
+            book = chapter = scene = None
+        conn.execute(
+            """
+            INSERT INTO scene_summaries
+                (id, universe_id, domain_id, episode_id, sequence_number,
+                 domain_payload, book_number, chapter_number, scene_number,
+                 summary, word_count, created_at, goal_id, branch_id, user_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                row["id"],
+                row["universe_id"],
+                domain_id,
+                episode_id,
+                sequence_number,
+                _json_dumps(payload),
+                book,
+                chapter,
+                scene,
+                row["summary"],
+                row["word_count"],
+                row["created_at"],
+                row["goal_id"],
+                row["branch_id"],
+                row["user_id"],
+            ),
+        )
+    conn.execute("DROP TABLE scene_summaries__old")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_scene_summaries_scope "
+        "ON scene_summaries(universe_id, goal_id, branch_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_scene_summaries_episode "
+        "ON scene_summaries(universe_id, domain_id, episode_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_scene_summaries_sequence "
+        "ON scene_summaries(universe_id, domain_id, sequence_number)"
+    )
+
+
+def _rewrite_reflections(
+    conn: sqlite3.Connection,
+    *,
+    legacy_domain_id: str,
+) -> None:
+    if not _table_exists(conn, "reflections"):
+        return
+    rows = conn.execute("SELECT * FROM reflections ORDER BY id").fetchall()
+    conn.execute("ALTER TABLE reflections RENAME TO reflections__old")
+    conn.execute(
+        """
+        CREATE TABLE reflections (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            universe_id   TEXT    NOT NULL,
+            domain_id     TEXT    NOT NULL DEFAULT '',
+            episode_id    TEXT    NOT NULL DEFAULT '',
+            sequence_number INTEGER NOT NULL DEFAULT 0,
+            domain_payload TEXT   NOT NULL DEFAULT '{}',
+            chapter_number INTEGER,
+            scene_number  INTEGER,
+            critique      TEXT    NOT NULL,
+            reflection    TEXT    NOT NULL,
+            created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+            goal_id       TEXT,
+            branch_id     TEXT,
+            user_id       TEXT
+        )
+        """
+    )
+    for row in rows:
+        domain_id = row["domain_id"] or legacy_domain_id
+        chapter = row["chapter_number"]
+        scene = row["scene_number"]
+        payload = _json_loads(row["domain_payload"])
+        if not payload:
+            payload = {
+                "chapter_number": chapter,
+                "scene_number": scene,
+            }
+        episode_id = row["episode_id"] or _fantasy_reflection_id(chapter, scene)
+        sequence_number = row["sequence_number"]
+        if sequence_number is None:
+            sequence_number = chapter or 0
+        if domain_id != FANTASY_DOMAIN_ID:
+            chapter = scene = None
+        conn.execute(
+            """
+            INSERT INTO reflections
+                (id, universe_id, domain_id, episode_id, sequence_number,
+                 domain_payload, chapter_number, scene_number, critique,
+                 reflection, created_at, goal_id, branch_id, user_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                row["id"],
+                row["universe_id"],
+                domain_id,
+                episode_id,
+                sequence_number,
+                _json_dumps(payload),
+                chapter,
+                scene,
+                row["critique"],
+                row["reflection"],
+                row["created_at"],
+                row["goal_id"],
+                row["branch_id"],
+                row["user_id"],
+            ),
+        )
+    conn.execute("DROP TABLE reflections__old")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_reflections_scope "
+        "ON reflections(universe_id, goal_id, branch_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_reflections_sequence "
+        "ON reflections(universe_id, domain_id, sequence_number)"
+    )
+
+
+def _ensure_scope_columns(conn: sqlite3.Connection) -> None:
+    for table in EpisodicMemory._SCOPED_TABLES:
+        if not _table_exists(conn, table):
+            continue
+        existing = _columns(conn, table)
+        for col_name, col_type in EpisodicMemory._SCOPE_COLUMNS:
+            if col_name not in existing:
+                conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN {col_name} {col_type}"
+                )
+
+
+def _ensure_domain_neutral_columns(conn: sqlite3.Connection) -> None:
+    for table, columns in EpisodicMemory._DOMAIN_NEUTRAL_COLUMNS.items():
+        if not _table_exists(conn, table):
+            continue
+        existing = _columns(conn, table)
+        for col_name, col_type in columns:
+            if col_name not in existing:
+                conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN {col_name} {col_type}"
+                )
+
+
+def _backup_sqlite_database(source: Path, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    src = sqlite3.connect(source)
+    try:
+        dst = sqlite3.connect(target)
+        try:
+            src.backup(dst)
+        finally:
+            dst.close()
+    finally:
+        src.close()
+
+
+def _remove_sqlite_sidecars(db_path: Path) -> None:
+    for suffix in ("-wal", "-shm"):
+        sidecar = db_path.with_name(f"{db_path.name}{suffix}")
+        if sidecar.exists():
+            sidecar.unlink()
+
+
+def _coerce_connection(
+    conn_or_path: sqlite3.Connection | str | Path,
+) -> tuple[sqlite3.Connection, bool]:
+    if isinstance(conn_or_path, sqlite3.Connection):
+        return conn_or_path, False
+    conn = sqlite3.connect(conn_or_path)
+    return conn, True
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _has_columns(
+    conn: sqlite3.Connection,
+    table: str,
+    columns: tuple[str, ...],
+) -> bool:
+    if not _table_exists(conn, table):
+        return False
+    existing = _columns(conn, table)
+    return all(column in existing for column in columns)
+
+
+def _row_counts(conn: sqlite3.Connection) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for table in (
+        "scene_summaries",
+        "episodic_facts",
+        "style_observations",
+        "reflections",
+    ):
+        if not _table_exists(conn, table):
+            continue
+        row = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+        counts[table] = int(row[0]) if row is not None else 0
+    return counts


### PR DESCRIPTION
## Summary
- adds domain-neutral episodic row coordinates (`domain_id`, `episode_id`, `sequence_number`, `domain_payload`) while preserving the legacy fantasy-facing `store_summary`/`get_recent` API
- registers fantasy book/chapter/scene as a domain-owned episodic coordinate shape instead of treating it as the substrate default
- adds an explicit host-gated schema rebuild migration with dry-run, SQLite backup, rollback, stale WAL/SHM cleanup, and no-bleed validation for non-fantasy rows
- mirrors changed runtime files into the Claude plugin package

## Verification
- python -m pytest tests/test_memory.py tests/test_memory_scope_stage_2b.py tests/test_memory_scope_stage_2b3.py tests/test_memory_scoping.py tests/test_workflow_runtime.py tests/test_research_probe.py tests/test_unified_execution.py tests/test_mcp_server.py tests/test_mcp_tool_canary.py tests/test_wiki_canary.py -q
- python -m ruff check workflow/memory/episodic.py workflow/domain_registry.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/memory/episodic.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/domain_registry.py domains/fantasy_daemon/memory/schemas.py tests/test_memory.py tests/test_memory_scope_stage_2b.py
- python -m scripts.invariants.mirror_parity
- python packaging\claude-plugin\build_plugin.py
- git diff --check
- pre-commit hooks on commit: mirror parity, mojibake scan, import graph smoke, path-resolver lint, cross-provider drift, skills-valid

## Gate status
Stacked PR-139 slice 10 behind slice 9 / PR #1100. Keep draft until #1098, #1099, and #1100 land/retarget and this branch is checked against the correct base. Do not merge until Cowork checker-key wiki position record exists for slice 10 and the standing host key is revalidated under the PR-139 runbook.