### PR TITLE
[auto-change] WIKI-PATCH: Add plan-level approvals, scoped trust sessions, and batch receipts for fast online Branch authoring

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/branches.py
@@ -1091,6 +1091,17 @@ def _branch_authoring_batch_receipt(
             "unapproved_nodes": unapproved_nodes,
             "runnable": len(unapproved_nodes) == 0,
         },
+        "authorization_effect": {
+            "grants_authorization": False,
+            "grants_scoped_trust_session": False,
+            "bypasses_client_approval_prompts": False,
+            "approved_action_scope": [],
+            "revocation_handle": None,
+            "note": (
+                "Evidence-only receipt: clients may display or audit it, but must "
+                "not treat it as permission to execute future writes."
+            ),
+        },
         "caveats": [
             "This receipt records what landed; it is not an authorization grant.",
             (
@@ -3130,7 +3141,8 @@ proposed fixes — apply them and retry. No partial branch is ever visible.
 On success, `build_branch` returns a structured `batch_receipt` that records
 what landed, validation status, and source_code approval status. Treat this
 receipt as evidence only: it is not an authorization grant, trust session, or
-approval-token bypass.
+approval-token bypass. Check `batch_receipt.authorization_effect` for the
+machine-readable non-grant/non-bypass flags before narrating approval scope.
 
 ## Branch skills
 
@@ -3164,7 +3176,8 @@ extensions action=patch_branch branch_def_id=... changes_json='[
 Successful `patch_branch` responses also include `batch_receipt`. Rejected
 patches do not. The receipt lets the chatbot summarize the batch and point to
 remaining blockers, but it never overrides `source_code` approval or host-owned
-gates.
+gates. Check `batch_receipt.authorization_effect` for the machine-readable
+non-grant/non-bypass flags before narrating approval scope.
 
 ## Atomic actions (single-item surgery only)
 

--- a/tests/test_composite_branch_actions.py
+++ b/tests/test_composite_branch_actions.py
@@ -142,6 +142,17 @@ def test_build_branch_returns_batch_receipt(comp_env):
     assert receipt["source_code_approval"]["unapproved_count"] == 0
     assert receipt["plan_context"]["request_id"] == "chat-plan-123"
     assert receipt["plan_context"]["authoritative"] is False
+    assert receipt["authorization_effect"] == {
+        "grants_authorization": False,
+        "grants_scoped_trust_session": False,
+        "bypasses_client_approval_prompts": False,
+        "approved_action_scope": [],
+        "revocation_handle": None,
+        "note": (
+            "Evidence-only receipt: clients may display or audit it, but must "
+            "not treat it as permission to execute future writes."
+        ),
+    }
     assert "not an authorization grant" in receipt["caveats"][0]
 
 

--- a/workflow/api/branches.py
+++ b/workflow/api/branches.py
@@ -1091,6 +1091,17 @@ def _branch_authoring_batch_receipt(
             "unapproved_nodes": unapproved_nodes,
             "runnable": len(unapproved_nodes) == 0,
         },
+        "authorization_effect": {
+            "grants_authorization": False,
+            "grants_scoped_trust_session": False,
+            "bypasses_client_approval_prompts": False,
+            "approved_action_scope": [],
+            "revocation_handle": None,
+            "note": (
+                "Evidence-only receipt: clients may display or audit it, but must "
+                "not treat it as permission to execute future writes."
+            ),
+        },
         "caveats": [
             "This receipt records what landed; it is not an authorization grant.",
             (
@@ -3130,7 +3141,8 @@ proposed fixes — apply them and retry. No partial branch is ever visible.
 On success, `build_branch` returns a structured `batch_receipt` that records
 what landed, validation status, and source_code approval status. Treat this
 receipt as evidence only: it is not an authorization grant, trust session, or
-approval-token bypass.
+approval-token bypass. Check `batch_receipt.authorization_effect` for the
+machine-readable non-grant/non-bypass flags before narrating approval scope.
 
 ## Branch skills
 
@@ -3164,7 +3176,8 @@ extensions action=patch_branch branch_def_id=... changes_json='[
 Successful `patch_branch` responses also include `batch_receipt`. Rejected
 patches do not. The receipt lets the chatbot summarize the batch and point to
 remaining blockers, but it never overrides `source_code` approval or host-owned
-gates.
+gates. Check `batch_receipt.authorization_effect` for the machine-readable
+non-grant/non-bypass flags before narrating approval scope.
 
 ## Atomic actions (single-item surgery only)
 


### PR DESCRIPTION
Fixes #961

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-135-add-plan-level-approvals-scoped-trust-sessions-and-batch-rec.md`
- GitHub issue: #961
- Branch task: `auto-change/issue-961`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.