### PR TITLE
[codex] Fix MCP canary structuredContent parsing

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -613,3 +613,14 @@ Notes:
   fixture handle, and legacy `is_host` equivalence evidence.
 - Ship condition: focused permission/auth/universe tests pass, branch pushed,
   PR opened for opposite-family checker review.
+
+## P0 Canary StructuredContent Parser - 2026-05-27
+
+- 2026-05-27 create `../wf-p0-canary-structured-content` on
+  `codex/p0-canary-structured-content` by codex-gpt5-desktop.
+- Source: public MCP uptime canary run 26557828602 failed because the live
+  tool result text is a preview and the JSON payload is in `structuredContent`.
+- Purpose: fix the canary parser to accept current structured MCP tool
+  payloads while preserving text-JSON fallback.
+- Ship condition: focused canary tests pass, local live canary passes, branch
+  pushed, PR opened for checker/host review.

--- a/scripts/_canary_common.py
+++ b/scripts/_canary_common.py
@@ -10,7 +10,7 @@ BUG-028 demonstrated for the wiki path.
 Scope (intentionally tight):
     - HTTP POST + parse logic.
     - MCP `initialize` payload builder + `notifications/initialized` constant.
-    - Tool-result text extraction.
+    - Tool-result text / structured payload extraction.
 
 Out of scope (per Task #14 conservative-scope rule):
     - Per-canary exception classes (ToolCanaryError, LastActivityError,
@@ -130,3 +130,16 @@ def _extract_tool_text(tool_result: dict[str, Any]) -> str:
         for item in tool_result.get("content", [])
         if item.get("type") == "text"
     )
+
+
+def _extract_structured_tool_payload(
+    tool_result: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Return a dict payload from MCP structuredContent when available."""
+    structured = tool_result.get("structuredContent")
+    if not isinstance(structured, dict):
+        return None
+    nested = structured.get("result")
+    if set(structured) == {"result"} and isinstance(nested, dict):
+        return nested
+    return structured

--- a/scripts/last_activity_canary.py
+++ b/scripts/last_activity_canary.py
@@ -74,6 +74,7 @@ if str(_SCRIPTS) not in sys.path:
 
 from _canary_common import (  # noqa: E402
     _INITIALIZED_NOTIF,  # noqa: F401
+    _extract_structured_tool_payload,
     _extract_tool_text,
     _init_payload,
 )
@@ -204,6 +205,9 @@ def fetch_inspect_result(
         raise LastActivityError(
             3, f"universe inspect isError=true: {text!r}",
         )
+    structured = _extract_structured_tool_payload(result)
+    if structured is not None:
+        return structured
     text = _extract_tool_text(result)
     if not text:
         raise LastActivityError(

--- a/scripts/mcp_tool_canary.py
+++ b/scripts/mcp_tool_canary.py
@@ -49,6 +49,7 @@ if str(_SCRIPTS) not in sys.path:
 
 from _canary_common import (  # noqa: E402
     _INITIALIZED_NOTIF,  # noqa: F401
+    _extract_structured_tool_payload,
     _extract_tool_text,
     _init_payload,
 )
@@ -112,6 +113,9 @@ def _parse_tool_json_result(resp: dict[str, Any] | None, label: str) -> dict[str
         raise ToolCanaryError(
             5, f"{label} isError=true: {text!r}",
         )
+    structured = _extract_structured_tool_payload(result)
+    if structured is not None:
+        return structured
     text = _extract_tool_text(result)
     if not text:
         raise ToolCanaryError(

--- a/scripts/revert_loop_canary.py
+++ b/scripts/revert_loop_canary.py
@@ -52,6 +52,7 @@ if str(_SCRIPTS) not in sys.path:
 
 from _canary_common import (  # noqa: E402
     _INITIALIZED_NOTIF,  # noqa: F401
+    _extract_structured_tool_payload,
     _extract_tool_text,
     _init_payload,
 )
@@ -247,17 +248,19 @@ def fetch_status_activity_tail(
     if result.get("isError"):
         text = _extract_tool_text(result)[:300]
         raise RevertLoopError(5, f"get_status isError=true: {text!r}")
-    text = _extract_tool_text(result)
-    if not text:
-        raise RevertLoopError(
-            5, f"get_status returned no text content: {result!r}",
-        )
-    try:
-        payload = json.loads(text)
-    except json.JSONDecodeError as exc:
-        raise RevertLoopError(
-            5, f"get_status text not JSON: {exc}; preview={text[:200]!r}",
-        ) from exc
+    payload = _extract_structured_tool_payload(result)
+    if payload is None:
+        text = _extract_tool_text(result)
+        if not text:
+            raise RevertLoopError(
+                5, f"get_status returned no text content: {result!r}",
+            )
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise RevertLoopError(
+                5, f"get_status text not JSON: {exc}; preview={text[:200]!r}",
+            ) from exc
 
     caveats = payload.get("evidence_caveats")
     if isinstance(caveats, dict):

--- a/scripts/wiki_canary.py
+++ b/scripts/wiki_canary.py
@@ -46,7 +46,12 @@ if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 from _canary_common import _INITIALIZED_NOTIF, _init_payload  # noqa: E402
-from mcp_tool_canary import ToolCanaryError, _extract_tool_text, _post  # noqa: E402
+from mcp_tool_canary import (  # noqa: E402
+    ToolCanaryError,
+    _extract_structured_tool_payload,
+    _extract_tool_text,
+    _post,
+)
 from uptime_canary import _append_log, _now_local_iso  # noqa: E402
 
 DEFAULT_URL = "https://tinyassets.io/mcp"
@@ -176,15 +181,17 @@ def run_canary(
     if write_result.get("isError"):
         text = _extract_tool_text(write_result)[:300]
         raise ToolCanaryError(6, f"wiki write isError=true: {text!r}")
-    write_text = _extract_tool_text(write_result)
-    if not write_text:
-        raise ToolCanaryError(6, f"wiki write returned no text content: {write_result!r}")
-    try:
-        write_obj = json.loads(write_text)
-    except json.JSONDecodeError as exc:
-        raise ToolCanaryError(
-            6, f"wiki write text not JSON: {exc}; preview={write_text[:200]!r}"
-        ) from exc
+    write_obj = _extract_structured_tool_payload(write_result)
+    if write_obj is None:
+        write_text = _extract_tool_text(write_result)
+        if not write_text:
+            raise ToolCanaryError(6, f"wiki write returned no text content: {write_result!r}")
+        try:
+            write_obj = json.loads(write_text)
+        except json.JSONDecodeError as exc:
+            raise ToolCanaryError(
+                6, f"wiki write text not JSON: {exc}; preview={write_text[:200]!r}"
+            ) from exc
     # Server returns "drafted" on first write of a new draft, "updated" on
     # any subsequent write to the same path. Both are healthy for the canary.
     if write_obj.get("status") not in (
@@ -208,9 +215,13 @@ def run_canary(
     if read_result.get("isError"):
         text = _extract_tool_text(read_result)[:300]
         raise ToolCanaryError(7, f"wiki read isError=true: {text!r}")
-    read_text = _extract_tool_text(read_result)
-    if not read_text:
-        raise ToolCanaryError(7, f"wiki read returned no text content: {read_result!r}")
+    read_obj = _extract_structured_tool_payload(read_result)
+    if read_obj is not None:
+        read_text = json.dumps(read_obj, default=str)
+    else:
+        read_text = _extract_tool_text(read_result)
+        if not read_text:
+            raise ToolCanaryError(7, f"wiki read returned no text content: {read_result!r}")
     if _CANARY_CONTENT not in read_text:
         raise ToolCanaryError(
             7,

--- a/tests/test_last_activity_canary.py
+++ b/tests/test_last_activity_canary.py
@@ -161,6 +161,7 @@ def _universe_inspect_resp(
     raw_text: str | None = None,
     last_activity_at: str | None = "2026-04-22T11:55:00+00:00",
     is_error: bool = False,
+    structured_content: dict | None = None,
     sid: str = "sess-x",
 ):
     if raw_text is None:
@@ -172,11 +173,14 @@ def _universe_inspect_resp(
                 "staleness": "fresh",
             },
         })
+    result = {
+        "content": [{"type": "text", "text": raw_text}],
+        "isError": is_error,
+    }
+    if structured_content is not None:
+        result["structuredContent"] = structured_content
     return (
-        {"jsonrpc": "2.0", "id": 2, "result": {
-            "content": [{"type": "text", "text": raw_text}],
-            "isError": is_error,
-        }},
+        {"jsonrpc": "2.0", "id": 2, "result": result},
         sid,
     )
 
@@ -188,6 +192,32 @@ def test_run_canary_fresh_returns_zero():
     scripted = ScriptedPost([
         _init_resp(), _notif_resp(),
         _universe_inspect_resp(last_activity_at="2026-04-22T11:55:00+00:00"),
+    ])
+    code, msg = lac.run_canary(
+        "https://fake/mcp", 5.0, 30,
+        post_fn=scripted, now=_utc("2026-04-22T12:00:00+00:00"),
+    )
+    assert code == 0
+    assert "FRESH" in msg
+
+
+def test_run_canary_accepts_structured_content_when_text_is_preview():
+    scripted = ScriptedPost([
+        _init_resp(), _notif_resp(),
+        _universe_inspect_resp(
+            raw_text=(
+                "Tool result: active_targets=5; recent_activity=10. "
+                "Full payload is in structuredContent."
+            ),
+            structured_content={
+                "universe_id": "concordance",
+                "daemon": {
+                    "phase": "writing",
+                    "last_activity_at": "2026-04-22T11:55:00+00:00",
+                    "staleness": "fresh",
+                },
+            },
+        ),
     ])
     code, msg = lac.run_canary(
         "https://fake/mcp", 5.0, 30,

--- a/tests/test_mcp_tool_canary.py
+++ b/tests/test_mcp_tool_canary.py
@@ -55,6 +55,7 @@ def _universe_inspect_resp(
     universe_id: str = "demo-universe",
     is_error: bool = False,
     raw_text: str | None = None,
+    structured_content: dict | None = None,
     sid: str = "sess-123",
 ) -> tuple[dict, str]:
     if raw_text is None:
@@ -62,11 +63,14 @@ def _universe_inspect_resp(
             "universe_id": universe_id,
             "daemon": {"phase": "idle"},
         })
+    result = {
+        "content": [{"type": "text", "text": raw_text}],
+        "isError": is_error,
+    }
+    if structured_content is not None:
+        result["structuredContent"] = structured_content
     return (
-        {"jsonrpc": "2.0", "id": 3, "result": {
-            "content": [{"type": "text", "text": raw_text}],
-            "isError": is_error,
-        }},
+        {"jsonrpc": "2.0", "id": 3, "result": result},
         sid,
     )
 
@@ -75,6 +79,7 @@ def _workflow_status_resp(
     schema_version: int = 1,
     is_error: bool = False,
     raw_text: str | None = None,
+    structured_content: dict | None = None,
     sid: str = "sess-123",
 ) -> tuple[dict, str]:
     if raw_text is None:
@@ -83,11 +88,14 @@ def _workflow_status_resp(
             "universe_id": "demo-universe",
             "active_host": {"host_id": "host"},
         })
+    result = {
+        "content": [{"type": "text", "text": raw_text}],
+        "isError": is_error,
+    }
+    if structured_content is not None:
+        result["structuredContent"] = structured_content
     return (
-        {"jsonrpc": "2.0", "id": 3, "result": {
-            "content": [{"type": "text", "text": raw_text}],
-            "isError": is_error,
-        }},
+        {"jsonrpc": "2.0", "id": 3, "result": result},
         sid,
     )
 
@@ -138,6 +146,26 @@ def test_happy_path_returns_inspect_dict():
     assert scripted.calls[3]["step_code"] == 5  # tools/call
 
 
+def test_happy_path_accepts_structured_content_when_text_is_preview():
+    scripted = ScriptedPost([
+        _init_resp(),
+        _initialized_notif_resp(),
+        _tools_list_resp(),
+        _universe_inspect_resp(
+            raw_text=(
+                "Tool result: active_targets=5; recent_activity=10. "
+                "Full payload is in structuredContent."
+            ),
+            structured_content={
+                "universe_id": "structured-uni",
+                "daemon": {"phase": "idle"},
+            },
+        ),
+    ])
+    result = tc.run_canary("https://fake/mcp", 5.0, post_fn=scripted)
+    assert result["universe_id"] == "structured-uni"
+
+
 def test_directory_tool_set_uses_workflow_status_probe():
     scripted = ScriptedPost([
         _init_resp(),
@@ -155,6 +183,28 @@ def test_directory_tool_set_uses_workflow_status_probe():
         "name": "read.graph",
         "arguments": {"target": "status"},
     }
+
+
+def test_directory_probe_accepts_nested_structured_content_result():
+    scripted = ScriptedPost([
+        _init_resp(),
+        _initialized_notif_resp(),
+        _tools_list_resp(tools=[
+            {"name": "read.graph", "description": "..."},
+        ]),
+        _workflow_status_resp(
+            raw_text="Tool result available in structuredContent.",
+            structured_content={
+                "result": {
+                    "schema_version": 1,
+                    "universe_id": "directory-uni",
+                },
+            },
+        ),
+    ])
+    result = tc.run_canary("https://fake/mcp-directory", 5.0, post_fn=scripted)
+    assert result["schema_version"] == 1
+    assert result["universe_id"] == "directory-uni"
 
 
 def test_main_exit_zero_on_happy_path(monkeypatch, capsys):

--- a/tests/test_revert_loop_canary.py
+++ b/tests/test_revert_loop_canary.py
@@ -258,6 +258,8 @@ def _make_tool_response(
     tail: list[str],
     *,
     evidence_caveats: dict | None = None,
+    raw_text: str | None = None,
+    structured_content: dict | None = None,
 ) -> dict:
     import json as _json
     payload = {
@@ -266,11 +268,17 @@ def _make_tool_response(
     }
     if evidence_caveats is not None:
         payload["evidence_caveats"] = evidence_caveats
+    result = {
+        "content": [{
+            "type": "text",
+            "text": raw_text if raw_text is not None else _json.dumps(payload),
+        }],
+    }
+    if structured_content is not None:
+        result["structuredContent"] = structured_content
     return {
         "jsonrpc": "2.0", "id": 2,
-        "result": {
-            "content": [{"type": "text", "text": _json.dumps(payload)}],
-        },
+        "result": result,
     }
 
 
@@ -291,6 +299,28 @@ class TestFetchStatusActivityTail:
             (_make_init_response(), "sid-abc"),
             (None, "sid-abc"),
             (_make_tool_response(tail), "sid-abc"),
+        ])
+        result = rlc.fetch_status_activity_tail(
+            "http://fake/mcp", 10.0, post_fn=stub,
+        )
+        assert result == tail
+
+    def test_happy_path_accepts_structured_content_when_text_is_preview(self):
+        tail = [_revert_line(5)]
+        stub = _StubPost([
+            (_make_init_response(), "sid-abc"),
+            (None, "sid-abc"),
+            (
+                _make_tool_response(
+                    [],
+                    raw_text="Tool result available in structuredContent.",
+                    structured_content={
+                        "active_host": {"host_id": "test"},
+                        "evidence": {"activity_log_tail": tail},
+                    },
+                ),
+                "sid-abc",
+            ),
         ])
         result = rlc.fetch_status_activity_tail(
             "http://fake/mcp", 10.0, post_fn=stub,

--- a/tests/test_wiki_canary.py
+++ b/tests/test_wiki_canary.py
@@ -66,21 +66,35 @@ def _notif_resp(sid: str = "sess-wiki") -> tuple[None, str]:
     return (None, sid)
 
 
-def _wiki_write_ok_resp(sid: str = "sess-wiki") -> tuple[dict, str]:
+def _wiki_write_ok_resp(
+    sid: str = "sess-wiki",
+    raw_text: str | None = None,
+    structured_content: dict | None = None,
+) -> tuple[dict, str]:
     body = json.dumps({
         "status": "drafted",
         "path": f"drafts/{wc._CANARY_CATEGORY}/{wc._CANARY_FILENAME}.md",
     })
+    result = {
+        "content": [{
+            "type": "text",
+            "text": raw_text if raw_text is not None else body,
+        }],
+        "isError": False,
+    }
+    if structured_content is not None:
+        result["structuredContent"] = structured_content
     return (
-        {"jsonrpc": "2.0", "id": 2, "result": {
-            "content": [{"type": "text", "text": body}],
-            "isError": False,
-        }},
+        {"jsonrpc": "2.0", "id": 2, "result": result},
         sid,
     )
 
 
-def _wiki_read_ok_resp(sid: str = "sess-wiki") -> tuple[dict, str]:
+def _wiki_read_ok_resp(
+    sid: str = "sess-wiki",
+    raw_text: str | None = None,
+    structured_content: dict | None = None,
+) -> tuple[dict, str]:
     # Read response body must contain the canary content text.
     body = json.dumps({
         "path": f"drafts/{wc._CANARY_CATEGORY}/{wc._CANARY_FILENAME}.md",
@@ -88,11 +102,17 @@ def _wiki_read_ok_resp(sid: str = "sess-wiki") -> tuple[dict, str]:
         "content": f"[DRAFT] {wc._CANARY_CONTENT}",
         "truncated": False,
     })
+    result = {
+        "content": [{
+            "type": "text",
+            "text": raw_text if raw_text is not None else body,
+        }],
+        "isError": False,
+    }
+    if structured_content is not None:
+        result["structuredContent"] = structured_content
     return (
-        {"jsonrpc": "2.0", "id": 3, "result": {
-            "content": [{"type": "text", "text": body}],
-            "isError": False,
-        }},
+        {"jsonrpc": "2.0", "id": 3, "result": result},
         sid,
     )
 
@@ -111,6 +131,30 @@ def _happy_scripted() -> ScriptedPost:
 
 def test_happy_path_run_canary_no_raise():
     wc.run_canary("https://fake/mcp", 5.0, post_fn=_happy_scripted())
+
+
+def test_happy_path_accepts_structured_content_previews():
+    scripted = ScriptedPost([
+        _init_resp(),
+        _notif_resp(),
+        _wiki_write_ok_resp(
+            raw_text="Tool result available in structuredContent.",
+            structured_content={
+                "status": "updated",
+                "path": f"drafts/{wc._CANARY_CATEGORY}/{wc._CANARY_FILENAME}.md",
+            },
+        ),
+        _wiki_read_ok_resp(
+            raw_text="Tool result available in structuredContent.",
+            structured_content={
+                "path": f"drafts/{wc._CANARY_CATEGORY}/{wc._CANARY_FILENAME}.md",
+                "is_draft": True,
+                "content": f"[DRAFT] {wc._CANARY_CONTENT}",
+                "truncated": False,
+            },
+        ),
+    ])
+    wc.run_canary("https://fake/mcp", 5.0, post_fn=scripted)
 
 
 def test_run_canary_can_scope_filename_for_bisect_replay():


### PR DESCRIPTION
## Summary
- teach the shared canary helpers to prefer MCP `structuredContent` payloads and keep text-JSON fallback for older responses
- apply the parser path to tool, last-activity, revert-loop, and wiki roundtrip canaries
- add regression coverage for preview text plus structured payload responses

## Root cause
After #1123 deployed, the live MCP surface returned large tool results as short text previews with the full JSON object in `structuredContent`. The uptime canary scripts still parsed only text content, so run 26557828602 failed even though the live MCP tool call itself worked.

## Validation
- `python -m pytest tests/test_mcp_tool_canary.py tests/test_last_activity_canary.py tests/test_revert_loop_canary.py tests/test_wiki_canary.py tests/test_canary_scripts_import_smoke.py -q` -> 162 passed
- `python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp --verbose` -> OK
- `python scripts/mcp_tool_canary.py --url https://tinyassets.io/mcp --timeout 20 --verbose` -> PASS, universe_id `local-bubble-galactic-survival-model`
- `python scripts/last_activity_canary.py --url https://tinyassets.io/mcp --timeout 20 --verbose` -> FRESH, last_activity_at `2026-05-28T06:11:15.419471+00:00`
- `python scripts/revert_loop_canary.py --url https://tinyassets.io/mcp --timeout 20 --verbose` -> OK, 0 REVERTs in last 10min
- `python scripts/wiki_canary.py --url https://tinyassets.io/mcp --timeout 20 --verbose` -> wiki write/read roundtrip OK

## Notes
Draft until checker/host keys are present. This is intended to clear the current P0 false-red canary gate, not change the live MCP response contract.