### PR TITLE
[auto-change] WIKI-DESIGN: Per-universe page substrate + writer-dispatcher universe routing — close the structural gap that causes wrong-place game-project content in Workflow wiki

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/helpers.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/helpers.py
@@ -32,10 +32,17 @@ from __future__ import annotations
 import json
 import logging
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+_WIKI_ROOT_OVERRIDE: ContextVar[Path | None] = ContextVar(
+    "workflow_wiki_root_override",
+    default=None,
+)
 
 
 def _base_path() -> Path:
@@ -114,8 +121,22 @@ def _wiki_root() -> Path:
     as the fallback, which broke every non-host deploy. See
     ``workflow.storage.wiki_path`` for the precedence + rationale.
     """
+    override = _WIKI_ROOT_OVERRIDE.get()
+    if override is not None:
+        return override
+
     from workflow.storage import wiki_path
     return wiki_path()
+
+
+@contextmanager
+def _scoped_wiki_root(root: Path) -> Iterator[None]:
+    """Temporarily route wiki helpers to an explicit wiki root."""
+    token = _WIKI_ROOT_OVERRIDE.set(root.resolve())
+    try:
+        yield
+    finally:
+        _WIKI_ROOT_OVERRIDE.reset(token)
 
 
 def _wiki_pages_dir() -> Path:
@@ -139,6 +160,7 @@ __all__ = [
     "_find_all_pages",
     "_read_json",
     "_read_text",
+    "_scoped_wiki_root",
     "_universe_dir",
     "_wiki_drafts_dir",
     "_wiki_pages_dir",

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -32,6 +32,7 @@ from workflow.api.helpers import (
     _default_universe,
     _find_all_pages,
     _read_text,
+    _scoped_wiki_root,
     _universe_dir,
     _wiki_drafts_dir,
     _wiki_pages_dir,
@@ -1921,6 +1922,7 @@ def _wiki_file_bug(
     cross_reference_count: int = 0,
     force_new: bool = False,
     verbose: bool = False,
+    universe_id: str = "",
     **_kwargs: Any,
 ) -> str:
     """File a bug, feature request, design proposal, or patch request.
@@ -2084,8 +2086,8 @@ def _wiki_file_bug(
             "repro": repro,
             "workaround": workaround,
         }
-        universe_id = _default_universe()
-        universe_path = _universe_dir(universe_id)
+        target_universe_id = universe_id.strip() or _default_universe()
+        universe_path = _universe_dir(target_universe_id)
         # Pre-write trigger receipt (status=pending). Read canonical branch_def_id
         # from env so the receipt records what we *expected* to invoke even if the
         # enqueue helper rejects.
@@ -2111,7 +2113,7 @@ def _wiki_file_bug(
                 bug_id=bug_id,
                 frontmatter=frontmatter,
                 base_path=universe_path,
-                universe_id=universe_id,
+                universe_id=target_universe_id,
             )
         except Exception as _enq_exc:
             # Trigger helper raised. Update receipt then re-raise into the outer
@@ -2245,7 +2247,30 @@ WIKI_WRITE_ACTIONS: frozenset[str] = frozenset({
 })
 
 
-def _dispatch_scope_error(tool: str, action: str) -> str | None:
+def _wiki_root_for_universe(universe_id: str) -> Path:
+    """Return the page-substrate root for a target universe."""
+    uid = universe_id.strip()
+    if not uid:
+        return _wiki_root()
+    if "/" in uid or "\\" in uid or uid.startswith("."):
+        raise ValueError(f"Invalid universe_id: {universe_id}")
+    return (_universe_dir(uid) / "wiki").resolve()
+
+
+def _stamp_universe_id(payload: str, universe_id: str) -> str:
+    if not universe_id:
+        return payload
+    try:
+        decoded = json.loads(payload)
+    except json.JSONDecodeError:
+        return payload
+    if not isinstance(decoded, dict):
+        return payload
+    decoded.setdefault("universe_id", universe_id)
+    return json.dumps(decoded)
+
+
+def _dispatch_scope_error(tool: str, action: str, universe_id: str = "") -> str | None:
     from workflow.auth.middleware import require_action_scope
     from workflow.auth.provider import PermissionScope
 
