### PR TITLE
[auto-change] WIKI-PATCH: Add review_depth enum field to operator-checker position-record schema — close the shape-only-vs-substantive ambiguity that costs review rework

### DIFF
--- a/.github/workflows/auto-check-pr.yml
+++ b/.github/workflows/auto-check-pr.yml
@@ -325,7 +325,7 @@ jobs:
               repo: context.repo.repo,
               issue_number: prNumber,
               body: [
-                `<!-- workflow-checker-verdict:v1 family=codex verdict=${markerVerdict} head=${process.env.HEAD_SHA} run=${process.env.GITHUB_RUN_ID} -->`,
+                `<!-- workflow-checker-verdict:v1 family=codex verdict=${markerVerdict} review_depth=substantive head=${process.env.HEAD_SHA} run=${process.env.GITHUB_RUN_ID} -->`,
                 `**Automated independent Codex checker verdict:** ${renderedVerdict}`,
                 '',
                 checkerBody,

--- a/scripts/merge_readiness.py
+++ b/scripts/merge_readiness.py
@@ -45,6 +45,13 @@ HOST_KEY_PATTERNS = (
 
 CHECKER_VERDICT_MARKER = "workflow-checker-verdict:v1"
 CHECKER_VERDICT_ATTR_RE = re.compile(r"([a-z_]+)=([^\s>]+)")
+REVIEW_DEPTHS = frozenset({
+    "shape-only",
+    "collision-lens",
+    "substantive",
+    "domain-deferred",
+})
+MERGE_APPROVAL_REVIEW_DEPTH = "substantive"
 
 INDEPENDENT_CHECKER_BLOCKER_TERMS = (
     "independent checker",
@@ -129,6 +136,7 @@ class PullRequestFacts:
     approve_with_amendment: bool = False
     precheck_blocked: bool = False
     checker_executor_ineligible: bool = False
+    checker_review_depth_blockers: tuple[str, ...] = ()
     consensus_mirror: ConsensusMirrorFacts = ConsensusMirrorFacts()
 
     @classmethod
@@ -174,6 +182,9 @@ class PullRequestFacts:
             checker_executor_ineligible=bool(
                 pr.get("checker_executor_ineligible")
                 or _has_checker_executor_ineligibility(comments, checker_family)
+            ),
+            checker_review_depth_blockers=tuple(
+                _checker_review_depth_blockers(comments, checker_family, head_oid)
             ),
             consensus_mirror=ConsensusMirrorFacts.from_mapping(pr.get("consensus_mirror")),
         )
@@ -328,7 +339,9 @@ def classify_pr(facts: PullRequestFacts) -> ReadinessResult:
             f"route to {checker_name} checker",
             risk_class,
             "blocked",
-            reasons + [f"required_checker_family={checker_family}"],
+            reasons
+            + list(facts.checker_review_depth_blockers)
+            + [f"required_checker_family={checker_family}"],
         )
 
     if not facts.host_keyed:
@@ -453,10 +466,40 @@ def _has_required_checker_verdict(
         if (
             verdict.get("family") == checker_family
             and verdict.get("verdict") == "approve"
+            and verdict.get("review_depth") == MERGE_APPROVAL_REVIEW_DEPTH
             and _head_matches(verdict, head_oid)
         ):
             return True
     return False
+
+
+def _checker_review_depth_blockers(
+    comments: Any,
+    checker_family: str | None,
+    head_oid: Any,
+) -> list[str]:
+    if not checker_family:
+        return []
+    blockers: list[str] = []
+    for verdict in _checker_verdicts(comments):
+        if (
+            verdict.get("family") != checker_family
+            or verdict.get("verdict") != "approve"
+            or not _head_matches(verdict, head_oid)
+        ):
+            continue
+        review_depth = verdict.get("review_depth")
+        if review_depth not in REVIEW_DEPTHS:
+            blockers.append(
+                "checker approval missing valid review_depth "
+                f"({', '.join(sorted(REVIEW_DEPTHS))})"
+            )
+        elif review_depth != MERGE_APPROVAL_REVIEW_DEPTH:
+            blockers.append(
+                f"checker approval review_depth={review_depth}; "
+                f"merge requires {MERGE_APPROVAL_REVIEW_DEPTH}"
+            )
+    return blockers
 
 
 def _has_checker_send_back_verdict(

--- a/tests/test_auto_check_workflow.py
+++ b/tests/test_auto_check_workflow.py
@@ -57,7 +57,9 @@ def test_auto_check_codex_lane_posts_structured_verdict_marker():
     assert "WORKFLOW_CODEX_AUTH_JSON_B64" in text
     assert "workflow-checker-verdict:v1 family=codex" in text
     assert "verdict=${markerVerdict}" in text
+    assert "review_depth=substantive" in text
     assert "approve_with_amendment" in text
+    assert "send_back" in text
     assert "auto-checker-amendment-required" in text
     assert "head=${process.env.HEAD_SHA}" in text
     assert "Do not commit, push, merge" in text

--- a/tests/test_merge_readiness.py
+++ b/tests/test_merge_readiness.py
@@ -93,7 +93,8 @@ def test_independent_checker_verdict_for_current_head_clears_ineligible_executor
                     {
                         "body": (
                             "<!-- workflow-checker-verdict:v1 "
-                            "family=codex verdict=approve head=abc123 run=42 -->\n"
+                            "family=codex verdict=approve review_depth=substantive "
+                            "head=abc123 run=42 -->\n"
                             "**Automated independent Codex checker verdict:** approve"
                         )
                     },
@@ -122,7 +123,8 @@ def test_independent_checker_verdict_for_stale_head_is_ignored():
                     {
                         "body": (
                             "<!-- workflow-checker-verdict:v1 "
-                            "family=codex verdict=approve head=old-head run=42 -->\n"
+                            "family=codex verdict=approve review_depth=substantive "
+                            "head=old-head run=42 -->\n"
                             "**Automated independent Codex checker verdict:** approve"
                         )
                     },
@@ -132,6 +134,59 @@ def test_independent_checker_verdict_for_stale_head_is_ignored():
     )
 
     assert result.state == "needs_independent_codex_checker"
+
+
+def test_checker_approval_without_review_depth_does_not_clear_merge_gate():
+    result = classify_pr(
+        PullRequestFacts.from_mapping(
+            _claude_pr(
+                headRefOid="abc123",
+                comments=[
+                    {
+                        "body": (
+                            "Host key recorded: user explicitly said `720 approved`.\n\n"
+                            "<!-- workflow-checker-verdict:v1 "
+                            "family=codex verdict=approve head=abc123 run=42 -->\n"
+                            "**Automated independent Codex checker verdict:** approve"
+                        )
+                    }
+                ],
+            )
+        )
+    )
+
+    assert result.state == "needs_codex_checker"
+    assert any(
+        "checker approval missing valid review_depth" in reason
+        for reason in result.reasons
+    )
+
+
+def test_shape_only_checker_approval_does_not_clear_merge_gate():
+    result = classify_pr(
+        PullRequestFacts.from_mapping(
+            _claude_pr(
+                headRefOid="abc123",
+                comments=[
+                    {
+                        "body": (
+                            "Host key recorded: user explicitly said `720 approved`.\n\n"
+                            "<!-- workflow-checker-verdict:v1 "
+                            "family=codex verdict=approve review_depth=shape-only "
+                            "head=abc123 run=42 -->\n"
+                            "**Automated independent Codex checker verdict:** approve"
+                        )
+                    }
+                ],
+            )
+        )
+    )
+
+    assert result.state == "needs_codex_checker"
+    assert (
+        "checker approval review_depth=shape-only; merge requires substantive"
+        in result.reasons
+    )
 
 
 def test_structured_checker_send_back_blocks_routing():


### PR DESCRIPTION
Fixes #1112

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-141-add-review-depth-enum-field-to-operator-checker-position-rec.md`
- GitHub issue: #1112
- Branch task: `auto-change/issue-1112`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.