### PR TITLE
chore(deploy): cutover — route file_bug investigations to patch_request_loop_v5

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -352,6 +352,17 @@ jobs:
           ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
               "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
               "printf '%s' '${NEW_IMAGE}' | sudo bash /tmp/install-workflow-env.sh set WORKFLOW_IMAGE"
+          # Cutover (2026-05-29): route file_bug investigation requests to the
+          # user-buildable patch-request loop instead of the legacy cheat branch.
+          # patch_request_loop_v5 (branch_def_id 0ca6e9c97f65) localizes via
+          # search_repo_files, reads existing files via read_repo_files, edits
+          # via the github_pull_request effector's edits_json diff format, and
+          # opens a real draft PR. Replaces fd5c66b1d87d, which produced only
+          # analysis packets and was failing every run. Idempotent set; reverting
+          # this block restores the prior handler on the next deploy.
+          ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
+              "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
+              "printf '%s' '0ca6e9c97f65' | sudo bash /tmp/install-workflow-env.sh set WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID"
           if [ "${HAS_CODEX_AUTH_BUNDLE}" = "true" ]; then
             echo "Deploy-visible WORKFLOW_CODEX_AUTH_JSON_B64 found; syncing subscription auth bundle."
             printf '%s' "${WORKFLOW_CODEX_AUTH_JSON_B64}" | ssh -i ~/.ssh/do_deploy -o BatchMode=yes \


### PR DESCRIPTION
## The cutover flip

Routes `file_bug` investigation requests from the legacy **cheat branch** `fd5c66b1d87d` (analysis packets only; failing every run — `_text`/`_caller`/JSON-contract/timeout errors) to the **user-buildable** `patch_request_loop_v5` (`branch_def_id 0ca6e9c97f65`).

One idempotent `set WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID` step in the prod deploy (PR-128 pattern) pins the env var that `_maybe_enqueue_investigation` reads at `file_bug` time. `+11` lines, deploy-only, revertable.

## v5 path (all substrate merged + live)
`localize → search_repo_files (#1193) → select canonical (excl. mirror) → read_repo_files (#1152) → propose (edits_json diff format #1197 for existing files, changes_json for new) → review-gate-with-read-evidence → github_pull_request effector`.

Proven end-to-end on real backlog inputs:
- small/medium files → clean PRs (#1192 calc.py, #1196 idempotency.py)
- **large ~100KB files → edit cleanly** via `edits_json` (#1198 `wiki.py`, +10/−14)
- bad / unlocalizable / pure-concept filings → **fail-safe REJECT** (no PR), never garbage

## Effect + safety
Future filings open real **draft** PRs (human-reviewed), gated by the review fail-safe. The existing failed backlog re-drives separately (no auto-backfill). Revert this block → prior handler restored on next deploy.

Gate: CI `actionlint` runs on this workflow edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)