### PR TITLE
fix: read structured status in LLM verifier

### DIFF
--- a/scripts/verify_llm_binding.py
+++ b/scripts/verify_llm_binding.py
@@ -99,6 +99,10 @@ def _post(
 
 
 def _parse_status(result: dict[str, Any]) -> dict[str, Any]:
+    structured = result.get("structuredContent")
+    if isinstance(structured, dict):
+        return structured
+
     for item in result.get("content", []):
         if item.get("type") == "text":
             try:
@@ -110,11 +114,11 @@ def _parse_status(result: dict[str, Any]) -> dict[str, Any]:
 
 def _llm_endpoint_bound(status: dict[str, Any]) -> Any:
     """Return the LLM binding from either historical or current status shape."""
+    active_host = status.get("active_host")
+    if isinstance(active_host, dict) and "llm_endpoint_bound" in active_host:
+        return active_host.get("llm_endpoint_bound")
     if "llm_endpoint_bound" in status:
         return status.get("llm_endpoint_bound")
-    active_host = status.get("active_host")
-    if isinstance(active_host, dict):
-        return active_host.get("llm_endpoint_bound", "unset")
     return "unset"
 
 

--- a/tests/test_verify_llm_binding.py
+++ b/tests/test_verify_llm_binding.py
@@ -45,6 +45,42 @@ _STATUS_BOUND_NESTED = {
         ]
     },
 }
+_STATUS_BOUND_NESTED_WITH_STALE_TOP_LEVEL = {
+    "jsonrpc": "2.0",
+    "id": 10,
+    "result": {
+        "content": [
+            {
+                "type": "text",
+                "text": (
+                    '{"llm_endpoint_bound": "unset", '
+                    '"active_host": {"llm_endpoint_bound": "codex"}, '
+                    '"phase": "idle"}'
+                ),
+            }
+        ]
+    },
+}
+_STATUS_BOUND_STRUCTURED_CONTENT = {
+    "jsonrpc": "2.0",
+    "id": 10,
+    "result": {
+        "content": [
+            {
+                "type": "text",
+                "text": (
+                    "Tool result: caveats=2. "
+                    "Full payload is in structuredContent."
+                ),
+            }
+        ],
+        "structuredContent": {
+            "schema_version": 1,
+            "active_host": {"llm_endpoint_bound": "codex"},
+            "sandbox_status": {"bwrap_available": True, "reason": None},
+        },
+    },
+}
 _STATUS_BOUND_SANDBOX_OK = {
     "jsonrpc": "2.0",
     "id": 10,
@@ -138,6 +174,31 @@ def test_llm_bound_accepts_current_nested_status_shape():
     )
     result = check_llm_binding("http://fake/mcp", 10.0, post_fn=post_fn)
     assert result["active_host"]["llm_endpoint_bound"] == "codex"
+
+
+def test_llm_bound_prefers_nested_status_over_stale_top_level():
+    post_fn = _make_post_fn(
+        (_INIT_OK, "sid1"),
+        (_NOTIF_NONE, "sid1"),
+        (_STATUS_BOUND_NESTED_WITH_STALE_TOP_LEVEL, "sid1"),
+        (_ADD_CANON_OK, "sid1"),
+    )
+    result = check_llm_binding("http://fake/mcp", 10.0, post_fn=post_fn)
+    assert result["active_host"]["llm_endpoint_bound"] == "codex"
+
+
+def test_llm_bound_accepts_structured_content_status_payload():
+    post_fn = _make_post_fn(
+        (_INIT_OK, "sid1"),
+        (_NOTIF_NONE, "sid1"),
+        (_STATUS_BOUND_STRUCTURED_CONTENT, "sid1"),
+        (_ADD_CANON_OK, "sid1"),
+    )
+    result = check_llm_binding(
+        "http://fake/mcp", 10.0, require_sandbox=True, post_fn=post_fn
+    )
+    assert result["active_host"]["llm_endpoint_bound"] == "codex"
+    assert result["sandbox_status"]["bwrap_available"] is True
 
 
 def test_llm_bound_add_canon_non_fatal():


### PR DESCRIPTION
## Summary
- Prefer MCP `structuredContent` when parsing `get_status` in the deploy LLM binding verifier.
- Keep compatibility with historical JSON-in-text status responses.
- Prefer authoritative `active_host.llm_endpoint_bound` over stale top-level `llm_endpoint_bound` when both are present.

## Why
Deploy-prod is rolling back otherwise-green images because the live MCP `get_status` response now puts the machine payload in `structuredContent` while the text content is a human summary (`Full payload is in structuredContent`). The verifier parsed only text, reduced the status to `raw`, and reported `llm_endpoint_bound='unset'`.

## Verification
- `python -m pytest tests/test_verify_llm_binding.py -q -p no:cacheprovider` -> 19 passed
- `python -m ruff check scripts/verify_llm_binding.py tests/test_verify_llm_binding.py` -> passed
- `python scripts/verify_llm_binding.py --url https://tinyassets.io/mcp --timeout 20 --require-sandbox --retries 3 --retry-delay 5` -> PASS (`codex`, sandbox true)

## Related
- Deploy failed issue: #1108
- Same failure pattern seen in #1106 and #1107