@@ -2253,7 +2278,11 @@ def _dispatch_scope_error(tool: str, action: str) -> str | None:
         require_action_scope(
             tool,
             action,
-            scope=PermissionScope(resource_type="wiki", resource_id=action),
+            scope=PermissionScope(
+                universe_id=universe_id,
+                resource_type="wiki",
+                resource_id=action,
+            ),
         )
     except PermissionError as exc:
         return json.dumps({
@@ -2301,22 +2330,25 @@ def wiki(
     reporter_context: str = "",
     verbose: bool = False,
     changed_since: str = "",
+    universe_id: str = "",
 ) -> str:
     """Dispatch entry for the wiki MCP tool. See universe_server.py for the
     chatbot-facing docstring; this function is the implementation invoked by
     the @mcp.tool wrapper there.
     """
+    target_universe_id = universe_id.strip()
     try:
-        wiki_root = _wiki_root()
+        wiki_root = _wiki_root_for_universe(target_universe_id)
     except ValueError as exc:
         # _wiki_root() raises when WORKFLOW_WIKI_PATH holds a Windows path on
-        # a POSIX runtime (2026-04-19 container incident).
+        # a POSIX runtime (2026-04-19 container incident). _universe_dir()
+        # raises for invalid universe identifiers.
         return json.dumps({
             "error": str(exc),
             "hint": (
-                "Unset WORKFLOW_WIKI_PATH to use the platform default "
-                "(data_dir()/wiki), or set it to a POSIX absolute path "
-                "like '/data/wiki'."
+                "Unset WORKFLOW_WIKI_PATH to use the platform default, set "
+                "it to a POSIX absolute path like '/data/wiki', or pass a "
+                "safe universe_id without path separators."
             ),
         })
 
@@ -2341,52 +2373,58 @@ def wiki(
             ),
         })
 
-    dispatch = WIKI_ACTIONS
-    handler = dispatch.get(action)
-    if handler is None:
-        return json.dumps({
-            "error": f"Unknown action '{action}'.",
-            "available_actions": sorted(dispatch.keys()),
-        })
-    scope_error = _dispatch_scope_error("wiki", action)
-    if scope_error is not None:
-        return scope_error
+    with _scoped_wiki_root(wiki_root):
+        dispatch = WIKI_ACTIONS
+        handler = dispatch.get(action)
+        if handler is None:
+            return json.dumps({
+                "error": f"Unknown action '{action}'.",
+                "available_actions": sorted(dispatch.keys()),
+            })
+        scope_error = _dispatch_scope_error(
+            "wiki",
+            action,
+            universe_id=target_universe_id,
+        )
+        if scope_error is not None:
+            return _stamp_universe_id(scope_error, target_universe_id)
 
-    kwargs: dict[str, Any] = {
-        "page": page,
-        "query": query,
-        "category": category,
-        "filename": filename,
-        "content": content,
-        "log_entry": log_entry,
-        "old_text": old_text,
-        "new_text": new_text,
-        "expected_sha256": expected_sha256,
-        "source_url": source_url,
-        "old_page": old_page,
-        "new_draft": new_draft,
-        "reason": reason,
-        "similarity_threshold": similarity_threshold,
-        "dry_run": dry_run,
-        "skip_lint": skip_lint,
-        "max_results": max_results,
-        "offset": offset,
-        "max_chars": max_chars,
-        "component": component,
-        "severity": severity,
-        "title": title,
-        "repro": repro,
-        "observed": observed,
-        "expected": expected,
-        "workaround": workaround,
-        "kind": kind,
-        "tags": tags,
-        "cross_reference_count": cross_reference_count,
-        "force_new": force_new,
-        "bug_id": bug_id,
-        "reporter_context": reporter_context,
-        "verbose": verbose,
-        "changed_since": changed_since,
-    }
+        kwargs: dict[str, Any] = {
+            "page": page,
+            "query": query,
+            "category": category,
+            "filename": filename,
+            "content": content,
+            "log_entry": log_entry,
+            "old_text": old_text,
+            "new_text": new_text,
+            "expected_sha256": expected_sha256,
+            "source_url": source_url,
+            "old_page": old_page,
+            "new_draft": new_draft,
+            "reason": reason,
+            "similarity_threshold": similarity_threshold,
+            "dry_run": dry_run,
+            "skip_lint": skip_lint,
+            "max_results": max_results,
+            "offset": offset,
+            "max_chars": max_chars,
+            "component": component,
+            "severity": severity,
+            "title": title,
+            "repro": repro,
+            "observed": observed,
+            "expected": expected,
+            "workaround": workaround,
+            "kind": kind,
+            "tags": tags,
+            "cross_reference_count": cross_reference_count,
+            "force_new": force_new,
+            "bug_id": bug_id,
+            "reporter_context": reporter_context,
+            "verbose": verbose,
+            "changed_since": changed_since,
+            "universe_id": target_universe_id,
+        }
 
