### PR TITLE
[auto-change] WIKI-PATCH: Derive canon filenames through a sandbox-safe slug helper — LLM topic slugs can path-traverse out of canon_dir

### DIFF
--- a/domains/fantasy_daemon/phases/worldbuild.py
+++ b/domains/fantasy_daemon/phases/worldbuild.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from domains.fantasy_daemon.phases.world_state_db import connect, get_all_facts, init_db
+from workflow.ingestion.canon_names import safe_canon_filename, safe_canon_slug
 from workflow.universe_soul import (
     premise_from_soul,
     read_legacy_premise,
@@ -479,7 +480,7 @@ def _handle_new_element(
     """Create a focused canon document for a newly discovered element."""
     from domains.fantasy_daemon.phases._provider_stub import call_provider, last_provider
 
-    topic_slug = topic.lower().replace(" ", "_").replace("-", "_")
+    topic_slug = safe_canon_slug(topic)
     topic_label = topic.replace("_", " ").title()
 
     # Read existing canon for context
@@ -510,7 +511,7 @@ def _handle_new_element(
         fallback_response=_mock_worldbuild_response(topic),
     )
     if content:
-        filename = f"{topic_slug}.md"
+        filename = safe_canon_filename(topic_slug)
         _write_canon_file(canon_dir, filename, content, model=last_provider)
         logger.info("Created canon for new element: %s", filename)
 
@@ -529,7 +530,7 @@ def _handle_contradiction(
     """
     from domains.fantasy_daemon.phases._provider_stub import call_provider, last_provider
 
-    topic_slug = topic.lower().replace(" ", "_").replace("-", "_")
+    topic_slug = safe_canon_slug(topic)
 
     # Find the relevant canon file
     canon_content = ""
@@ -597,7 +598,7 @@ def _handle_expansion(
     """Expand an existing thin canon document with new details from prose."""
     from domains.fantasy_daemon.phases._provider_stub import call_provider, last_provider
 
-    topic_slug = topic.lower().replace(" ", "_").replace("-", "_")
+    topic_slug = safe_canon_slug(topic)
 
     # Find the relevant canon file
     canon_content = ""
@@ -864,10 +865,10 @@ def _generate_canon_documents(state: dict[str, Any]) -> list[str]:
             )
             if content:
                 from domains.fantasy_daemon.phases._provider_stub import last_provider
-                filename = f"{topic}.md"
+                filename = safe_canon_filename(topic)
                 _write_canon_file(canon_dir, filename, content, model=last_provider)
                 # Verify the file actually exists on disk
-                written_path = canon_dir / filename
+                written_path = (canon_dir / filename).resolve()
                 if written_path.exists():
                     generated.append(filename)
                     logger.info(
@@ -1033,11 +1034,18 @@ def _write_canon_file(
     import time as _time
 
     canon_dir.mkdir(parents=True, exist_ok=True)
-    filepath = canon_dir / filename
-    filepath.write_text(content, encoding="utf-8")
+    safe_filename = safe_canon_filename(filename)
+    canon_root = canon_dir.resolve()
+    filepath = (canon_dir / safe_filename).resolve()
+    if not filepath.is_relative_to(canon_root):
+        raise ValueError(f"canon filename escapes canon directory: {filename!r}")
 
     # Write provenance marker
-    marker = canon_dir / f".{filename}.reviewed"
+    marker = (canon_dir / f".{safe_filename}.reviewed").resolve()
+    if not marker.is_relative_to(canon_root):
+        raise ValueError(f"canon marker escapes canon directory: {filename!r}")
+
+    filepath.write_text(content, encoding="utf-8")
     try:
         marker.write_text(
             _json.dumps({"reviewed_at": _time.time(), "model": model}),

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/ingestion/canon_names.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/ingestion/canon_names.py
@@ -1,0 +1,28 @@
+"""Sandbox-safe canon filename helpers."""
+
+from __future__ import annotations
+
+import re
+
+_CANON_SLUG_RE = re.compile(r"[^a-z0-9_]+")
+
+
+def safe_canon_slug(value: str) -> str:
+    """Return a sandbox-safe canon topic slug.
+
+    LLM-synthesized topic names are not trusted path components. Canon topic
+    slugs are restricted to lowercase ASCII letters, digits, and underscores.
+    """
+    slug = _CANON_SLUG_RE.sub("_", str(value).lower())
+    slug = re.sub(r"_+", "_", slug).strip("_")
+    if not slug:
+        raise ValueError("canon topic must resolve to a non-empty safe slug")
+    return slug
+
+
+def safe_canon_filename(value: str) -> str:
+    """Return a safe ``.md`` filename for a canon topic or filename."""
+    raw = str(value).strip()
+    if raw.lower().endswith(".md"):
+        raw = raw[:-3]
+    return f"{safe_canon_slug(raw)}.md"

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/ingestion/extractors.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/ingestion/extractors.py
@@ -18,6 +18,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from workflow.ingestion.canon_names import safe_canon_filename
 from workflow.ingestion.core import FileType, detect_file_type
 from workflow.utils.json_parsing import parse_llm_json
 
@@ -278,8 +279,11 @@ def synthesize_source(
     for topic, content in docs.items():
         if not content or not content.strip():
             continue
-        slug = topic.lower().replace("-", "_").replace(" ", "_")
-        doc_filename = f"{slug}.md"
+        try:
+            doc_filename = safe_canon_filename(topic)
+        except ValueError:
+            logger.warning("Skipping synthesized canon topic with unsafe empty slug: %r", topic)
+            continue
 
         # Don't overwrite user-authored canon (check for .reviewed marker)
         marker = canon_dir / f".{doc_filename}.reviewed"

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -877,6 +877,30 @@ class TestWorldbuildSynthesisSignal:
         assert acted == 1
         assert 0 in consumed
 
+    def test_synthesis_sanitizes_llm_topic_before_writing(self, tmp_path):
+        """Synthesized LLM topic names must not become path components."""
+        canon_dir = tmp_path / "canon"
+        canon_dir.mkdir()
+
+        mock_response = json.dumps({
+            "../../escape": "# Escape\n\nShould stay inside canon.",
+        })
+
+        with patch(
+            "domains.fantasy_daemon.phases._provider_stub.call_provider",
+            return_value=mock_response,
+        ):
+            generated = synthesize_source(
+                "# Source\n\nA malicious topic.",
+                "source.md",
+                canon_dir,
+                "Epic fantasy.",
+            )
+
+        assert generated == ["escape.md"]
+        assert (canon_dir / "escape.md").exists()
+        assert not (tmp_path / "escape.md").exists()
+
     def test_synthesis_failure_consumes_signal_and_records_attempt(self, tmp_path):
         """When synthesis fails, signal is consumed and attempt is recorded.
 

--- a/tests/test_universe_nodes.py
+++ b/tests/test_universe_nodes.py
@@ -39,6 +39,7 @@ from domains.fantasy_daemon.phases.worldbuild import (
     _read_direction_notes,
     _read_premise,
     _scan_existing_canon,
+    _write_canon_file,
     worldbuild,
 )
 from workflow.notes import add_note, update_note_status
@@ -569,6 +570,40 @@ class TestWorldbuildCanonGeneration:
         """No gaps when everything is covered."""
         existing = set(WORLDBUILD_TOPICS)
         assert _identify_gaps(existing) == []
+
+    def test_write_canon_file_sanitizes_traversal_filename(self, tmp_path):
+        """LLM-derived canon filenames must not escape canon_dir."""
+        canon_dir = tmp_path / "canon"
+
+        _write_canon_file(canon_dir, "../../escape.md", "# Escaped")
+
+        assert (canon_dir / "escape.md").read_text(encoding="utf-8") == "# Escaped"
+        assert not (tmp_path / "escape.md").exists()
+
+    def test_write_canon_file_rejects_empty_safe_filename(self, tmp_path):
+        """A filename that sanitizes to empty is not written."""
+        canon_dir = tmp_path / "canon"
+
+        try:
+            _write_canon_file(canon_dir, "../..", "# Empty")
+        except ValueError as exc:
+            assert "non-empty safe slug" in str(exc)
+        else:
+            raise AssertionError("expected unsafe empty canon filename to fail")
+
+    def test_write_canon_file_rejects_marker_symlink_escape(self, tmp_path):
+        """The provenance marker write must stay under canon_dir too."""
+        canon_dir = tmp_path / "canon"
+        canon_dir.mkdir()
+        (canon_dir / ".escape.md.reviewed").symlink_to(tmp_path / "marker-outside")
+
+        try:
+            _write_canon_file(canon_dir, "escape.md", "# Escaped")
+        except ValueError as exc:
+            assert "canon marker escapes" in str(exc)
+        else:
+            raise AssertionError("expected escaped marker path to fail")
+        assert not (canon_dir / "escape.md").exists()
 
     def test_mock_worldbuild_response_has_content(self):
         """Mock response should produce valid markdown."""

--- a/workflow/ingestion/canon_names.py
+++ b/workflow/ingestion/canon_names.py
@@ -1,0 +1,28 @@
+"""Sandbox-safe canon filename helpers."""
+
+from __future__ import annotations
+
+import re
+
+_CANON_SLUG_RE = re.compile(r"[^a-z0-9_]+")
+
+
+def safe_canon_slug(value: str) -> str:
+    """Return a sandbox-safe canon topic slug.
+
+    LLM-synthesized topic names are not trusted path components. Canon topic
+    slugs are restricted to lowercase ASCII letters, digits, and underscores.
+    """
+    slug = _CANON_SLUG_RE.sub("_", str(value).lower())
+    slug = re.sub(r"_+", "_", slug).strip("_")
+    if not slug:
+        raise ValueError("canon topic must resolve to a non-empty safe slug")
+    return slug
+
+
+def safe_canon_filename(value: str) -> str:
+    """Return a safe ``.md`` filename for a canon topic or filename."""
+    raw = str(value).strip()
+    if raw.lower().endswith(".md"):
+        raw = raw[:-3]
+    return f"{safe_canon_slug(raw)}.md"

--- a/workflow/ingestion/extractors.py
+++ b/workflow/ingestion/extractors.py
@@ -18,6 +18,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from workflow.ingestion.canon_names import safe_canon_filename
 from workflow.ingestion.core import FileType, detect_file_type
 from workflow.utils.json_parsing import parse_llm_json
 
@@ -278,8 +279,11 @@ def synthesize_source(
     for topic, content in docs.items():
         if not content or not content.strip():
             continue
-        slug = topic.lower().replace("-", "_").replace(" ", "_")
-        doc_filename = f"{slug}.md"
+        try:
+            doc_filename = safe_canon_filename(topic)
+        except ValueError:
+            logger.warning("Skipping synthesized canon topic with unsafe empty slug: %r", topic)
+            continue
 
         # Don't overwrite user-authored canon (check for .reviewed marker)
         marker = canon_dir / f".{doc_filename}.reviewed"


### PR DESCRIPTION
Fixes #1180

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-159-derive-canon-filenames-through-a-sandbox-safe-slug-helper-ll.md`
- GitHub issue: #1180
- Branch task: `auto-change/issue-1180`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.