### PR TITLE
feat(effector): edits_json — diff-based change format for large-file edits

### DIFF
--- a/docs/design-notes/2026-05-29-diff-based-change-format.md
+++ b/docs/design-notes/2026-05-29-diff-based-change-format.md
@@ -1,0 +1,81 @@
+# Diff-based change format: `edits_json` (search/replace blocks)
+
+Date: 2026-05-29
+Status: proposed (extends the github_pull_request effector materialize path,
+PR #1145 / design note 2026-05-29-github-pr-effector-materialize-branch.md)
+Writer: Claude. Checker gate: opposite-provider review + host merge key.
+
+## Problem
+
+The patch-request loop's `propose` step emits `changes_json = {path: FULL new
+file contents}`, and the effector commits those full contents. For small/medium
+files this works (proven: PR #1192 calc.py, PR #1196 idempotency.py). For **large
+files** (~100 KB, e.g. `workflow/api/wiki.py`) the writer model degrades to
+placeholders like `# ... existing content unchanged ...` when asked to reproduce
+the whole file. The review gate correctly REJECTs (it would corrupt the file),
+so no bad PR is opened — but the edit cannot flow through. This is the documented
+blocker to cutting the bug-investigation handler over to the user-buildable loop
+(the cheat branch fails 100%; the new loop must cover large files too).
+
+## Decision
+
+Add a second, optional way to express a change in the `external_write_packet`
+payload: **`edits_json`** — `{path: [{"search": <str>, "replace": <str>}, ...]}`.
+The effector resolves it to full file contents **server-side** and feeds the
+existing blob → tree → commit → ref materialize path. The writer emits only the
+changed hunks, anchored on exact text it already has from `read_repo_files`, so
+it never has to reproduce (and never truncates) a large file.
+
+`changes_json` (full-file create/replace/delete) stays exactly as-is. A packet
+may carry `changes_json`, `edits_json`, or both (disjoint paths). At least one
+non-empty is required (no silent empty-branch PR).
+
+### Why search/replace blocks, not a unified diff
+
+Search/replace (the Aider / Claude-Code-Edit model) is the most LLM-robust edit
+format: no line numbers (which drift and break), the anchor is verbatim existing
+text, and correctness is locally checkable. Unified diffs fail to apply when the
+model's context lines or offsets are slightly off. Since `read_repo_files`
+already hands the writer the exact current contents, anchoring on a verbatim
+slice is natural and reliable.
+
+## Application semantics (fail-closed)
+
+For each `edits_json` path, the effector:
+1. Fetches the file at `base_branch` via the Contents API
+   (`GET /repos/{repo}/contents/{path}?ref={base}`), base64-decoded.
+   404 → `edit_target_missing` (cannot edit a file that doesn't exist — use
+   `changes_json` to create it). >1 MB / no inline content → fetch error.
+2. Applies blocks **in order**; each later block sees earlier results.
+3. Each `search` must occur **exactly once**:
+   - 0 matches → `edit_search_not_found`
+   - >1 matches → `edit_search_not_unique` (writer must add surrounding context)
+   This is the same exact-unique-match contract as the Claude Code Edit tool and
+   guarantees an edit can never silently land in the wrong place or corrupt the
+   file. Any failure aborts **before** any blob/commit/ref is created.
+
+Caps: ≤100 blocks/file (`_MAX_EDIT_BLOCKS_PER_FILE`); non-string search/replace
+or empty search → `invalid_edits`. A path present in both `changes_json` and
+`edits_json` → `invalid_edits` (ambiguous).
+
+## Contract additions
+
+`payload.edits_json` (optional): `{ "<repo-relative path>": [ {"search": "...",
+"replace": "..."}, ... ] }`. Resolved against `base_branch`. Distinct error
+kinds: `edit_target_missing`, `edit_fetch_failed`, `edit_search_not_found`,
+`edit_search_not_unique`, `invalid_edits` (plus the existing materialize kinds).
+Auth reuses the same write capability token (it has read access). Never raises.
+
+## Loop side (separate, post-merge)
+
+This PR is the **effector capability** only. The loop's `propose` node must then
+be updated (a connector-side branch rebuild — patch_request_loop v5) to emit
+`edits_json` for existing-file edits (anchored on the `read_repo_files` contents)
+and reserve `changes_json` for new-file creates. That rebuild + a re-validation
+against a large-file backlog item (e.g. BUG-109 → `wiki.py`) is the proof that
+unblocks the cutover flip.
+
+## Out of scope
+- Unified-diff / patch(1) application (rejected above).
+- Fuzzy / whitespace-insensitive matching — exact match only, fail-closed.
+- The cutover flip itself (separate gated deploy step).

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_pr.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_pr.py
@@ -72,6 +72,7 @@ Design source: ``drafts/concepts/external-write-phase-2-authority.md``.
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import os
@@ -80,6 +81,7 @@ import sqlite3
 import subprocess
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -608,6 +610,126 @@ def _scope_or(error: dict[str, Any], step_kind: str) -> str:
     return step_kind
 
 
