### PR TITLE
[auto-change] BUG-107: Universe lister treats top-level operational data directories as universes

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -946,6 +946,22 @@ def _daemon_liveness(udir: Path, status: dict[str, Any] | None) -> dict[str, Any
     }
 
 
+_TOP_LEVEL_OPERATIONAL_DATA_DIRS = frozenset({
+    "lance",
+    "output",
+    "runs",
+    "wiki",
+})
+
+
+def _is_listable_universe_dir(path: Path) -> bool:
+    return (
+        path.is_dir()
+        and not path.name.startswith(".")
+        and path.name not in _TOP_LEVEL_OPERATIONAL_DATA_DIRS
+    )
+
+
 def _action_list_universes(**_kwargs: Any) -> str:
     base = _base_path()
     if not base.is_dir():
@@ -966,7 +982,7 @@ def _action_list_universes(**_kwargs: Any) -> str:
 
     universes = []
     for child in sorted(all_entries):
-        if not child.is_dir() or child.name.startswith("."):
+        if not _is_listable_universe_dir(child):
             continue
         status = _read_json(child / "status.json")
         liveness = _daemon_liveness(child, status if isinstance(status, dict) else None)
@@ -990,7 +1006,8 @@ def _action_list_universes(**_kwargs: Any) -> str:
         else:
             result["note"] = (
                 f"Base directory has {len(all_entries)} entries but none "
-                f"are valid universes (all hidden or non-directories): {base}"
+                f"are valid universes (all hidden or non-directories or "
+                f"reserved operational data directories): {base}"
             )
     return json.dumps(result)
 

--- a/tests/test_universe_list_observability.py
+++ b/tests/test_universe_list_observability.py
@@ -16,6 +16,8 @@ import pytest
 
 from workflow.api.universe import _action_list_universes
 from workflow.universe_server import get_status
+
+
 @pytest.fixture
 def empty_base(tmp_path, monkeypatch):
     """Point WORKFLOW_DATA_DIR at an empty existing directory."""
@@ -50,6 +52,16 @@ def populated_base(tmp_path, monkeypatch):
     return tmp_path
 
 
+@pytest.fixture
+def operational_dirs_base(tmp_path, monkeypatch):
+    """Base dir contains storage subsystem directories beside universes."""
+    (tmp_path / "alpha").mkdir()
+    for name in ("wiki", "runs", "lance", "output"):
+        (tmp_path / name).mkdir()
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    return tmp_path
+
+
 class TestListUniversesEmptyNote:
     def test_missing_base_returns_does_not_exist_note(self, missing_base):
         result = json.loads(_action_list_universes())
@@ -74,6 +86,11 @@ class TestListUniversesEmptyNote:
         assert result["count"] == 1
         assert result["universes"][0]["id"] == "alpha"
         assert "note" not in result
+
+    def test_operational_storage_dirs_are_not_universes(self, operational_dirs_base):
+        result = json.loads(_action_list_universes())
+        assert result["count"] == 1
+        assert [u["id"] for u in result["universes"]] == ["alpha"]
 
 
 class TestGetStatusUniverseExists:

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -946,6 +946,22 @@ def _daemon_liveness(udir: Path, status: dict[str, Any] | None) -> dict[str, Any
     }
 
 
+_TOP_LEVEL_OPERATIONAL_DATA_DIRS = frozenset({
+    "lance",
+    "output",
+    "runs",
+    "wiki",
+})
+
+
+def _is_listable_universe_dir(path: Path) -> bool:
+    return (
+        path.is_dir()
+        and not path.name.startswith(".")
+        and path.name not in _TOP_LEVEL_OPERATIONAL_DATA_DIRS
+    )
+
+
 def _action_list_universes(**_kwargs: Any) -> str:
     base = _base_path()
     if not base.is_dir():
@@ -966,7 +982,7 @@ def _action_list_universes(**_kwargs: Any) -> str:
 
     universes = []
     for child in sorted(all_entries):
-        if not child.is_dir() or child.name.startswith("."):
+        if not _is_listable_universe_dir(child):
             continue
         status = _read_json(child / "status.json")
         liveness = _daemon_liveness(child, status if isinstance(status, dict) else None)
@@ -990,7 +1006,8 @@ def _action_list_universes(**_kwargs: Any) -> str:
         else:
             result["note"] = (
                 f"Base directory has {len(all_entries)} entries but none "
-                f"are valid universes (all hidden or non-directories): {base}"
+                f"are valid universes (all hidden or non-directories or "
+                f"reserved operational data directories): {base}"
             )
     return json.dumps(result)
 


### PR DESCRIPTION
Fixes #1109

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-107-universe-lister-treats-top-level-operational-data-directorie.md`
- GitHub issue: #1109
- Branch task: `auto-change/issue-1109`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.