### PR TITLE
[auto-change] WIKI-PATCH: Enforce per-universe ownership on api/universe.py handlers — universe_id is currently trusted from the request (IDOR)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -89,6 +89,8 @@ ACTION_SUBMIT_PRIORITY_REQUEST = "submit_priority_request"
 ACTION_CANCEL_BRANCH_TASK = "cancel_branch_task"
 ACTION_POST_PRIORITY_GOAL_POOL = "post_priority_goal_pool"
 LEGACY_FANTASY_LOOP_BRANCH_DEF_ID = "fantasy_author:universe_cycle_wrapper"
+_ACL_READ_PERMISSIONS = frozenset({"read", "write", "admin"})
+_ACL_WRITE_PERMISSIONS = frozenset({"write", "admin"})
 
 
 def _env_actor_grants() -> tuple[str, ...]:
@@ -107,6 +109,50 @@ def _env_actor_can(action: str, *, universe_id: str = "") -> bool:
         grants=grants,
         scope=PermissionScope(universe_id=universe_id),
     ).allowed
+
+
+def _current_actor_id() -> str:
+    from workflow.auth.middleware import current_identity
+
+    identity = current_identity()
+    return identity.user_id or "anonymous"
+
+
+def _universe_acl_allows(uid: str, *, write: bool = False) -> bool:
+    from workflow.daemon_server import (
+        universe_access_permission,
+        universe_is_private,
+    )
+
+    if not uid:
+        return True
+    base = _base_path()
+    if not universe_is_private(base, universe_id=uid):
+        return True
+    permission = universe_access_permission(
+        base,
+        universe_id=uid,
+        actor_id=_current_actor_id(),
+    )
+    allowed = _ACL_WRITE_PERMISSIONS if write else _ACL_READ_PERMISSIONS
+    return permission in allowed
+
+
+def _universe_acl_error(action: str, *, universe_id: str = "") -> str | None:
+    if action in {"list", "create_universe"}:
+        return None
+
+    uid = universe_id or _default_universe()
+    write = action in WRITE_ACTIONS
+    if _universe_acl_allows(uid, write=write):
+        return None
+
+    return json.dumps({
+        "error": "universe_access_denied",
+        "universe_id": uid,
+        "actor_id": _current_actor_id(),
+        "required_permission": "write" if write else "read",
+    })
 
 # WRITE_ACTIONS is the single source of truth for which `universe` tool
 # actions are writes. The dispatcher consults this table; any action
@@ -983,6 +1029,8 @@ def _action_list_universes(**_kwargs: Any) -> str:
     universes = []
     for child in sorted(all_entries):
         if not _is_listable_universe_dir(child):
+            continue
+        if not _universe_acl_allows(child.name):
             continue
         status = _read_json(child / "status.json")
         liveness = _daemon_liveness(child, status if isinstance(status, dict) else None)
