### PR TITLE
fix(backfill): version-agnostic dedup so loop changes don't re-drive the whole corpus

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/bug_investigation.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/bug_investigation.py
@@ -486,15 +486,21 @@ def backfill_investigations(base_path: "Path | str", *, universe_id: str = "") -
             continue
         # Carry the original bug frontmatter forward (observed/expected/etc.).
         inputs_by_bug.setdefault(bid, dict(t.inputs or {}))
-        if t.branch_def_id != canonical:
-            # Other-loop history (e.g. the retired cheat branch) supplies inputs
-            # but does NOT count toward this loop's resolved/failed state.
-            continue
+        # Resolved + in-flight are VERSION-AGNOSTIC: a succeeded run under ANY
+        # loop version parks the bug permanently, and a pending/running task
+        # under any version means it is already in flight. This is what keeps a
+        # loop-version change (or the cheat->v5 cutover) from re-driving the
+        # entire historical corpus — only genuinely-unresolved bugs are driven.
         if t.status == "succeeded":
             succeeded.add(bid)
-        elif t.status in ("pending", "running"):
+            continue
+        if t.status in ("pending", "running"):
             active.add(bid)
-        elif t.status == "failed":
+            continue
+        # The failed RETRY BUDGET stays scoped to the CURRENT canonical, so a
+        # new/better loop gets a fresh retry budget on bugs that only ever
+        # errored under a prior loop version (those are unresolved, not parked).
+        if t.status == "failed" and t.branch_def_id == canonical:
             failed[bid] += 1
 
     retry_cap = _backfill_int("WORKFLOW_BUG_INVESTIGATION_BACKFILL_RETRIES", 3)

--- a/tests/test_bug_investigation_backfill.py
+++ b/tests/test_bug_investigation_backfill.py
@@ -88,6 +88,24 @@ def test_succeeded_overrides_old_failed(tmp_path, monkeypatch):
     assert backfill_investigations(tmp_path) == 0
 
 
+def test_succeeded_under_old_loop_version_parks_bug(tmp_path, monkeypatch):
+    # Version-agnostic resolution: a succeeded run under a PRIOR loop version
+    # (e.g. the retired cheat branch) parks the bug — a loop-version change /
+    # cutover must NOT re-drive bugs the old loop already resolved. Regression
+    # for the current-canonical-scoped dedup that re-drove the whole corpus.
+    _set(monkeypatch)
+    append_task(tmp_path, _task("BUG-1", "succeeded", branch_def_id=OLD))
+    assert backfill_investigations(tmp_path) == 0
+
+
+def test_in_flight_under_old_loop_version_skips(tmp_path, monkeypatch):
+    # In-flight is also version-agnostic: a pending/running task under any loop
+    # version means the bug is already being worked — do not double-enqueue.
+    _set(monkeypatch)
+    append_task(tmp_path, _task("BUG-1", "running", branch_def_id=OLD))
+    assert backfill_investigations(tmp_path) == 0
+
+
 def test_skips_in_flight(tmp_path, monkeypatch):
     _set(monkeypatch)
     append_task(tmp_path, _task("BUG-1", "running"))

--- a/workflow/bug_investigation.py
+++ b/workflow/bug_investigation.py
@@ -486,15 +486,21 @@ def backfill_investigations(base_path: "Path | str", *, universe_id: str = "") -
             continue
         # Carry the original bug frontmatter forward (observed/expected/etc.).
         inputs_by_bug.setdefault(bid, dict(t.inputs or {}))
-        if t.branch_def_id != canonical:
-            # Other-loop history (e.g. the retired cheat branch) supplies inputs
-            # but does NOT count toward this loop's resolved/failed state.
-            continue
+        # Resolved + in-flight are VERSION-AGNOSTIC: a succeeded run under ANY
+        # loop version parks the bug permanently, and a pending/running task
+        # under any version means it is already in flight. This is what keeps a
+        # loop-version change (or the cheat->v5 cutover) from re-driving the
+        # entire historical corpus — only genuinely-unresolved bugs are driven.
         if t.status == "succeeded":
             succeeded.add(bid)
-        elif t.status in ("pending", "running"):
+            continue
+        if t.status in ("pending", "running"):
             active.add(bid)
-        elif t.status == "failed":
+            continue
+        # The failed RETRY BUDGET stays scoped to the CURRENT canonical, so a
+        # new/better loop gets a fresh retry budget on bugs that only ever
+        # errored under a prior loop version (those are unresolved, not parked).
+        if t.status == "failed" and t.branch_def_id == canonical:
             failed[bid] += 1
 
     retry_cap = _backfill_int("WORKFLOW_BUG_INVESTIGATION_BACKFILL_RETRIES", 3)


### PR DESCRIPTION
## Problem (found while watching the live backfill drain)

The autonomous backfill (#1207, live on the droplet since `afaf1bd5`) was **filling, not draining**: `pending` climbed 35→47→… while drain held ~8/hr. Root cause: `backfill_investigations` scoped *resolved* to the **current canonical** loop — it ran `if t.branch_def_id != canonical: continue` **before** counting `succeeded`. So a bug the **prior loop version / retired cheat loop** already resolved looked unresolved under v5 and got re-driven.

Net effect: the cheat→v5 cutover re-drove the **entire historical bug corpus** (bugs + design/proposal pages, IDs spanning `bug-096`…`pr-148`), not the ~59 failed backlog. This:
- contradicts the function's own docstring — *"loop version is not part of the dedup; only unresolved/failed bugs are ever (re)driven"*; and
- is exactly the *"are we re-running all bugs each time we update the loop?"* failure mode the host flagged — every future loop-version bump would re-flood.

## Fix

- `succeeded` / `active` become **version-agnostic**: a succeeded run under *any* loop version parks the bug permanently; a pending/running task under any version counts as in-flight.
- The `failed` **retry budget stays current-canonical-scoped**, so a new/better loop still gets a fresh retry budget on bugs that only ever errored under a prior version (those are genuinely unresolved, not parked).

## Tests

- Adds `test_succeeded_under_old_loop_version_parks_bug` and `test_in_flight_under_old_loop_version_skips` — both **fail on the prior logic**, pass now.
- Full file: 13 passed (`pytest tests/test_bug_investigation_backfill.py -p no:cacheprovider`). `ruff` clean. Plugin mirror rebuilt (pre-commit parity verified).

## Note on the in-flight corpus

This stops *future* over-enqueue. The ~47 already-pending corpus items will drain harmlessly (mostly fail-safe REJECTs, no PR); they can be left to drain or purged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)