### PR TITLE
fix(deploy): install gh CLI in daemon runtime image (unblocks BUG-110)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,12 @@ FROM python:3.11-slim
 # Node.js 20 LTS via nodesource — same version as builder so the copied
 # codex binary's native addons are ABI-compatible. No npm needed at
 # runtime; the codex module tree is COPY'd from the builder.
+#
+# GitHub CLI (gh) — the github_pull_request effector shells out to
+# `gh pr create` (workflow/effectors/github_pr.py). Without gh on the
+# runtime PATH the effector fails with error_kind=gh_not_installed
+# (BUG-110), which blocks every real PR open from the patch-request loop.
+# Installed from cli.github.com before curl is purged below.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         bubblewrap \
@@ -104,6 +110,14 @@ RUN apt-get update && \
         util-linux \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y --no-install-recommends nodejs \
+    && mkdir -p -m 755 /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
     && apt-get purge -y curl \
     && rm -rf /var/lib/apt/lists/* && \
     groupadd --system --gid 1001 workflow && \


### PR DESCRIPTION
## Summary
The `github_pull_request` effector (`workflow/effectors/github_pr.py`) shells out to `gh pr create`, but the daemon image's **runtime** stage never installed the GitHub CLI. A live probe (2026-05-28) confirmed every real PR open fails at `phase_2` with `error_kind=gh_not_installed` — reservation, idempotency, and destination resolution all succeed, then the subprocess call hits a missing binary. **This blocks the entire ship side of the patch-request loop.** Filed as **BUG-110**.

## Change
- Install `gh` from `cli.github.com` in the runtime stage's apt block, before `curl` is purged (one `RUN` block, +14 lines, no new stages).
- Uses the official keyring + signed apt source.

## Scope note
The effector today invokes **`gh pr create` only** — it opens a PR between branches that already exist on the remote; it does **not** git-push the head branch itself. So `gh` is the complete fix for the *observed* `gh_not_installed` error. (Who creates/pushes the head branch with the materialized changes is a separate effector-scope question, not this PR.)

## Verification
- Edit is the documented GitHub-CLI Debian install incantation; pre-commit gates pass.
- **Not built locally** (full image build pulls the rust/node toolchain) — CI image build + the post-deploy probe are the gates. After deploy, re-running the BUG-110 repro (probe branch `96f4cc46f4d6`) should advance past `gh_not_installed` (next stop: capability/consent gates, i.e. a dry-run packet unless a grant is configured).

## Caution
Production-deploy-impacting: merging rebuilds and redeploys the live daemon image. Leaving the merge to the host gate.

## Test plan
- [ ] CI builds the image successfully with `gh` present.
- [ ] On a built image, `gh --version` resolves on PATH.
- [ ] Post-deploy: re-run probe `96f4cc46f4d6`; confirm `external_write_results` no longer reports `gh_not_installed`.