### PR TITLE
Guard release_bonus against retracted claims

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/gates/actions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/gates/actions.py
@@ -214,6 +214,11 @@ def release_bonus(
 
     claim = GateBonusClaim.from_row(row)
 
+    if claim.is_retracted:
+        return {
+            "status": "rejected",
+            "error": "Cannot release bonus on a retracted claim.",
+        }
     if claim.bonus_stake == 0:
         return {
             "status": "rejected",

--- a/workflow/gates/actions.py
+++ b/workflow/gates/actions.py
@@ -214,6 +214,11 @@ def release_bonus(
 
     claim = GateBonusClaim.from_row(row)
 
+    if claim.is_retracted:
+        return {
+            "status": "rejected",
+            "error": "Cannot release bonus on a retracted claim.",
+        }
     if claim.bonus_stake == 0:
         return {
             "status": "rejected",


### PR DESCRIPTION
Update `release_bonus` in `workflow/gates/actions.py` to enforce the same `claim.is_retracted` handling already used by `stake_bonus` and `unstake_bonus`. This change rejects bonus release attempts for later-retracted claims before any disbursement logic runs, preventing payout or release from a retracted claim and keeping behavior aligned with the sibling gate bonus action handlers described in the request.