+_MAX_EDIT_BLOCKS_PER_FILE = 100
+
+
+def _fetch_file_at_ref(
+    *, owner_repo: str, path: str, ref: str, capability_token: str
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Fetch a file's decoded text at ``ref`` via the Contents API.
+
+    Returns ``(contents, None)`` on success or ``(None, error)`` where error is
+    the ``_git_data_api`` error dict. A 404 means the path does not exist at the
+    ref — edits cannot anchor on a missing file, so the caller maps that to
+    ``edit_target_missing``.
+    """
+    encoded = urllib.parse.quote(path, safe="/")
+    encoded_ref = urllib.parse.quote(ref, safe="")
+    obj, err = _git_data_api(
+        method="GET",
+        path=f"/repos/{owner_repo}/contents/{encoded}?ref={encoded_ref}",
+        capability_token=capability_token,
+    )
+    if err is not None:
+        return None, err
+    if not isinstance(obj, dict) or obj.get("type") != "file":
+        return None, {"http_status": None, "detail": "path is not a file"}
+    encoded_content = obj.get("content")
+    if not isinstance(encoded_content, str) or not encoded_content:
+        # Files >1MB return no inline content via the Contents API.
+        return None, {"http_status": None, "detail": "no inline content (file too large?)"}
+    try:
+        return base64.b64decode(encoded_content).decode("utf-8"), None
+    except (ValueError, UnicodeDecodeError) as exc:
+        return None, {"http_status": None, "detail": f"decode failed: {exc}"}
+
+
+def _apply_edit_blocks(
+    contents: str, blocks: Any
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Apply ordered search/replace blocks to ``contents`` (exact, unique).
+
+    Each block is ``{"search": <str>, "replace": <str>}``. The ``search`` text
+    must occur EXACTLY ONCE in the current contents (anchoring on real fetched
+    text — read_repo_files gives the model that text). Zero matches or multiple
+    matches fail closed so a bad edit never produces a corrupt commit. Blocks
+    apply in order; a later block sees the result of earlier ones.
+    """
+    def _bad(kind: str, detail: str):
+        return None, {"error_kind": kind, "detail": detail}
+
+    if not isinstance(blocks, list) or not blocks:
+        return _bad("invalid_edits", "edits must be a non-empty list of blocks")
+    if len(blocks) > _MAX_EDIT_BLOCKS_PER_FILE:
+        return _bad("invalid_edits", f"too many edit blocks (>{_MAX_EDIT_BLOCKS_PER_FILE})")
+    out = contents
+    for i, block in enumerate(blocks):
+        if not isinstance(block, dict):
+            return _bad("invalid_edits", f"block {i} is not an object")
+        search = block.get("search")
+        replace = block.get("replace")
+        if not isinstance(search, str) or not search:
+            return _bad("invalid_edits", f"block {i} has empty/non-string search")
+        if not isinstance(replace, str):
+            return _bad("invalid_edits", f"block {i} has non-string replace")
+        count = out.count(search)
+        if count == 0:
+            return _bad("edit_search_not_found", f"block {i} search text not found")
+        if count > 1:
+            return _bad(
+                "edit_search_not_unique",
+                f"block {i} search matches {count}x (must be unique; add context)",
+            )
+        out = out.replace(search, replace, 1)
+    return out, None
+
+
+def _resolve_edits(
+    *, edits_json: Any, destination: str, base_branch: str, capability_token: str
+) -> tuple[dict[str, str], dict[str, Any] | None]:
+    """Resolve ``edits_json`` ({path: [blocks]}) to ``{path: full_new_contents}``.
+
+    Fetches each target file at ``base_branch`` and applies its blocks. Returns
+    ``(resolved, None)`` or ``({}, error)`` with a distinct ``error_kind``. This
+    is the large-file path: the model emits only the changed hunks, never the
+    whole file, so it cannot truncate a big file into placeholders.
+    """
+    if not isinstance(edits_json, dict) or not edits_json:
+        return {}, {"error": "edits_json must be a non-empty object", "error_kind": "invalid_edits"}
+    resolved: dict[str, str] = {}
+    for path_key, blocks in edits_json.items():
+        if not isinstance(path_key, str) or not path_key.strip():
+            return {}, {
+                "error": "edits_json keys must be non-empty path strings",
+                "error_kind": "invalid_edits",
+            }
+        current, err = _fetch_file_at_ref(
+            owner_repo=destination, path=path_key, ref=base_branch,
+            capability_token=capability_token,
+        )
+        if err is not None:
+            if err.get("http_status") == 404:
+                return {}, {
+                    "error": (
+                        f"edit target {path_key!r} does not exist at {base_branch} "
+                        "(cannot edit a missing file; use changes_json to create it)"
+                    ),
+                    "error_kind": "edit_target_missing",
+                }
+            return {}, {
+                "error": f"could not fetch {path_key!r} to apply edits: {err.get('detail')}",
+                "error_kind": _scope_or(err, "edit_fetch_failed"),
+            }
+        new_contents, edit_err = _apply_edit_blocks(current, blocks)
+        if edit_err is not None:
+            return {}, {
+                "error": f"edits for {path_key!r}: {edit_err['detail']}",
+                "error_kind": edit_err["error_kind"],
+            }
+        resolved[path_key] = new_contents
+    return resolved, None
+
+
 def _materialize_branch(
     *,
     changes_json: Any,
@@ -616,6 +738,7 @@ def _materialize_branch(
     head_branch: str,
     commit_message: str,
     capability_token: str,
+    edits_json: Any = None,
 ) -> dict[str, Any]:
     """Build a remote head branch from ``changes_json`` via the Git Data API.
 
@@ -638,33 +761,68 @@ def _materialize_branch(
             "error": f"invalid GitHub repository destination: {destination!r}",
             "error_kind": "invalid_destination",
         }
-    if not isinstance(changes_json, dict) or not changes_json:
-        # Constraint: no silent empty-branch PR. A real-write packet must
-        # carry the change set; failing loudly beats opening an empty PR.
-        return {
-            "error": (
-                "packet.payload.changes_json is required and must be a "
-                "non-empty object mapping repo-relative paths to full new "
-                "file contents (null to delete)"
-            ),
-            "error_kind": "missing_changes",
-        }
     if not head_branch:
         return {
             "error": "packet.payload.head_branch is required to materialize a branch",
             "error_kind": "missing_head_branch",
         }
-    for path_key, contents in changes_json.items():
-        if not isinstance(path_key, str) or not path_key.strip():
+
+    # Build the effective {path: full-new-contents|None} map from two sources:
+    #   - changes_json: full-file replacements / creates / deletes (null).
+    #   - edits_json:   {path: [search/replace blocks]} resolved server-side
+    #                   against the file fetched at base_branch — the large-file
+    #                   path, so the model never has to re-emit a whole big file.
+    effective: dict[str, Any] = {}
+    if changes_json is not None:
+        if not isinstance(changes_json, dict):
             return {
-                "error": "changes_json keys must be non-empty repo-relative path strings",
+                "error": "packet.payload.changes_json must be an object or omitted",
                 "error_kind": "invalid_changes",
             }
-        if contents is not None and not isinstance(contents, str):
-            return {
-                "error": f"changes_json[{path_key!r}] must be a string or null (delete)",
-                "error_kind": "invalid_changes",
-            }
+        for path_key, contents in changes_json.items():
+            if not isinstance(path_key, str) or not path_key.strip():
+                return {
+                    "error": "changes_json keys must be non-empty repo-relative path strings",
+                    "error_kind": "invalid_changes",
+                }
+            if contents is not None and not isinstance(contents, str):
+                return {
+                    "error": f"changes_json[{path_key!r}] must be a string or null (delete)",
+                    "error_kind": "invalid_changes",
+                }
+            effective[path_key] = contents
+    if edits_json is not None:
+        resolved, edit_err = _resolve_edits(
+            edits_json=edits_json,
+            destination=owner_repo,
+            base_branch=base_branch,
+            capability_token=capability_token,
+        )
+        if edit_err is not None:
+            return edit_err
+        for path_key, contents in resolved.items():
+            if path_key in effective:
+                return {
+                    "error": (
+                        f"{path_key!r} appears in both changes_json and "
+                        "edits_json — supply only one per path"
+                    ),
+                    "error_kind": "invalid_edits",
+                }
+            effective[path_key] = contents
+    if not effective:
+        # Constraint: no silent empty-branch PR. A real-write packet must carry
+        # the change set in changes_json (full files) and/or edits_json
+        # (search/replace blocks); failing loudly beats opening an empty PR.
+        return {
+            "error": (
+                "packet.payload must carry changes_json (object mapping "
+                "repo-relative paths to full new file contents, null to delete) "
+                "and/or edits_json (object mapping paths to a list of "
+                "{search, replace} blocks)"
+            ),
+            "error_kind": "missing_changes",
+        }
 
     # Step 1: base ref → base commit sha.
     ref_obj, err = _git_data_api(
@@ -705,7 +863,7 @@ def _materialize_branch(
 
     # Step 3: one blob per modified/created path (deletions carry no blob).
     tree_entries: list[dict[str, Any]] = []
-    for path_key, contents in changes_json.items():
+    for path_key, contents in effective.items():
         if contents is None:
             tree_entries.append(
                 {"path": path_key, "mode": "100644", "type": "blob", "sha": None}
@@ -1213,6 +1371,7 @@ def run_github_pr_effector(
     head_branch = payload.get("head_branch") or ""
     materialize = _materialize_branch(
         changes_json=payload.get("changes_json"),
+        edits_json=payload.get("edits_json"),
         destination=destination,
         base_branch=payload.get("base_branch") or "main",
         head_branch=head_branch,

--- a/tests/test_github_pr_edits_json.py
+++ b/tests/test_github_pr_edits_json.py
@@ -1,0 +1,208 @@
+"""Diff-based change format: edits_json (search/replace blocks) in the effector.
+
+The full-file `changes_json` path makes the writer re-emit a whole file, which
+truncates to placeholders on large files. `edits_json` lets the writer emit only
+the changed hunks as ``{path: [{search, replace}, ...]}``; the effector fetches
+the file at base_branch and applies the blocks (exact, unique-match, fail-closed)
+to produce full contents, then reuses the existing blob -> tree -> commit -> ref
+materialize path.
+
+Mocks ``_git_data_api`` so no network is touched. The contents fetch (Contents
+API GET) happens before the ref sequence.
+
+Design note: docs/design-notes/2026-05-29-diff-based-change-format.md
+"""
+
+from __future__ import annotations
+
+import base64
+
+from workflow.effectors import github_pr
+
+_DEST = "Jonnyton/Workflow"
+_HEAD = "patch-loop/edit-probe"
+_BASE = "main"
+
+
+def _b64(text: str) -> str:
+    return base64.b64encode(text.encode("utf-8")).decode("ascii")
+
+
+def _scripted_api(responses):
+    def fake(*, method, path, capability_token, body=None):
+        fake.calls.append((method, path, body))
+        for matcher, result in responses:
+            if matcher(method, path):
+                return result
+        raise AssertionError(f"no scripted response for {method} {path}")
+
+    fake.calls = []
+    return fake
+
+
+def _contents_response(path_frag: str, text: str):
+    return (
+        lambda m, p: m == "GET" and "/contents/" in p and path_frag in p,
+        ({"type": "file", "content": _b64(text)}, None),
+    )
+
+
+def _happy_tail():
+    """ref -> commit -> blob -> tree -> commit -> ref success sequence."""
+    return [
+        (lambda m, p: m == "GET" and p.endswith(f"/git/ref/heads/{_BASE}"),
+         ({"object": {"sha": "basecommitsha"}}, None)),
+        (lambda m, p: m == "GET" and "/git/commits/basecommitsha" in p,
+         ({"tree": {"sha": "basetreesha"}}, None)),
+        (lambda m, p: m == "POST" and p.endswith("/git/blobs"),
+         ({"sha": "blobsha"}, None)),
+        (lambda m, p: m == "POST" and p.endswith("/git/trees"),
+         ({"sha": "newtreesha"}, None)),
+        (lambda m, p: m == "POST" and p.endswith("/git/commits"),
+         ({"sha": "newcommitsha"}, None)),
+        (lambda m, p: m == "POST" and p.endswith("/git/refs"),
+         ({"ref": f"refs/heads/{_HEAD}"}, None)),
+    ]
+
+
+def _materialize(*, changes=None, edits=None):
+    return github_pr._materialize_branch(
+        changes_json=changes,
+        edits_json=edits,
+        destination=_DEST,
+        base_branch=_BASE,
+        head_branch=_HEAD,
+        commit_message="Edit probe",
+        capability_token="tok",
+    )
+
+
+# ── _apply_edit_blocks unit tests ──────────────────────────────────────────
+
+def test_apply_blocks_single_replace():
+    out, err = github_pr._apply_edit_blocks(
+        "a\nTARGET\nb\n", [{"search": "TARGET", "replace": "FIXED"}]
+    )
+    assert err is None
+    assert out == "a\nFIXED\nb\n"
+
+
+def test_apply_blocks_ordered_sequential():
+    out, err = github_pr._apply_edit_blocks(
+        "one two\n",
+        [{"search": "one", "replace": "1"}, {"search": "two", "replace": "2"}],
+    )
+    assert err is None and out == "1 2\n"
+
+
+def test_apply_blocks_not_found():
+    out, err = github_pr._apply_edit_blocks("abc", [{"search": "zzz", "replace": "x"}])
+    assert out is None and err["error_kind"] == "edit_search_not_found"
+
+
+def test_apply_blocks_not_unique():
+    out, err = github_pr._apply_edit_blocks(
+        "dup dup", [{"search": "dup", "replace": "x"}]
+    )
+    assert out is None and err["error_kind"] == "edit_search_not_unique"
+
+
+def test_apply_blocks_invalid_shape():
+    assert github_pr._apply_edit_blocks("a", [])[1]["error_kind"] == "invalid_edits"
+    assert github_pr._apply_edit_blocks("a", "nope")[1]["error_kind"] == "invalid_edits"
+    assert github_pr._apply_edit_blocks(
+        "a", [{"search": "", "replace": "x"}]
+    )[1]["error_kind"] == "invalid_edits"
+
+
+# ── _materialize_branch with edits_json ────────────────────────────────────
+
+def test_edits_happy_builds_branch_with_edited_content(monkeypatch):
+    current = "import os\n\n\ndef f():\n    return OLD\n"
+    responses = [_contents_response("calc.py", current)] + _happy_tail()
+    fake = _scripted_api(responses)
+    monkeypatch.setattr(github_pr, "_git_data_api", fake)
+    result = _materialize(edits={"calc.py": [{"search": "return OLD", "replace": "return NEW"}]})
+    assert result["materialized"] is True
+    # The blob created must hold the EDITED full contents, not the original.
+    blob_body = next(b for m, p, b in fake.calls if p.endswith("/git/blobs"))
+    assert blob_body["content"] == "import os\n\n\ndef f():\n    return NEW\n"
+    # Contents fetch happened before the ref lookup.
+    assert "/contents/" in fake.calls[0][1]
+
+
+def test_edits_only_no_changes_json_is_allowed(monkeypatch):
+    # Proves changes_json is no longer required when edits_json carries the change.
+    responses = [_contents_response("a.py", "x = 1\n")] + _happy_tail()
+    monkeypatch.setattr(github_pr, "_git_data_api", _scripted_api(responses))
+    result = _materialize(edits={"a.py": [{"search": "x = 1", "replace": "x = 2"}]})
+    assert result["materialized"] is True
+
+
+def test_edit_target_missing_maps_to_distinct_kind(monkeypatch):
+    responses = [
+        (lambda m, p: m == "GET" and "/contents/" in p,
+         (None, {"http_status": 404, "detail": "Not Found"})),
+    ]
+    monkeypatch.setattr(github_pr, "_git_data_api", _scripted_api(responses))
+    result = _materialize(edits={"missing.py": [{"search": "a", "replace": "b"}]})
+    assert result["error_kind"] == "edit_target_missing"
+
+
+def test_edit_search_not_found_fails_closed(monkeypatch):
+    responses = [_contents_response("a.py", "actual contents\n")]
+    monkeypatch.setattr(github_pr, "_git_data_api", _scripted_api(responses))
+    result = _materialize(edits={"a.py": [{"search": "nonexistent", "replace": "x"}]})
+    assert result["error_kind"] == "edit_search_not_found"
+    # No blob/commit/ref were created — failed before any write.
+
+
+def test_edit_search_not_unique_fails_closed(monkeypatch):
+    responses = [_contents_response("a.py", "dup\ndup\n")]
+    fake = _scripted_api(responses)
+    monkeypatch.setattr(github_pr, "_git_data_api", fake)
+    result = _materialize(edits={"a.py": [{"search": "dup", "replace": "x"}]})
+    assert result["error_kind"] == "edit_search_not_unique"
+    assert not any(p.endswith("/git/blobs") for _m, p, _b in fake.calls)
+
+
+def test_edit_fetch_scope_denied_maps_to_contents_write(monkeypatch):
+    responses = [
+        (lambda m, p: m == "GET" and "/contents/" in p,
+         (None, {"http_status": 403, "detail": "denied"})),
+    ]
+    monkeypatch.setattr(github_pr, "_git_data_api", _scripted_api(responses))
+    result = _materialize(edits={"a.py": [{"search": "a", "replace": "b"}]})
+    assert result["error_kind"] == "github_contents_write_denied"
+
+
+def test_path_in_both_changes_and_edits_rejected(monkeypatch):
+    responses = [_contents_response("a.py", "x\n")] + _happy_tail()
+    monkeypatch.setattr(github_pr, "_git_data_api", _scripted_api(responses))
+    result = _materialize(
+        changes={"a.py": "whole\n"},
+        edits={"a.py": [{"search": "x", "replace": "y"}]},
+    )
+    assert result["error_kind"] == "invalid_edits"
+
+
+def test_neither_changes_nor_edits_is_missing_changes(monkeypatch):
+    monkeypatch.setattr(github_pr, "_git_data_api", _scripted_api([]))
+    assert _materialize()["error_kind"] == "missing_changes"
+
+
+def test_changes_json_still_works_alongside_edits(monkeypatch):
+    # changes_json (new file) + edits_json (existing file) in one packet.
+    responses = [_contents_response("existing.py", "v = 1\n")] + _happy_tail()
+    # Two blobs needed (one per path); the scripted blob matcher returns the
+    # same sha for both, which is fine for this materialize-shape assertion.
+    fake = _scripted_api(responses)
+    monkeypatch.setattr(github_pr, "_git_data_api", fake)
+    result = _materialize(
+        changes={"newfile.py": "created\n"},
+        edits={"existing.py": [{"search": "v = 1", "replace": "v = 2"}]},
+    )
+    assert result["materialized"] is True
+    tree_call = next(b for m, p, b in fake.calls if p.endswith("/git/trees"))
+    paths = {e["path"] for e in tree_call["tree"]}
+    assert paths == {"newfile.py", "existing.py"}

--- a/workflow/effectors/github_pr.py
+++ b/workflow/effectors/github_pr.py
@@ -72,6 +72,7 @@ Design source: ``drafts/concepts/external-write-phase-2-authority.md``.
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import os
@@ -80,6 +81,7 @@ import sqlite3
 import subprocess
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -608,6 +610,126 @@ def _scope_or(error: dict[str, Any], step_kind: str) -> str:
     return step_kind
 
 
+_MAX_EDIT_BLOCKS_PER_FILE = 100
+
+
+def _fetch_file_at_ref(
+    *, owner_repo: str, path: str, ref: str, capability_token: str
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Fetch a file's decoded text at ``ref`` via the Contents API.
+
+    Returns ``(contents, None)`` on success or ``(None, error)`` where error is
+    the ``_git_data_api`` error dict. A 404 means the path does not exist at the
+    ref — edits cannot anchor on a missing file, so the caller maps that to
+    ``edit_target_missing``.
+    """
+    encoded = urllib.parse.quote(path, safe="/")
+    encoded_ref = urllib.parse.quote(ref, safe="")
+    obj, err = _git_data_api(
+        method="GET",
+        path=f"/repos/{owner_repo}/contents/{encoded}?ref={encoded_ref}",
+        capability_token=capability_token,
+    )
+    if err is not None:
+        return None, err
+    if not isinstance(obj, dict) or obj.get("type") != "file":
+        return None, {"http_status": None, "detail": "path is not a file"}
+    encoded_content = obj.get("content")
+    if not isinstance(encoded_content, str) or not encoded_content:
+        # Files >1MB return no inline content via the Contents API.
+        return None, {"http_status": None, "detail": "no inline content (file too large?)"}
+    try:
+        return base64.b64decode(encoded_content).decode("utf-8"), None
+    except (ValueError, UnicodeDecodeError) as exc:
+        return None, {"http_status": None, "detail": f"decode failed: {exc}"}
+
+
+def _apply_edit_blocks(
+    contents: str, blocks: Any
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Apply ordered search/replace blocks to ``contents`` (exact, unique).
+
+    Each block is ``{"search": <str>, "replace": <str>}``. The ``search`` text
+    must occur EXACTLY ONCE in the current contents (anchoring on real fetched
+    text — read_repo_files gives the model that text). Zero matches or multiple
+    matches fail closed so a bad edit never produces a corrupt commit. Blocks
+    apply in order; a later block sees the result of earlier ones.
+    """
+    def _bad(kind: str, detail: str):
+        return None, {"error_kind": kind, "detail": detail}
+
+    if not isinstance(blocks, list) or not blocks:
+        return _bad("invalid_edits", "edits must be a non-empty list of blocks")
+    if len(blocks) > _MAX_EDIT_BLOCKS_PER_FILE:
+        return _bad("invalid_edits", f"too many edit blocks (>{_MAX_EDIT_BLOCKS_PER_FILE})")
+    out = contents
+    for i, block in enumerate(blocks):
+        if not isinstance(block, dict):
+            return _bad("invalid_edits", f"block {i} is not an object")
+        search = block.get("search")
+        replace = block.get("replace")
+        if not isinstance(search, str) or not search:
+            return _bad("invalid_edits", f"block {i} has empty/non-string search")
+        if not isinstance(replace, str):
+            return _bad("invalid_edits", f"block {i} has non-string replace")
+        count = out.count(search)
+        if count == 0:
+            return _bad("edit_search_not_found", f"block {i} search text not found")
+        if count > 1:
+            return _bad(
+                "edit_search_not_unique",
+                f"block {i} search matches {count}x (must be unique; add context)",
+            )
+        out = out.replace(search, replace, 1)
+    return out, None
+
+
+def _resolve_edits(
+    *, edits_json: Any, destination: str, base_branch: str, capability_token: str
+) -> tuple[dict[str, str], dict[str, Any] | None]:
+    """Resolve ``edits_json`` ({path: [blocks]}) to ``{path: full_new_contents}``.
+
+    Fetches each target file at ``base_branch`` and applies its blocks. Returns
+    ``(resolved, None)`` or ``({}, error)`` with a distinct ``error_kind``. This
+    is the large-file path: the model emits only the changed hunks, never the
+    whole file, so it cannot truncate a big file into placeholders.
+    """
+    if not isinstance(edits_json, dict) or not edits_json:
+        return {}, {"error": "edits_json must be a non-empty object", "error_kind": "invalid_edits"}
+    resolved: dict[str, str] = {}
+    for path_key, blocks in edits_json.items():
+        if not isinstance(path_key, str) or not path_key.strip():
+            return {}, {
+                "error": "edits_json keys must be non-empty path strings",
+                "error_kind": "invalid_edits",
+            }
+        current, err = _fetch_file_at_ref(
+            owner_repo=destination, path=path_key, ref=base_branch,
+            capability_token=capability_token,
+        )
+        if err is not None:
+            if err.get("http_status") == 404:
+                return {}, {
+                    "error": (
+                        f"edit target {path_key!r} does not exist at {base_branch} "
+                        "(cannot edit a missing file; use changes_json to create it)"
+                    ),
+                    "error_kind": "edit_target_missing",
+                }
+            return {}, {
+                "error": f"could not fetch {path_key!r} to apply edits: {err.get('detail')}",
+                "error_kind": _scope_or(err, "edit_fetch_failed"),
+            }
+        new_contents, edit_err = _apply_edit_blocks(current, blocks)
+        if edit_err is not None:
+            return {}, {
+                "error": f"edits for {path_key!r}: {edit_err['detail']}",
+                "error_kind": edit_err["error_kind"],
+            }
+        resolved[path_key] = new_contents
+    return resolved, None
+
+
 def _materialize_branch(
     *,
     changes_json: Any,
@@ -616,6 +738,7 @@ def _materialize_branch(
     head_branch: str,
     commit_message: str,
     capability_token: str,
+    edits_json: Any = None,
 ) -> dict[str, Any]:
     """Build a remote head branch from ``changes_json`` via the Git Data API.
 
@@ -638,33 +761,68 @@ def _materialize_branch(
             "error": f"invalid GitHub repository destination: {destination!r}",
             "error_kind": "invalid_destination",
         }
-    if not isinstance(changes_json, dict) or not changes_json:
-        # Constraint: no silent empty-branch PR. A real-write packet must
-        # carry the change set; failing loudly beats opening an empty PR.
-        return {
-            "error": (
-                "packet.payload.changes_json is required and must be a "
-                "non-empty object mapping repo-relative paths to full new "
-                "file contents (null to delete)"
-            ),
-            "error_kind": "missing_changes",
-        }
     if not head_branch:
         return {
             "error": "packet.payload.head_branch is required to materialize a branch",
             "error_kind": "missing_head_branch",
         }
-    for path_key, contents in changes_json.items():
-        if not isinstance(path_key, str) or not path_key.strip():
+
+    # Build the effective {path: full-new-contents|None} map from two sources:
+    #   - changes_json: full-file replacements / creates / deletes (null).
+    #   - edits_json:   {path: [search/replace blocks]} resolved server-side
+    #                   against the file fetched at base_branch — the large-file
+    #                   path, so the model never has to re-emit a whole big file.
+    effective: dict[str, Any] = {}
+    if changes_json is not None:
+        if not isinstance(changes_json, dict):
             return {
-                "error": "changes_json keys must be non-empty repo-relative path strings",
+                "error": "packet.payload.changes_json must be an object or omitted",
                 "error_kind": "invalid_changes",
             }
-        if contents is not None and not isinstance(contents, str):
-            return {
-                "error": f"changes_json[{path_key!r}] must be a string or null (delete)",
-                "error_kind": "invalid_changes",
-            }
+        for path_key, contents in changes_json.items():
+            if not isinstance(path_key, str) or not path_key.strip():
+                return {
+                    "error": "changes_json keys must be non-empty repo-relative path strings",
+                    "error_kind": "invalid_changes",
+                }
+            if contents is not None and not isinstance(contents, str):
+                return {
+                    "error": f"changes_json[{path_key!r}] must be a string or null (delete)",
+                    "error_kind": "invalid_changes",
+                }
+            effective[path_key] = contents
+    if edits_json is not None:
+        resolved, edit_err = _resolve_edits(
+            edits_json=edits_json,
+            destination=owner_repo,
+            base_branch=base_branch,
+            capability_token=capability_token,
+        )
+        if edit_err is not None:
+            return edit_err
+        for path_key, contents in resolved.items():
+            if path_key in effective:
+                return {
+                    "error": (
+                        f"{path_key!r} appears in both changes_json and "
+                        "edits_json — supply only one per path"
+                    ),
+                    "error_kind": "invalid_edits",
+                }
+            effective[path_key] = contents
+    if not effective:
+        # Constraint: no silent empty-branch PR. A real-write packet must carry
+        # the change set in changes_json (full files) and/or edits_json
+        # (search/replace blocks); failing loudly beats opening an empty PR.
+        return {
+            "error": (
+                "packet.payload must carry changes_json (object mapping "
+                "repo-relative paths to full new file contents, null to delete) "
+                "and/or edits_json (object mapping paths to a list of "
+                "{search, replace} blocks)"
+            ),
+            "error_kind": "missing_changes",
+        }
 
     # Step 1: base ref → base commit sha.
     ref_obj, err = _git_data_api(
@@ -705,7 +863,7 @@ def _materialize_branch(
 
     # Step 3: one blob per modified/created path (deletions carry no blob).
     tree_entries: list[dict[str, Any]] = []
-    for path_key, contents in changes_json.items():
+    for path_key, contents in effective.items():
         if contents is None:
             tree_entries.append(
                 {"path": path_key, "mode": "100644", "type": "blob", "sha": None}
@@ -1213,6 +1371,7 @@ def run_github_pr_effector(
     head_branch = payload.get("head_branch") or ""
     materialize = _materialize_branch(
         changes_json=payload.get("changes_json"),
+        edits_json=payload.get("edits_json"),
         destination=destination,
         base_branch=payload.get("base_branch") or "main",
         head_branch=head_branch,


### PR DESCRIPTION
## What

Adds an optional `payload.edits_json` field to the `github_pull_request` packet: `{path: [{"search": "...", "replace": "..."}, ...]}`. The effector resolves it **server-side** to full file contents and reuses the existing blob→tree→commit→ref materialize path. The writer emits only the changed hunks, anchored on the exact text `read_repo_files` already gave it — so it never has to reproduce (and never truncates) a large file.

`changes_json` (full-file create/replace/delete) is unchanged. A packet may carry `changes_json`, `edits_json`, or both (disjoint paths); at least one non-empty required.

## Why

The small-sample re-drive showed the loop produces high-quality PRs on small/medium files (#1192, #1196) but **REJECTs large files** (~100KB `wiki.py`): the full-file-rewrite `propose` degrades to placeholders and the review gate correctly catches it. This is the documented **cutover blocker**. Search/replace edits remove the need to reproduce the whole file.

## Why search/replace, not unified diff
No line numbers (which drift/break); the anchor is verbatim existing text; correctness is locally checkable. Same exact-unique-match contract as the Claude Code Edit tool. Composes directly with `read_repo_files`.

## Semantics (fail-closed)
Per `edits_json` path: fetch at `base_branch` (Contents API) → apply blocks in order → each `search` must occur **exactly once** (0 → `edit_search_not_found`, >1 → `edit_search_not_unique`). Any failure aborts **before** any blob/commit/ref — a bad edit can never corrupt the file. 404 → `edit_target_missing`. ≤100 blocks/file. Path in both `changes_json` and `edits_json` → `invalid_edits`. Auth reuses the write token. Never raises.

## Tests
12 new (`tests/test_github_pr_edits_json.py`): `_apply_edit_blocks` unit (single/ordered/not-found/not-unique/invalid-shape), happy materialize with edited blob content, edits-only (no changes_json), target-missing, scope-denied, both-sources overlap, neither-source, changes+edits combined. **66 passed** with the full materialize/effector regression; ruff clean; mirror byte-identical.

## Scope
Effector capability only. The loop's `propose` emitting `edits_json` for existing-file edits is a separate connector-side rebuild (patch_request_loop **v5**) which — with this merged+deployed — unblocks the large-file cutover (re-validate against BUG-109 → `wiki.py`).

## Gate
Substrate primitive — opposite-provider checker review + host merge key, same as #1145/#1152/#1193.

Design note: `docs/design-notes/2026-05-29-diff-based-change-format.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)