### PR TITLE
fix(search): rank path-like query terms above the same-basename flood

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_search.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_search.py
@@ -197,9 +197,19 @@ def _term_variants(term: str) -> list[str]:
 def _match_rank(path: str, terms: list[str]) -> int:
     """Rank a path against terms. 0 = no match; higher = better.
 
-    3 = a term matches the basename exactly or as a prefix;
-    2 = a term matches inside the basename (or glob matches the path);
-    1 = a term matches inside the full path only.
+    A path-like term (contains ``/``) is the strongest signal a caller can
+    give — it names a location, not just a filename — so it must outrank the
+    flood of same-basename hits. Without this, a query carrying both the exact
+    path ``workflow/api/__init__.py`` and a common basename term gets the exact
+    file buried among hundreds of rank-3 ``__init__.py`` matches and truncated
+    out by the result cap (the PR-157 localization miss).
+
+    6 = exact full-path equality (term == path);
+    5 = path-suffix match (path ends with the slash-bearing term);
+    4 = the slash-bearing term appears anywhere in the path;
+    3 = basename equals or is prefixed by the term;
+    2 = the term appears inside the basename, or a glob matches;
+    1 = the term appears anywhere in the full path.
     """
     lower = path.lower()
     basename = path.rsplit("/", 1)[-1].lower()
@@ -210,6 +220,15 @@ def _match_rank(path: str, terms: list[str]) -> int:
             if _GLOB_CHARS.search(variant):
                 if fnmatch.fnmatch(lower, v) or fnmatch.fnmatch(basename, v):
                     best = max(best, 2)
+                continue
+            if "/" in v:
+                # Path-like term: location signal beats basename-only matches.
+                if lower == v:
+                    best = max(best, 6)
+                elif lower.endswith("/" + v) or lower.endswith(v):
+                    best = max(best, 5)
+                elif v in lower:
+                    best = max(best, 4)
                 continue
             if basename == v or basename.startswith(v):
                 best = max(best, 3)

--- a/tests/test_github_search_repo_files.py
+++ b/tests/test_github_search_repo_files.py
@@ -78,6 +78,42 @@ def test_happy_substring_match_and_ranking(monkeypatch):
     assert status["ref"] == "main"
 
 
+def test_exact_path_term_outranks_basename_flood(monkeypatch):
+    # PR-157 regression: a query carrying the exact path AND a common basename
+    # must surface the exact file at the top, not let a crowd of same-basename
+    # files truncate it out under the result cap.
+    flood = [f"pkg{i}/__init__.py" for i in range(40)]
+    http = _fake_http(tree=_tree("workflow/api/__init__.py", *flood))
+    matched, status = _run(
+        {"search_destination": _DEST,
+         "search_query": "workflow/api/__init__.py __init__.py"},
+        monkeypatch, http, env={"WORKFLOW_GITHUB_SEARCH_MAX_RESULTS": "5"},
+    )
+    # Even capped at 5 of 41 matches, the exact-path file ranks first.
+    assert matched[0] == "workflow/api/__init__.py"
+
+
+def test_path_suffix_term_ranks_above_basename(monkeypatch):
+    http = _fake_http(tree=_tree(
+        "workflow/api/runs.py", "tests/test_runs.py", "other/runs.py",
+    ))
+    matched, _status = _run(
+        {"search_destination": _DEST, "search_query": "api/runs.py runs.py"},
+        monkeypatch, http,
+    )
+    assert matched[0] == "workflow/api/runs.py"
+
+
+def test_rank_exact_path_beats_suffix_beats_basename():
+    # Unit check on the rank tiers for a path-like term.
+    terms = ["workflow/api/wiki.py"]
+    assert gs._match_rank("workflow/api/wiki.py", terms) == 6      # exact
+    assert gs._match_rank("x/workflow/api/wiki.py", terms) == 5    # suffix
+    assert gs._match_rank("workflow/api/wiki.py.bak", terms) == 4  # contains
+    # basename-only candidate: a path-like term does not match it at all.
+    assert gs._match_rank("other/wiki.py", terms) == 0
+
+
 def test_dotted_module_matches_slash_path(monkeypatch):
     http = _fake_http(tree=_tree("workflow/api/wiki.py", "workflow/api/runs.py"))
     matched, _status = _run(

--- a/workflow/effectors/github_search.py
+++ b/workflow/effectors/github_search.py
@@ -197,9 +197,19 @@ def _term_variants(term: str) -> list[str]:
 def _match_rank(path: str, terms: list[str]) -> int:
     """Rank a path against terms. 0 = no match; higher = better.
 
-    3 = a term matches the basename exactly or as a prefix;
-    2 = a term matches inside the basename (or glob matches the path);
-    1 = a term matches inside the full path only.
+    A path-like term (contains ``/``) is the strongest signal a caller can
+    give — it names a location, not just a filename — so it must outrank the
+    flood of same-basename hits. Without this, a query carrying both the exact
+    path ``workflow/api/__init__.py`` and a common basename term gets the exact
+    file buried among hundreds of rank-3 ``__init__.py`` matches and truncated
+    out by the result cap (the PR-157 localization miss).
+
+    6 = exact full-path equality (term == path);
+    5 = path-suffix match (path ends with the slash-bearing term);
+    4 = the slash-bearing term appears anywhere in the path;
+    3 = basename equals or is prefixed by the term;
+    2 = the term appears inside the basename, or a glob matches;
+    1 = the term appears anywhere in the full path.
     """
     lower = path.lower()
     basename = path.rsplit("/", 1)[-1].lower()
@@ -210,6 +220,15 @@ def _match_rank(path: str, terms: list[str]) -> int:
             if _GLOB_CHARS.search(variant):
                 if fnmatch.fnmatch(lower, v) or fnmatch.fnmatch(basename, v):
                     best = max(best, 2)
+                continue
+            if "/" in v:
+                # Path-like term: location signal beats basename-only matches.
+                if lower == v:
+                    best = max(best, 6)
+                elif lower.endswith("/" + v) or lower.endswith(v):
+                    best = max(best, 5)
+                elif v in lower:
+                    best = max(best, 4)
                 continue
             if basename == v or basename.startswith(v):
                 best = max(best, 3)


### PR DESCRIPTION
## What
`search_repo_files._match_rank` ranked a full-path query term (e.g. `workflow/api/__init__.py`) only as a generic full-path substring (rank **1**) — below basename matches (rank 3). A query carrying both the exact path and a common basename buried the exact file among hundreds of rank-3 `__init__.py` hits, and the result cap truncated it out (the PR-157 localization miss: select_paths got a candidate list missing the target).

New tiers for a path-like term (contains `/`): **6** exact equality, **5** path-suffix, **4** path-contains — all above basename (3) / basename-substring (2) / full-path-substring (1). Exact file now sorts to the top and survives the cap.

## Why (process note)
Found by *measuring* (running PR-157 through the loop), not assuming the fix was in the loop prompt or a speculative content-grep primitive — neither would have helped. Measuring before building avoided a wrong, token-gated `grep_repo` build.

## Tests
3 new (PR-157 flood-under-cap reproduction; path-suffix ranking; rank-tier unit) + full search suite = **18 passed**. ruff clean; plugin mirror byte-identical.

## Scope/safety
Strict ranking improvement; existing tests unchanged-green. Does not change live cutover until a redeploy + v6 re-point. Revert = restore prior `_match_rank`.

Gate: opposite-provider checker / host merge key (substrate primitive, same as #1152/#1193/#1197).

🤖 Generated with [Claude Code](https://claude.com/claude-code)