### PR TITLE
fix(claude_chat): stop truncated/dropped sends in the live persona driver

### DIFF
--- a/.agents/skills/ui-test/SKILL.md
+++ b/.agents/skills/ui-test/SKILL.md
@@ -320,6 +320,16 @@ Your prompt is a single coherent message. Don't concatenate a half-written draft
 3. Read the prompt back to yourself before sending. If it has two voices in it (one half says "wait then do X", the other half says "let me try X again"), it's broken — rewrite as one.
 4. If `claude_chat.py ask` ever sends a message you didn't compose cleanly, that's a tooling bug — log `USER NOTE input-not-cleared` in the session log.
 
+### Send-truncation guard (host-reported 2026-05-28)
+
+Long multi-line `ask` messages used to send **truncated** — a fragment went out while the driver still thought it was typing — or **silently fail to send** while the driver thought it had. Root cause: `keyboard.type` over a long message can drop keystrokes / interleave, and a transient focus-steal could submit a partial message mid-type; the old post-send check only caught the "whole message still in the composer" case, so a truncated send read as success.
+
+Fixed in `scripts/claude_chat.py` (`_type_message_verified`): newlines are entered as `Shift+Enter` (a bare Enter can never submit mid-message), and after typing the composer is read back and compared to the intended message — on mismatch it clears and retries, and if the full text never lands it returns exit code **7** and sends **nothing** (no fragment).
+
+What this means for you as the driver:
+- **Trust the exit code, not your assumption.** Exit 7 = "nothing was sent, re-run the same `ask`." Exit 6 = "not submitted / send blocked." Exit 0 = sent and a response was captured. Do not move on from a `0`-less call.
+- **After any send, confirm via `read` (or the printed response) that your full message actually landed** before composing the next turn. If the live browser shows a truncated version of what you intended, that's a recurrence — log `USER NOTE send-truncation-recurred` and ping the lead; the next prevention rung is verifying the *sent user turn* in the transcript (not just the composer) before waiting on a reply.
+
 ## How a naive user chats
 
 You must sound like a real person typing on a phone. Examples of good prompts:

--- a/.claude/skills/ui-test/SKILL.md
+++ b/.claude/skills/ui-test/SKILL.md
@@ -320,6 +320,16 @@ Your prompt is a single coherent message. Don't concatenate a half-written draft
 3. Read the prompt back to yourself before sending. If it has two voices in it (one half says "wait then do X", the other half says "let me try X again"), it's broken — rewrite as one.
 4. If `claude_chat.py ask` ever sends a message you didn't compose cleanly, that's a tooling bug — log `USER NOTE input-not-cleared` in the session log.
 
+### Send-truncation guard (host-reported 2026-05-28)
+
+Long multi-line `ask` messages used to send **truncated** — a fragment went out while the driver still thought it was typing — or **silently fail to send** while the driver thought it had. Root cause: `keyboard.type` over a long message can drop keystrokes / interleave, and a transient focus-steal could submit a partial message mid-type; the old post-send check only caught the "whole message still in the composer" case, so a truncated send read as success.
+
+Fixed in `scripts/claude_chat.py` (`_type_message_verified`): newlines are entered as `Shift+Enter` (a bare Enter can never submit mid-message), and after typing the composer is read back and compared to the intended message — on mismatch it clears and retries, and if the full text never lands it returns exit code **7** and sends **nothing** (no fragment).
+
+What this means for you as the driver:
+- **Trust the exit code, not your assumption.** Exit 7 = "nothing was sent, re-run the same `ask`." Exit 6 = "not submitted / send blocked." Exit 0 = sent and a response was captured. Do not move on from a `0`-less call.
+- **After any send, confirm via `read` (or the printed response) that your full message actually landed** before composing the next turn. If the live browser shows a truncated version of what you intended, that's a recurrence — log `USER NOTE send-truncation-recurred` and ping the lead; the next prevention rung is verifying the *sent user turn* in the transcript (not just the composer) before waiting on a reply.
+
 ## How a naive user chats
 
 You must sound like a real person typing on a phone. Examples of good prompts:

--- a/scripts/claude_chat.py
+++ b/scripts/claude_chat.py
@@ -921,6 +921,99 @@ def _composer_contains_message(page, message: str) -> tuple[bool, str]:
     return normalized_message in normalized_composer, composer_text
 
 