@@ -4525,6 +4573,9 @@ def _universe_impl(
     scope_error = _dispatch_scope_error("universe", action, universe_id=universe_id)
     if scope_error is not None:
         return scope_error
+    acl_error = _universe_acl_error(action, universe_id=universe_id)
+    if acl_error is not None:
+        return acl_error
 
     # Build kwargs from all optional params
     kwargs: dict[str, Any] = {

--- a/tests/test_universe_server_isolation.py
+++ b/tests/test_universe_server_isolation.py
@@ -19,6 +19,43 @@ from pathlib import Path
 import pytest
 
 import workflow.api.universe as us
+from workflow.auth.middleware import auth_middleware, set_provider
+from workflow.auth.provider import AuthProvider, DevAuthProvider, Identity
+from workflow.daemon_server import grant_universe_access
+
+
+class _StaticAuthProvider(AuthProvider):
+    def __init__(self, identity: Identity | None) -> None:
+        self.identity = identity
+
+    def resolve_token(self, token: str) -> Identity | None:
+        return self.identity if token == "ok" else None
+
+    def is_auth_required(self) -> bool:
+        return True
+
+    def register_client(self, metadata: dict) -> dict:
+        return {"client_id": "test-client", **metadata}
+
+    def create_authorization(
+        self,
+        client_id: str,
+        redirect_uri: str,
+        scope: str,
+        state: str,
+        code_challenge: str,
+        code_challenge_method: str,
+    ) -> str:
+        return "test-code"
+
+    def exchange_code(
+        self,
+        code: str,
+        client_id: str,
+        redirect_uri: str,
+        code_verifier: str,
+    ) -> dict | None:
+        return None
 
 
 @pytest.fixture
@@ -27,6 +64,29 @@ def universe_base(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     base.mkdir()
     monkeypatch.setenv("WORKFLOW_DATA_DIR", str(base))
     return base
+
+
+@pytest.fixture(autouse=True)
+def _reset_auth_provider() -> None:
+    set_provider(DevAuthProvider())
+    auth_middleware(None)
+    yield
+    set_provider(DevAuthProvider())
+    auth_middleware(None)
+
+
+def _authenticate(user_id: str, scopes: list[str] | None = None) -> None:
+    identity = Identity(
+        user_id=user_id,
+        username=user_id,
+        capabilities=scopes or [
+            "workflow.universe.read",
+            "workflow.universe.write",
+            "workflow.universe.admin",
+        ],
+    )
+    set_provider(_StaticAuthProvider(identity))
+    auth_middleware("ok")
 
 
 def _make_universe(base: Path, uid: str) -> Path:
@@ -126,6 +186,99 @@ class TestUniverseIdInResponses:
         _make_universe(universe_base, "alpha")
         out = json.loads(us._action_inspect_universe(universe_id="alpha"))
         assert out["universe_id"] == "alpha"
+
+
+class TestUniverseAclEnforcement:
+    def test_private_universe_rejects_unlisted_reader(self, universe_base):
+        udir = _make_universe(universe_base, "private")
+        (udir / "output").mkdir()
+        (udir / "output" / "secret.md").write_text("secret", encoding="utf-8")
+        grant_universe_access(
+            universe_base,
+            universe_id="private",
+            actor_id="owner",
+            permission="admin",
+            granted_by="owner",
+        )
+
+        _authenticate("intruder", ["workflow.universe.read"])
+
+        inspect_out = json.loads(us._universe_impl(
+            action="inspect",
+            universe_id="private",
+        ))
+        read_out = json.loads(us._universe_impl(
+            action="read_output",
+            universe_id="private",
+            path="secret.md",
+        ))
+
+        assert inspect_out["error"] == "universe_access_denied"
+        assert inspect_out["universe_id"] == "private"
+        assert inspect_out["required_permission"] == "read"
+        assert read_out["error"] == "universe_access_denied"
+
+    def test_private_universe_rejects_reader_write(self, universe_base):
+        _make_universe(universe_base, "private")
+        grant_universe_access(
+            universe_base,
+            universe_id="private",
+            actor_id="reader",
+            permission="read",
+            granted_by="owner",
+        )
+
+        _authenticate("reader", ["workflow.universe.write"])
+
+        out = json.loads(us._universe_impl(
+            action="set_premise",
+            universe_id="private",
+            text="Overwrite attempt.",
+        ))
+
+        assert out["error"] == "universe_access_denied"
+        assert out["required_permission"] == "write"
+        assert not (universe_base / "private" / "PROGRAM.md").exists()
+
+    def test_private_universe_allows_granted_writer(self, universe_base):
+        _make_universe(universe_base, "private")
+        grant_universe_access(
+            universe_base,
+            universe_id="private",
+            actor_id="writer",
+            permission="write",
+            granted_by="owner",
+        )
+
+        _authenticate("writer", ["workflow.universe.write"])
+
+        out = json.loads(us._universe_impl(
+            action="set_premise",
+            universe_id="private",
+            text="Allowed update.",
+        ))
+
+        assert out["status"] == "updated"
+        assert (universe_base / "private" / "PROGRAM.md").read_text(
+            encoding="utf-8",
+        ) == "Allowed update."
+
+    def test_list_filters_private_universes_without_grant(self, universe_base):
+        _make_universe(universe_base, "public")
+        _make_universe(universe_base, "private")
+        grant_universe_access(
+            universe_base,
+            universe_id="private",
+            actor_id="owner",
+            permission="admin",
+            granted_by="owner",
+        )
+
+        _authenticate("intruder", ["workflow.universe.read"])
+
+        out = json.loads(us._universe_impl(action="list"))
+
+        assert [row["id"] for row in out["universes"]] == ["public"]
 
 
 class TestScopeHeader:

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -89,6 +89,8 @@ ACTION_SUBMIT_PRIORITY_REQUEST = "submit_priority_request"
 ACTION_CANCEL_BRANCH_TASK = "cancel_branch_task"
 ACTION_POST_PRIORITY_GOAL_POOL = "post_priority_goal_pool"
 LEGACY_FANTASY_LOOP_BRANCH_DEF_ID = "fantasy_author:universe_cycle_wrapper"
+_ACL_READ_PERMISSIONS = frozenset({"read", "write", "admin"})
+_ACL_WRITE_PERMISSIONS = frozenset({"write", "admin"})
 
 
 def _env_actor_grants() -> tuple[str, ...]:
@@ -107,6 +109,50 @@ def _env_actor_can(action: str, *, universe_id: str = "") -> bool:
         grants=grants,
         scope=PermissionScope(universe_id=universe_id),
     ).allowed
+
+
+def _current_actor_id() -> str:
+    from workflow.auth.middleware import current_identity
+
+    identity = current_identity()
+    return identity.user_id or "anonymous"
+
+
+def _universe_acl_allows(uid: str, *, write: bool = False) -> bool:
+    from workflow.daemon_server import (
+        universe_access_permission,
+        universe_is_private,
+    )
+
+    if not uid:
+        return True
+    base = _base_path()
+    if not universe_is_private(base, universe_id=uid):
+        return True
+    permission = universe_access_permission(
+        base,
+        universe_id=uid,
+        actor_id=_current_actor_id(),
+    )
+    allowed = _ACL_WRITE_PERMISSIONS if write else _ACL_READ_PERMISSIONS
+    return permission in allowed
+
+
+def _universe_acl_error(action: str, *, universe_id: str = "") -> str | None:
+    if action in {"list", "create_universe"}:
+        return None
+
+    uid = universe_id or _default_universe()
+    write = action in WRITE_ACTIONS
+    if _universe_acl_allows(uid, write=write):
+        return None
+
+    return json.dumps({
+        "error": "universe_access_denied",
+        "universe_id": uid,
+        "actor_id": _current_actor_id(),
+        "required_permission": "write" if write else "read",
+    })
 
 # WRITE_ACTIONS is the single source of truth for which `universe` tool
 # actions are writes. The dispatcher consults this table; any action
@@ -983,6 +1029,8 @@ def _action_list_universes(**_kwargs: Any) -> str:
     universes = []
     for child in sorted(all_entries):
         if not _is_listable_universe_dir(child):
+            continue
+        if not _universe_acl_allows(child.name):
             continue
         status = _read_json(child / "status.json")
         liveness = _daemon_liveness(child, status if isinstance(status, dict) else None)
@@ -4525,6 +4573,9 @@ def _universe_impl(
     scope_error = _dispatch_scope_error("universe", action, universe_id=universe_id)
     if scope_error is not None:
         return scope_error
+    acl_error = _universe_acl_error(action, universe_id=universe_id)
+    if acl_error is not None:
+        return acl_error
 
     # Build kwargs from all optional params
     kwargs: dict[str, Any] = {


### PR DESCRIPTION
Fixes #1168

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-147-enforce-per-universe-ownership-on-api-universe-py-handlers-u.md`
- GitHub issue: #1168
- Branch task: `auto-change/issue-1168`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.