### PR TITLE
[auto-change] WIKI-PATCH: Add an identity/privilege gate to the node `approve` action — registrant can currently self-approve code execution

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/extensions.py
@@ -111,6 +111,9 @@ class NodeRegistration:
     registered_at: str = ""
     enabled: bool = True
     approved: bool = False
+    approved_by: str = ""
+    approved_at: str = ""
+    approved_source_hash: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -854,6 +857,9 @@ def _ext_inspect(node_id: str) -> str:
 
 
 def _ext_manage(node_id: str, action: str) -> str:
+    from workflow.api.branches import _source_code_hash
+    from workflow.api.engine_helpers import _current_actor
+
     if not node_id:
         return json.dumps({"error": "node_id is required."})
 
@@ -872,7 +878,22 @@ def _ext_manage(node_id: str, action: str) -> str:
         })
 
     if action == "approve":
+        actor = _current_actor()
+        registrant = (nodes[idx].get("author") or "").strip() or "anonymous"
+        if actor == registrant:
+            return json.dumps({
+                "status": "rejected",
+                "error": "node_approval_requires_distinct_actor",
+                "node_id": node_id,
+                "registrant": registrant,
+                "approver": actor,
+            })
         nodes[idx]["approved"] = True
+        nodes[idx]["approved_by"] = actor
+        nodes[idx]["approved_at"] = datetime.now(timezone.utc).isoformat()
+        nodes[idx]["approved_source_hash"] = _source_code_hash(
+            nodes[idx].get("source_code", ""),
+        )
     elif action == "disable":
         nodes[idx]["enabled"] = False
     elif action == "enable":