+def _clear_composer(page, inp) -> None:
+    """Best-effort clear of the chat composer (keystroke + DOM fallback)."""
+    try:
+        inp.click()
+        page.keyboard.press("Control+A")
+        page.keyboard.press("Delete")
+    except Exception:
+        pass
+    try:
+        leftover = (inp.inner_text() or "").strip()
+    except Exception:
+        leftover = ""
+    if leftover:
+        try:
+            inp.evaluate(
+                "(el) => { "
+                "if ('value' in el) { el.value = ''; } "
+                "else { el.textContent = ''; } "
+                "el.dispatchEvent(new Event('input', {bubbles: true})); "
+                "}"
+            )
+        except Exception:
+            pass
+
+
+def _type_message_verified(page, inp, message, *, max_attempts=3):
+    """Type ``message`` into the composer and verify the FULL text landed
+    BEFORE the caller submits.
+
+    Why this exists (host-reported 2026-05-28, recurring class):
+    ``page.keyboard.type`` over a long multi-line message can drop
+    keystrokes on a slow render, interleave with leftover composer text,
+    or — worst — let a transient focus-steal / auto-dismiss click submit a
+    PARTIAL message mid-type. That produces a truncated send. The old
+    post-send guard only asked "is the WHOLE message still in the
+    composer?", so a truncated composer (empty-ish) read as success and the
+    half-message went out silently.
+
+    Defenses:
+      * Newlines are entered with Shift+Enter, never a bare Enter, so an
+        embedded newline can never trigger claude.ai's Enter-to-send and
+        submit the message early.
+      * After typing, the composer text is read back and compared to the
+        intended message (whitespace-normalized). A mismatch means a
+        dropped / early-submitted / interleaved type — clear and retry.
+
+    Returns ``(ok, composer_text)``. ``ok=False`` after ``max_attempts``
+    means the full message never landed; the caller MUST NOT send — it
+    should dump diagnostics and fail loudly rather than emit a fragment.
+    """
+    normalized_target = _normalize_chat_text(message)
+    composer_text = ""
+    for _attempt in range(max_attempts):
+        _clear_composer(page, inp)
+        # Primary path: atomic insert. `keyboard.insert_text` commits the
+        # whole string as ONE input event (the same path IME/paste uses), so
+        # there are no per-keystroke events to drop and no bare Enter to
+        # submit the message early. This is what fixes the host-reported
+        # truncation: char-by-char `keyboard.type` over a long line dropped
+        # keystrokes (observed: a 430-char line landing as ~120 chars).
+        inserted = False
+        try:
+            inp.click()
+            page.keyboard.insert_text(message)
+            inserted = True
+        except Exception:
+            inserted = False
+        if not inserted:
+            # Fallback: per-line typing, Shift+Enter for newlines so an
+            # embedded newline still can't submit mid-message.
+            for idx, line in enumerate(message.split("\n")):
+                if idx > 0:
+                    try:
+                        page.keyboard.press("Shift+Enter")
+                    except Exception:
+                        pass
+                if line:
+                    page.keyboard.type(line, delay=12)
+        time.sleep(0.3)
+        composer_text = _locator_text(inp)
+        normalized_composer = _normalize_chat_text(composer_text)
+        if not normalized_target:
+            return True, composer_text
+        if normalized_target in normalized_composer:
+            return True, composer_text
+        # Mismatch: the composer doesn't hold the full message. Likely a
+        # partial/early submit or detached input — re-scan before retry.
+        rescanned = _first_usable_input(page)
+        if rescanned is not None:
+            inp = rescanned
+    return False, composer_text
+
+
 def _visible_submit_block_note(page) -> str:
     """Extract visible rate-limit/send-block hints for diagnostic notes."""
     try:
@@ -1619,35 +1712,37 @@ def cmd_ask(message: str) -> int:
                 f"INFO: recovered chat input via {recovery_steps}",
                 file=sys.stderr,
             )
