### PR TITLE
[codex] Fix wiki bug sync structuredContent parsing

### DIFF
--- a/.agents/skills/loop-uptime-maintenance/incidents/2026-05-28-wiki-bug-sync-structuredcontent.md
+++ b/.agents/skills/loop-uptime-maintenance/incidents/2026-05-28-wiki-bug-sync-structuredcontent.md
@@ -1,0 +1,55 @@
+---
+date: 2026-05-28
+severity: P0
+status: pending-merge
+related_issue: https://github.com/Jonnyton/Workflow/issues/1118
+related_run: https://github.com/Jonnyton/Workflow/actions/runs/26605636623
+---
+
+# Wiki bug sync structuredContent incident
+
+## Symptoms
+
+Community loop watch issue #1118 stayed red after PR #1125 recovered the public MCP canary. The remaining red intake stage was `wiki-bug-sync.yml` run `26605636623`, which crashed in `scripts/wiki_bug_sync.py` while parsing `wiki action=list`.
+
+## Evidence Snapshot
+
+- `wiki-bug-sync.yml` run `26605636623` failed at 2026-05-28T22:20Z.
+- Stack trace: `json.decoder.JSONDecodeError` at `wiki_list = json.loads(_parse_text_result(list_result))`.
+- The failure class matches PR #1125: MCP tool text is now a short preview and the full payload is in `structuredContent`.
+- Post-#1125 public MCP canary run `26606206467` was green, so the MCP surface itself was healthy.
+- Local live dry-run after this branch's fix: `python scripts/wiki_bug_sync.py --url https://tinyassets.io/mcp --include-community-requests --dry-run` exited 0 and found BUG-109 plus PR-144 without parser failure.
+
+## Immediate Fix Applied
+
+`scripts/wiki_bug_sync.py` now prefers MCP `structuredContent` for wiki list/read results and keeps the old text JSON fallback. Regression tests cover preview-text plus structuredContent for both `wiki action=list` and `wiki action=read`.
+
+## Verification
+
+- Reproduction tests failed before the code fix:
+  - `test_sync_no_new_bugs_accepts_structured_content_list_preview`
+  - `test_fetch_wiki_page_detail_accepts_structured_content_preview`
+- Focused tests after fix: `python -m pytest tests/test_wiki_bug_sync.py tests/test_canary_scripts_import_smoke.py -q` -> 88 passed.
+- Compile check: `python -m compileall -q scripts/wiki_bug_sync.py scripts/_canary_common.py` -> passed.
+- Live dry-run against `https://tinyassets.io/mcp` -> passed.
+- Full recovery proof remains pending until the PR merges and `wiki-bug-sync.yml` plus `community-loop-watch.yml` run green on `main`.
+
+## How Did The Loop Break This Time?
+
+The live MCP server shifted large tool payloads into `structuredContent`, leaving human-readable preview text in `content[].text`. PR #1125 fixed the public uptime canaries, but `wiki_bug_sync.py` was an independent MCP client and still parsed only text. The intake sync therefore crashed before it could bridge new wiki BUG/PR filings into GitHub.
+
+## How Can The Loop Notice This Break Next Time, Automatically?
+
+Community loop watch already noticed the intake sync stage red, but the failure signature should be classified as an MCP structuredContent parser regression rather than a generic workflow failure. The stack trace plus preview-text marker is distinctive: `Full payload is in structuredContent` combined with `JSONDecodeError`.
+
+## How Can The Loop Fix This Break Next Time, Automatically?
+
+All repo-owned MCP client scripts should share one helper for tool-result payload extraction. When one client learns a new response shape, the loop should either run a scanner for remaining text-only parse sites or open a follow-up patch automatically for each affected script.
+
+## How Can The Loop Avoid This Break In The First Place Next Time?
+
+Move `_extract_structured_tool_payload` out of canary-specific naming into a general MCP client utility, then require every script that consumes MCP tool results to use that utility. Add a static test that flags direct `json.loads(_parse_text_result(...))` patterns in MCP clients unless paired with structuredContent handling.
+
+## Substrate Improvement Filed
+
+This branch is the immediate substrate fix. A follow-up should generalize the helper name and add a text-only-parser scanner once the loop is green again.

