### PR TITLE
[auto-change] BUG-109: file_bug silently discards unknown kwargs (including a `content` body arg) and returns success, filing title-only empty-body shells — the bug that cost two filings this session; cross-ref PR-144

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1940,6 +1940,28 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
+    unsupported = {
+        key: value for key, value in _kwargs.items()
+        if value not in ("", None, False)
+        and not (
+            (key == "dry_run" and value is True)
+            or (key == "similarity_threshold" and value == 0.25)
+            or (key == "max_results" and value == 10)
+            or (key == "offset" and value == 0)
+            or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
+        )
+    }
+    if unsupported:
+        return json.dumps({
+            "error": (
+                "Unsupported file_bug field(s): "
+                + ", ".join(sorted(unsupported.keys()))
+            ),
+            "hint": (
+                "Use repro, observed, expected, and workaround for the filing body; "
+                "content is only for wiki write/patch actions."
+            ),
+        })
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",

--- a/tests/test_api_wiki.py
+++ b/tests/test_api_wiki.py
@@ -30,6 +30,7 @@ from workflow.api.wiki import (
     _parse_frontmatter,
     _sanitize_slug,
     _slugify_title,
+    _wiki_file_bug,
     _wiki_similarity_score,
     wiki,
 )
@@ -672,6 +673,37 @@ def test_wiki_file_bug_files_clean_when_no_dups(wiki_env):
     )
     assert res["status"] == "filed"
     assert res["bug_id"].startswith("BUG-")
+
+
+def test_wiki_file_bug_rejects_unsupported_body_field(wiki_env):
+    res = json.loads(
+        wiki(
+            action="file_bug",
+            component="api.wiki",
+            severity="major",
+            title="Content body should not be discarded",
+            content="This body would be lost if file_bug silently accepted it.",
+        )
+    )
+
+    assert "error" in res
+    assert "content" in res["error"]
+    assert not list((wiki_env / "pages" / "bugs").glob("bug-*.md"))
+
+
+def test_wiki_file_bug_rejects_unknown_direct_kwarg(wiki_env):
+    res = json.loads(
+        _wiki_file_bug(
+            component="api.wiki",
+            severity="major",
+            title="Unknown direct kwarg should not be discarded",
+            body="This field is not part of the file_bug contract.",
+        )
+    )
+
+    assert "error" in res
+    assert "body" in res["error"]
+    assert not list((wiki_env / "pages" / "bugs").glob("bug-*.md"))
 
 
 def test_wiki_file_bug_queued_investigation_returns_branch_task_lease_shape(

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1940,6 +1940,28 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
+    unsupported = {
+        key: value for key, value in _kwargs.items()
+        if value not in ("", None, False)
+        and not (
+            (key == "dry_run" and value is True)
+            or (key == "similarity_threshold" and value == 0.25)
+            or (key == "max_results" and value == 10)
+            or (key == "offset" and value == 0)
+            or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
+        )
+    }
+    if unsupported:
+        return json.dumps({
+            "error": (
+                "Unsupported file_bug field(s): "
+                + ", ".join(sorted(unsupported.keys()))
+            ),
+            "hint": (
+                "Use repro, observed, expected, and workaround for the filing body; "
+                "content is only for wiki write/patch actions."
+            ),
+        })
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",


### PR DESCRIPTION
Fixes #1130

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-109-file-bug-silently-discards-unknown-kwargs-including-a-conten.md`
- GitHub issue: #1130
- Branch task: `auto-change/issue-1130`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.