### PR TITLE
Scaffold gap 1: soul-scoped effect-authority (implements PR #1126 design)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/authority.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/authority.py
@@ -1,0 +1,76 @@
+"""Soul-scoped effect-authority resolution for external-write effectors.
+
+Gap 1 of the souled-universe self-maintenance model (design note
+``docs/design-notes/2026-05-28-souled-universe-effect-authority.md``). The
+running universe's soul is the SOURCE of effect-authority: it declares which
+real-world hands (``<sink>:<destination>`` grants) the universe's founder
+authorizes. The env capability map (``WORKFLOW_GITHUB_PR_CAPABILITIES``)
+carries the *secret/token*; the soul carries the *authority decision*.
+
+Transitional contract (this scaffold):
+
+- declared + match    -> ``AUTHORIZED``  (proceed to capability/consent gates)
+- declared + no match -> ``DENIED``      (fail closed; effector returns dry-run)
+- nothing declared    -> ``UNDECLARED``  (legacy fall-through to env + consent)
+
+The cutover (post-review, after Tiny's soul declares its grants) removes the
+``UNDECLARED`` fall-through so a soul grant becomes strictly required. Until
+then, ``UNDECLARED`` preserves the pre-existing env-capability + consent
+behavior so no live universe breaks. This module is effect-sink-agnostic;
+any effector resolves authority the same way.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+AUTHORIZED = "authorized"
+DENIED = "denied"
+UNDECLARED = "undeclared"
+
+
+def effect_authority_key(sink: str, destination: str) -> str:
+    """Canonical ``<sink>:<destination>`` grant key, both sides stripped."""
+    return f"{(sink or '').strip()}:{(destination or '').strip()}"
+
+
+def resolve_soul_effect_authority(
+    universe_dir: Path | None,
+    sink: str,
+    destination: str,
+) -> str:
+    """Resolve a (sink, destination) against the running universe's soul.
+
+    Returns one of ``AUTHORIZED`` / ``DENIED`` / ``UNDECLARED``. Never raises —
+    authority resolution must not break the effector path. Unexpected failures
+    fail closed (``DENIED``) rather than silently permitting a real write.
+    """
+    if universe_dir is None:
+        # No universe context (e.g. Phase-1 backward-compat invocations).
+        # Nothing to resolve against; defer to the legacy gates.
+        return UNDECLARED
+    try:
+        from workflow.universe_soul import effect_authority_from_soul
+
+        grants = effect_authority_from_soul(universe_dir)
+    except Exception:  # pragma: no cover - defensive; soul read is OSError-safe
+        logger.exception(
+            "soul effect-authority lookup crashed for %s; failing closed",
+            destination,
+        )
+        return DENIED
+    if not grants:
+        return UNDECLARED
+    return AUTHORIZED if effect_authority_key(sink, destination) in set(grants) else DENIED
+
+
+__all__ = [
+    "AUTHORIZED",
+    "DENIED",
+    "UNDECLARED",
+    "effect_authority_key",
+    "resolve_soul_effect_authority",
+]

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_pr.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_pr.py
@@ -82,6 +82,14 @@ import time
 from pathlib import Path
 from typing import Any
 
+from workflow.effectors.authority import (
+    DENIED as SOUL_AUTHORITY_DENIED,
+)
+from workflow.effectors.authority import (
+    effect_authority_key,
+    resolve_soul_effect_authority,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -626,6 +634,34 @@ def run_github_pr_effector(
         }
 
     universe_dir = _resolve_universe_dir(base_path)
+
+    # ── Gate 0: soul-scoped effect-authority ───────────────────────────
+    # The running universe's soul is the source of effect-authority (gap 1 of
+    # the souled-universe self-maintenance model). A universe whose soul.md
+    # declares effect_authority grants must include this sink:destination, or
+    # the write fails closed here. A universe that declares NOTHING falls
+    # through to the legacy env-capability + consent gates below — transitional
+    # behavior the cutover removes once souls declare their grants. See
+    # docs/design-notes/2026-05-28-souled-universe-effect-authority.md.
+    soul_authority = resolve_soul_effect_authority(
+        universe_dir, EXTERNAL_WRITE_SINK_GITHUB_PR, destination
+    )
+    if soul_authority == SOUL_AUTHORITY_DENIED:
+        return {
+            "dry_run": True,
+            "phase": "phase_2",
+            "reason": "soul_not_authorized",
+            "destination": destination,
+            "intent": packet,
+            "matched_output_key": matched_key,
+            "hint": (
+                "This universe's soul declares effect_authority grants but "
+                "none match "
+                f'"{effect_authority_key(EXTERNAL_WRITE_SINK_GITHUB_PR, destination)}". '
+                "Add that grant to the soul's '## Effect Authority' section to "
+                "authorize this hand."
+            ),
+        }
 
     # ── Gate 1: capability env ─────────────────────────────────────────
     # Round-2 P1.2: lookup is by exact destination string against the

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_soul.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_soul.py
@@ -33,6 +33,11 @@ class UniverseSoul:
     lineage: str = "template"
     edit_authority: str = DEFAULT_EDIT_AUTHORITY
     loop_branch_def_id: str = NO_LOOP_DECLARED
+    # Each entry is a "<sink>:<destination>" grant naming a real-world hand
+    # this universe's founder authorizes (e.g. "github_pull_request:owner/repo").
+    # Empty = nothing declared (transitional: effectors fall through to the
+    # legacy env-capability + consent gates until the soul-authority cutover).
+    effect_authority: tuple[str, ...] = ()
 
     def summary(self) -> dict[str, object]:
         return {
@@ -43,6 +48,7 @@ class UniverseSoul:
             "lineage": self.lineage,
             "edit_authority": self.edit_authority,
             "loop_branch_def_id": self.loop_branch_def_id,
+            "effect_authority": list(self.effect_authority),
             "versions_dir": SOUL_VERSIONS_DIR,
         }
 
@@ -71,6 +77,7 @@ class PinnedUniverseSoul:
             "lineage": self.soul.lineage,
             "edit_authority": self.soul.edit_authority,
             "loop_branch_def_id": self.soul.loop_branch_def_id,
+            "effect_authority": list(self.soul.effect_authority),
             "identity_boundary": (
                 "Universe soul guides this context only; it does not change "
                 "the actor identity or user memory scope."
@@ -126,6 +133,10 @@ def render_soul_markdown(soul: UniverseSoul) -> str:
         "",
         soul.edit_authority.strip() or DEFAULT_EDIT_AUTHORITY,
         "",
+        "## Effect Authority",
+        "",
+        _render_list(soul.effect_authority),
+        "",
     ])
 
 
@@ -152,6 +163,7 @@ def read_universe_soul(universe_dir: Path) -> UniverseSoul | None:
             or _read_meta(text, "Edit authority", DEFAULT_EDIT_AUTHORITY)
         ),
         loop_branch_def_id=_read_loop_branch_meta(text),
+        effect_authority=_read_list_section(text, "Effect Authority"),
     )
 
 
@@ -190,6 +202,7 @@ def write_universe_soul(
     lineage: str = "template",
     edit_authority: str = DEFAULT_EDIT_AUTHORITY,
     loop_branch_def_id: str = NO_LOOP_DECLARED,
+    effect_authority: tuple[str, ...] = (),
 ) -> UniverseSoul:
     universe_dir.mkdir(parents=True, exist_ok=True)
     existing = read_universe_soul(universe_dir)
@@ -208,6 +221,9 @@ def write_universe_soul(
             lineage=lineage.strip() or "template",
             edit_authority=edit_authority.strip() or DEFAULT_EDIT_AUTHORITY,
             loop_branch_def_id=loop_branch_def_id.strip(),
+            effect_authority=tuple(
+                item.strip() for item in effect_authority if item.strip()
+            ),
         )
     else:
         soul = replace(
@@ -231,6 +247,10 @@ def write_universe_soul(
             edit_authority=edit_authority.strip() or existing.edit_authority,
             loop_branch_def_id=(
                 loop_branch_def_id.strip() or existing.loop_branch_def_id
+            ),
+            effect_authority=(
+                tuple(item.strip() for item in effect_authority if item.strip())
+                or existing.effect_authority
             ),
         )
 
@@ -277,6 +297,12 @@ def premise_from_soul(universe_dir: Path) -> str:
 def loop_branch_from_soul(universe_dir: Path) -> str:
     soul = read_universe_soul(universe_dir)
     return soul.loop_branch_def_id if soul is not None else NO_LOOP_DECLARED
+
+
+def effect_authority_from_soul(universe_dir: Path) -> tuple[str, ...]:
+    """Return the soul-declared effect-authority grants, or () if none/no soul."""
+    soul = read_universe_soul(universe_dir)
+    return soul.effect_authority if soul is not None else ()
 
 
 def _render_list(items: tuple[str, ...]) -> str:

--- a/tests/test_soul_scoped_effect_authority.py
+++ b/tests/test_soul_scoped_effect_authority.py
@@ -1,0 +1,238 @@
+"""Soul-scoped effect-authority (gap 1 of the souled-universe model).
+
+Covers three layers:
+  1. ``universe_soul`` round-trips the ``effect_authority`` field through
+     soul.md render/parse.
+  2. ``resolve_soul_effect_authority`` returns AUTHORIZED / DENIED / UNDECLARED.
+  3. The github_pr effector's Gate 0 enforces soul-declared grants (fail
+     closed on mismatch) and falls through to the legacy gates when a
+     universe declares nothing (transitional).
+
+Design note: docs/design-notes/2026-05-28-souled-universe-effect-authority.md
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from workflow.effectors.authority import (
+    AUTHORIZED,
+    DENIED,
+    UNDECLARED,
+    effect_authority_key,
+    resolve_soul_effect_authority,
+)
+from workflow.effectors.github_pr import (
+    _CAPABILITIES_ENV,
+    EXTERNAL_WRITE_SINK_GITHUB_PR,
+    run_github_pr_effector,
+)
+from workflow.storage.effector_consents import grant_consent
+from workflow.universe_soul import (
+    effect_authority_from_soul,
+    read_universe_soul,
+    render_soul_markdown,
+    write_universe_soul,
+)
+
+_DESTINATION = "Jonnyton/Workflow"
+_GRANT = f"{EXTERNAL_WRITE_SINK_GITHUB_PR}:{_DESTINATION}"
+
+
+@pytest.fixture
+def universe_dir(tmp_path):
+    universe = tmp_path / "u-test"
+    universe.mkdir()
+    return universe
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv(_CAPABILITIES_ENV, raising=False)
+    monkeypatch.delenv("WORKFLOW_EXTERNAL_WRITE_ENABLED", raising=False)
+    monkeypatch.delenv("WORKFLOW_EXTERNAL_WRITE_DRY_RUN", raising=False)
+
+
+def _set_capability(monkeypatch, destination: str, token: str) -> None:
+    monkeypatch.setenv(_CAPABILITIES_ENV, json.dumps({destination: token}))
+
+
+def _make_packet(*, destination: str = _DESTINATION) -> dict:
+    return {
+        "sink": EXTERNAL_WRITE_SINK_GITHUB_PR,
+        "destination": destination,
+        "idempotency_hint": "soul-auth-test-001",
+        "payload": {
+            "title": "Soul-auth test",
+            "body": "test",
+            "base_branch": "main",
+            "head_branch": "auto/soul-auth-test",
+            "draft": True,
+        },
+        "expected_evidence_keys": ["pr_number", "pr_url"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — soul.md round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_soul_round_trips_effect_authority(universe_dir):
+    write_universe_soul(
+        universe_dir,
+        purpose="maintain the platform",
+        effect_authority=(_GRANT, "tweet:@workflow"),
+    )
+    soul = read_universe_soul(universe_dir)
+    assert soul is not None
+    assert soul.effect_authority == (_GRANT, "tweet:@workflow")
+    assert effect_authority_from_soul(universe_dir) == (_GRANT, "tweet:@workflow")
+
+
+def test_render_contains_effect_authority_section(universe_dir):
+    soul = write_universe_soul(universe_dir, effect_authority=(_GRANT,))
+    rendered = render_soul_markdown(soul)
+    assert "## Effect Authority" in rendered
+    assert f"- {_GRANT}" in rendered
+
+
+def test_soul_without_effect_authority_reads_empty(universe_dir):
+    write_universe_soul(universe_dir, purpose="no hands declared")
+    assert effect_authority_from_soul(universe_dir) == ()
+
+
+def test_effect_authority_blank_entries_are_dropped(universe_dir):
+    write_universe_soul(universe_dir, effect_authority=(_GRANT, "  ", ""))
+    assert read_universe_soul(universe_dir).effect_authority == (_GRANT,)
+
+
+def test_effect_authority_merge_preserves_existing(universe_dir):
+    write_universe_soul(universe_dir, effect_authority=(_GRANT,))
+    # A later write that does not pass effect_authority keeps the prior grants.
+    write_universe_soul(universe_dir, purpose="updated purpose only")
+    assert effect_authority_from_soul(universe_dir) == (_GRANT,)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — resolver
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_undeclared_when_universe_dir_none():
+    assert (
+        resolve_soul_effect_authority(None, EXTERNAL_WRITE_SINK_GITHUB_PR, _DESTINATION)
+        == UNDECLARED
+    )
+
+
+def test_resolver_undeclared_when_no_soul(universe_dir):
+    assert (
+        resolve_soul_effect_authority(universe_dir, EXTERNAL_WRITE_SINK_GITHUB_PR, _DESTINATION)
+        == UNDECLARED
+    )
+
+
+def test_resolver_authorized_on_match(universe_dir):
+    write_universe_soul(universe_dir, effect_authority=(_GRANT,))
+    assert (
+        resolve_soul_effect_authority(universe_dir, EXTERNAL_WRITE_SINK_GITHUB_PR, _DESTINATION)
+        == AUTHORIZED
+    )
+
+
+def test_resolver_denied_on_declared_mismatch(universe_dir):
+    write_universe_soul(
+        universe_dir,
+        effect_authority=(f"{EXTERNAL_WRITE_SINK_GITHUB_PR}:other/repo",),
+    )
+    assert (
+        resolve_soul_effect_authority(universe_dir, EXTERNAL_WRITE_SINK_GITHUB_PR, _DESTINATION)
+        == DENIED
+    )
+
+
+def test_effect_authority_key_strips():
+    assert (
+        effect_authority_key(" github_pull_request ", " owner/repo ")
+        == "github_pull_request:owner/repo"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — effector Gate 0 integration
+# ---------------------------------------------------------------------------
+
+
+def test_gate0_blocks_when_soul_declares_mismatch_even_with_capability_and_consent(
+    universe_dir, monkeypatch
+):
+    """Soul-authority is checked BEFORE capability/consent — a declared soul
+    that omits this destination fails closed regardless of env/consent."""
+    write_universe_soul(
+        universe_dir,
+        effect_authority=(f"{EXTERNAL_WRITE_SINK_GITHUB_PR}:other/repo",),
+    )
+    _set_capability(monkeypatch, _DESTINATION, "tok")
+    grant_consent(
+        universe_dir,
+        sink=EXTERNAL_WRITE_SINK_GITHUB_PR,
+        destination=_DESTINATION,
+        granted_by="host",
+    )
+
+    result = run_github_pr_effector(
+        node_id="n",
+        output_keys=["pr_packet"],
+        run_state={"pr_packet": _make_packet()},
+        base_path=universe_dir,
+    )
+    assert result["dry_run"] is True
+    assert result["reason"] == "soul_not_authorized"
+    assert result["destination"] == _DESTINATION
+
+
+def test_gate0_passes_to_capability_gate_when_soul_authorizes(universe_dir, monkeypatch):
+    """A matching soul grant clears Gate 0; with no capability the effector
+    then reports missing_capability — proving Gate 0 passed and Gate 1 ran."""
+    write_universe_soul(universe_dir, effect_authority=(_GRANT,))
+    result = run_github_pr_effector(
+        node_id="n",
+        output_keys=["pr_packet"],
+        run_state={"pr_packet": _make_packet()},
+        base_path=universe_dir,
+    )
+    assert result["dry_run"] is True
+    assert result["reason"] == "missing_capability"
+
+
+def test_undeclared_soul_falls_through_to_legacy_gates(universe_dir):
+    """Transitional: a universe with no soul effect_authority is NOT blocked by
+    Gate 0 — it falls through to the legacy capability gate (missing_capability)."""
+    result = run_github_pr_effector(
+        node_id="n",
+        output_keys=["pr_packet"],
+        run_state={"pr_packet": _make_packet()},
+        base_path=universe_dir,
+    )
+    assert result["dry_run"] is True
+    assert result["reason"] == "missing_capability"
+
+
+def test_gate0_passes_then_consent_gate_when_soul_and_capability_present(
+    universe_dir, monkeypatch
+):
+    """Soul authorizes + capability present + no consent -> missing_consent,
+    proving Gate 0 and Gate 1 both passed and Gate 2 ran."""
+    write_universe_soul(universe_dir, effect_authority=(_GRANT,))
+    _set_capability(monkeypatch, _DESTINATION, "tok")
+    result = run_github_pr_effector(
+        node_id="n",
+        output_keys=["pr_packet"],
+        run_state={"pr_packet": _make_packet()},
+        base_path=universe_dir,
+    )
+    assert result["dry_run"] is True
+    assert result["reason"] == "missing_consent"

--- a/workflow/effectors/authority.py
+++ b/workflow/effectors/authority.py
@@ -1,0 +1,76 @@
+"""Soul-scoped effect-authority resolution for external-write effectors.
+
+Gap 1 of the souled-universe self-maintenance model (design note
+``docs/design-notes/2026-05-28-souled-universe-effect-authority.md``). The
+running universe's soul is the SOURCE of effect-authority: it declares which
+real-world hands (``<sink>:<destination>`` grants) the universe's founder
+authorizes. The env capability map (``WORKFLOW_GITHUB_PR_CAPABILITIES``)
+carries the *secret/token*; the soul carries the *authority decision*.
+
+Transitional contract (this scaffold):
+
+- declared + match    -> ``AUTHORIZED``  (proceed to capability/consent gates)
+- declared + no match -> ``DENIED``      (fail closed; effector returns dry-run)
+- nothing declared    -> ``UNDECLARED``  (legacy fall-through to env + consent)
+
+The cutover (post-review, after Tiny's soul declares its grants) removes the
+``UNDECLARED`` fall-through so a soul grant becomes strictly required. Until
+then, ``UNDECLARED`` preserves the pre-existing env-capability + consent
+behavior so no live universe breaks. This module is effect-sink-agnostic;
+any effector resolves authority the same way.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+AUTHORIZED = "authorized"
+DENIED = "denied"
+UNDECLARED = "undeclared"
+
+
+def effect_authority_key(sink: str, destination: str) -> str:
+    """Canonical ``<sink>:<destination>`` grant key, both sides stripped."""
+    return f"{(sink or '').strip()}:{(destination or '').strip()}"
+
+
+def resolve_soul_effect_authority(
+    universe_dir: Path | None,
+    sink: str,
+    destination: str,
+) -> str:
+    """Resolve a (sink, destination) against the running universe's soul.
+
+    Returns one of ``AUTHORIZED`` / ``DENIED`` / ``UNDECLARED``. Never raises —
+    authority resolution must not break the effector path. Unexpected failures
+    fail closed (``DENIED``) rather than silently permitting a real write.
+    """
+    if universe_dir is None:
+        # No universe context (e.g. Phase-1 backward-compat invocations).
+        # Nothing to resolve against; defer to the legacy gates.
+        return UNDECLARED
+    try:
+        from workflow.universe_soul import effect_authority_from_soul
+
+        grants = effect_authority_from_soul(universe_dir)
+    except Exception:  # pragma: no cover - defensive; soul read is OSError-safe
+        logger.exception(
+            "soul effect-authority lookup crashed for %s; failing closed",
+            destination,
+        )
+        return DENIED
+    if not grants:
+        return UNDECLARED
+    return AUTHORIZED if effect_authority_key(sink, destination) in set(grants) else DENIED
+
+
+__all__ = [
+    "AUTHORIZED",
+    "DENIED",
+    "UNDECLARED",
+    "effect_authority_key",
+    "resolve_soul_effect_authority",
+]

--- a/workflow/effectors/github_pr.py
+++ b/workflow/effectors/github_pr.py
@@ -82,6 +82,14 @@ import time
 from pathlib import Path
 from typing import Any
 
+from workflow.effectors.authority import (
+    DENIED as SOUL_AUTHORITY_DENIED,
+)
+from workflow.effectors.authority import (
+    effect_authority_key,
+    resolve_soul_effect_authority,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -626,6 +634,34 @@ def run_github_pr_effector(
         }
 
     universe_dir = _resolve_universe_dir(base_path)
+
+    # ── Gate 0: soul-scoped effect-authority ───────────────────────────
+    # The running universe's soul is the source of effect-authority (gap 1 of
+    # the souled-universe self-maintenance model). A universe whose soul.md
+    # declares effect_authority grants must include this sink:destination, or
+    # the write fails closed here. A universe that declares NOTHING falls
+    # through to the legacy env-capability + consent gates below — transitional
+    # behavior the cutover removes once souls declare their grants. See
+    # docs/design-notes/2026-05-28-souled-universe-effect-authority.md.
+    soul_authority = resolve_soul_effect_authority(
+        universe_dir, EXTERNAL_WRITE_SINK_GITHUB_PR, destination
+    )
+    if soul_authority == SOUL_AUTHORITY_DENIED:
+        return {
+            "dry_run": True,
+            "phase": "phase_2",
+            "reason": "soul_not_authorized",
+            "destination": destination,
+            "intent": packet,
+            "matched_output_key": matched_key,
+            "hint": (
+                "This universe's soul declares effect_authority grants but "
+                "none match "
+                f'"{effect_authority_key(EXTERNAL_WRITE_SINK_GITHUB_PR, destination)}". '
+                "Add that grant to the soul's '## Effect Authority' section to "
+                "authorize this hand."
+            ),
+        }
 
     # ── Gate 1: capability env ─────────────────────────────────────────
     # Round-2 P1.2: lookup is by exact destination string against the

--- a/workflow/universe_soul.py
+++ b/workflow/universe_soul.py
@@ -33,6 +33,11 @@ class UniverseSoul:
     lineage: str = "template"
     edit_authority: str = DEFAULT_EDIT_AUTHORITY
     loop_branch_def_id: str = NO_LOOP_DECLARED
+    # Each entry is a "<sink>:<destination>" grant naming a real-world hand
+    # this universe's founder authorizes (e.g. "github_pull_request:owner/repo").
+    # Empty = nothing declared (transitional: effectors fall through to the
+    # legacy env-capability + consent gates until the soul-authority cutover).
+    effect_authority: tuple[str, ...] = ()
 
     def summary(self) -> dict[str, object]:
         return {
@@ -43,6 +48,7 @@ class UniverseSoul:
             "lineage": self.lineage,
             "edit_authority": self.edit_authority,
             "loop_branch_def_id": self.loop_branch_def_id,
+            "effect_authority": list(self.effect_authority),
             "versions_dir": SOUL_VERSIONS_DIR,
         }
 
@@ -71,6 +77,7 @@ class PinnedUniverseSoul:
             "lineage": self.soul.lineage,
             "edit_authority": self.soul.edit_authority,
             "loop_branch_def_id": self.soul.loop_branch_def_id,
+            "effect_authority": list(self.soul.effect_authority),
             "identity_boundary": (
                 "Universe soul guides this context only; it does not change "
                 "the actor identity or user memory scope."
@@ -126,6 +133,10 @@ def render_soul_markdown(soul: UniverseSoul) -> str:
         "",
         soul.edit_authority.strip() or DEFAULT_EDIT_AUTHORITY,
         "",
+        "## Effect Authority",
+        "",
+        _render_list(soul.effect_authority),
+        "",
     ])
 
 
@@ -152,6 +163,7 @@ def read_universe_soul(universe_dir: Path) -> UniverseSoul | None:
             or _read_meta(text, "Edit authority", DEFAULT_EDIT_AUTHORITY)
         ),
         loop_branch_def_id=_read_loop_branch_meta(text),
+        effect_authority=_read_list_section(text, "Effect Authority"),
     )
 
 
@@ -190,6 +202,7 @@ def write_universe_soul(
     lineage: str = "template",
     edit_authority: str = DEFAULT_EDIT_AUTHORITY,
     loop_branch_def_id: str = NO_LOOP_DECLARED,
+    effect_authority: tuple[str, ...] = (),
 ) -> UniverseSoul:
     universe_dir.mkdir(parents=True, exist_ok=True)
     existing = read_universe_soul(universe_dir)
@@ -208,6 +221,9 @@ def write_universe_soul(
             lineage=lineage.strip() or "template",
             edit_authority=edit_authority.strip() or DEFAULT_EDIT_AUTHORITY,
             loop_branch_def_id=loop_branch_def_id.strip(),
+            effect_authority=tuple(
+                item.strip() for item in effect_authority if item.strip()
+            ),
         )
     else:
         soul = replace(
@@ -231,6 +247,10 @@ def write_universe_soul(
             edit_authority=edit_authority.strip() or existing.edit_authority,
             loop_branch_def_id=(
                 loop_branch_def_id.strip() or existing.loop_branch_def_id
+            ),
+            effect_authority=(
+                tuple(item.strip() for item in effect_authority if item.strip())
+                or existing.effect_authority
             ),
         )
 
@@ -277,6 +297,12 @@ def premise_from_soul(universe_dir: Path) -> str:
 def loop_branch_from_soul(universe_dir: Path) -> str:
     soul = read_universe_soul(universe_dir)
     return soul.loop_branch_def_id if soul is not None else NO_LOOP_DECLARED
+
+
+def effect_authority_from_soul(universe_dir: Path) -> tuple[str, ...]:
+    """Return the soul-declared effect-authority grants, or () if none/no soul."""
+    soul = read_universe_soul(universe_dir)
+    return soul.effect_authority if soul is not None else ()
 
 
 def _render_list(items: tuple[str, ...]) -> str:


### PR DESCRIPTION
## Summary

Implements the first slice of the souled-universe effect-authority design note (**PR #1126**): move PR-effect authority from the global env capability map toward **the running universe's soul**. Scaffold — needs the design note's review to land.

- **`universe_soul.py`**: new `effect_authority` tuple field on `UniverseSoul` (`<sink>:<destination>` grants), rendered/parsed as a `## Effect Authority` soul.md section, versioned like every soul write; `effect_authority_from_soul` reader.
- **`effectors/authority.py`** (new): `resolve_soul_effect_authority()` → `AUTHORIZED` / `DENIED` / `UNDECLARED`. Sink-agnostic, fails closed on error.
- **`effectors/github_pr.py`**: **Gate 0** (soul-authority) runs *before* the capability gate. A universe whose soul declares grants must include this `sink:destination` or the write fails closed (`reason=soul_not_authorized`); a universe that declares **nothing** falls through to the legacy capability + consent gates.
- **Transitional, not a shim:** the cutover (post-review, once souls declare grants — Tiny first) removes the undeclared fall-through so a soul grant is strictly required. Removal is in-arc.
- 14 tests (soul round-trip, resolver, effector gate order). Plugin mirror rebuilt.

### Scope guard
Stays on the **user-buildable loop's** effect path. Does **not** touch the `bug_investigation` cheat trigger (the retiring path). Generic by construction — no `universe == tiny` special-casing.

### Why now
Diagnosis of Goal 4ff5862cc26d showed the loop is healthy but honestly capped at `learned_failure` because the next rung requires a **real merged PR** and the loop has never had authority to perform a real external write. This gate is that authority, scoped to the universe's soul.

### Review
writer: claude / checker: codex (cross-family). Host merge key required. Should land after / with PR #1126 (the design).

## Test plan
- [x] `pytest tests/test_soul_scoped_effect_authority.py` — 14 pass
- [x] existing effector/soul suites pass (no regression); ruff clean; mirror parity verified
- [ ] Codex review of gate ordering + transitional fall-through semantics
- [ ] Host decision (PR #1126 open Q): `edit_authority` reuse vs distinct `effect_authority` field — this scaffold chose distinct