### PR TITLE
Add per-staker funded escrow reservations

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/payments/actions.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/payments/actions.py
@@ -16,6 +16,7 @@ from typing import Any
 from workflow.payments.escrow import (
     DuplicateLockError,
     EscrowLock,
+    InsufficientFundsError,
     LockAlreadyResolvedError,
     LockNotFoundError,
     get_lock,
@@ -83,6 +84,7 @@ def action_escrow_lock(
             gate_claim_id=node_id,
             staker_id=claimer,
             amount=amount,
+            currency=currency,
             locked_at=locked_at,
         )
     except DuplicateLockError:
@@ -95,13 +97,15 @@ def action_escrow_lock(
             ),
             "existing_lock_id": existing.lock_id if existing else None,
         }
+    except InsufficientFundsError as exc:
+        return {"status": "rejected", "error": str(exc)}
 
     return {
         "status": "ok",
         "lock_id": lock.lock_id,
         "node_id": node_id,
         "amount": lock.amount,
-        "currency": currency,
+        "currency": lock.currency,
         "claimer": claimer,
         "locked_at": lock.locked_at,
     }
@@ -223,6 +227,7 @@ def action_escrow_inspect(
             "node_id": lk.gate_claim_id,
             "claimer": lk.staker_id,
             "amount": lk.amount,
+            "currency": lk.currency,
             "status": lk.status,
             "locked_at": lk.locked_at,
             "resolved_at": lk.resolved_at,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/payments/escrow.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/payments/escrow.py
@@ -28,13 +28,18 @@ import sqlite3
 from dataclasses import dataclass
 from typing import Literal
 
+from workflow.payments.schema import STAKER_ESCROW_BUDGET_SCHEMA, StakerEscrowBudget
+
+DEFAULT_CURRENCY = "MicroToken"
+
 # ── Schema ────────────────────────────────────────────────────────────────────
 
-ESCROW_SCHEMA = """
+ESCROW_LOCKS_SCHEMA = """
 CREATE TABLE IF NOT EXISTS escrow_locks (
     lock_id         TEXT PRIMARY KEY,
     gate_claim_id   TEXT NOT NULL,
     staker_id       TEXT NOT NULL,
+    currency        TEXT NOT NULL DEFAULT 'MicroToken',
     amount          INTEGER NOT NULL CHECK (amount >= 0),
     status          TEXT NOT NULL DEFAULT 'locked'
                         CHECK (status IN ('locked', 'released', 'refunded')),
@@ -50,6 +55,8 @@ CREATE INDEX IF NOT EXISTS idx_escrow_gate_claim
 CREATE INDEX IF NOT EXISTS idx_escrow_staker
     ON escrow_locks(staker_id);
 """
+
+ESCROW_SCHEMA = STAKER_ESCROW_BUDGET_SCHEMA + "\n" + ESCROW_LOCKS_SCHEMA
 
 # ── Status type ───────────────────────────────────────────────────────────────
 
@@ -74,6 +81,10 @@ class LockAlreadyResolvedError(EscrowError):
     """Raised when attempting to release/refund an already-resolved lock."""
 
 
+class InsufficientFundsError(EscrowError):
+    """Raised when a staker budget lacks enough uncommitted funds."""
+
+
 class UnauthorizedUnstakeError(EscrowError):
     """Raised when a non-staker attempts to unstake."""
 
@@ -87,6 +98,7 @@ class EscrowLock:
     lock_id: str
     gate_claim_id: str
     staker_id: str
+    currency: str
     amount: int
     status: EscrowStatus
     locked_at: str
@@ -112,6 +124,7 @@ class EscrowLock:
             lock_id=d["lock_id"],
             gate_claim_id=d["gate_claim_id"],
             staker_id=d["staker_id"],
+            currency=d.get("currency") or DEFAULT_CURRENCY,
             amount=int(d["amount"]),
             status=d["status"],
             locked_at=d["locked_at"],
@@ -122,9 +135,190 @@ class EscrowLock:
 
 # ── Migration ─────────────────────────────────────────────────────────────────
 
+def _canonical_currency(currency: str) -> str:
+    return DEFAULT_CURRENCY if currency == "token" else currency or DEFAULT_CURRENCY
+
+
 def migrate_escrow_schema(conn: sqlite3.Connection) -> None:
-    """Create escrow_locks table if absent. Idempotent."""
+    """Create escrow tables if absent and backfill required columns."""
     conn.executescript(ESCROW_SCHEMA)
+    columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(escrow_locks)").fetchall()
+    }
+    if "currency" not in columns:
+        conn.execute(
+            "ALTER TABLE escrow_locks "
+            "ADD COLUMN currency TEXT NOT NULL DEFAULT 'MicroToken'"
+        )
+
+
+def get_staker_balance(
+    conn: sqlite3.Connection,
+    *,
+    staker_id: str,
+    currency: str = DEFAULT_CURRENCY,
+) -> StakerEscrowBudget | None:
+    """Return the persisted budget for a staker/currency pair, if present."""
+    row = conn.execute(
+        """
+        SELECT * FROM staker_escrow_budget
+        WHERE staker_id = ? AND currency = ?
+        """,
+        (staker_id, _canonical_currency(currency)),
+    ).fetchone()
+    return StakerEscrowBudget.from_row(row) if row else None
+
+
+def upsert_staker_balance(
+    conn: sqlite3.Connection,
+    *,
+    staker_id: str,
+    currency: str = DEFAULT_CURRENCY,
+    total_amount: int,
+    reserved_amount: int = 0,
+    updated_at: str,
+) -> StakerEscrowBudget:
+    """Create or replace a staker budget record."""
+    if total_amount < 0:
+        raise EscrowError(f"total_amount must be >= 0, got {total_amount!r}")
+    if reserved_amount < 0:
+        raise EscrowError(
+            f"reserved_amount must be >= 0, got {reserved_amount!r}"
+        )
+    if reserved_amount > total_amount:
+        raise EscrowError(
+            "reserved_amount cannot exceed total_amount "
+            f"({reserved_amount!r} > {total_amount!r})"
+        )
+    currency = _canonical_currency(currency)
+    conn.execute(
+        """
+        INSERT INTO staker_escrow_budget
+            (staker_id, currency, total_amount, reserved_amount, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(staker_id, currency) DO UPDATE SET
+            total_amount = excluded.total_amount,
+            reserved_amount = excluded.reserved_amount,
+            updated_at = excluded.updated_at
+        """,
+        (staker_id, currency, total_amount, reserved_amount, updated_at),
+    )
+    row = conn.execute(
+        """
+        SELECT * FROM staker_escrow_budget
+        WHERE staker_id = ? AND currency = ?
+        """,
+        (staker_id, currency),
+    ).fetchone()
+    return StakerEscrowBudget.from_row(row)
+
+
+def reserve_staker_balance(
+    conn: sqlite3.Connection,
+    *,
+    staker_id: str,
+    currency: str = DEFAULT_CURRENCY,
+    amount: int,
+    updated_at: str,
+) -> StakerEscrowBudget:
+    """Reserve spendable balance for a pending escrow lock."""
+    if amount <= 0:
+        raise EscrowError(f"amount must be > 0, got {amount!r}")
+    currency = _canonical_currency(currency)
+    cursor = conn.execute(
+        """
+        UPDATE staker_escrow_budget
+        SET reserved_amount = reserved_amount + ?,
+            updated_at = ?
+        WHERE staker_id = ?
+          AND currency = ?
+          AND (total_amount - reserved_amount) >= ?
+        """,
+        (amount, updated_at, staker_id, currency, amount),
+    )
+    if cursor.rowcount != 1:
+        current = get_staker_balance(conn, staker_id=staker_id, currency=currency)
+        available = current.spendable_amount if current else 0
+        raise InsufficientFundsError(
+            "Insufficient uncommitted funds for "
+            f"claimer={staker_id!r} currency={currency!r}: "
+            f"requested {amount}, available {available}."
+        )
+    row = conn.execute(
+        """
+        SELECT * FROM staker_escrow_budget
+        WHERE staker_id = ? AND currency = ?
+        """,
+        (staker_id, currency),
+    ).fetchone()
+    return StakerEscrowBudget.from_row(row)
+
+
+def _release_reserved_staker_balance(
+    conn: sqlite3.Connection,
+    *,
+    staker_id: str,
+    currency: str,
+    amount: int,
+    updated_at: str,
+) -> None:
+    cursor = conn.execute(
+        """
+        UPDATE staker_escrow_budget
+        SET reserved_amount = reserved_amount - ?,
+            updated_at = ?
+        WHERE staker_id = ?
+          AND currency = ?
+          AND reserved_amount >= ?
+        """,
+        (amount, updated_at, staker_id, _canonical_currency(currency), amount),
+    )
+    if cursor.rowcount != 1:
+        raise EscrowError(
+            "Cannot refund reserved escrow funds for "
+            f"staker={staker_id!r} currency={currency!r} amount={amount!r}."
+        )
+
+
+def _consume_reserved_staker_balance(
+    conn: sqlite3.Connection,
+    *,
+    staker_id: str,
+    currency: str,
+    amount: int,
+    updated_at: str,
+) -> None:
+    cursor = conn.execute(
+        """
+        UPDATE staker_escrow_budget
+        SET total_amount = total_amount - ?,
+            reserved_amount = reserved_amount - ?,
+            updated_at = ?
+        WHERE staker_id = ?
+          AND currency = ?
+          AND reserved_amount >= ?
+          AND total_amount >= ?
+        """,
+        (
+            amount,
+            amount,
+            updated_at,
+            staker_id,
+            _canonical_currency(currency),
+            amount,
+            amount,
+        ),
+    )
+    if cursor.rowcount != 1:
+        raise EscrowError(
+            "Cannot release reserved escrow funds for "
+            f"staker={staker_id!r} currency={currency!r} amount={amount!r}."
+        )
+
+
+def _rollback_savepoint(conn: sqlite3.Connection, name: str) -> None:
+    conn.execute(f"ROLLBACK TO SAVEPOINT {name}")
+    conn.execute(f"RELEASE SAVEPOINT {name}")
 
 
 # ── Primitives ────────────────────────────────────────────────────────────────
@@ -136,6 +330,7 @@ def lock_bonus(
     gate_claim_id: str,
     staker_id: str,
     amount: int,
+    currency: str = DEFAULT_CURRENCY,
     locked_at: str,
 ) -> EscrowLock:
     """Lock ``amount`` from staker's budget for a gate bonus claim.
@@ -143,22 +338,37 @@ def lock_bonus(
     Raises DuplicateLockError if a lock already exists for
     (gate_claim_id, staker_id).
     """
-    if amount < 0:
-        raise EscrowError(f"amount must be >= 0, got {amount!r}")
+    if amount <= 0:
+        raise EscrowError(f"amount must be > 0, got {amount!r}")
+    currency = _canonical_currency(currency)
+    savepoint = "escrow_lock_bonus"
+    conn.execute(f"SAVEPOINT {savepoint}")
     try:
+        reserve_staker_balance(
+            conn,
+            staker_id=staker_id,
+            currency=currency,
+            amount=amount,
+            updated_at=locked_at,
+        )
         conn.execute(
             """
             INSERT INTO escrow_locks
-                (lock_id, gate_claim_id, staker_id, amount, status, locked_at)
-            VALUES (?, ?, ?, ?, 'locked', ?)
+                (lock_id, gate_claim_id, staker_id, currency, amount, status, locked_at)
+            VALUES (?, ?, ?, ?, ?, 'locked', ?)
             """,
-            (lock_id, gate_claim_id, staker_id, amount, locked_at),
+            (lock_id, gate_claim_id, staker_id, currency, amount, locked_at),
         )
     except sqlite3.IntegrityError as exc:
+        _rollback_savepoint(conn, savepoint)
         raise DuplicateLockError(
             f"Escrow lock already exists for claim={gate_claim_id!r} "
             f"staker={staker_id!r}"
         ) from exc
+    except Exception:
+        _rollback_savepoint(conn, savepoint)
+        raise
+    conn.execute(f"RELEASE SAVEPOINT {savepoint}")
     row = conn.execute(
         "SELECT * FROM escrow_locks WHERE lock_id = ?", (lock_id,)
     ).fetchone()
@@ -187,14 +397,28 @@ def release_bonus(
         raise LockAlreadyResolvedError(
             f"Lock {lock_id!r} is already {lock.status!r}"
         )
-    conn.execute(
-        """
-        UPDATE escrow_locks
-        SET status = 'released', recipient_id = ?, resolved_at = ?
-        WHERE lock_id = ?
-        """,
-        (recipient_id, resolved_at, lock_id),
-    )
+    savepoint = "escrow_release_bonus"
+    conn.execute(f"SAVEPOINT {savepoint}")
+    try:
+        _consume_reserved_staker_balance(
+            conn,
+            staker_id=lock.staker_id,
+            currency=lock.currency,
+            amount=lock.amount,
+            updated_at=resolved_at,
+        )
+        conn.execute(
+            """
+            UPDATE escrow_locks
+            SET status = 'released', recipient_id = ?, resolved_at = ?
+            WHERE lock_id = ?
+            """,
+            (recipient_id, resolved_at, lock_id),
+        )
+    except Exception:
+        _rollback_savepoint(conn, savepoint)
+        raise
+    conn.execute(f"RELEASE SAVEPOINT {savepoint}")
     row = conn.execute(
         "SELECT * FROM escrow_locks WHERE lock_id = ?", (lock_id,)
     ).fetchone()
@@ -222,14 +446,28 @@ def refund_bonus(
         raise LockAlreadyResolvedError(
             f"Lock {lock_id!r} is already {lock.status!r}"
         )
-    conn.execute(
-        """
-        UPDATE escrow_locks
-        SET status = 'refunded', recipient_id = staker_id, resolved_at = ?
-        WHERE lock_id = ?
-        """,
-        (resolved_at, lock_id),
-    )
+    savepoint = "escrow_refund_bonus"
+    conn.execute(f"SAVEPOINT {savepoint}")
+    try:
+        _release_reserved_staker_balance(
+            conn,
+            staker_id=lock.staker_id,
+            currency=lock.currency,
+            amount=lock.amount,
+            updated_at=resolved_at,
+        )
+        conn.execute(
+            """
+            UPDATE escrow_locks
+            SET status = 'refunded', recipient_id = staker_id, resolved_at = ?
+            WHERE lock_id = ?
+            """,
+            (resolved_at, lock_id),
+        )
+    except Exception:
+        _rollback_savepoint(conn, savepoint)
+        raise
+    conn.execute(f"RELEASE SAVEPOINT {savepoint}")
     row = conn.execute(
         "SELECT * FROM escrow_locks WHERE lock_id = ?", (lock_id,)
     ).fetchone()

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/payments/schema.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/payments/schema.py
@@ -2,11 +2,12 @@
 
 Spec: project_monetization_crypto_1pct + project_node_escrow_and_abandonment.
 
-Four tables:
-  escrow_balance     — per-node locked funds (node is the escrow holder)
-  pending_settlement — individual settlement events awaiting batch or direct settle
-  settlement_batch   — grouped settlements flushed together (sub-$1 batching)
-  transaction_log    — immutable append-only audit trail for every state change
+Five tables:
+  staker_escrow_budget — per-staker funded budget for escrow reservations
+  escrow_balance       — per-node locked funds (node is the escrow holder)
+  pending_settlement   — individual settlement events awaiting batch or direct settle
+  settlement_batch     — grouped settlements flushed together (sub-$1 batching)
+  transaction_log      — immutable append-only audit trail for every state change
 
 Treasury fee (1%) is computed at settlement time from MicroToken.treasury_fee().
 Batch threshold: pending_settlements with amount < 1 Token defer to a batch.
@@ -31,6 +32,21 @@ TransactionKind = Literal[
 ]
 
 # ── DDL ───────────────────────────────────────────────────────────────────────
+
+STAKER_ESCROW_BUDGET_SCHEMA = """
+CREATE TABLE IF NOT EXISTS staker_escrow_budget (
+    staker_id       TEXT NOT NULL,
+    currency        TEXT NOT NULL,
+    total_amount    INTEGER NOT NULL DEFAULT 0 CHECK (total_amount >= 0),
+    reserved_amount INTEGER NOT NULL DEFAULT 0 CHECK (reserved_amount >= 0),
+    updated_at      TEXT NOT NULL,
+    PRIMARY KEY (staker_id, currency),
+    CHECK (reserved_amount <= total_amount)
+);
+
+CREATE INDEX IF NOT EXISTS idx_staker_escrow_budget_currency
+    ON staker_escrow_budget(currency);
+"""
 
 SETTLEMENT_SCHEMA = """
 CREATE TABLE IF NOT EXISTS escrow_balance (
@@ -117,6 +133,38 @@ CREATE INDEX IF NOT EXISTS idx_txlog_recorded
 """
 
 # ── Dataclasses ───────────────────────────────────────────────────────────────
+
+@dataclass
+class StakerEscrowBudget:
+    """Spendable and reserved escrow funds for one staker/currency pair."""
+
+    staker_id: ActorId
+    currency: str
+    total_amount: MicroToken
+    reserved_amount: MicroToken
+    updated_at: str
+
+    def __post_init__(self) -> None:
+        if int(self.reserved_amount) > int(self.total_amount):
+            raise ValueError(
+                f"reserved_amount ({self.reserved_amount}) cannot exceed "
+                f"total_amount ({self.total_amount})"
+            )
+
+    @property
+    def spendable_amount(self) -> int:
+        return int(self.total_amount) - int(self.reserved_amount)
+
+    @classmethod
+    def from_row(cls, row: dict) -> StakerEscrowBudget:
+        return cls(
+            staker_id=ActorId(row["staker_id"]),
+            currency=row["currency"],
+            total_amount=MicroToken(int(row.get("total_amount") or 0)),
+            reserved_amount=MicroToken(int(row.get("reserved_amount") or 0)),
+            updated_at=row["updated_at"],
+        )
+
 
 @dataclass
 class EscrowEntry:
@@ -279,4 +327,4 @@ class BatchedTransaction:
 
 def migrate_settlement_schema(conn) -> None:  # type: ignore[no-untyped-def]
     """Create settlement tables if absent. Idempotent."""
-    conn.executescript(SETTLEMENT_SCHEMA)
+    conn.executescript(STAKER_ESCROW_BUDGET_SCHEMA + "\n" + SETTLEMENT_SCHEMA)

--- a/tests/payments/test_escrow_funding.py
+++ b/tests/payments/test_escrow_funding.py
@@ -1,0 +1,128 @@
+import sqlite3
+
+from workflow.payments.actions import action_escrow_lock
+from workflow.payments.escrow import (
+    get_staker_balance,
+    get_lock,
+    list_locks_for_claim,
+    migrate_escrow_schema,
+    release_bonus,
+    upsert_staker_balance,
+)
+
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    migrate_escrow_schema(conn)
+    return conn
+
+
+def test_lock_bonus_reserves_then_release_debits_budget() -> None:
+    conn = _conn()
+    upsert_staker_balance(
+        conn,
+        staker_id="claimer-1",
+        currency="MicroToken",
+        total_amount=100,
+        reserved_amount=0,
+        updated_at="2026-05-30T00:00:00+00:00",
+    )
+
+    result = action_escrow_lock(
+        conn,
+        node_id="node-1",
+        amount=40,
+        claimer="claimer-1",
+        currency="MicroToken",
+    )
+
+    assert result["status"] == "ok"
+    budget = get_staker_balance(conn, staker_id="claimer-1", currency="MicroToken")
+    assert budget is not None
+    assert int(budget.total_amount) == 100
+    assert int(budget.reserved_amount) == 40
+    assert budget.spendable_amount == 60
+
+    release_bonus(
+        conn,
+        lock_id=result["lock_id"],
+        recipient_id="worker-1",
+        resolved_at="2026-05-30T00:05:00+00:00",
+    )
+
+    budget = get_staker_balance(conn, staker_id="claimer-1", currency="MicroToken")
+    assert budget is not None
+    assert int(budget.total_amount) == 60
+    assert int(budget.reserved_amount) == 0
+    assert budget.spendable_amount == 60
+
+
+def test_lock_bonus_rejects_when_budget_is_too_low() -> None:
+    conn = _conn()
+    upsert_staker_balance(
+        conn,
+        staker_id="claimer-2",
+        currency="MicroToken",
+        total_amount=25,
+        reserved_amount=0,
+        updated_at="2026-05-30T00:00:00+00:00",
+    )
+
+    result = action_escrow_lock(
+        conn,
+        node_id="node-2",
+        amount=30,
+        claimer="claimer-2",
+        currency="MicroToken",
+    )
+
+    assert result["status"] == "rejected"
+    assert "Insufficient uncommitted funds" in result["error"]
+    assert get_lock(conn, "lock-does-not-exist") is None
+    assert list_locks_for_claim(conn, gate_claim_id="node-2") == []
+
+    budget = get_staker_balance(conn, staker_id="claimer-2", currency="MicroToken")
+    assert budget is not None
+    assert int(budget.total_amount) == 25
+    assert int(budget.reserved_amount) == 0
+    assert budget.spendable_amount == 25
+
+
+def test_concurrent_claim_locks_cannot_exceed_staker_budget() -> None:
+    conn = _conn()
+    upsert_staker_balance(
+        conn,
+        staker_id="claimer-3",
+        currency="MicroToken",
+        total_amount=70,
+        reserved_amount=0,
+        updated_at="2026-05-30T00:00:00+00:00",
+    )
+
+    first = action_escrow_lock(
+        conn,
+        node_id="node-a",
+        amount=50,
+        claimer="claimer-3",
+        currency="MicroToken",
+    )
+    second = action_escrow_lock(
+        conn,
+        node_id="node-b",
+        amount=30,
+        claimer="claimer-3",
+        currency="MicroToken",
+    )
+
+    assert first["status"] == "ok"
+    assert second["status"] == "rejected"
+    assert "Insufficient uncommitted funds" in second["error"]
+    assert len(list_locks_for_claim(conn, gate_claim_id="node-a")) == 1
+    assert list_locks_for_claim(conn, gate_claim_id="node-b") == []
+
+    budget = get_staker_balance(conn, staker_id="claimer-3", currency="MicroToken")
+    assert budget is not None
+    assert int(budget.total_amount) == 70
+    assert int(budget.reserved_amount) == 50
+    assert budget.spendable_amount == 20

--- a/workflow/payments/actions.py
+++ b/workflow/payments/actions.py
@@ -16,6 +16,7 @@ from typing import Any
 from workflow.payments.escrow import (
     DuplicateLockError,
     EscrowLock,
+    InsufficientFundsError,
     LockAlreadyResolvedError,
     LockNotFoundError,
     get_lock,
@@ -83,6 +84,7 @@ def action_escrow_lock(
             gate_claim_id=node_id,
             staker_id=claimer,
             amount=amount,
+            currency=currency,
             locked_at=locked_at,
         )
     except DuplicateLockError:
@@ -95,13 +97,15 @@ def action_escrow_lock(
             ),
             "existing_lock_id": existing.lock_id if existing else None,
         }
+    except InsufficientFundsError as exc:
+        return {"status": "rejected", "error": str(exc)}
 
     return {
         "status": "ok",
         "lock_id": lock.lock_id,
         "node_id": node_id,
         "amount": lock.amount,
-        "currency": currency,
+        "currency": lock.currency,
         "claimer": claimer,
         "locked_at": lock.locked_at,
     }
@@ -223,6 +227,7 @@ def action_escrow_inspect(
             "node_id": lk.gate_claim_id,
             "claimer": lk.staker_id,
             "amount": lk.amount,
+            "currency": lk.currency,
             "status": lk.status,
             "locked_at": lk.locked_at,
             "resolved_at": lk.resolved_at,

--- a/workflow/payments/escrow.py
+++ b/workflow/payments/escrow.py
@@ -28,13 +28,18 @@ import sqlite3
 from dataclasses import dataclass
 from typing import Literal
 
+from workflow.payments.schema import STAKER_ESCROW_BUDGET_SCHEMA, StakerEscrowBudget
+
+DEFAULT_CURRENCY = "MicroToken"
+
 # ── Schema ────────────────────────────────────────────────────────────────────
 
-ESCROW_SCHEMA = """
+ESCROW_LOCKS_SCHEMA = """
 CREATE TABLE IF NOT EXISTS escrow_locks (
     lock_id         TEXT PRIMARY KEY,
     gate_claim_id   TEXT NOT NULL,
     staker_id       TEXT NOT NULL,
+    currency        TEXT NOT NULL DEFAULT 'MicroToken',
     amount          INTEGER NOT NULL CHECK (amount >= 0),
     status          TEXT NOT NULL DEFAULT 'locked'
                         CHECK (status IN ('locked', 'released', 'refunded')),
@@ -50,6 +55,8 @@ CREATE INDEX IF NOT EXISTS idx_escrow_gate_claim
 CREATE INDEX IF NOT EXISTS idx_escrow_staker
     ON escrow_locks(staker_id);
 """
+
+ESCROW_SCHEMA = STAKER_ESCROW_BUDGET_SCHEMA + "\n" + ESCROW_LOCKS_SCHEMA
 
 # ── Status type ───────────────────────────────────────────────────────────────
 
@@ -74,6 +81,10 @@ class LockAlreadyResolvedError(EscrowError):
     """Raised when attempting to release/refund an already-resolved lock."""
 
 
+class InsufficientFundsError(EscrowError):
+    """Raised when a staker budget lacks enough uncommitted funds."""
+
+
 class UnauthorizedUnstakeError(EscrowError):
     """Raised when a non-staker attempts to unstake."""
 
@@ -87,6 +98,7 @@ class EscrowLock:
     lock_id: str
     gate_claim_id: str
     staker_id: str
+    currency: str
     amount: int
     status: EscrowStatus
     locked_at: str
@@ -112,6 +124,7 @@ class EscrowLock:
             lock_id=d["lock_id"],
             gate_claim_id=d["gate_claim_id"],
             staker_id=d["staker_id"],
+            currency=d.get("currency") or DEFAULT_CURRENCY,
             amount=int(d["amount"]),
             status=d["status"],
             locked_at=d["locked_at"],
@@ -122,9 +135,190 @@ class EscrowLock:
 
 # ── Migration ─────────────────────────────────────────────────────────────────
 
+def _canonical_currency(currency: str) -> str:
+    return DEFAULT_CURRENCY if currency == "token" else currency or DEFAULT_CURRENCY
+
+
 def migrate_escrow_schema(conn: sqlite3.Connection) -> None:
-    """Create escrow_locks table if absent. Idempotent."""
+    """Create escrow tables if absent and backfill required columns."""
     conn.executescript(ESCROW_SCHEMA)
+    columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(escrow_locks)").fetchall()
+    }
+    if "currency" not in columns:
+        conn.execute(
+            "ALTER TABLE escrow_locks "
+            "ADD COLUMN currency TEXT NOT NULL DEFAULT 'MicroToken'"
+        )
+
+
+def get_staker_balance(
+    conn: sqlite3.Connection,
+    *,
+    staker_id: str,
+    currency: str = DEFAULT_CURRENCY,
+) -> StakerEscrowBudget | None:
+    """Return the persisted budget for a staker/currency pair, if present."""
+    row = conn.execute(
+        """
+        SELECT * FROM staker_escrow_budget
+        WHERE staker_id = ? AND currency = ?
+        """,
+        (staker_id, _canonical_currency(currency)),
+    ).fetchone()
+    return StakerEscrowBudget.from_row(row) if row else None
+
+
+def upsert_staker_balance(
+    conn: sqlite3.Connection,
+    *,
+    staker_id: str,
+    currency: str = DEFAULT_CURRENCY,
+    total_amount: int,
+    reserved_amount: int = 0,
+    updated_at: str,
+) -> StakerEscrowBudget:
+    """Create or replace a staker budget record."""
+    if total_amount < 0:
+        raise EscrowError(f"total_amount must be >= 0, got {total_amount!r}")
+    if reserved_amount < 0:
+        raise EscrowError(
+            f"reserved_amount must be >= 0, got {reserved_amount!r}"
+        )
+    if reserved_amount > total_amount:
+        raise EscrowError(
+            "reserved_amount cannot exceed total_amount "
+            f"({reserved_amount!r} > {total_amount!r})"
+        )
+    currency = _canonical_currency(currency)
+    conn.execute(
+        """
+        INSERT INTO staker_escrow_budget
+            (staker_id, currency, total_amount, reserved_amount, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(staker_id, currency) DO UPDATE SET
+            total_amount = excluded.total_amount,
+            reserved_amount = excluded.reserved_amount,
+            updated_at = excluded.updated_at
+        """,
+        (staker_id, currency, total_amount, reserved_amount, updated_at),
+    )
+    row = conn.execute(
+        """
+        SELECT * FROM staker_escrow_budget
+        WHERE staker_id = ? AND currency = ?
+        """,
+        (staker_id, currency),
+    ).fetchone()
+    return StakerEscrowBudget.from_row(row)
+
+
+def reserve_staker_balance(
+    conn: sqlite3.Connection,
+    *,
+    staker_id: str,
+    currency: str = DEFAULT_CURRENCY,
+    amount: int,
+    updated_at: str,
+) -> StakerEscrowBudget:
+    """Reserve spendable balance for a pending escrow lock."""
+    if amount <= 0:
+        raise EscrowError(f"amount must be > 0, got {amount!r}")
+    currency = _canonical_currency(currency)
+    cursor = conn.execute(
+        """
+        UPDATE staker_escrow_budget
+        SET reserved_amount = reserved_amount + ?,
+            updated_at = ?
+        WHERE staker_id = ?
+          AND currency = ?
+          AND (total_amount - reserved_amount) >= ?
+        """,
+        (amount, updated_at, staker_id, currency, amount),
+    )
+    if cursor.rowcount != 1:
+        current = get_staker_balance(conn, staker_id=staker_id, currency=currency)
+        available = current.spendable_amount if current else 0
+        raise InsufficientFundsError(
+            "Insufficient uncommitted funds for "
+            f"claimer={staker_id!r} currency={currency!r}: "
+            f"requested {amount}, available {available}."
+        )
+    row = conn.execute(
+        """
+        SELECT * FROM staker_escrow_budget
+        WHERE staker_id = ? AND currency = ?
+        """,
+        (staker_id, currency),
+    ).fetchone()
+    return StakerEscrowBudget.from_row(row)
+
+
+def _release_reserved_staker_balance(
+    conn: sqlite3.Connection,
+    *,
+    staker_id: str,
+    currency: str,
+    amount: int,
+    updated_at: str,
+) -> None:
+    cursor = conn.execute(
+        """
+        UPDATE staker_escrow_budget
+        SET reserved_amount = reserved_amount - ?,
+            updated_at = ?
+        WHERE staker_id = ?
+          AND currency = ?
+          AND reserved_amount >= ?
+        """,
+        (amount, updated_at, staker_id, _canonical_currency(currency), amount),
+    )
+    if cursor.rowcount != 1:
+        raise EscrowError(
+            "Cannot refund reserved escrow funds for "
+            f"staker={staker_id!r} currency={currency!r} amount={amount!r}."
+        )
+
+
+def _consume_reserved_staker_balance(
+    conn: sqlite3.Connection,
+    *,
+    staker_id: str,
+    currency: str,
+    amount: int,
+    updated_at: str,
+) -> None:
+    cursor = conn.execute(
+        """
+        UPDATE staker_escrow_budget
+        SET total_amount = total_amount - ?,
+            reserved_amount = reserved_amount - ?,
+            updated_at = ?
+        WHERE staker_id = ?
+          AND currency = ?
+          AND reserved_amount >= ?
+          AND total_amount >= ?
+        """,
+        (
+            amount,
+            amount,
+            updated_at,
+            staker_id,
+            _canonical_currency(currency),
+            amount,
+            amount,
+        ),
+    )
+    if cursor.rowcount != 1:
+        raise EscrowError(
+            "Cannot release reserved escrow funds for "
+            f"staker={staker_id!r} currency={currency!r} amount={amount!r}."
+        )
+
+
+def _rollback_savepoint(conn: sqlite3.Connection, name: str) -> None:
+    conn.execute(f"ROLLBACK TO SAVEPOINT {name}")
+    conn.execute(f"RELEASE SAVEPOINT {name}")
 
 
 # ── Primitives ────────────────────────────────────────────────────────────────
@@ -136,6 +330,7 @@ def lock_bonus(
     gate_claim_id: str,
     staker_id: str,
     amount: int,
+    currency: str = DEFAULT_CURRENCY,
     locked_at: str,
 ) -> EscrowLock:
     """Lock ``amount`` from staker's budget for a gate bonus claim.
@@ -143,22 +338,37 @@ def lock_bonus(
     Raises DuplicateLockError if a lock already exists for
     (gate_claim_id, staker_id).
     """
-    if amount < 0:
-        raise EscrowError(f"amount must be >= 0, got {amount!r}")
+    if amount <= 0:
+        raise EscrowError(f"amount must be > 0, got {amount!r}")
+    currency = _canonical_currency(currency)
+    savepoint = "escrow_lock_bonus"
+    conn.execute(f"SAVEPOINT {savepoint}")
     try:
+        reserve_staker_balance(
+            conn,
+            staker_id=staker_id,
+            currency=currency,
+            amount=amount,
+            updated_at=locked_at,
+        )
         conn.execute(
             """
             INSERT INTO escrow_locks
-                (lock_id, gate_claim_id, staker_id, amount, status, locked_at)
-            VALUES (?, ?, ?, ?, 'locked', ?)
+                (lock_id, gate_claim_id, staker_id, currency, amount, status, locked_at)
+            VALUES (?, ?, ?, ?, ?, 'locked', ?)
             """,
-            (lock_id, gate_claim_id, staker_id, amount, locked_at),
+            (lock_id, gate_claim_id, staker_id, currency, amount, locked_at),
         )
     except sqlite3.IntegrityError as exc:
+        _rollback_savepoint(conn, savepoint)
         raise DuplicateLockError(
             f"Escrow lock already exists for claim={gate_claim_id!r} "
             f"staker={staker_id!r}"
         ) from exc
+    except Exception:
+        _rollback_savepoint(conn, savepoint)
+        raise
+    conn.execute(f"RELEASE SAVEPOINT {savepoint}")
     row = conn.execute(
         "SELECT * FROM escrow_locks WHERE lock_id = ?", (lock_id,)
     ).fetchone()
@@ -187,14 +397,28 @@ def release_bonus(
         raise LockAlreadyResolvedError(
             f"Lock {lock_id!r} is already {lock.status!r}"
         )
-    conn.execute(
-        """
-        UPDATE escrow_locks
-        SET status = 'released', recipient_id = ?, resolved_at = ?
-        WHERE lock_id = ?
-        """,
-        (recipient_id, resolved_at, lock_id),
-    )
+    savepoint = "escrow_release_bonus"
+    conn.execute(f"SAVEPOINT {savepoint}")
+    try:
+        _consume_reserved_staker_balance(
+            conn,
+            staker_id=lock.staker_id,
+            currency=lock.currency,
+            amount=lock.amount,
+            updated_at=resolved_at,
+        )
+        conn.execute(
+            """
+            UPDATE escrow_locks
+            SET status = 'released', recipient_id = ?, resolved_at = ?
+            WHERE lock_id = ?
+            """,
+            (recipient_id, resolved_at, lock_id),
+        )
+    except Exception:
+        _rollback_savepoint(conn, savepoint)
+        raise
+    conn.execute(f"RELEASE SAVEPOINT {savepoint}")
     row = conn.execute(
         "SELECT * FROM escrow_locks WHERE lock_id = ?", (lock_id,)
     ).fetchone()
@@ -222,14 +446,28 @@ def refund_bonus(
         raise LockAlreadyResolvedError(
             f"Lock {lock_id!r} is already {lock.status!r}"
         )
-    conn.execute(
-        """
-        UPDATE escrow_locks
-        SET status = 'refunded', recipient_id = staker_id, resolved_at = ?
-        WHERE lock_id = ?
-        """,
-        (resolved_at, lock_id),
-    )
+    savepoint = "escrow_refund_bonus"
+    conn.execute(f"SAVEPOINT {savepoint}")
+    try:
+        _release_reserved_staker_balance(
+            conn,
+            staker_id=lock.staker_id,
+            currency=lock.currency,
+            amount=lock.amount,
+            updated_at=resolved_at,
+        )
+        conn.execute(
+            """
+            UPDATE escrow_locks
+            SET status = 'refunded', recipient_id = staker_id, resolved_at = ?
+            WHERE lock_id = ?
+            """,
+            (resolved_at, lock_id),
+        )
+    except Exception:
+        _rollback_savepoint(conn, savepoint)
+        raise
+    conn.execute(f"RELEASE SAVEPOINT {savepoint}")
     row = conn.execute(
         "SELECT * FROM escrow_locks WHERE lock_id = ?", (lock_id,)
     ).fetchone()

--- a/workflow/payments/schema.py
+++ b/workflow/payments/schema.py
@@ -2,11 +2,12 @@
 
 Spec: project_monetization_crypto_1pct + project_node_escrow_and_abandonment.
 
-Four tables:
-  escrow_balance     — per-node locked funds (node is the escrow holder)
-  pending_settlement — individual settlement events awaiting batch or direct settle
-  settlement_batch   — grouped settlements flushed together (sub-$1 batching)
-  transaction_log    — immutable append-only audit trail for every state change
+Five tables:
+  staker_escrow_budget — per-staker funded budget for escrow reservations
+  escrow_balance       — per-node locked funds (node is the escrow holder)
+  pending_settlement   — individual settlement events awaiting batch or direct settle
+  settlement_batch     — grouped settlements flushed together (sub-$1 batching)
+  transaction_log      — immutable append-only audit trail for every state change
 
 Treasury fee (1%) is computed at settlement time from MicroToken.treasury_fee().
 Batch threshold: pending_settlements with amount < 1 Token defer to a batch.
@@ -31,6 +32,21 @@ TransactionKind = Literal[
 ]
 
 # ── DDL ───────────────────────────────────────────────────────────────────────
+
+STAKER_ESCROW_BUDGET_SCHEMA = """
+CREATE TABLE IF NOT EXISTS staker_escrow_budget (
+    staker_id       TEXT NOT NULL,
+    currency        TEXT NOT NULL,
+    total_amount    INTEGER NOT NULL DEFAULT 0 CHECK (total_amount >= 0),
+    reserved_amount INTEGER NOT NULL DEFAULT 0 CHECK (reserved_amount >= 0),
+    updated_at      TEXT NOT NULL,
+    PRIMARY KEY (staker_id, currency),
+    CHECK (reserved_amount <= total_amount)
+);
+
+CREATE INDEX IF NOT EXISTS idx_staker_escrow_budget_currency
+    ON staker_escrow_budget(currency);
+"""
 
 SETTLEMENT_SCHEMA = """
 CREATE TABLE IF NOT EXISTS escrow_balance (
@@ -117,6 +133,38 @@ CREATE INDEX IF NOT EXISTS idx_txlog_recorded
 """
 
 # ── Dataclasses ───────────────────────────────────────────────────────────────
+
+@dataclass
+class StakerEscrowBudget:
+    """Spendable and reserved escrow funds for one staker/currency pair."""
+
+    staker_id: ActorId
+    currency: str
+    total_amount: MicroToken
+    reserved_amount: MicroToken
+    updated_at: str
+
+    def __post_init__(self) -> None:
+        if int(self.reserved_amount) > int(self.total_amount):
+            raise ValueError(
+                f"reserved_amount ({self.reserved_amount}) cannot exceed "
+                f"total_amount ({self.total_amount})"
+            )
+
+    @property
+    def spendable_amount(self) -> int:
+        return int(self.total_amount) - int(self.reserved_amount)
+
+    @classmethod
+    def from_row(cls, row: dict) -> StakerEscrowBudget:
+        return cls(
+            staker_id=ActorId(row["staker_id"]),
+            currency=row["currency"],
+            total_amount=MicroToken(int(row.get("total_amount") or 0)),
+            reserved_amount=MicroToken(int(row.get("reserved_amount") or 0)),
+            updated_at=row["updated_at"],
+        )
+
 
 @dataclass
 class EscrowEntry:
@@ -279,4 +327,4 @@ class BatchedTransaction:
 
 def migrate_settlement_schema(conn) -> None:  # type: ignore[no-untyped-def]
     """Create settlement tables if absent. Idempotent."""
-    conn.executescript(SETTLEMENT_SCHEMA)
+    conn.executescript(STAKER_ESCROW_BUDGET_SCHEMA + "\n" + SETTLEMENT_SCHEMA)


### PR DESCRIPTION
## Summary
- introduce a persistent per-staker escrow budget keyed by staker and currency
- atomically reserve/debit funded balance inside `lock_bonus` before creating escrow locks
- route `escrow_lock` through the new funding primitive and add coverage for insufficient-funds and concurrent-lock exhaustion

## Request
Implements the paid-market escrow funding primitive requested here: escrow locks now require an actual staker funding source, reject insufficient uncommitted funds without creating a lock, and prevent repeated locks across different claims from minting unlimited concurrent obligations.