### PR TITLE
Warn when file_bug drops unknown keyword arguments

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1940,8 +1940,8 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
-    unsupported = {
-        key: value for key, value in _kwargs.items()
+    dropped_kwargs = sorted(
+        key for key, value in _kwargs.items()
         if value not in ("", None, False)
         and not (
             (key == "dry_run" and value is True)
@@ -1950,18 +1950,7 @@ def _wiki_file_bug(
             or (key == "offset" and value == 0)
             or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
         )
-    }
-    if unsupported:
-        return json.dumps({
-            "error": (
-                "Unsupported file_bug field(s): "
-                + ", ".join(sorted(unsupported.keys()))
-            ),
-            "hint": (
-                "Use repro, observed, expected, and workaround for the filing body; "
-                "content is only for wiki write/patch actions."
-            ),
-        })
+    )
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",
@@ -2224,6 +2213,13 @@ def _wiki_file_bug(
         "note": "Filing sent to navigator triage pipeline. "
                 f"Use `wiki action=list category={category_dir}` to view.",
     }
+    if dropped_kwargs:
+        response_body["warning"] = (
+            "Dropped unsupported file_bug field(s): "
+            + ", ".join(dropped_kwargs)
+            + ". Use repro, observed, expected, and workaround for the filing body; "
+              "content is only for wiki write/patch actions."
+        )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries
         # / chatbots / operators) have a per-request-id join key without log

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1940,8 +1940,8 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
-    unsupported = {
-        key: value for key, value in _kwargs.items()
+    dropped_kwargs = sorted(
+        key for key, value in _kwargs.items()
         if value not in ("", None, False)
         and not (
             (key == "dry_run" and value is True)
@@ -1950,18 +1950,7 @@ def _wiki_file_bug(
             or (key == "offset" and value == 0)
             or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
         )
-    }
-    if unsupported:
-        return json.dumps({
-            "error": (
-                "Unsupported file_bug field(s): "
-                + ", ".join(sorted(unsupported.keys()))
-            ),
-            "hint": (
-                "Use repro, observed, expected, and workaround for the filing body; "
-                "content is only for wiki write/patch actions."
-            ),
-        })
+    )
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",
@@ -2224,6 +2213,13 @@ def _wiki_file_bug(
         "note": "Filing sent to navigator triage pipeline. "
                 f"Use `wiki action=list category={category_dir}` to view.",
     }
+    if dropped_kwargs:
+        response_body["warning"] = (
+            "Dropped unsupported file_bug field(s): "
+            + ", ".join(dropped_kwargs)
+            + ". Use repro, observed, expected, and workaround for the filing body; "
+              "content is only for wiki write/patch actions."
+        )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries
         # / chatbots / operators) have a per-request-id join key without log


### PR DESCRIPTION
Update `workflow/api/wiki.py` so `_wiki_file_bug` no longer rejects or silently ignores substantive unknown keyword arguments. This keeps the existing filing behavior, but adds a warning to successful `file_bug` responses that explicitly lists dropped kwarg names such as `content`, matching the request and surfacing potential data loss to callers.