--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -624,3 +624,16 @@ Notes:
   payloads while preserving text-JSON fallback.
 - Ship condition: focused canary tests pass, local live canary passes, branch
   pushed, PR opened for checker/host review.
+
+## P0 Wiki Bug Sync StructuredContent Parser - 2026-05-28
+
+- 2026-05-28 create `../wf-wiki-bug-sync-structured-content` on
+  `codex/wiki-bug-sync-structured-content` by codex-gpt5-desktop.
+- Source: community loop watch issue #1118 red; `wiki-bug-sync.yml` run
+  26605636623 crashed because `scripts/wiki_bug_sync.py` parsed text only while
+  MCP list payload now lives in `structuredContent`.
+- Purpose: port the structuredContent/text-fallback parser pattern from #1125
+  into the intake sync script and prove it with regression coverage.
+- Ship condition: focused tests pass, branch pushed, PR opened, GitHub
+  `wiki-bug-sync.yml` dispatch succeeds, community loop watch recovers or
+  residual non-intake blockers are documented.

--- a/.claude/skills/loop-uptime-maintenance/incidents/2026-05-28-wiki-bug-sync-structuredcontent.md
+++ b/.claude/skills/loop-uptime-maintenance/incidents/2026-05-28-wiki-bug-sync-structuredcontent.md
@@ -1,0 +1,55 @@
+---
+date: 2026-05-28
+severity: P0
+status: pending-merge
+related_issue: https://github.com/Jonnyton/Workflow/issues/1118
+related_run: https://github.com/Jonnyton/Workflow/actions/runs/26605636623
+---
+
+# Wiki bug sync structuredContent incident
+
+## Symptoms
+
+Community loop watch issue #1118 stayed red after PR #1125 recovered the public MCP canary. The remaining red intake stage was `wiki-bug-sync.yml` run `26605636623`, which crashed in `scripts/wiki_bug_sync.py` while parsing `wiki action=list`.
+
+## Evidence Snapshot
+
+- `wiki-bug-sync.yml` run `26605636623` failed at 2026-05-28T22:20Z.
+- Stack trace: `json.decoder.JSONDecodeError` at `wiki_list = json.loads(_parse_text_result(list_result))`.
+- The failure class matches PR #1125: MCP tool text is now a short preview and the full payload is in `structuredContent`.
+- Post-#1125 public MCP canary run `26606206467` was green, so the MCP surface itself was healthy.
+- Local live dry-run after this branch's fix: `python scripts/wiki_bug_sync.py --url https://tinyassets.io/mcp --include-community-requests --dry-run` exited 0 and found BUG-109 plus PR-144 without parser failure.
+
+## Immediate Fix Applied
+
+`scripts/wiki_bug_sync.py` now prefers MCP `structuredContent` for wiki list/read results and keeps the old text JSON fallback. Regression tests cover preview-text plus structuredContent for both `wiki action=list` and `wiki action=read`.
+
+## Verification
+
+- Reproduction tests failed before the code fix:
+  - `test_sync_no_new_bugs_accepts_structured_content_list_preview`
+  - `test_fetch_wiki_page_detail_accepts_structured_content_preview`
+- Focused tests after fix: `python -m pytest tests/test_wiki_bug_sync.py tests/test_canary_scripts_import_smoke.py -q` -> 88 passed.
+- Compile check: `python -m compileall -q scripts/wiki_bug_sync.py scripts/_canary_common.py` -> passed.
+- Live dry-run against `https://tinyassets.io/mcp` -> passed.
+- Full recovery proof remains pending until the PR merges and `wiki-bug-sync.yml` plus `community-loop-watch.yml` run green on `main`.
+
+## How Did The Loop Break This Time?
+
+The live MCP server shifted large tool payloads into `structuredContent`, leaving human-readable preview text in `content[].text`. PR #1125 fixed the public uptime canaries, but `wiki_bug_sync.py` was an independent MCP client and still parsed only text. The intake sync therefore crashed before it could bridge new wiki BUG/PR filings into GitHub.
+
+## How Can The Loop Notice This Break Next Time, Automatically?
+
+Community loop watch already noticed the intake sync stage red, but the failure signature should be classified as an MCP structuredContent parser regression rather than a generic workflow failure. The stack trace plus preview-text marker is distinctive: `Full payload is in structuredContent` combined with `JSONDecodeError`.
+
+## How Can The Loop Fix This Break Next Time, Automatically?
+
+All repo-owned MCP client scripts should share one helper for tool-result payload extraction. When one client learns a new response shape, the loop should either run a scanner for remaining text-only parse sites or open a follow-up patch automatically for each affected script.
+
+## How Can The Loop Avoid This Break In The First Place Next Time?
+
+Move `_extract_structured_tool_payload` out of canary-specific naming into a general MCP client utility, then require every script that consumes MCP tool results to use that utility. Add a static test that flags direct `json.loads(_parse_text_result(...))` patterns in MCP clients unless paired with structuredContent handling.
+
+## Substrate Improvement Filed
+
+This branch is the immediate substrate fix. A follow-up should generalize the helper name and add a text-only-parser scanner once the loop is green again.