-    return handler(**kwargs)
+        return _stamp_universe_id(handler(**kwargs), target_universe_id)

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
@@ -346,6 +346,7 @@ def read_page(
     category: str = "",
     changed_since: str = "",
     max_results: int = 10,
+    universe_id: str = "",
 ) -> str:
     """Read or search Workflow wiki pages.
 
@@ -357,6 +358,7 @@ def read_page(
             With an empty page/query/category, returns pages changed after this
             timestamp.
         max_results: Maximum result count.
+        universe_id: Optional target universe page substrate.
     """
     if page:
         return _wiki_impl(
@@ -365,18 +367,21 @@ def read_page(
             query=query,
             changed_since=changed_since,
             max_results=max_results,
+            universe_id=universe_id,
         )
     if changed_since.strip() and not query.strip() and not category.strip():
         return _wiki_impl(
             action="since",
             changed_since=changed_since,
             max_results=max_results,
+            universe_id=universe_id,
         )
     return _wiki_impl(
         action="search",
         query=query,
         category=category,
         max_results=max_results,
+        universe_id=universe_id,
     )
 
 
@@ -417,10 +422,12 @@ def write_page(
     force_new: bool = False,
     reporter_context: str = "",
     dry_run: bool = True,
+    universe_id: str = "",
 ) -> str:
     """Write, patch, or file a Workflow wiki page.
 
     Args:
+        universe_id: Optional target universe page substrate.
         page: Wiki page slug or path for page writes.
         category: Wiki category for full page writes.
         filename: Wiki filename for full page writes.
@@ -457,6 +464,7 @@ def write_page(
             tags=tags,
             force_new=force_new,
             reporter_context=reporter_context,
+            universe_id=universe_id,
         )
     if old_text or new_text:
         return _wiki_impl(
@@ -467,6 +475,7 @@ def write_page(
             expected_sha256=expected_sha256,
             log_entry=log_entry,
             dry_run=dry_run,
+            universe_id=universe_id,
         )
     write_filename = filename or page
     return _wiki_impl(
@@ -476,6 +485,7 @@ def write_page(
         content=content,
         log_entry=log_entry,
         dry_run=dry_run,
+        universe_id=universe_id,
     )
 
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -1062,6 +1062,7 @@ def wiki(
             ),
         ),
     ] = "",
+    universe_id: str = "",
 ) -> str:
     """Read, write, and manage the cross-project knowledge wiki.
 
@@ -1094,6 +1095,8 @@ def wiki(
             after this timestamp are returned.
         offset/max_chars: For action="read", read a bounded character window
             from large pages. Truncated responses include `next_offset`.
+        universe_id: Optional target universe page substrate. Omit to use the
+            shared Workflow wiki.
     """
     return _wiki_impl(
         action=action,
@@ -1129,6 +1132,7 @@ def wiki(
         bug_id=bug_id,
         reporter_context=reporter_context,
         changed_since=changed_since,
+        universe_id=universe_id,
     )
 
 

--- a/tests/test_directory_server.py
+++ b/tests/test_directory_server.py
@@ -281,6 +281,55 @@ def test_directory_write_page_drafts_temp_wiki_page(monkeypatch, tmp_path) -> No
     ).read_text(encoding="utf-8") == "# Directory page smoke\n"
 
 
+def test_directory_write_page_honors_target_universe(monkeypatch, tmp_path) -> None:
+    """A writer scoped to a universe writes to that universe's page substrate."""
+    shared_wiki = tmp_path / "shared-wiki"
+    monkeypatch.setenv("WORKFLOW_WIKI_PATH", str(shared_wiki))
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+
+    drafted = json.loads(
+        write_page(
+            universe_id="splitroot",
+            category="plans",
+            filename="archon-telemetry-contract",
+            content="# Archon telemetry contract\n",
+            log_entry="splitroot writer target",
+        )
+    )
+
+    assert drafted["status"] == "drafted"
+    assert drafted["universe_id"] == "splitroot"
+    assert drafted["path"] == "drafts/plans/archon-telemetry-contract.md"
+    target = (
+        tmp_path
+        / "splitroot"
+        / "wiki"
+        / "drafts"
+        / "plans"
+        / "archon-telemetry-contract.md"
+    )
+    assert target.read_text(encoding="utf-8") == "# Archon telemetry contract\n"
+    assert not (
+        shared_wiki / "drafts" / "plans" / "archon-telemetry-contract.md"
+    ).exists()
+
+
+def test_directory_write_page_rejects_dot_universe(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+
+    result = json.loads(
+        write_page(
+            universe_id=".",
+            category="plans",
+            filename="bad-target",
+            content="# Bad target\n",
+        )
+    )
+
+    assert "Invalid universe_id" in result["error"]
+    assert not (tmp_path / "wiki" / "drafts" / "plans" / "bad-target.md").exists()
+
+
 def test_directory_read_page_changed_since_routes_to_since_feed(
     monkeypatch, tmp_path,
 ) -> None:

--- a/workflow/api/helpers.py
+++ b/workflow/api/helpers.py
@@ -32,10 +32,17 @@ from __future__ import annotations
 import json
 import logging
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+_WIKI_ROOT_OVERRIDE: ContextVar[Path | None] = ContextVar(
+    "workflow_wiki_root_override",
+    default=None,
+)
 
 
 def _base_path() -> Path:
@@ -114,8 +121,22 @@ def _wiki_root() -> Path:
     as the fallback, which broke every non-host deploy. See
     ``workflow.storage.wiki_path`` for the precedence + rationale.
     """
+    override = _WIKI_ROOT_OVERRIDE.get()
+    if override is not None:
+        return override
+
     from workflow.storage import wiki_path
     return wiki_path()
+
+
+@contextmanager
+def _scoped_wiki_root(root: Path) -> Iterator[None]:
+    """Temporarily route wiki helpers to an explicit wiki root."""
+    token = _WIKI_ROOT_OVERRIDE.set(root.resolve())
+    try:
+        yield
+    finally:
+        _WIKI_ROOT_OVERRIDE.reset(token)
 
 
 def _wiki_pages_dir() -> Path:
@@ -139,6 +160,7 @@ __all__ = [
     "_find_all_pages",
     "_read_json",
     "_read_text",
+    "_scoped_wiki_root",
     "_universe_dir",
     "_wiki_drafts_dir",
     "_wiki_pages_dir",

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -32,6 +32,7 @@ from workflow.api.helpers import (
     _default_universe,
     _find_all_pages,
     _read_text,
+    _scoped_wiki_root,
     _universe_dir,
     _wiki_drafts_dir,
     _wiki_pages_dir,
@@ -1921,6 +1922,7 @@ def _wiki_file_bug(
     cross_reference_count: int = 0,
     force_new: bool = False,
     verbose: bool = False,
+    universe_id: str = "",
     **_kwargs: Any,
 ) -> str:
     """File a bug, feature request, design proposal, or patch request.
@@ -2084,8 +2086,8 @@ def _wiki_file_bug(
             "repro": repro,
             "workaround": workaround,
         }
-        universe_id = _default_universe()
-        universe_path = _universe_dir(universe_id)
+        target_universe_id = universe_id.strip() or _default_universe()
+        universe_path = _universe_dir(target_universe_id)
         # Pre-write trigger receipt (status=pending). Read canonical branch_def_id
         # from env so the receipt records what we *expected* to invoke even if the
         # enqueue helper rejects.
@@ -2111,7 +2113,7 @@ def _wiki_file_bug(
                 bug_id=bug_id,
                 frontmatter=frontmatter,
                 base_path=universe_path,
-                universe_id=universe_id,
+                universe_id=target_universe_id,
             )
         except Exception as _enq_exc:
             # Trigger helper raised. Update receipt then re-raise into the outer
@@ -2245,7 +2247,30 @@ WIKI_WRITE_ACTIONS: frozenset[str] = frozenset({
 })
 
 
-def _dispatch_scope_error(tool: str, action: str) -> str | None:
+def _wiki_root_for_universe(universe_id: str) -> Path:
+    """Return the page-substrate root for a target universe."""
+    uid = universe_id.strip()
+    if not uid:
+        return _wiki_root()
+    if "/" in uid or "\\" in uid or uid.startswith("."):
+        raise ValueError(f"Invalid universe_id: {universe_id}")
+    return (_universe_dir(uid) / "wiki").resolve()
+
+
+def _stamp_universe_id(payload: str, universe_id: str) -> str:
+    if not universe_id:
+        return payload
+    try:
+        decoded = json.loads(payload)
+    except json.JSONDecodeError:
+        return payload
+    if not isinstance(decoded, dict):
+        return payload
+    decoded.setdefault("universe_id", universe_id)
+    return json.dumps(decoded)
+
+
+def _dispatch_scope_error(tool: str, action: str, universe_id: str = "") -> str | None:
     from workflow.auth.middleware import require_action_scope
     from workflow.auth.provider import PermissionScope
 
@@ -2253,7 +2278,11 @@ def _dispatch_scope_error(tool: str, action: str) -> str | None:
         require_action_scope(
             tool,
             action,
-            scope=PermissionScope(resource_type="wiki", resource_id=action),
+            scope=PermissionScope(
+                universe_id=universe_id,
+                resource_type="wiki",
+                resource_id=action,
+            ),
         )
     except PermissionError as exc:
         return json.dumps({
@@ -2301,22 +2330,25 @@ def wiki(
     reporter_context: str = "",
     verbose: bool = False,
     changed_since: str = "",
+    universe_id: str = "",
 ) -> str:
     """Dispatch entry for the wiki MCP tool. See universe_server.py for the
     chatbot-facing docstring; this function is the implementation invoked by
     the @mcp.tool wrapper there.
     """
+    target_universe_id = universe_id.strip()
     try:
-        wiki_root = _wiki_root()
+        wiki_root = _wiki_root_for_universe(target_universe_id)
     except ValueError as exc:
         # _wiki_root() raises when WORKFLOW_WIKI_PATH holds a Windows path on
-        # a POSIX runtime (2026-04-19 container incident).
+        # a POSIX runtime (2026-04-19 container incident). _universe_dir()
+        # raises for invalid universe identifiers.
         return json.dumps({
             "error": str(exc),
             "hint": (
-                "Unset WORKFLOW_WIKI_PATH to use the platform default "
-                "(data_dir()/wiki), or set it to a POSIX absolute path "
-                "like '/data/wiki'."
+                "Unset WORKFLOW_WIKI_PATH to use the platform default, set "
+                "it to a POSIX absolute path like '/data/wiki', or pass a "
+                "safe universe_id without path separators."
             ),
         })
 
@@ -2341,52 +2373,58 @@ def wiki(
             ),
         })
 
-    dispatch = WIKI_ACTIONS
-    handler = dispatch.get(action)
-    if handler is None:
-        return json.dumps({
-            "error": f"Unknown action '{action}'.",
-            "available_actions": sorted(dispatch.keys()),
-        })
-    scope_error = _dispatch_scope_error("wiki", action)
-    if scope_error is not None:
-        return scope_error
+    with _scoped_wiki_root(wiki_root):
+        dispatch = WIKI_ACTIONS
+        handler = dispatch.get(action)
+        if handler is None:
+            return json.dumps({
+                "error": f"Unknown action '{action}'.",
+                "available_actions": sorted(dispatch.keys()),
+            })
+        scope_error = _dispatch_scope_error(
+            "wiki",
+            action,
+            universe_id=target_universe_id,
+        )
+        if scope_error is not None:
+            return _stamp_universe_id(scope_error, target_universe_id)
 
-    kwargs: dict[str, Any] = {
-        "page": page,
-        "query": query,
-        "category": category,
-        "filename": filename,
-        "content": content,
-        "log_entry": log_entry,
-        "old_text": old_text,
-        "new_text": new_text,
-        "expected_sha256": expected_sha256,
-        "source_url": source_url,
-        "old_page": old_page,
-        "new_draft": new_draft,
-        "reason": reason,
-        "similarity_threshold": similarity_threshold,
-        "dry_run": dry_run,
-        "skip_lint": skip_lint,
-        "max_results": max_results,
-        "offset": offset,
-        "max_chars": max_chars,
-        "component": component,
-        "severity": severity,
-        "title": title,
-        "repro": repro,
-        "observed": observed,
-        "expected": expected,
-        "workaround": workaround,
-        "kind": kind,
-        "tags": tags,
-        "cross_reference_count": cross_reference_count,
-        "force_new": force_new,
-        "bug_id": bug_id,
-        "reporter_context": reporter_context,
-        "verbose": verbose,
-        "changed_since": changed_since,
-    }
+        kwargs: dict[str, Any] = {
+            "page": page,
+            "query": query,
+            "category": category,
+            "filename": filename,
+            "content": content,
+            "log_entry": log_entry,
+            "old_text": old_text,
+            "new_text": new_text,
+            "expected_sha256": expected_sha256,
+            "source_url": source_url,
+            "old_page": old_page,
+            "new_draft": new_draft,
+            "reason": reason,
+            "similarity_threshold": similarity_threshold,
+            "dry_run": dry_run,
+            "skip_lint": skip_lint,
+            "max_results": max_results,
+            "offset": offset,
+            "max_chars": max_chars,
+            "component": component,
+            "severity": severity,
+            "title": title,
+            "repro": repro,
+            "observed": observed,
+            "expected": expected,
+            "workaround": workaround,
+            "kind": kind,
+            "tags": tags,
+            "cross_reference_count": cross_reference_count,
+            "force_new": force_new,
+            "bug_id": bug_id,
+            "reporter_context": reporter_context,
+            "verbose": verbose,
+            "changed_since": changed_since,
+            "universe_id": target_universe_id,
+        }
 
-    return handler(**kwargs)
+        return _stamp_universe_id(handler(**kwargs), target_universe_id)

--- a/workflow/directory_server.py
+++ b/workflow/directory_server.py
@@ -346,6 +346,7 @@ def read_page(
     category: str = "",
     changed_since: str = "",
     max_results: int = 10,
+    universe_id: str = "",
 ) -> str:
     """Read or search Workflow wiki pages.
 
@@ -357,6 +358,7 @@ def read_page(
             With an empty page/query/category, returns pages changed after this
             timestamp.
         max_results: Maximum result count.
+        universe_id: Optional target universe page substrate.
     """
     if page:
         return _wiki_impl(
@@ -365,18 +367,21 @@ def read_page(
             query=query,
             changed_since=changed_since,
             max_results=max_results,
+            universe_id=universe_id,
         )
     if changed_since.strip() and not query.strip() and not category.strip():
         return _wiki_impl(
             action="since",
             changed_since=changed_since,
             max_results=max_results,
+            universe_id=universe_id,
         )
     return _wiki_impl(
         action="search",
         query=query,
         category=category,
         max_results=max_results,
+        universe_id=universe_id,
     )
 
 
@@ -417,10 +422,12 @@ def write_page(
     force_new: bool = False,
     reporter_context: str = "",
     dry_run: bool = True,
+    universe_id: str = "",
 ) -> str:
     """Write, patch, or file a Workflow wiki page.
 
     Args:
+        universe_id: Optional target universe page substrate.
         page: Wiki page slug or path for page writes.
         category: Wiki category for full page writes.
         filename: Wiki filename for full page writes.
@@ -457,6 +464,7 @@ def write_page(
             tags=tags,
             force_new=force_new,
             reporter_context=reporter_context,
+            universe_id=universe_id,
         )
     if old_text or new_text:
         return _wiki_impl(
@@ -467,6 +475,7 @@ def write_page(
             expected_sha256=expected_sha256,
             log_entry=log_entry,
             dry_run=dry_run,
+            universe_id=universe_id,
         )
     write_filename = filename or page
     return _wiki_impl(
@@ -476,6 +485,7 @@ def write_page(
         content=content,
         log_entry=log_entry,
         dry_run=dry_run,
+        universe_id=universe_id,
     )
 
 

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -1062,6 +1062,7 @@ def wiki(
             ),
         ),
     ] = "",
+    universe_id: str = "",
 ) -> str:
     """Read, write, and manage the cross-project knowledge wiki.
 
@@ -1094,6 +1095,8 @@ def wiki(
             after this timestamp are returned.
         offset/max_chars: For action="read", read a bounded character window
             from large pages. Truncated responses include `next_offset`.
+        universe_id: Optional target universe page substrate. Omit to use the
+            shared Workflow wiki.
     """
     return _wiki_impl(
         action=action,
@@ -1129,6 +1132,7 @@ def wiki(
         bug_id=bug_id,
         reporter_context=reporter_context,
         changed_since=changed_since,
+        universe_id=universe_id,
     )
 
 


### PR DESCRIPTION
Fixes #1111

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-140-per-universe-page-substrate-writer-dispatcher-universe-routi.md`
- GitHub issue: #1111
- Branch task: `auto-change/issue-1111`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.