### PR TITLE
[auto-change] BUG-108: Codex auth volume is invisible to provider binding when HOME is not /app

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -43,6 +43,10 @@ services:
     ports:
       - "127.0.0.1:8001:8001"
     environment:
+      # Keep Codex CLI + get_status provider binding aligned with the
+      # persistent bind mount below. If HOME drifts, ~/.codex points away
+      # from /app/.codex and the mounted subscription auth becomes invisible.
+      HOME: /app
       WORKFLOW_DATA_DIR: /data
       WORKFLOW_REPO_ROOT: /data/community-pool
       WORKFLOW_ALLOW_API_KEY_PROVIDERS: "0"
@@ -160,6 +164,8 @@ services:
       - apparmor=unconfined
     command: ["python", "-m", "workflow.cloud_worker"]
     environment:
+      # Same HOME/auth alignment as `daemon`; worker also invokes codex exec.
+      HOME: /app
       WORKFLOW_DATA_DIR: /data
       WORKFLOW_REPO_ROOT: /data/community-pool
       WORKFLOW_ALLOW_API_KEY_PROVIDERS: "0"

--- a/tests/test_dockerfile_shape.py
+++ b/tests/test_dockerfile_shape.py
@@ -241,6 +241,25 @@ def test_compose_env_file_covers_daemon_service():
     )
 
 
+def test_compose_codex_auth_mount_matches_home_for_cli_binding():
+    """Services that invoke codex must keep HOME aligned with /app/.codex."""
+    yaml = __import__("yaml")
+    data = yaml.safe_load(COMPOSE.read_text(encoding="utf-8"))
+
+    for service_name in ("daemon", "worker"):
+        service = data["services"][service_name]
+        environment = service.get("environment") or {}
+        volumes = service.get("volumes") or []
+        assert environment.get("HOME") == "/app", (
+            f"{service_name} must set HOME=/app so Codex CLI and get_status "
+            "look for subscription auth at /app/.codex/auth.json"
+        )
+        assert "/var/lib/workflow-codex:/app/.codex" in volumes, (
+            f"{service_name} must mount the persistent Codex auth volume at "
+            "/app/.codex to match HOME=/app"
+        )
+
+
 # ---------------------------------------------------------------------------
 # codex_provider.py — --skip-git-repo-check flag (BUG-004 fix A)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1110

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-108-codex-auth-volume-is-invisible-to-provider-binding-when-home.md`
- GitHub issue: #1110
- Branch task: `auto-change/issue-1110`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.