--- a/scripts/wiki_bug_sync.py
+++ b/scripts/wiki_bug_sync.py
@@ -45,6 +45,8 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+from _canary_common import _extract_structured_tool_payload
+
 DEFAULT_URL = "https://tinyassets.io/mcp"
 DEFAULT_TIMEOUT = 20.0
 GITHUB_API = "https://api.github.com"
@@ -272,6 +274,19 @@ def _parse_text_result(result: dict[str, Any]) -> str:
     raise SyncError(1, "tool returned no text content")
 
 
+def _parse_json_result(result: dict[str, Any]) -> dict[str, Any]:
+    structured = _extract_structured_tool_payload(result)
+    if structured is not None:
+        return structured
+    text = _parse_text_result(result)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SyncError(
+            1, f"tool text not JSON: {exc}; preview={text[:200]!r}",
+        ) from exc
+
+
 # ---------------------------------------------------------------------------
 # Cursor
 # ---------------------------------------------------------------------------
@@ -464,12 +479,16 @@ def fetch_wiki_page_detail(
     result = _mcp_call_tool(
         url, sid, "wiki", {"action": "read", "page": page}, timeout, post_fn
     )
-    text = _parse_text_result(result)
-    try:
-        data = json.loads(text)
-        content = data.get("content", "")
-    except (json.JSONDecodeError, AttributeError):
-        content = text
+    structured = _extract_structured_tool_payload(result)
+    if structured is not None:
+        content = structured.get("content", "")
+    else:
+        text = _parse_text_result(result)
+        try:
+            data = json.loads(text)
+            content = data.get("content", "")
+        except (json.JSONDecodeError, AttributeError):
+            content = text
 
     meta, body = _split_frontmatter(content)
     return {"meta": meta, "body": body, "content": content}
@@ -822,7 +841,7 @@ def sync(
 
         # Fetch wiki list
         list_result = _mcp_call_tool(url, sid, "wiki", {"action": "list"}, timeout, post_fn)
-        wiki_list = json.loads(_parse_text_result(list_result))
+        wiki_list = _parse_json_result(list_result)
 
         cursor = read_cursor(cursor_path)
         new_bugs = list_new_bugs(wiki_list, cursor)

--- a/tests/test_wiki_bug_sync.py
+++ b/tests/test_wiki_bug_sync.py
@@ -52,6 +52,30 @@ def _wiki_list_resp(bugs: list[dict]) -> dict:
     }
 
 
+def _wiki_list_structured_resp(bugs: list[dict]) -> dict:
+    """Build a wiki list response with preview text plus structuredContent."""
+    promoted = [
+        {"path": b["path"], "title": b.get("title", b["path"]), "type": "bug"}
+        for b in bugs
+    ]
+    return {
+        "jsonrpc": "2.0",
+        "id": 10,
+        "result": {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        "Tool result: promoted=%d; drafts=0. "
+                        "Full payload is in structuredContent."
+                    ) % len(promoted),
+                }
+            ],
+            "structuredContent": {"promoted": promoted, "drafts": []},
+        },
+    }
+
+
 def _wiki_read_resp(meta: dict, body: str = "# Body") -> dict:
     """Build a mock MCP tools/call result for wiki action=read."""
     fm_lines = "\n".join(f"{k}: {v}" for k, v in meta.items())
@@ -63,6 +87,25 @@ def _wiki_read_resp(meta: dict, body: str = "# Body") -> dict:
             "content": [
                 {"type": "text", "text": json.dumps({"content": content})}
             ]
