### PR TITLE
feat(read): read_repo_files — loop can now edit existing files (BUG-111 read side)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/__init__.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/__init__.py
@@ -22,14 +22,24 @@ from workflow.effectors.github_pr import (
     run_effects_for_branch,
     run_github_pr_effector,
 )
+from workflow.effectors.github_read import (
+    read_repo_files,
+    register_read_repo_files,
+)
 from workflow.effectors.windows_desktop import (
     EXTERNAL_WRITE_SINK_WINDOWS_DESKTOP_CLASSIC_GAME,
     run_windows_desktop_effector,
 )
 
+# Register the read_repo_files opaque domain callable at package import so a
+# branch that uses it resolves a body at compile time (read side of BUG-111).
+register_read_repo_files()
+
 __all__ = [
     "EXTERNAL_WRITE_SINK_GITHUB_PR",
     "EXTERNAL_WRITE_SINK_WINDOWS_DESKTOP_CLASSIC_GAME",
+    "read_repo_files",
+    "register_read_repo_files",
     "run_github_pr_effector",
     "run_windows_desktop_effector",
     "run_effects_for_branch",

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_read.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_read.py
@@ -47,6 +47,7 @@ import logging
 import os
 import re
 import urllib.error
+import urllib.parse
 import urllib.request
 
 logger = logging.getLogger(__name__)
@@ -63,6 +64,7 @@ DOMAIN_ID = "workflow"
 NODE_ID = "read_repo_files"
 
 _REPO_RE = re.compile(r"[\w.-]+/[\w.-]+")
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 
 
 def _int_env(name: str, default: int) -> int:
@@ -124,11 +126,30 @@ def _parse_paths(raw: object) -> list[str]:
 
 
 def _path_rejected(path: str) -> bool:
-    """True when a path is unsafe (absolute or parent-traversal)."""
-    if path.startswith("/") or path.startswith("\\"):
+    """True when a path is unsafe or not a normalized repo-relative path."""
+    if not path or path.startswith("/") or "\\" in path or _CONTROL_CHAR_RE.search(path):
         return True
-    parts = re.split(r"[\\/]+", path)
-    return any(p == ".." for p in parts)
+    for part in path.split("/"):
+        if part in {"", ".", ".."}:
+            return True
+        decoded = part
+        for _ in range(3):
+            unquoted = urllib.parse.unquote(decoded)
+            if unquoted == decoded:
+                break
+            decoded = unquoted
+        if (
+            decoded in {".", ".."}
+            or "/" in decoded
+            or "\\" in decoded
+            or _CONTROL_CHAR_RE.search(decoded)
+        ):
+            return True
+    return False
+
+
+def _quote_contents_path(path: str) -> str:
+    return urllib.parse.quote(path, safe="/")
 
 
 def _read_request(
@@ -146,8 +167,9 @@ def _read_request(
     }
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    encoded_path = _quote_contents_path(path)
     req = urllib.request.Request(
-        f"{_GITHUB_API}/repos/{destination}/contents/{path}",
+        f"{_GITHUB_API}/repos/{destination}/contents/{encoded_path}",
         method="GET",
         headers=headers,
     )

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_read.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_read.py
@@ -1,0 +1,277 @@
+"""read_repo_files: a platform-trusted opaque node that reads repo files into state.
+
+The read counterpart to the github_pull_request write effector. It lets a
+user-buildable loop EDIT existing files: a node named ``read_repo_files`` (in the
+``workflow`` domain) fetches the current contents of caller-named paths from a
+GitHub repository and writes them into run state, so a downstream
+``propose_changes`` node can base a correct diff on the real file contents
+instead of guessing.
+
+Design note: docs/design-notes/2026-05-29-read-repo-files-primitive.md
+(Option A — opaque domain callable; Cowork + Codex review, amendments folded).
+
+Contract (opaque callable — ``fn(state) -> dict`` of state updates):
+
+  reads from state:
+    - ``read_destination`` (str): ``owner/repo`` to read from. The user's branch
+      supplies this (e.g. a state-schema default); the platform never hardcodes a
+      repo.
+    - ``target_paths`` (str): repo-relative paths as a JSON array or a comma/
+      semicolon list.
+  writes to state:
+    - ``current_contents_json`` (str): JSON object ``{path: contents|null}``.
+      ``null`` means the path does not exist at the ref (a new-file create), NOT
+      an error.
+    - ``read_status_json`` (str): JSON object with per-path status
+      (present|missing|denied|rejected|too_large|truncated|error), a ``_truncated``
+      boolean, and an ``_errors`` map of path -> structured ``error_kind``.
+
+Build decisions from review (design note §"Build decisions from review"):
+  1. Read scope is SEPARATE from write scope — resolve a read token from
+     ``WORKFLOW_GITHUB_READ_CAPABILITIES`` (NOT the write map). When no token is
+     configured, fall back to an unauthenticated read, which works for public
+     repos (rate-limited). A private repo without a read token returns
+     ``denied`` per file rather than silently leaking the write token.
+  2. The platform callable (not node config) enforces path safety + size caps.
+  3. Missing file -> explicit ``null``.
+  4. Distinct per-step ``error_kind``s; per-file status metadata.
+  5. Platform-trusted opaque callable — the user references it but cannot supply
+     its body.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import re
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_API = "https://api.github.com"
+_READ_CAPABILITIES_ENV = "WORKFLOW_GITHUB_READ_CAPABILITIES"
+_READ_TIMEOUT_S = 30.0
+
+_DEFAULT_MAX_FILES = 20
+_DEFAULT_MAX_BYTES_PER_FILE = 100_000
+_DEFAULT_MAX_TOTAL_BYTES = 400_000
+
+DOMAIN_ID = "workflow"
+NODE_ID = "read_repo_files"
+
+_REPO_RE = re.compile(r"[\w.-]+/[\w.-]+")
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        val = int(raw)
+    except ValueError:
+        return default
+    return val if val > 0 else default
+
+
+def _read_token(destination: str) -> str:
+    """Resolve a READ-scoped token for ``destination`` (empty if none).
+
+    Separate from the write capability map by design — a universe may be granted
+    read-only without write. Empty string => unauthenticated read (public repos).
+    """
+    raw = os.environ.get(_READ_CAPABILITIES_ENV, "").strip()
+    if not raw:
+        return ""
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "%s is set but not valid JSON; treating reads as unauthenticated",
+            _READ_CAPABILITIES_ENV,
+        )
+        return ""
+    if not isinstance(parsed, dict):
+        return ""
+    token = parsed.get(destination, "")
+    return token.strip() if isinstance(token, str) else ""
+
+
+def _parse_paths(raw: object) -> list[str]:
+    """Parse target_paths from a JSON array or comma/semicolon list."""
+    if isinstance(raw, list):
+        items = raw
+    else:
+        text = str(raw or "").strip()
+        if not text:
+            return []
+        if text.startswith("["):
+            try:
+                parsed = json.loads(text)
+                items = parsed if isinstance(parsed, list) else [text]
+            except (TypeError, ValueError):
+                items = re.split(r"[,;]", text)
+        else:
+            items = re.split(r"[,;]", text)
+    out: list[str] = []
+    for it in items:
+        s = str(it or "").strip()
+        if s:
+            out.append(s)
+    return out
+
+
+def _path_rejected(path: str) -> bool:
+    """True when a path is unsafe (absolute or parent-traversal)."""
+    if path.startswith("/") or path.startswith("\\"):
+        return True
+    parts = re.split(r"[\\/]+", path)
+    return any(p == ".." for p in parts)
+
+
+def _read_request(
+    *, destination: str, path: str, token: str
+) -> tuple[dict | None, dict | None]:
+    """GET the contents API for one path. Returns ``(parsed, error)``.
+
+    ``error`` is ``{"http_status": int|None, "detail": str}``; a 404 is returned
+    as an error here and mapped to ``missing`` (null) by the caller.
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "workflow-github-read/1.0",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(
+        f"{_GITHUB_API}/repos/{destination}/contents/{path}",
+        method="GET",
+        headers=headers,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_READ_TIMEOUT_S) as resp:
+            raw = resp.read().decode("utf-8")
+            return (json.loads(raw) if raw.strip() else {}), None
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:200]
+        return None, {"http_status": exc.code, "detail": detail}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return None, {"http_status": None, "detail": str(exc)}
+    except (TypeError, ValueError) as exc:
+        return None, {"http_status": None, "detail": f"parse error: {exc}"}
+
+
+def read_repo_files(state: dict) -> dict:
+    """Opaque-node body: read caller-named repo files into state. Never raises."""
+    destination = str(
+        state.get("read_destination") or state.get("destination") or ""
+    ).strip().strip("/")
+    contents: dict[str, object] = {}
+    status: dict[str, object] = {}
+    errors: dict[str, str] = {}
+
+    def _emit(truncated: bool = False) -> dict:
+        status["_truncated"] = truncated
+        status["_errors"] = errors
+        return {
+            "current_contents_json": json.dumps(contents, ensure_ascii=False),
+            "read_status_json": json.dumps(status, ensure_ascii=False),
+        }
+
+    if not destination or not _REPO_RE.fullmatch(destination):
+        errors["_destination"] = "read_destination_invalid"
+        return _emit()
+
+    paths = _parse_paths(state.get("target_paths"))
+    if not paths:
+        errors["_paths"] = "no_target_paths"
+        return _emit()
+
+    max_files = _int_env("WORKFLOW_GITHUB_READ_MAX_FILES", _DEFAULT_MAX_FILES)
+    max_bytes_file = _int_env(
+        "WORKFLOW_GITHUB_READ_MAX_BYTES_PER_FILE", _DEFAULT_MAX_BYTES_PER_FILE
+    )
+    max_total = _int_env(
+        "WORKFLOW_GITHUB_READ_MAX_TOTAL_BYTES", _DEFAULT_MAX_TOTAL_BYTES
+    )
+    token = _read_token(destination)
+
+    truncated = False
+    if len(paths) > max_files:
+        truncated = True
+        for extra in paths[max_files:]:
+            status[extra] = "truncated"
+            errors[extra] = "read_truncated"
+        paths = paths[:max_files]
+
+    total = 0
+    for path in paths:
+        if _path_rejected(path):
+            status[path] = "rejected"
+            errors[path] = "read_path_rejected"
+            continue
+        parsed, err = _read_request(destination=destination, path=path, token=token)
+        if err is not None:
+            code = err.get("http_status")
+            if code == 404:
+                contents[path] = None  # missing => new-file create, not an error
+                status[path] = "missing"
+            elif code in (401, 403):
+                status[path] = "denied"
+                errors[path] = "read_contents_denied"
+            else:
+                status[path] = "error"
+                errors[path] = "read_request_failed"
+            continue
+        node_type = (parsed or {}).get("type")
+        if node_type != "file":
+            status[path] = "rejected"
+            errors[path] = "read_path_rejected"  # dir / symlink / submodule
+            continue
+        size = (parsed or {}).get("size")
+        encoded = (parsed or {}).get("content")
+        if (isinstance(size, int) and size > max_bytes_file) or not encoded:
+            contents[path] = None
+            status[path] = "too_large"
+            errors[path] = "read_file_too_large"
+            continue
+        try:
+            decoded = base64.b64decode(encoded).decode("utf-8")
+        except (ValueError, UnicodeDecodeError):
+            status[path] = "error"
+            errors[path] = "read_decode_failed"
+            continue
+        if len(decoded.encode("utf-8")) > max_bytes_file:
+            contents[path] = None
+            status[path] = "too_large"
+            errors[path] = "read_file_too_large"
+            continue
+        if total + len(decoded.encode("utf-8")) > max_total:
+            truncated = True
+            status[path] = "truncated"
+            errors[path] = "read_truncated"
+            continue
+        contents[path] = decoded
+        status[path] = "present"
+        total += len(decoded.encode("utf-8"))
+
+    return _emit(truncated=truncated)
+
+
+def register_read_repo_files() -> None:
+    """Register the read_repo_files opaque callable for the workflow domain.
+
+    Idempotent (register_domain_callable overwrites the same key with a debug
+    log). Called from workflow/effectors/__init__.py at import and lazily from
+    the compiler's opaque-resolution path so it is always present before a
+    branch that uses it compiles.
+    """
+    from workflow.domain_registry import register_domain_callable
+
+    register_domain_callable(DOMAIN_ID, NODE_ID, read_repo_files)
+
+
+__all__ = ["read_repo_files", "register_read_repo_files", "DOMAIN_ID", "NODE_ID"]

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
@@ -2135,6 +2135,14 @@ def _build_node(
         )
         return _wrap_with_checkpoints(inner, node, event_sink)
     if domain_id:
+        # Ensure platform opaque callables (e.g. read_repo_files) are
+        # registered before we resolve — importing the effectors package runs
+        # its registration side effects. Lazy + best-effort so a missing
+        # optional dependency can't break compilation of unrelated branches.
+        try:
+            import workflow.effectors  # noqa: F401
+        except Exception:  # pragma: no cover - registration is best-effort
+            logger.debug("effectors import for opaque registration failed", exc_info=True)
         opaque = resolve_domain_callable(domain_id, node.node_id)
         if opaque is not None:
             inner = _build_opaque_node(node, opaque, event_sink=event_sink)

--- a/tests/test_github_read_repo_files.py
+++ b/tests/test_github_read_repo_files.py
@@ -1,0 +1,199 @@
+"""read_repo_files opaque callable — read side of the patch-request loop.
+
+Mocks ``_read_request`` so no network is touched. Covers happy read, missing ->
+null, denied, rejected paths, too-large, truncation (file-count and total-byte),
+token resolution (separate read map, not the write map), and registration.
+
+Design note: docs/design-notes/2026-05-29-read-repo-files-primitive.md
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+from workflow.effectors import github_read as gr
+
+_DEST = "Jonnyton/Workflow"
+
+
+def _b64(text: str) -> str:
+    return base64.b64encode(text.encode("utf-8")).decode("ascii")
+
+
+def _file_resp(text: str) -> tuple[dict, None]:
+    body = text.encode("utf-8")
+    return {"type": "file", "size": len(body), "content": _b64(text)}, None
+
+
+def _scripted_reader(by_path):
+    """Build a fake _read_request from a {path: (parsed, error)} map."""
+    def fake(*, destination, path, token):
+        fake.calls.append((destination, path, token))
+        if path in by_path:
+            return by_path[path]
+        return None, {"http_status": 404, "detail": "Not Found"}
+    fake.calls = []
+    return fake
+
+
+def _run(state, monkeypatch, reader=None, env=None):
+    for k, v in (env or {}).items():
+        monkeypatch.setenv(k, v)
+    if reader is not None:
+        monkeypatch.setattr(gr, "_read_request", reader)
+    result = gr.read_repo_files(state)
+    return (
+        json.loads(result["current_contents_json"]),
+        json.loads(result["read_status_json"]),
+    )
+
+
+def test_happy_read_returns_contents_and_present_status(monkeypatch):
+    reader = _scripted_reader({"a.py": _file_resp("print('a')\n")})
+    contents, status = _run(
+        {"read_destination": _DEST, "target_paths": "a.py"}, monkeypatch, reader
+    )
+    assert contents == {"a.py": "print('a')\n"}
+    assert status["a.py"] == "present"
+    assert status["_truncated"] is False
+    assert status["_errors"] == {}
+
+
+def test_missing_file_is_null_not_error(monkeypatch):
+    reader = _scripted_reader({})  # everything 404
+    contents, status = _run(
+        {"read_destination": _DEST, "target_paths": "nope.py"}, monkeypatch, reader
+    )
+    assert contents == {"nope.py": None}
+    assert status["nope.py"] == "missing"
+    assert "nope.py" not in status["_errors"]
+
+
+def test_denied_maps_to_scope_signal(monkeypatch):
+    reader = _scripted_reader(
+        {"secret.py": (None, {"http_status": 403, "detail": "no access"})}
+    )
+    contents, status = _run(
+        {"read_destination": _DEST, "target_paths": "secret.py"}, monkeypatch, reader
+    )
+    assert "secret.py" not in contents
+    assert status["secret.py"] == "denied"
+    assert status["_errors"]["secret.py"] == "read_contents_denied"
+
+
+def test_absolute_and_traversal_paths_rejected(monkeypatch):
+    reader = _scripted_reader({})
+    contents, status = _run(
+        {"read_destination": _DEST, "target_paths": "/etc/passwd, ../../secrets.env"},
+        monkeypatch,
+        reader,
+    )
+    assert status["/etc/passwd"] == "rejected"
+    assert status["../../secrets.env"] == "rejected"
+    assert status["_errors"]["/etc/passwd"] == "read_path_rejected"
+    # Rejected paths never hit the network.
+    assert reader.calls == []
+
+
+def test_directory_type_rejected(monkeypatch):
+    reader = _scripted_reader({"src": ({"type": "dir"}, None)})
+    _contents, status = _run(
+        {"read_destination": _DEST, "target_paths": "src"}, monkeypatch, reader
+    )
+    assert status["src"] == "rejected"
+    assert status["_errors"]["src"] == "read_path_rejected"
+
+
+def test_too_large_by_size_returns_null(monkeypatch):
+    reader = _scripted_reader(
+        {"big.py": ({"type": "file", "size": 999_999, "content": _b64("x")}, None)}
+    )
+    contents, status = _run(
+        {"read_destination": _DEST, "target_paths": "big.py"},
+        monkeypatch,
+        reader,
+        env={"WORKFLOW_GITHUB_READ_MAX_BYTES_PER_FILE": "100"},
+    )
+    assert contents == {"big.py": None}
+    assert status["big.py"] == "too_large"
+    assert status["_errors"]["big.py"] == "read_file_too_large"
+
+
+def test_file_count_cap_truncates_extras(monkeypatch):
+    reader = _scripted_reader(
+        {"a.py": _file_resp("a"), "b.py": _file_resp("b")}
+    )
+    contents, status = _run(
+        {"read_destination": _DEST, "target_paths": "a.py, b.py"},
+        monkeypatch,
+        reader,
+        env={"WORKFLOW_GITHUB_READ_MAX_FILES": "1"},
+    )
+    assert "a.py" in contents and contents["a.py"] == "a"
+    assert status["b.py"] == "truncated"
+    assert status["_errors"]["b.py"] == "read_truncated"
+    assert status["_truncated"] is True
+
+
+def test_total_byte_cap_truncates(monkeypatch):
+    reader = _scripted_reader(
+        {"a.py": _file_resp("aaaaa"), "b.py": _file_resp("bbbbb")}
+    )
+    contents, status = _run(
+        {"read_destination": _DEST, "target_paths": "a.py, b.py"},
+        monkeypatch,
+        reader,
+        env={"WORKFLOW_GITHUB_READ_MAX_TOTAL_BYTES": "6"},
+    )
+    assert contents["a.py"] == "aaaaa"
+    assert status["b.py"] == "truncated"
+    assert status["_truncated"] is True
+
+
+def test_invalid_destination(monkeypatch):
+    _contents, status = _run(
+        {"read_destination": "not-a-repo", "target_paths": "a.py"}, monkeypatch
+    )
+    assert status["_errors"]["_destination"] == "read_destination_invalid"
+
+
+def test_no_target_paths(monkeypatch):
+    _contents, status = _run({"read_destination": _DEST}, monkeypatch)
+    assert status["_errors"]["_paths"] == "no_target_paths"
+
+
+def test_json_array_paths_parsed(monkeypatch):
+    reader = _scripted_reader({"a.py": _file_resp("a"), "b.py": _file_resp("b")})
+    contents, _status = _run(
+        {"read_destination": _DEST, "target_paths": '["a.py", "b.py"]'},
+        monkeypatch,
+        reader,
+    )
+    assert set(contents) == {"a.py", "b.py"}
+
+
+def test_read_token_uses_separate_map_not_write_map(monkeypatch):
+    # Write map present, read map absent -> reads stay unauthenticated (empty
+    # token), proving we do NOT reuse the write credential.
+    monkeypatch.setenv("WORKFLOW_GITHUB_PR_CAPABILITIES", json.dumps({_DEST: "WRITETOKEN"}))
+    monkeypatch.delenv("WORKFLOW_GITHUB_READ_CAPABILITIES", raising=False)
+    reader = _scripted_reader({"a.py": _file_resp("a")})
+    _run({"read_destination": _DEST, "target_paths": "a.py"}, monkeypatch, reader)
+    assert reader.calls[0][2] == ""  # token empty -> unauthenticated
+
+
+def test_read_token_resolved_from_read_map(monkeypatch):
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_READ_CAPABILITIES", json.dumps({_DEST: "READTOKEN"})
+    )
+    reader = _scripted_reader({"a.py": _file_resp("a")})
+    _run({"read_destination": _DEST, "target_paths": "a.py"}, monkeypatch, reader)
+    assert reader.calls[0][2] == "READTOKEN"
+
+
+def test_registration_resolves_in_domain_registry():
+    from workflow.domain_registry import resolve_domain_callable
+
+    gr.register_read_repo_files()
+    assert resolve_domain_callable("workflow", "read_repo_files") is gr.read_repo_files

--- a/tests/test_github_read_repo_files.py
+++ b/tests/test_github_read_repo_files.py
@@ -96,6 +96,61 @@ def test_absolute_and_traversal_paths_rejected(monkeypatch):
     assert reader.calls == []
 
 
+def test_encoded_traversal_and_backslash_paths_rejected(monkeypatch):
+    reader = _scripted_reader({})
+    paths = [
+        "%2e%2e/secrets.env",
+        ".%2e/secrets.env",
+        "safe\\evil.py",
+        "a/%2F/b.py",
+        "a/./b.py",
+    ]
+    _contents, status = _run(
+        {"read_destination": _DEST, "target_paths": paths},
+        monkeypatch,
+        reader,
+    )
+    for path in paths:
+        assert status[path] == "rejected"
+        assert status["_errors"][path] == "read_path_rejected"
+    assert reader.calls == []
+
+
+def test_read_request_quotes_path_component(monkeypatch):
+    urls = []
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps(
+                {"type": "file", "size": 1, "content": _b64("x")}
+            ).encode("utf-8")
+
+    def fake_urlopen(req, timeout):
+        urls.append(req.full_url)
+        return FakeResponse()
+
+    monkeypatch.setattr(gr.urllib.request, "urlopen", fake_urlopen)
+
+    parsed, err = gr._read_request(
+        destination=_DEST,
+        path="dir/a b#c?ref=other.py",
+        token="",
+    )
+
+    assert err is None
+    assert parsed["type"] == "file"
+    assert urls == [
+        "https://api.github.com/repos/Jonnyton/Workflow/contents/"
+        "dir/a%20b%23c%3Fref%3Dother.py"
+    ]
+
+
 def test_directory_type_rejected(monkeypatch):
     reader = _scripted_reader({"src": ({"type": "dir"}, None)})
     _contents, status = _run(

--- a/workflow/effectors/__init__.py
+++ b/workflow/effectors/__init__.py
@@ -22,14 +22,24 @@ from workflow.effectors.github_pr import (
     run_effects_for_branch,
     run_github_pr_effector,
 )
+from workflow.effectors.github_read import (
+    read_repo_files,
+    register_read_repo_files,
+)
 from workflow.effectors.windows_desktop import (
     EXTERNAL_WRITE_SINK_WINDOWS_DESKTOP_CLASSIC_GAME,
     run_windows_desktop_effector,
 )
 
+# Register the read_repo_files opaque domain callable at package import so a
+# branch that uses it resolves a body at compile time (read side of BUG-111).
+register_read_repo_files()
+
 __all__ = [
     "EXTERNAL_WRITE_SINK_GITHUB_PR",
     "EXTERNAL_WRITE_SINK_WINDOWS_DESKTOP_CLASSIC_GAME",
+    "read_repo_files",
+    "register_read_repo_files",
     "run_github_pr_effector",
     "run_windows_desktop_effector",
     "run_effects_for_branch",

--- a/workflow/effectors/github_read.py
+++ b/workflow/effectors/github_read.py
@@ -47,6 +47,7 @@ import logging
 import os
 import re
 import urllib.error
+import urllib.parse
 import urllib.request
 
 logger = logging.getLogger(__name__)
@@ -63,6 +64,7 @@ DOMAIN_ID = "workflow"
 NODE_ID = "read_repo_files"
 
 _REPO_RE = re.compile(r"[\w.-]+/[\w.-]+")
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 
 
 def _int_env(name: str, default: int) -> int:
@@ -124,11 +126,30 @@ def _parse_paths(raw: object) -> list[str]:
 
 
 def _path_rejected(path: str) -> bool:
-    """True when a path is unsafe (absolute or parent-traversal)."""
-    if path.startswith("/") or path.startswith("\\"):
+    """True when a path is unsafe or not a normalized repo-relative path."""
+    if not path or path.startswith("/") or "\\" in path or _CONTROL_CHAR_RE.search(path):
         return True
-    parts = re.split(r"[\\/]+", path)
-    return any(p == ".." for p in parts)
+    for part in path.split("/"):
+        if part in {"", ".", ".."}:
+            return True
+        decoded = part
+        for _ in range(3):
+            unquoted = urllib.parse.unquote(decoded)
+            if unquoted == decoded:
+                break
+            decoded = unquoted
+        if (
+            decoded in {".", ".."}
+            or "/" in decoded
+            or "\\" in decoded
+            or _CONTROL_CHAR_RE.search(decoded)
+        ):
+            return True
+    return False
+
+
+def _quote_contents_path(path: str) -> str:
+    return urllib.parse.quote(path, safe="/")
 
 
 def _read_request(
@@ -146,8 +167,9 @@ def _read_request(
     }
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    encoded_path = _quote_contents_path(path)
     req = urllib.request.Request(
-        f"{_GITHUB_API}/repos/{destination}/contents/{path}",
+        f"{_GITHUB_API}/repos/{destination}/contents/{encoded_path}",
         method="GET",
         headers=headers,
     )

--- a/workflow/effectors/github_read.py
+++ b/workflow/effectors/github_read.py
@@ -1,0 +1,277 @@
+"""read_repo_files: a platform-trusted opaque node that reads repo files into state.
+
+The read counterpart to the github_pull_request write effector. It lets a
+user-buildable loop EDIT existing files: a node named ``read_repo_files`` (in the
+``workflow`` domain) fetches the current contents of caller-named paths from a
+GitHub repository and writes them into run state, so a downstream
+``propose_changes`` node can base a correct diff on the real file contents
+instead of guessing.
+
+Design note: docs/design-notes/2026-05-29-read-repo-files-primitive.md
+(Option A — opaque domain callable; Cowork + Codex review, amendments folded).
+
+Contract (opaque callable — ``fn(state) -> dict`` of state updates):
+
+  reads from state:
+    - ``read_destination`` (str): ``owner/repo`` to read from. The user's branch
+      supplies this (e.g. a state-schema default); the platform never hardcodes a
+      repo.
+    - ``target_paths`` (str): repo-relative paths as a JSON array or a comma/
+      semicolon list.
+  writes to state:
+    - ``current_contents_json`` (str): JSON object ``{path: contents|null}``.
+      ``null`` means the path does not exist at the ref (a new-file create), NOT
+      an error.
+    - ``read_status_json`` (str): JSON object with per-path status
+      (present|missing|denied|rejected|too_large|truncated|error), a ``_truncated``
+      boolean, and an ``_errors`` map of path -> structured ``error_kind``.
+
+Build decisions from review (design note §"Build decisions from review"):
+  1. Read scope is SEPARATE from write scope — resolve a read token from
+     ``WORKFLOW_GITHUB_READ_CAPABILITIES`` (NOT the write map). When no token is
+     configured, fall back to an unauthenticated read, which works for public
+     repos (rate-limited). A private repo without a read token returns
+     ``denied`` per file rather than silently leaking the write token.
+  2. The platform callable (not node config) enforces path safety + size caps.
+  3. Missing file -> explicit ``null``.
+  4. Distinct per-step ``error_kind``s; per-file status metadata.
+  5. Platform-trusted opaque callable — the user references it but cannot supply
+     its body.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import re
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_API = "https://api.github.com"
+_READ_CAPABILITIES_ENV = "WORKFLOW_GITHUB_READ_CAPABILITIES"
+_READ_TIMEOUT_S = 30.0
+
+_DEFAULT_MAX_FILES = 20
+_DEFAULT_MAX_BYTES_PER_FILE = 100_000
+_DEFAULT_MAX_TOTAL_BYTES = 400_000
+
+DOMAIN_ID = "workflow"
+NODE_ID = "read_repo_files"
+
+_REPO_RE = re.compile(r"[\w.-]+/[\w.-]+")
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        val = int(raw)
+    except ValueError:
+        return default
+    return val if val > 0 else default
+
+
+def _read_token(destination: str) -> str:
+    """Resolve a READ-scoped token for ``destination`` (empty if none).
+
+    Separate from the write capability map by design — a universe may be granted
+    read-only without write. Empty string => unauthenticated read (public repos).
+    """
+    raw = os.environ.get(_READ_CAPABILITIES_ENV, "").strip()
+    if not raw:
+        return ""
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "%s is set but not valid JSON; treating reads as unauthenticated",
+            _READ_CAPABILITIES_ENV,
+        )
+        return ""
+    if not isinstance(parsed, dict):
+        return ""
+    token = parsed.get(destination, "")
+    return token.strip() if isinstance(token, str) else ""
+
+
+def _parse_paths(raw: object) -> list[str]:
+    """Parse target_paths from a JSON array or comma/semicolon list."""
+    if isinstance(raw, list):
+        items = raw
+    else:
+        text = str(raw or "").strip()
+        if not text:
+            return []
+        if text.startswith("["):
+            try:
+                parsed = json.loads(text)
+                items = parsed if isinstance(parsed, list) else [text]
+            except (TypeError, ValueError):
+                items = re.split(r"[,;]", text)
+        else:
+            items = re.split(r"[,;]", text)
+    out: list[str] = []
+    for it in items:
+        s = str(it or "").strip()
+        if s:
+            out.append(s)
+    return out
+
+
+def _path_rejected(path: str) -> bool:
+    """True when a path is unsafe (absolute or parent-traversal)."""
+    if path.startswith("/") or path.startswith("\\"):
+        return True
+    parts = re.split(r"[\\/]+", path)
+    return any(p == ".." for p in parts)
+
+
+def _read_request(
+    *, destination: str, path: str, token: str
+) -> tuple[dict | None, dict | None]:
+    """GET the contents API for one path. Returns ``(parsed, error)``.
+
+    ``error`` is ``{"http_status": int|None, "detail": str}``; a 404 is returned
+    as an error here and mapped to ``missing`` (null) by the caller.
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "workflow-github-read/1.0",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(
+        f"{_GITHUB_API}/repos/{destination}/contents/{path}",
+        method="GET",
+        headers=headers,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_READ_TIMEOUT_S) as resp:
+            raw = resp.read().decode("utf-8")
+            return (json.loads(raw) if raw.strip() else {}), None
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:200]
+        return None, {"http_status": exc.code, "detail": detail}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return None, {"http_status": None, "detail": str(exc)}
+    except (TypeError, ValueError) as exc:
+        return None, {"http_status": None, "detail": f"parse error: {exc}"}
+
+
+def read_repo_files(state: dict) -> dict:
+    """Opaque-node body: read caller-named repo files into state. Never raises."""
+    destination = str(
+        state.get("read_destination") or state.get("destination") or ""
+    ).strip().strip("/")
+    contents: dict[str, object] = {}
+    status: dict[str, object] = {}
+    errors: dict[str, str] = {}
+
+    def _emit(truncated: bool = False) -> dict:
+        status["_truncated"] = truncated
+        status["_errors"] = errors
+        return {
+            "current_contents_json": json.dumps(contents, ensure_ascii=False),
+            "read_status_json": json.dumps(status, ensure_ascii=False),
+        }
+
+    if not destination or not _REPO_RE.fullmatch(destination):
+        errors["_destination"] = "read_destination_invalid"
+        return _emit()
+
+    paths = _parse_paths(state.get("target_paths"))
+    if not paths:
+        errors["_paths"] = "no_target_paths"
+        return _emit()
+
+    max_files = _int_env("WORKFLOW_GITHUB_READ_MAX_FILES", _DEFAULT_MAX_FILES)
+    max_bytes_file = _int_env(
+        "WORKFLOW_GITHUB_READ_MAX_BYTES_PER_FILE", _DEFAULT_MAX_BYTES_PER_FILE
+    )
+    max_total = _int_env(
+        "WORKFLOW_GITHUB_READ_MAX_TOTAL_BYTES", _DEFAULT_MAX_TOTAL_BYTES
+    )
+    token = _read_token(destination)
+
+    truncated = False
+    if len(paths) > max_files:
+        truncated = True
+        for extra in paths[max_files:]:
+            status[extra] = "truncated"
+            errors[extra] = "read_truncated"
+        paths = paths[:max_files]
+
+    total = 0
+    for path in paths:
+        if _path_rejected(path):
+            status[path] = "rejected"
+            errors[path] = "read_path_rejected"
+            continue
+        parsed, err = _read_request(destination=destination, path=path, token=token)
+        if err is not None:
+            code = err.get("http_status")
+            if code == 404:
+                contents[path] = None  # missing => new-file create, not an error
+                status[path] = "missing"
+            elif code in (401, 403):
+                status[path] = "denied"
+                errors[path] = "read_contents_denied"
+            else:
+                status[path] = "error"
+                errors[path] = "read_request_failed"
+            continue
+        node_type = (parsed or {}).get("type")
+        if node_type != "file":
+            status[path] = "rejected"
+            errors[path] = "read_path_rejected"  # dir / symlink / submodule
+            continue
+        size = (parsed or {}).get("size")
+        encoded = (parsed or {}).get("content")
+        if (isinstance(size, int) and size > max_bytes_file) or not encoded:
+            contents[path] = None
+            status[path] = "too_large"
+            errors[path] = "read_file_too_large"
+            continue
+        try:
+            decoded = base64.b64decode(encoded).decode("utf-8")
+        except (ValueError, UnicodeDecodeError):
+            status[path] = "error"
+            errors[path] = "read_decode_failed"
+            continue
+        if len(decoded.encode("utf-8")) > max_bytes_file:
+            contents[path] = None
+            status[path] = "too_large"
+            errors[path] = "read_file_too_large"
+            continue
+        if total + len(decoded.encode("utf-8")) > max_total:
+            truncated = True
+            status[path] = "truncated"
+            errors[path] = "read_truncated"
+            continue
+        contents[path] = decoded
+        status[path] = "present"
+        total += len(decoded.encode("utf-8"))
+
+    return _emit(truncated=truncated)
+
+
+def register_read_repo_files() -> None:
+    """Register the read_repo_files opaque callable for the workflow domain.
+
+    Idempotent (register_domain_callable overwrites the same key with a debug
+    log). Called from workflow/effectors/__init__.py at import and lazily from
+    the compiler's opaque-resolution path so it is always present before a
+    branch that uses it compiles.
+    """
+    from workflow.domain_registry import register_domain_callable
+
+    register_domain_callable(DOMAIN_ID, NODE_ID, read_repo_files)
+
+
+__all__ = ["read_repo_files", "register_read_repo_files", "DOMAIN_ID", "NODE_ID"]

--- a/workflow/graph_compiler.py
+++ b/workflow/graph_compiler.py
@@ -2135,6 +2135,14 @@ def _build_node(
         )
         return _wrap_with_checkpoints(inner, node, event_sink)
     if domain_id:
+        # Ensure platform opaque callables (e.g. read_repo_files) are
+        # registered before we resolve — importing the effectors package runs
+        # its registration side effects. Lazy + best-effort so a missing
+        # optional dependency can't break compilation of unrelated branches.
+        try:
+            import workflow.effectors  # noqa: F401
+        except Exception:  # pragma: no cover - registration is best-effort
+            logger.debug("effectors import for opaque registration failed", exc_info=True)
         opaque = resolve_domain_callable(domain_id, node.node_id)
         if opaque is not None:
             inner = _build_opaque_node(node, opaque, event_sink=event_sink)


### PR DESCRIPTION
## Summary
Implements the **read** primitive from the merged design note (PR #1149, Cowork + Codex review). This is the last piece of the goal: `patch_request_loop_v1` could open real PRs (PR #1148) but only for **new files** or user-pasted contents — it couldn't **read** existing files, so it couldn't service the common request *"change how existing file X behaves."* With this, the loop reads X itself and proposes a correct edit.

## What it is
`read_repo_files` — a **platform-trusted opaque domain callable** (`domain=workflow`, `node_id=read_repo_files`; resolved via `_build_opaque_node`, **no approval wall**). It reads `state.target_paths` from `state.read_destination` via the GitHub contents API and writes `current_contents_json` `{path: contents|null}` + `read_status_json` into state. Composes directly:
```
intake → read_repo_files → propose_changes → review_gate ──KEEP──→ open_pr → log → END
```

## Review amendments folded (design note §"Build decisions from review")
1. **Read capability separate from write** — token from `WORKFLOW_GITHUB_READ_CAPABILITIES`, never the write map; absent ⇒ unauthenticated read (public repos, rate-limited). A test proves the write token is *not* reused.
2. **Server-enforced safety/limits** in the callable — relative paths only (absolute + `..` rejected before any network call), max files / bytes-per-file / total bytes, `read_truncated` signal.
3. **Missing file ⇒ explicit `null`** (new-file create), not a run failure.
4. **Distinct per-file error kinds** + per-file status (present|missing|denied|rejected|too_large|truncated|error).
5. **Platform-trusted opaque callable** — user references it, can't supply its body.

## Verification
- `py_compile` + `ruff` clean; plugin mirror rebuilt byte-identical (3 files); pre-commit gates pass.
- **53 passed**: 14 new `read_repo_files` tests (mock the HTTP layer, no network — happy read, missing→null, denied/scope, path rejection, dir rejection, too-large, file-count + total-byte truncation, JSON-array parsing, separate-token resolution, registration) + existing effector suites, no regressions.

## Gate
writer:claude — **needs checker:codex + host third key** (new substrate primitive; real-repo read capability).

## Post-merge plan
- Deploy, then build `patch_request_loop_v2` = v1 + a `read_repo_files` node, and run a real **edit-an-existing-file** patch request end-to-end → PR. That is the goal genuinely met.