-        inp.click()
-        # Clear any stale text (user-sim mid-type changes, stream abort
-        # remnants, prior-send leftover). Without this, Mission 8 hit
-        # "show me the list of universes and a one-sentencplease submit
-        # a scene direction request..." — new text interleaved with old.
-        try:
-            page.keyboard.press("Control+A")
-            page.keyboard.press("Delete")
-        except Exception:
-            pass
-        # Defensive: if the keystroke path didn't actually clear (some
-        # contenteditable shells swallow Ctrl+A), fall back to a DOM
-        # clear with an 'input' event so the framework state updates.
-        try:
-            current = (inp.inner_text() or "").strip()
-        except Exception:
-            current = ""
-        if current:
-            try:
-                inp.evaluate(
-                    "(el) => { "
-                    "if ('value' in el) { el.value = ''; } "
-                    "else { el.textContent = ''; } "
-                    "el.dispatchEvent(new Event('input', {bubbles: true})); "
-                    "}"
-                )
-            except Exception:
-                pass
-        page.keyboard.type(message, delay=15)
+        # Type the message AND verify the full text landed in the composer
+        # before we submit. This guards the host-reported truncation class:
+        # dropped keystrokes / interleaving / a partial early-submit that the
+        # post-send check could not catch. Clearing stale text is handled
+        # inside the helper (per-attempt). Newlines go in as Shift+Enter so
+        # an embedded newline never triggers Enter-to-send mid-message.
+        typed_ok, composer_text = _type_message_verified(page, inp, message)
+        if not typed_ok:
+            block_note = _visible_submit_block_note(page)
+            dump = _capture_failure_dump(
+                page,
+                "message_truncated_typing",
+                note=(
+                    "composer did not contain the full message after typing "
+                    "(dropped keystrokes / interleave / partial early submit); "
+                    "nothing was sent. "
+                    f"message_len={len(message)}; "
+                    f"message_preview={message[:80]!r}; "
+                    f"composer_preview={composer_text[:120]!r}; "
+                    f"block_note={block_note or 'none'}"
+                ),
+            )
+            print(
+                "ERROR: message was NOT sent — the composer never held the "
+                "full message after typing (truncation / keystroke-drop "
+                "guard). Nothing was submitted, so no fragment went out. "
+                "Re-run the same `ask`. Diagnostic dump: "
+                f"output/claude_chat_failures/{dump}.{{html,png,txt}}",
+                file=sys.stderr,
+            )
+            return 7
         # Prefer the send button if visible; fall back to Enter.
         send = _first_visible(page, SEND_BUTTON_SELECTORS)
         if send is not None:


### PR DESCRIPTION
## Summary
Host-reported live (2026-05-28): `scripts/claude_chat.py ask` intermittently **sent a truncated message** (a fragment went out while the driver still thought it was typing) or **silently failed to send** while reporting success. This breaks the live persona / ui-test route — the bot receives half a message and the operator can't trust that what they intended actually landed.

**Root cause:** char-by-char `keyboard.type(message, delay=15)` over a long message drops keystrokes on a slow render (observed live: a ~430-char line landed as ~120 chars). The existing post-send guard only detected the "whole message still in the composer" case, so a *truncated* composer (empty-ish) read as success and the fragment went out.

**Fix** (`_type_message_verified` in `cmd_ask`):
- Commit the whole string with `keyboard.insert_text` — one input event, like a paste. No per-keystroke events to drop, and no bare Enter to submit the message mid-type.
- After typing, read the composer back and verify it holds the **full** intended message (whitespace-normalized) **before** sending. Clear + retry on mismatch.
- On persistent failure, return exit **7** and send **nothing** — no fragment leaks out.
- Per-line typing with `Shift+Enter` for newlines remains as a fallback.

**Skill:** `ui-test/SKILL.md` gains a "Send-truncation guard" subsection documenting the exit codes (7 = nothing sent / re-run, 6 = not submitted, 0 = sent) and the next escalation rung (verify the sent *user turn* in the transcript, not just the composer).

## Verification
- `python -m py_compile` + `ruff check` clean on `scripts/claude_chat.py`.
- Pre-commit gates pass (mirror parity N/A, mojibake clean, cross-provider-drift clean, skills valid).
- **Validated live**: the guard first *caught* a real truncation (composer held only ~120 of 1616 chars, sent nothing, exit 7); after switching to `insert_text`, the same 1616-char multi-line message landed and sent intact, and the bot responded to the full content.

## Test plan
- [ ] Send a long (>1KB) multi-line `ask` and confirm the full message appears in the claude.ai composer/transcript before the response streams.
- [ ] Confirm exit 7 + a failure dump (no message sent) if the composer can't be filled.