### PR TITLE
fix(exec): BUG-112 — source_code nodes exec into a single namespace (helpers visible to run())

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/executors/node_bid.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/executors/node_bid.py
@@ -143,14 +143,13 @@ def execute_node_bid(
     # Strip producer-internal keys before exposing to node body.
     user_inputs = _strip_producer_keys(dict(bid.inputs or {}))
 
-    # Execute source — define runner, call run(state).
-    local_scope: dict = {}
+    # Execute source — define runner, call run(state). BUG-112: a SINGLE
+    # namespace (globals == locals) so top-level helpers are visible to run();
+    # split globals/locals puts defs in locals but their __globals__ is the
+    # globals dict, so run() can't see sibling helpers -> NameError.
+    namespace: dict = {"__builtins__": __builtins__}
     try:
-        exec(  # noqa: S102 — approved source with expanded pattern scan
-            source,
-            {"__builtins__": __builtins__},
-            local_scope,
-        )
+        exec(source, namespace)  # noqa: S102 — approved source, pattern-scanned
     except Exception as exc:  # noqa: BLE001
         return NodeBidResult(
             node_bid_id=node_bid_id,
@@ -158,7 +157,7 @@ def execute_node_bid(
             error=f"source_load_error: {exc}",
         )
 
-    runner = local_scope.get("run")
+    runner = namespace.get("run")
     if not callable(runner):
         return NodeBidResult(
             node_bid_id=node_bid_id,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
@@ -1306,21 +1306,23 @@ def _build_source_code_node(
     timeout_s = float(node.timeout_seconds or 300.0)
     invoke_mcp_action = _build_node_mcp_invoker(node, event_sink=event_sink)
 
-    local_scope: dict[str, Any] = {}
+    # BUG-112: exec into a SINGLE namespace (globals == locals). With split
+    # globals/locals, top-level defs land in locals, but each function's
+    # __globals__ is the globals dict — so run() cannot see a sibling top-level
+    # helper (def _helper) and raises NameError at call time. One namespace
+    # restores module-level semantics: every top-level name is visible to every
+    # other. The injected globals (builtins, invoke_mcp_action) seed it.
+    namespace: dict[str, Any] = {
+        "__builtins__": __builtins__,
+        "invoke_mcp_action": invoke_mcp_action,
+    }
     try:
-        exec(  # noqa: S102
-            src,
-            {
-                "__builtins__": __builtins__,
-                "invoke_mcp_action": invoke_mcp_action,
-            },
-            local_scope,
-        )
+        exec(src, namespace)  # noqa: S102
     except Exception as exc:
         raise CompilerError(
             f"Node '{node.node_id}' source_code failed to load: {exc}"
         ) from exc
-    runner = local_scope.get("run")
+    runner = namespace.get("run")
     if not callable(runner):
         raise CompilerError(
             f"Node '{node.node_id}' source_code must define `def run(state)`."

--- a/tests/test_node_bid.py
+++ b/tests/test_node_bid.py
@@ -356,6 +356,31 @@ def test_execute_succeeds_writes_artifact(tmp_path):
     assert json.loads(artifact.read_text()) == {"echo": 42}
 
 
+def test_execute_run_sees_top_level_helpers(tmp_path):
+    """BUG-112 regression (node_bid exec path): run() must see sibling
+    top-level helpers. Split globals/locals raised NameError; a single
+    exec namespace restores module-level visibility.
+    """
+    node = _make_approved_node(
+        "with_helper",
+        "def _double(n):\n"
+        "    return n * 2\n"
+        "\n"
+        "def run(state):\n"
+        "    return {'echo': _double(state.get('x', 0))}\n",
+    )
+    bid = NodeBid(
+        node_bid_id="nb_helper", node_def_id="with_helper",
+        inputs={"x": 21}, status="open",
+    )
+    result = execute_node_bid(
+        bid, node_lookup_fn=lambda nid: node if nid == "with_helper" else None,
+        output_dir=tmp_path,
+    )
+    assert result.status == "succeeded"
+    assert result.output == {"echo": 42}
+
+
 def test_execute_unknown_node_fails(tmp_path):
     bid = NodeBid(node_bid_id="nb_nf", node_def_id="missing", status="open")
     result = execute_node_bid(

--- a/tests/test_unified_execution.py
+++ b/tests/test_unified_execution.py
@@ -126,6 +126,29 @@ def test_opaque_node_resolves_via_registry(clean_registry):
     assert result.get("seen") is True
 
 
+def test_source_code_node_run_sees_top_level_helpers(clean_registry):
+    """BUG-112 regression: a source_code node's run() must see sibling
+    top-level helper functions. Split globals/locals put the defs in
+    locals while run.__globals__ stayed the globals dict, so calling a
+    helper raised NameError (the live `name '_text' is not defined`).
+    A single exec namespace restores module-level visibility.
+    """
+    from workflow.graph_compiler import compile_branch
+
+    src = (
+        "def _text(value):\n"
+        "    return f'helper:{value}'\n"
+        "\n"
+        "def run(state):\n"
+        "    return {'foo': _text(state.get('name', 'n'))}\n"
+    )
+    branch = _minimal_branch(node_body={"source_code": src, "approved": True})
+    compiled = compile_branch(branch)
+    runner = compiled.graph.compile()
+    result = runner.invoke({"name": "Z"})
+    assert result.get("foo") == "helper:Z"
+
+
 def test_unregistered_opaque_node_raises_compiler_error(clean_registry):
     """A body-less node whose (domain_id, node_id) is not in the
     registry raises CompilerError at compile time, not at runtime.

--- a/workflow/executors/node_bid.py
+++ b/workflow/executors/node_bid.py
@@ -143,14 +143,13 @@ def execute_node_bid(
     # Strip producer-internal keys before exposing to node body.
     user_inputs = _strip_producer_keys(dict(bid.inputs or {}))
 
-    # Execute source — define runner, call run(state).
-    local_scope: dict = {}
+    # Execute source — define runner, call run(state). BUG-112: a SINGLE
+    # namespace (globals == locals) so top-level helpers are visible to run();
+    # split globals/locals puts defs in locals but their __globals__ is the
+    # globals dict, so run() can't see sibling helpers -> NameError.
+    namespace: dict = {"__builtins__": __builtins__}
     try:
-        exec(  # noqa: S102 — approved source with expanded pattern scan
-            source,
-            {"__builtins__": __builtins__},
-            local_scope,
-        )
+        exec(source, namespace)  # noqa: S102 — approved source, pattern-scanned
     except Exception as exc:  # noqa: BLE001
         return NodeBidResult(
             node_bid_id=node_bid_id,
@@ -158,7 +157,7 @@ def execute_node_bid(
             error=f"source_load_error: {exc}",
         )
 
-    runner = local_scope.get("run")
+    runner = namespace.get("run")
     if not callable(runner):
         return NodeBidResult(
             node_bid_id=node_bid_id,

--- a/workflow/graph_compiler.py
+++ b/workflow/graph_compiler.py
@@ -1306,21 +1306,23 @@ def _build_source_code_node(
     timeout_s = float(node.timeout_seconds or 300.0)
     invoke_mcp_action = _build_node_mcp_invoker(node, event_sink=event_sink)
 
-    local_scope: dict[str, Any] = {}
+    # BUG-112: exec into a SINGLE namespace (globals == locals). With split
+    # globals/locals, top-level defs land in locals, but each function's
+    # __globals__ is the globals dict — so run() cannot see a sibling top-level
+    # helper (def _helper) and raises NameError at call time. One namespace
+    # restores module-level semantics: every top-level name is visible to every
+    # other. The injected globals (builtins, invoke_mcp_action) seed it.
+    namespace: dict[str, Any] = {
+        "__builtins__": __builtins__,
+        "invoke_mcp_action": invoke_mcp_action,
+    }
     try:
-        exec(  # noqa: S102
-            src,
-            {
-                "__builtins__": __builtins__,
-                "invoke_mcp_action": invoke_mcp_action,
-            },
-            local_scope,
-        )
+        exec(src, namespace)  # noqa: S102
     except Exception as exc:
         raise CompilerError(
             f"Node '{node.node_id}' source_code failed to load: {exc}"
         ) from exc
-    runner = local_scope.get("run")
+    runner = namespace.get("run")
     if not callable(runner):
         raise CompilerError(
             f"Node '{node.node_id}' source_code must define `def run(state)`."


### PR DESCRIPTION
## What
`graph_compiler.py` and `executors/node_bid.py` exec'd approved `source_code` with **separate globals/locals**. Top-level `def`s land in *locals*, but each function's `__globals__` is the *globals* dict — so `run(state)` calling a sibling top-level helper (`def _text`) resolved the name against globals, which lacked it → **NameError**.

Fix: exec into **one namespace** (`globals == locals`), restoring module-level semantics where every top-level name is visible to every other. Both sites; the injected globals (`__builtins__`, `invoke_mcp_action`) seed the namespace.

## Why it matters
Live root cause of `release_ship_validator → "name '_text' is not defined"` — **11 of 39** failed queue tasks in `local-bubble-galactic-survival-model`. It makes **any multi-function user `source_code` node** fail, so it must land before user-built loops run `source_code` nodes. (The current v5 cutover loop has no `source_code` nodes, so it isn't broken today — this is the user-buildability completeness fix.)

## Tests
2 regressions — a node defining a helper and calling it from `run()`, via **both** exec paths (`test_unified_execution::test_source_code_node_run_sees_top_level_helpers`, `test_node_bid::test_execute_run_sees_top_level_helpers`). **96 passed** across the touched suites; ruff clean.

## Mirror
The report required propagating to the vendored copies — plugin mirror regenerated, byte-identical parity (pre-commit verified 2 canonical files).

Wiki: `pages/bugs/bug-112-node-source-code-exec-uses-split-globals-locals-namespace-he.md`
Gate: opposite-provider checker + host merge key (substrate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)