### PR TITLE
fix(deploy): write release receipt into workflow data volume

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -572,6 +572,13 @@ jobs:
           if [ -n "${config_hash}" ]; then
             config_hash="sha256:${config_hash}"
           fi
+          release_state_host_dir="$(ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
+              "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
+              "sudo docker volume inspect workflow-data --format '{{ .Mountpoint }}' 2>/dev/null" || true)"
+          if [ -z "${release_state_host_dir}" ]; then
+            echo "::error::Could not resolve workflow-data Docker volume mountpoint"
+            exit 1
+          fi
 
           export image_digest config_hash BUILD_RUN_URL DEPLOY_RUN_ID DEPLOY_RUN_URL
           python - <<'PY' > /tmp/workflow-release-state.json
@@ -605,11 +612,14 @@ jobs:
               "${DO_SSH_USER}@${DO_DROPLET_HOST}:/tmp/workflow-release-state.json"
           ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
               "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
-              "sudo install -m 0644 -o workflow -g workflow /tmp/workflow-release-state.json /data/release-state.json"
+              "set -e; \
+               sudo install -d -m 0755 -o workflow -g workflow '${release_state_host_dir}'; \
+               sudo install -m 0644 -o workflow -g workflow /tmp/workflow-release-state.json '${release_state_host_dir}/release-state.json'"
           {
             echo "### Release-state receipt"
             echo ""
-            echo "- Path: \`/data/release-state.json\`"
+            echo "- Container path: \`/data/release-state.json\`"
+            echo "- Host volume path: \`${release_state_host_dir}/release-state.json\`"
             echo "- Source SHA: \`${SOURCE_SHA}\`"
             echo "- Image: \`${TARGET_IMAGE}\`"
             echo "- Digest: \`${image_digest:-unknown}\`"

--- a/tests/test_deploy_prod_workflow.py
+++ b/tests/test_deploy_prod_workflow.py
@@ -415,7 +415,11 @@ def test_deploy_publishes_release_state_after_canaries_and_access_gate():
     assert "WORKFLOW_EVENT" in step_env
     assert "docker image inspect" in run_script
     assert "sha256sum /etc/workflow/env" in run_script
+    assert "docker volume inspect workflow-data" in run_script
+    assert "release_state_host_dir" in run_script
     assert "/data/release-state.json" in run_script
+    assert "${release_state_host_dir}/release-state.json" in run_script
+    assert "/tmp/workflow-release-state.json /data/release-state.json" not in run_script
     assert "canary_bundle_status\": \"passed\"" in run_script
 
 


### PR DESCRIPTION
## Summary

Fixes the deploy-prod rollback from issue #1142 after the PR #1136 release-state receipt slice landed.

The failed deploy proved the host does not have `/data`; `/data` is the container mount backed by the Docker named volume `workflow-data`. The receipt writer now resolves the host mountpoint with `docker volume inspect workflow-data --format '{{ .Mountpoint }}'` and installs `release-state.json` into that host volume path, so the daemon still reads it at `/data/release-state.json` inside the container.

Fixes #1142.

## Verification

- `python -m pytest tests/test_deploy_prod_workflow.py` — 39 passed
- `git diff --check`
- pre-commit hooks: mirror parity N/A, mojibake clean, cross-provider drift clean, skills valid; local `actionlint` binary unavailable, CI will run it

## Notes

This is a narrow recovery patch for the deploy failure at `Publish release-state receipt` in run 26613557248. It does not change `get_status`; the container-visible contract remains `/data/release-state.json`.