@@ -882,6 +903,10 @@ def _ext_manage(node_id: str, action: str) -> str:
     return json.dumps({
         "node_id": node_id,
         "action": action,
+        "status": "approved" if action == "approve" else action,
         "approved": nodes[idx].get("approved"),
+        "approved_by": nodes[idx].get("approved_by", ""),
+        "approved_at": nodes[idx].get("approved_at", ""),
+        "approved_source_hash": nodes[idx].get("approved_source_hash", ""),
         "enabled": nodes[idx].get("enabled"),
     })

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/provider.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/provider.py
@@ -303,6 +303,7 @@ _EXTENSIONS_COSTLY_ACTIONS = frozenset({
     "record_remix",
 })
 _EXTENSIONS_ADMIN_ACTIONS = frozenset({
+    "approve",
     "delete_branch",
     "approve_source_code",
     "cancel_run",

--- a/tests/test_composite_branch_actions.py
+++ b/tests/test_composite_branch_actions.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -82,7 +83,15 @@ def _build_approved_source_branch(us, *, node_id="approved_calc"):
         source_code="def run(state): return {'answer': 1}",
         dependencies="",
     )
-    approved = _call(us, "approve", node_id=node_id)
+    prior_actor = os.environ.get("UNIVERSE_SERVER_USER")
+    os.environ["UNIVERSE_SERVER_USER"] = "host-operator"
+    try:
+        approved = _call(us, "approve", node_id=node_id)
+    finally:
+        if prior_actor is None:
+            os.environ.pop("UNIVERSE_SERVER_USER", None)
+        else:
+            os.environ["UNIVERSE_SERVER_USER"] = prior_actor
     assert approved["approved"] is True
     spec = {
         "name": "Approved source branch",

--- a/tests/test_node_ref_reuse.py
+++ b/tests/test_node_ref_reuse.py
@@ -258,15 +258,21 @@ class TestExplicitNodeRefCopiesCanonicalBody:
         assert nd["prompt_template"] == "audit: {x}"
         assert nd["description"] == "canonical audit node"
 
-    def test_build_branch_node_ref_preserves_standalone_approval(self, ext_env):
+    def test_build_branch_node_ref_preserves_standalone_approval(
+        self, ext_env, monkeypatch,
+    ):
         us, base = ext_env
         _register_standalone(
             us, "approved_recipe", "Approved Recipe",
             source="def run(state): return {'manifest': 'ok'}\n",
         )
-        approved = _call(
-            us, "extensions", "approve", node_id="approved_recipe",
-        )
+        monkeypatch.setenv("UNIVERSE_SERVER_USER", "host-operator")
+        try:
+            approved = _call(
+                us, "extensions", "approve", node_id="approved_recipe",
+            )
+        finally:
+            monkeypatch.setenv("UNIVERSE_SERVER_USER", "tester")
         assert approved["approved"] is True
 
         spec = {
@@ -284,7 +290,10 @@ class TestExplicitNodeRefCopiesCanonicalBody:
                 {"from": "START", "to": "approved_recipe"},
                 {"from": "approved_recipe", "to": "END"},
             ],
-            "state_schema": [{"name": "manifest", "type": "str"}],
+            "state_schema": [
+                {"name": "manifest", "type": "str"},
+                {"name": "state", "type": "dict"},
+            ],
         }
         built = _call(us, "extensions", "build_branch",
                       spec_json=json.dumps(spec))

--- a/tests/test_standalone_node_approval_gate.py
+++ b/tests/test_standalone_node_approval_gate.py
@@ -1,0 +1,83 @@
+"""Regression coverage for standalone node approval identity gates."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def ext_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    base = tmp_path / "output"
+    base.mkdir()
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(base))
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "registrant")
+    from workflow import universe_server as us
+
+    importlib.reload(us)
+    yield us, base, monkeypatch
+    importlib.reload(us)
+
+
+def _call(us, action: str, **kwargs):
+    return json.loads(us.extensions(action=action, **kwargs))
+
+
+def _register_node(us, node_id: str = "code_node") -> dict:
+    return _call(
+        us,
+        "register",
+        node_id=node_id,
+        display_name="Code Node",
+        description="User contributed code",
+        phase="custom",
+        input_keys="",
+        output_keys="ok",
+        source_code="def run(state): return {'ok': True}\n",
+        dependencies="",
+    )
+
+
+def test_standalone_node_registrant_cannot_self_approve(ext_env):
+    us, _base, _monkeypatch = ext_env
+    registered = _register_node(us)
+    assert registered["status"] == "registered"
+
+    rejected = _call(us, "approve", node_id="code_node")
+
+    assert rejected["status"] == "rejected"
+    assert rejected["error"] == "node_approval_requires_distinct_actor"
+    inspected = _call(us, "inspect", node_id="code_node")
+    assert inspected["approved"] is False
+    assert inspected.get("approved_by", "") == ""
+
+
+def test_standalone_node_distinct_actor_approval_records_metadata(ext_env):
+    us, _base, monkeypatch = ext_env
+    _register_node(us)
+
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "host-operator")
+    approved = _call(us, "approve", node_id="code_node")
+
+    assert approved["status"] == "approved"
+    assert approved["approved"] is True
+    assert approved["approved_by"] == "host-operator"
+    assert len(approved["approved_source_hash"]) == 64
+
+    inspected = _call(us, "inspect", node_id="code_node")
+    assert inspected["approved"] is True
+    assert inspected["approved_by"] == "host-operator"
+    assert inspected["approved_at"]
+    assert inspected["approved_source_hash"] == approved["approved_source_hash"]
+
+
+def test_standalone_node_approve_requires_extensions_admin_scope_when_auth_enabled():
+    from workflow.auth.provider import action_scope_for
+
+    metadata = action_scope_for("extensions", "approve")
+    assert metadata is not None
+    assert metadata.oauth_scope == "workflow.extensions.admin"
+    assert metadata.effect == "admin"

--- a/workflow/api/extensions.py
+++ b/workflow/api/extensions.py
@@ -111,6 +111,9 @@ class NodeRegistration:
     registered_at: str = ""
     enabled: bool = True
     approved: bool = False
+    approved_by: str = ""
+    approved_at: str = ""
+    approved_source_hash: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -854,6 +857,9 @@ def _ext_inspect(node_id: str) -> str:
 
 
 def _ext_manage(node_id: str, action: str) -> str:
+    from workflow.api.branches import _source_code_hash
+    from workflow.api.engine_helpers import _current_actor
+
     if not node_id:
         return json.dumps({"error": "node_id is required."})
 
@@ -872,7 +878,22 @@ def _ext_manage(node_id: str, action: str) -> str:
         })
 
     if action == "approve":
+        actor = _current_actor()
+        registrant = (nodes[idx].get("author") or "").strip() or "anonymous"
+        if actor == registrant:
+            return json.dumps({
+                "status": "rejected",
+                "error": "node_approval_requires_distinct_actor",
+                "node_id": node_id,
+                "registrant": registrant,
+                "approver": actor,
+            })
         nodes[idx]["approved"] = True
+        nodes[idx]["approved_by"] = actor
+        nodes[idx]["approved_at"] = datetime.now(timezone.utc).isoformat()
+        nodes[idx]["approved_source_hash"] = _source_code_hash(
+            nodes[idx].get("source_code", ""),
+        )
     elif action == "disable":
         nodes[idx]["enabled"] = False
     elif action == "enable":
@@ -882,6 +903,10 @@ def _ext_manage(node_id: str, action: str) -> str:
     return json.dumps({
         "node_id": node_id,
         "action": action,
+        "status": "approved" if action == "approve" else action,
         "approved": nodes[idx].get("approved"),
+        "approved_by": nodes[idx].get("approved_by", ""),
+        "approved_at": nodes[idx].get("approved_at", ""),
+        "approved_source_hash": nodes[idx].get("approved_source_hash", ""),
         "enabled": nodes[idx].get("enabled"),
     })

--- a/workflow/auth/provider.py
+++ b/workflow/auth/provider.py
@@ -303,6 +303,7 @@ _EXTENSIONS_COSTLY_ACTIONS = frozenset({
     "record_remix",
 })
 _EXTENSIONS_ADMIN_ACTIONS = frozenset({
+    "approve",
     "delete_branch",
     "approve_source_code",
     "cancel_run",


### PR DESCRIPTION
Fixes #1167

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-146-add-an-identity-privilege-gate-to-the-node-approve-action-re.md`
- GitHub issue: #1167
- Branch task: `auto-change/issue-1167`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.