+        },
+    }
+
+
+def _wiki_read_structured_resp(meta: dict, body: str = "# Body") -> dict:
+    """Build a wiki read response with preview text plus structuredContent."""
+    fm_lines = "\n".join(f"{k}: {v}" for k, v in meta.items())
+    content = f"---\n{fm_lines}\n---\n\n{body}"
+    return {
+        "jsonrpc": "2.0",
+        "id": 10,
+        "result": {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Tool result: content preview. Full payload is in structuredContent.",
+                }
+            ],
+            "structuredContent": {"content": content},
         },
     }
 
@@ -632,6 +675,25 @@ def test_fetch_wiki_page_detail_returns_body_without_frontmatter():
     assert "title:" not in detail["body"]
 
 
+def test_fetch_wiki_page_detail_accepts_structured_content_preview():
+    detail = fetch_wiki_page_detail(
+        "http://fake/mcp",
+        "sid1",
+        "pages/plans/user-buildable-community-change-loop-v0-substrate-readiness-baseline.md",
+        5.0,
+        post_fn=CapturingPost([
+            (_wiki_read_structured_resp(
+                {"title": "User-Buildable Community Change Loop"},
+                "## Main finding\n\nStructured payloads are canonical.",
+            ), "sid1"),
+        ]),
+    )
+
+    assert detail["meta"]["title"] == "User-Buildable Community Change Loop"
+    assert "Structured payloads are canonical." in detail["body"]
+    assert "Full payload is in structuredContent" not in detail["body"]
+
+
 def test_format_change_issue_body_includes_bounded_source_context():
     body = format_change_issue_body(
         {"type": "plan"},
@@ -664,6 +726,23 @@ def test_sync_no_new_bugs(tmp_path):
     rc = sync("http://fake/mcp", 5.0, dry_run=True, cursor_path=cursor_path, post_fn=post_fn)
     assert rc == 0
     assert read_cursor(cursor_path) == 5  # unchanged
+
+
+def test_sync_no_new_bugs_accepts_structured_content_list_preview(tmp_path):
+    cursor_path = tmp_path / "cursor"
+    write_cursor(5, cursor_path)
+
+    post_fn = _make_post_fn(
+        (_INIT_OK, "sid1"),
+        (_NOTIF_NONE, "sid1"),
+        (_wiki_list_structured_resp([
+            {"path": "bugs/BUG-001-a"},
+            {"path": "bugs/BUG-005-e"},
+        ]), "sid1"),
+    )
+    rc = sync("http://fake/mcp", 5.0, dry_run=True, cursor_path=cursor_path, post_fn=post_fn)
+    assert rc == 0
+    assert read_cursor(cursor_path) == 5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- teach `scripts/wiki_bug_sync.py` to prefer MCP `structuredContent` payloads for wiki list/read results
- preserve the existing text/JSON fallback for older MCP responses
- add regression coverage for preview text plus structured wiki list/read payloads
- record the loop-uptime incident for #1118 in the shared skill incident log

## Root cause
After the live MCP surface moved large tool results into `structuredContent`, `wiki_bug_sync.py` still called `json.loads(_parse_text_result(list_result))`. `wiki-bug-sync.yml` run 26605636623 therefore crashed on preview text and kept community-loop issue #1118 red. This is the same response-shape class fixed for canaries in #1125, but in the intake-sync script.

## Validation
- Reproduction tests failed before the parser change:
  - `test_sync_no_new_bugs_accepts_structured_content_list_preview`
  - `test_fetch_wiki_page_detail_accepts_structured_content_preview`
- `python -m pytest tests/test_wiki_bug_sync.py tests/test_canary_scripts_import_smoke.py -q` -> 88 passed
- `python -m compileall -q scripts/wiki_bug_sync.py scripts/_canary_common.py` -> passed
- `python scripts/wiki_bug_sync.py --url https://tinyassets.io/mcp --include-community-requests --dry-run` -> passed against live MCP, found BUG-109 and PR-144 without parser failure

## Gate
Writer: Codex/OpenAI-family. Needs independent Claude/Cowork checker key and explicit host merge key before merge. After merge, dispatch `wiki-bug-sync.yml` on main and then `community-loop-watch.yml`; #1118 should clear or narrow to non-intake residuals.