### PR TITLE
Improve ADR index documentation

### DIFF
--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -1,3 +1,5 @@
 # Decisions Index
 
+This file is the directory index of Architecture Decision Records (ADRs) for the project.
+
 - [ADR-001-truth-hierarchy-and-freshness.md](ADR-001-truth-hierarchy-and-freshness.md)


### PR DESCRIPTION
This change updates `docs/decisions/INDEX.md` per the request by adding a one-line description under the existing `# Decisions Index` title explaining that the file is the directory index of the project's Architecture Decision Records (ADRs). The existing ADR-001 link line is preserved exactly as provided, with no removal, reordering, or other alteration.