### PR TITLE
[auto-change] BUG-110: github_pull_request effector reaches phase_2 then fails gh_not_installed — gh CLI absent from daemon environment blocks all real PR opens

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_pr.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_pr.py
@@ -79,6 +79,8 @@ import re
 import sqlite3
 import subprocess
 import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -114,6 +116,7 @@ _DRY_RUN_ENV = "WORKFLOW_EXTERNAL_WRITE_DRY_RUN"
 # the raw destination so two distinct destinations cannot collide.
 _CAPABILITIES_ENV = "WORKFLOW_GITHUB_PR_CAPABILITIES"
 _GH_PR_TIMEOUT_S = 60.0
+_GITHUB_API = "https://api.github.com"
 
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
 
@@ -427,6 +430,7 @@ def _invoke_gh_pr_create(
     *,
     payload: dict[str, Any],
     destination: str,
+    capability_token: str,
 ) -> dict[str, Any]:
     """Invoke ``gh pr create`` and return parsed evidence.
 
@@ -464,18 +468,22 @@ def _invoke_gh_pr_create(
             cmd.extend(["--label", label])
 
     try:
+        env = os.environ.copy()
+        env["GH_TOKEN"] = capability_token
         proc = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
             timeout=_GH_PR_TIMEOUT_S,
             check=False,
+            env=env,
         )
     except FileNotFoundError:
-        return {
-            "error": "gh CLI not installed in the daemon environment",
-            "error_kind": "gh_not_installed",
-        }
+        return _invoke_github_api_pr_create(
+            payload=payload,
+            destination=destination,
+            capability_token=capability_token,
+        )
     except subprocess.TimeoutExpired:
         return {
             "error": f"gh pr create exceeded {_GH_PR_TIMEOUT_S}s timeout",
@@ -516,8 +524,121 @@ def _invoke_gh_pr_create(
     return {
         "pr_url": pr_url,
         "pr_number": pr_number,
+        "invocation_mode": "gh",
         "stdout": stdout,
     }
+
+
+def _github_api_request(
+    *,
+    path: str,
+    capability_token: str,
+    body: dict[str, Any],
+) -> dict[str, Any]:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        f"{_GITHUB_API}{path}",
+        data=data,
+        method="POST",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {capability_token}",
+            "Content-Type": "application/json",
+            "User-Agent": "workflow-github-pr-effector/1.0",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=_GH_PR_TIMEOUT_S) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _invoke_github_api_pr_create(
+    *,
+    payload: dict[str, Any],
+    destination: str,
+    capability_token: str,
+) -> dict[str, Any]:
+    """Create a PR through GitHub's REST API when ``gh`` is unavailable."""
+    owner_repo = destination.strip().strip("/")
+    if not re.fullmatch(r"[\w.-]+/[\w.-]+", owner_repo):
+        return {
+            "error": f"invalid GitHub repository destination: {destination!r}",
+            "error_kind": "invalid_destination",
+        }
+
+    title = payload["title"].strip()
+    body = payload.get("body", "") or ""
+    base_branch = payload.get("base_branch") or "main"
+    head_branch = payload.get("head_branch") or ""
+    labels = payload.get("labels") or []
+    draft = bool(payload.get("draft", True))
+
+    request_body = {
+        "title": title,
+        "body": body,
+        "base": base_branch,
+        "draft": draft,
+    }
+    if head_branch:
+        request_body["head"] = head_branch
+
+    try:
+        created = _github_api_request(
+            path=f"/repos/{owner_repo}/pulls",
+            capability_token=capability_token,
+            body=request_body,
+        )
+        pr_url = created.get("html_url") if isinstance(created, dict) else ""
+        pr_number = created.get("number") if isinstance(created, dict) else None
+        if not isinstance(pr_url, str) or not pr_url:
+            return {
+                "error": "GitHub API created PR response did not include html_url",
+                "error_kind": "github_api_error",
+            }
+        if not isinstance(pr_number, int):
+            pr_number = None
+        label_error = ""
+        if labels and pr_number is not None:
+            try:
+                _github_api_request(
+                    path=f"/repos/{owner_repo}/issues/{pr_number}/labels",
+                    capability_token=capability_token,
+                    body={"labels": labels},
+                )
+            except (
+                urllib.error.HTTPError,
+                urllib.error.URLError,
+                TimeoutError,
+                OSError,
+                TypeError,
+                ValueError,
+            ) as exc:
+                label_error = str(exc)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:400]
+        return {
+            "error": f"GitHub API HTTP {exc.code}: {detail}",
+            "error_kind": "github_api_error",
+        }
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {
+            "error": f"GitHub API request failed: {exc}",
+            "error_kind": "github_api_error",
+        }
+    except (TypeError, ValueError) as exc:
+        return {
+            "error": f"GitHub API response could not be parsed: {exc}",
+            "error_kind": "github_api_error",
+        }
+
+    result: dict[str, Any] = {
+        "pr_url": pr_url,
+        "pr_number": pr_number,
+        "invocation_mode": "github_api",
+    }
+    if label_error:
+        result["label_error"] = label_error
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -800,6 +921,7 @@ def run_github_pr_effector(
     invocation = _invoke_gh_pr_create(
         payload=payload if isinstance(payload, dict) else {},
         destination=destination,
+        capability_token=capability,
     )
     if "error" in invocation:
         # Release the reservation so a retry can re-acquire under the
@@ -824,9 +946,12 @@ def run_github_pr_effector(
         "matched_output_key": matched_key,
         "pr_url": invocation["pr_url"],
         "pr_number": invocation.get("pr_number"),
+        "invocation_mode": invocation.get("invocation_mode", "gh"),
         "stdout": invocation.get("stdout", ""),
         "recorded_at": time.time(),
     }
+    if invocation.get("label_error"):
+        evidence["label_error"] = invocation["label_error"]
     if idempotency_hint:
         evidence["idempotency_hint"] = idempotency_hint
     # Reservation status is surfaced so a downstream auditor can see

--- a/tests/test_external_write_phase_2.py
+++ b/tests/test_external_write_phase_2.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import urllib.error
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -534,12 +535,20 @@ def test_gh_nonzero_exit_releases_reservation_to_failed(
     assert receipt["status"] == STATUS_FAILED
 
 
-def test_gh_not_installed_returns_structured_error(universe_dir, monkeypatch):
+def test_gh_not_installed_and_api_unavailable_returns_structured_error(
+    universe_dir, monkeypatch,
+):
     _open_all_gates(universe_dir, monkeypatch)
     packet = _make_packet()
-    with patch(
-        "workflow.effectors.github_pr.subprocess.run",
-        side_effect=FileNotFoundError("gh"),
+    with (
+        patch(
+            "workflow.effectors.github_pr.subprocess.run",
+            side_effect=FileNotFoundError("gh"),
+        ),
+        patch(
+            "workflow.effectors.github_pr.urllib.request.urlopen",
+            side_effect=urllib.error.URLError("offline"),
+        ),
     ):
         result = run_github_pr_effector(
             node_id="emit",
@@ -548,7 +557,83 @@ def test_gh_not_installed_returns_structured_error(universe_dir, monkeypatch):
             base_path=universe_dir,
             run_id="run-1",
         )
-    assert result["error_kind"] == "gh_not_installed"
+    assert result["error_kind"] == "github_api_error"
+    assert "GitHub API request failed" in result["error"]
+
+
+def test_gh_not_installed_falls_back_to_github_api(
+    universe_dir, monkeypatch,
+):
+    _open_all_gates(universe_dir, monkeypatch)
+    packet = _make_packet()
+
+    class FakeResponse:
+        headers = {}
+
+        def __init__(self, payload: dict):
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return json.dumps(self._payload).encode("utf-8")
+
+    requests = []
+
+    def fake_urlopen(req, timeout):
+        requests.append((req, timeout, req.data))
+        if req.full_url.endswith("/pulls"):
+            body = json.loads(req.data.decode("utf-8"))
+            assert body["title"] == packet["payload"]["title"]
+            assert body["base"] == "main"
+            assert body["head"] == _HEAD_BRANCH
+            assert body["draft"] is True
+            assert req.headers["Authorization"] == "Bearer tok"
+            return FakeResponse({
+                "html_url": "https://github.com/Jonnyton/Workflow/pull/5678",
+                "number": 5678,
+            })
+        if req.full_url.endswith("/issues/5678/labels"):
+            body = json.loads(req.data.decode("utf-8"))
+            assert body == {"labels": ["writer:loop-2"]}
+            return FakeResponse({"labels": []})
+        raise AssertionError(f"unexpected URL {req.full_url}")
+
+    with (
+        patch(
+            "workflow.effectors.github_pr.subprocess.run",
+            side_effect=FileNotFoundError("gh"),
+        ) as mock_run,
+        patch("workflow.effectors.github_pr.urllib.request.urlopen", fake_urlopen),
+    ):
+        result = run_github_pr_effector(
+            node_id="emit",
+            output_keys=["pr_packet"],
+            run_state={"pr_packet": packet},
+            base_path=universe_dir,
+            run_id="run-1",
+        )
+
+    mock_run.assert_called_once()
+    assert len(requests) == 2
+    assert result["phase"] == "phase_2"
+    assert result["pr_url"] == "https://github.com/Jonnyton/Workflow/pull/5678"
+    assert result["pr_number"] == 5678
+    assert result["invocation_mode"] == "github_api"
+    assert "tok" not in json.dumps(result)
+
+    receipt = lookup_receipt(
+        universe_dir,
+        idempotency_hint="loop-2-cycle-001",
+        sink=EXTERNAL_WRITE_SINK_GITHUB_PR,
+    )
+    assert receipt is not None
+    assert receipt["status"] == STATUS_SUCCEEDED
+    assert receipt["evidence"]["pr_number"] == 5678
 
 
 def test_gh_timeout_returns_structured_error(universe_dir, monkeypatch):

--- a/workflow/effectors/github_pr.py
+++ b/workflow/effectors/github_pr.py
@@ -79,6 +79,8 @@ import re
 import sqlite3
 import subprocess
 import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -114,6 +116,7 @@ _DRY_RUN_ENV = "WORKFLOW_EXTERNAL_WRITE_DRY_RUN"
 # the raw destination so two distinct destinations cannot collide.
 _CAPABILITIES_ENV = "WORKFLOW_GITHUB_PR_CAPABILITIES"
 _GH_PR_TIMEOUT_S = 60.0
+_GITHUB_API = "https://api.github.com"
 
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
 
@@ -427,6 +430,7 @@ def _invoke_gh_pr_create(
     *,
     payload: dict[str, Any],
     destination: str,
+    capability_token: str,
 ) -> dict[str, Any]:
     """Invoke ``gh pr create`` and return parsed evidence.
 
@@ -464,18 +468,22 @@ def _invoke_gh_pr_create(
             cmd.extend(["--label", label])
 
     try:
+        env = os.environ.copy()
+        env["GH_TOKEN"] = capability_token
         proc = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
             timeout=_GH_PR_TIMEOUT_S,
             check=False,
+            env=env,
         )
     except FileNotFoundError:
-        return {
-            "error": "gh CLI not installed in the daemon environment",
-            "error_kind": "gh_not_installed",
-        }
+        return _invoke_github_api_pr_create(
+            payload=payload,
+            destination=destination,
+            capability_token=capability_token,
+        )
     except subprocess.TimeoutExpired:
         return {
             "error": f"gh pr create exceeded {_GH_PR_TIMEOUT_S}s timeout",
@@ -516,8 +524,121 @@ def _invoke_gh_pr_create(
     return {
         "pr_url": pr_url,
         "pr_number": pr_number,
+        "invocation_mode": "gh",
         "stdout": stdout,
     }
+
+
+def _github_api_request(
+    *,
+    path: str,
+    capability_token: str,
+    body: dict[str, Any],
+) -> dict[str, Any]:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        f"{_GITHUB_API}{path}",
+        data=data,
+        method="POST",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {capability_token}",
+            "Content-Type": "application/json",
+            "User-Agent": "workflow-github-pr-effector/1.0",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=_GH_PR_TIMEOUT_S) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _invoke_github_api_pr_create(
+    *,
+    payload: dict[str, Any],
+    destination: str,
+    capability_token: str,
+) -> dict[str, Any]:
+    """Create a PR through GitHub's REST API when ``gh`` is unavailable."""
+    owner_repo = destination.strip().strip("/")
+    if not re.fullmatch(r"[\w.-]+/[\w.-]+", owner_repo):
+        return {
+            "error": f"invalid GitHub repository destination: {destination!r}",
+            "error_kind": "invalid_destination",
+        }
+
+    title = payload["title"].strip()
+    body = payload.get("body", "") or ""
+    base_branch = payload.get("base_branch") or "main"
+    head_branch = payload.get("head_branch") or ""
+    labels = payload.get("labels") or []
+    draft = bool(payload.get("draft", True))
+
+    request_body = {
+        "title": title,
+        "body": body,
+        "base": base_branch,
+        "draft": draft,
+    }
+    if head_branch:
+        request_body["head"] = head_branch
+
+    try:
+        created = _github_api_request(
+            path=f"/repos/{owner_repo}/pulls",
+            capability_token=capability_token,
+            body=request_body,
+        )
+        pr_url = created.get("html_url") if isinstance(created, dict) else ""
+        pr_number = created.get("number") if isinstance(created, dict) else None
+        if not isinstance(pr_url, str) or not pr_url:
+            return {
+                "error": "GitHub API created PR response did not include html_url",
+                "error_kind": "github_api_error",
+            }
+        if not isinstance(pr_number, int):
+            pr_number = None
+        label_error = ""
+        if labels and pr_number is not None:
+            try:
+                _github_api_request(
+                    path=f"/repos/{owner_repo}/issues/{pr_number}/labels",
+                    capability_token=capability_token,
+                    body={"labels": labels},
+                )
+            except (
+                urllib.error.HTTPError,
+                urllib.error.URLError,
+                TimeoutError,
+                OSError,
+                TypeError,
+                ValueError,
+            ) as exc:
+                label_error = str(exc)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:400]
+        return {
+            "error": f"GitHub API HTTP {exc.code}: {detail}",
+            "error_kind": "github_api_error",
+        }
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {
+            "error": f"GitHub API request failed: {exc}",
+            "error_kind": "github_api_error",
+        }
+    except (TypeError, ValueError) as exc:
+        return {
+            "error": f"GitHub API response could not be parsed: {exc}",
+            "error_kind": "github_api_error",
+        }
+
+    result: dict[str, Any] = {
+        "pr_url": pr_url,
+        "pr_number": pr_number,
+        "invocation_mode": "github_api",
+    }
+    if label_error:
+        result["label_error"] = label_error
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -800,6 +921,7 @@ def run_github_pr_effector(
     invocation = _invoke_gh_pr_create(
         payload=payload if isinstance(payload, dict) else {},
         destination=destination,
+        capability_token=capability,
     )
     if "error" in invocation:
         # Release the reservation so a retry can re-acquire under the
@@ -824,9 +946,12 @@ def run_github_pr_effector(
         "matched_output_key": matched_key,
         "pr_url": invocation["pr_url"],
         "pr_number": invocation.get("pr_number"),
+        "invocation_mode": invocation.get("invocation_mode", "gh"),
         "stdout": invocation.get("stdout", ""),
         "recorded_at": time.time(),
     }
+    if invocation.get("label_error"):
+        evidence["label_error"] = invocation["label_error"]
     if idempotency_hint:
         evidence["idempotency_hint"] = idempotency_hint
     # Reservation status is surfaced so a downstream auditor can see


### PR DESCRIPTION
Fixes #1131

## Request artifact reconciliation

- Wiki page: `pages/bugs/bug-110-github-pull-request-effector-reaches-phase-2-then-fails-gh-n.md`
- GitHub issue: #1131
- Branch task: `auto-change/issue-1131`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.