### PR TITLE
feat(graph): expose wiki READ to in-node invoke_mcp_action (slice 1/2 of closing the driver-branch gap)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
@@ -1212,6 +1212,19 @@ _NODE_MCP_ACTION_ALIASES: dict[str, tuple[str, str]] = {
     "gates.leaderboard": ("gates", "leaderboard"),
     "gates_leaderboard": ("gates", "leaderboard"),
     "gates.get_ladder": ("gates", "get_ladder"),
+    # Wiki READS only — knowledge-commons consultation (e.g. a driver branch
+    # enumerating the bug/patch backlog). Writes are never aliased in-node; a
+    # node that needs to publish goes through an effect, not invoke_mcp_action.
+    "wiki.read": ("wiki", "read"),
+    "wiki_read": ("wiki", "read"),
+    "wiki.search": ("wiki", "search"),
+    "wiki_search": ("wiki", "search"),
+    "wiki.list": ("wiki", "list"),
+    "wiki_list": ("wiki", "list"),
+    "wiki.since": ("wiki", "since"),
+    "wiki_since": ("wiki", "since"),
+    "wiki.lint": ("wiki", "lint"),
+    "wiki_lint": ("wiki", "lint"),
 }
 
 
@@ -1267,6 +1280,17 @@ def _build_node_mcp_invoker(
             from workflow.api.market import gates
 
             raw = gates(action=action, **kwargs)
+        elif tool_name == "wiki":
+            from workflow.api.wiki import WIKI_WRITE_ACTIONS, wiki
+
+            # Defense-in-depth: the alias map only lists reads, but never let a
+            # write reach the wiki from in-node code even if one is aliased.
+            if action in WIKI_WRITE_ACTIONS:
+                raise CompilerError(
+                    f"Node '{node.node_id}' may call wiki READ actions only; "
+                    f"'{action}' is a write and is not exposed in-node."
+                )
+            raw = wiki(action=action, **kwargs)
         else:  # pragma: no cover - mapping owns the dispatch domains.
             raise CompilerError(
                 f"Node '{node.node_id}' requested unsupported MCP tool "

--- a/tests/test_branch_runner.py
+++ b/tests/test_branch_runner.py
@@ -231,6 +231,136 @@ def test_source_code_node_rejects_mcp_action_not_in_tools_allowed(monkeypatch):
     assert "not allowed" in str(exc_info.value)
 
 
+def test_source_code_node_can_call_wiki_read(monkeypatch):
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    import workflow.api.wiki as wiki_mod
+    from workflow.graph_compiler import compile_branch
+
+    calls: list[tuple[str, dict]] = []
+
+    def fake_wiki(*, action: str, **kwargs):
+        calls.append((action, kwargs))
+        return json.dumps({"status": "ok", "results": [{"page": "BUG-001"}]})
+
+    monkeypatch.setattr(wiki_mod, "wiki", fake_wiki)
+
+    b = BranchDefinition(name="test", entry_point="only")
+    b.node_defs = [NodeDefinition(
+        node_id="only",
+        display_name="Only",
+        source_code=(
+            "def run(state):\n"
+            "    hits = invoke_mcp_action('wiki.search', query=state['q'])\n"
+            "    return {'n': len(hits['results'])}\n"
+        ),
+        input_keys=["q"],
+        output_keys=["n"],
+        tools_allowed=["wiki.search"],
+        approved=True,
+    )]
+    b.graph_nodes = [GraphNodeRef(id="only", node_def_id="only")]
+    b.edges = [
+        EdgeDefinition(from_node="START", to_node="only"),
+        EdgeDefinition(from_node="only", to_node="END"),
+    ]
+    b.state_schema = [
+        {"name": "q", "type": "str"},
+        {"name": "n", "type": "int"},
+    ]
+    compiled = compile_branch(b)
+    app = compiled.graph.compile(checkpointer=InMemorySaver())
+    result = app.invoke(
+        {"q": "backlog"}, config={"configurable": {"thread_id": "wiki-ok"}},
+    )
+
+    assert result["n"] == 1
+    assert calls == [("search", {"query": "backlog"})]
+
+
+def test_source_code_node_cannot_call_wiki_write(monkeypatch):
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    import workflow.api.wiki as wiki_mod
+    from workflow.graph_compiler import CompilerError, compile_branch
+
+    def fake_wiki(*, action: str, **kwargs):
+        raise AssertionError("wiki write must not dispatch from a node")
+
+    monkeypatch.setattr(wiki_mod, "wiki", fake_wiki)
+
+    b = BranchDefinition(name="test", entry_point="only")
+    b.node_defs = [NodeDefinition(
+        node_id="only",
+        display_name="Only",
+        source_code=(
+            "def run(state):\n"
+            "    invoke_mcp_action('wiki.write', page='X', content='Y')\n"
+            "    return {'out': 'unreachable'}\n"
+        ),
+        output_keys=["out"],
+        tools_allowed=["wiki.write"],
+        approved=True,
+    )]
+    b.graph_nodes = [GraphNodeRef(id="only", node_def_id="only")]
+    b.edges = [
+        EdgeDefinition(from_node="START", to_node="only"),
+        EdgeDefinition(from_node="only", to_node="END"),
+    ]
+    b.state_schema = [{"name": "out", "type": "str"}]
+    compiled = compile_branch(b)
+    app = compiled.graph.compile(checkpointer=InMemorySaver())
+
+    # 'wiki.write' is not in the alias allow-list at all — unsupported action.
+    with pytest.raises(CompilerError) as exc_info:
+        app.invoke({}, config={"configurable": {"thread_id": "wiki-write"}})
+    assert "unsupported MCP action" in str(exc_info.value)
+
+
+def test_node_wiki_dispatch_blocks_write_even_if_aliased(monkeypatch):
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    import workflow.api.wiki as wiki_mod
+    import workflow.graph_compiler as gc
+    from workflow.graph_compiler import CompilerError, compile_branch
+
+    def fake_wiki(*, action: str, **kwargs):
+        raise AssertionError("wiki write must not dispatch from a node")
+
+    monkeypatch.setattr(wiki_mod, "wiki", fake_wiki)
+    # Simulate a future mistake: a write action wired into the alias map.
+    # The dispatch-time WIKI_WRITE_ACTIONS guard must still refuse it.
+    monkeypatch.setitem(
+        gc._NODE_MCP_ACTION_ALIASES, "wiki.write", ("wiki", "write"),
+    )
+
+    b = BranchDefinition(name="test", entry_point="only")
+    b.node_defs = [NodeDefinition(
+        node_id="only",
+        display_name="Only",
+        source_code=(
+            "def run(state):\n"
+            "    invoke_mcp_action('wiki.write', page='X', content='Y')\n"
+            "    return {'out': 'unreachable'}\n"
+        ),
+        output_keys=["out"],
+        tools_allowed=["wiki.write"],
+        approved=True,
+    )]
+    b.graph_nodes = [GraphNodeRef(id="only", node_def_id="only")]
+    b.edges = [
+        EdgeDefinition(from_node="START", to_node="only"),
+        EdgeDefinition(from_node="only", to_node="END"),
+    ]
+    b.state_schema = [{"name": "out", "type": "str"}]
+    compiled = compile_branch(b)
+    app = compiled.graph.compile(checkpointer=InMemorySaver())
+
+    with pytest.raises(CompilerError) as exc_info:
+        app.invoke({}, config={"configurable": {"thread_id": "wiki-dd"}})
+    assert "write" in str(exc_info.value)
+
+
 def test_branch_spec_preserves_tools_allowed():
     from workflow.api.branches import _apply_node_spec
 

--- a/workflow/graph_compiler.py
+++ b/workflow/graph_compiler.py
@@ -1212,6 +1212,19 @@ _NODE_MCP_ACTION_ALIASES: dict[str, tuple[str, str]] = {
     "gates.leaderboard": ("gates", "leaderboard"),
     "gates_leaderboard": ("gates", "leaderboard"),
     "gates.get_ladder": ("gates", "get_ladder"),
+    # Wiki READS only — knowledge-commons consultation (e.g. a driver branch
+    # enumerating the bug/patch backlog). Writes are never aliased in-node; a
+    # node that needs to publish goes through an effect, not invoke_mcp_action.
+    "wiki.read": ("wiki", "read"),
+    "wiki_read": ("wiki", "read"),
+    "wiki.search": ("wiki", "search"),
+    "wiki_search": ("wiki", "search"),
+    "wiki.list": ("wiki", "list"),
+    "wiki_list": ("wiki", "list"),
+    "wiki.since": ("wiki", "since"),
+    "wiki_since": ("wiki", "since"),
+    "wiki.lint": ("wiki", "lint"),
+    "wiki_lint": ("wiki", "lint"),
 }
 
 
@@ -1267,6 +1280,17 @@ def _build_node_mcp_invoker(
             from workflow.api.market import gates
 
             raw = gates(action=action, **kwargs)
+        elif tool_name == "wiki":
+            from workflow.api.wiki import WIKI_WRITE_ACTIONS, wiki
+
+            # Defense-in-depth: the alias map only lists reads, but never let a
+            # write reach the wiki from in-node code even if one is aliased.
+            if action in WIKI_WRITE_ACTIONS:
+                raise CompilerError(
+                    f"Node '{node.node_id}' may call wiki READ actions only; "
+                    f"'{action}' is a write and is not exposed in-node."
+                )
+            raw = wiki(action=action, **kwargs)
         else:  # pragma: no cover - mapping owns the dispatch domains.
             raise CompilerError(
                 f"Node '{node.node_id}' requested unsupported MCP tool "


### PR DESCRIPTION
## Context

We cut the platform backfill (#1212) because intake/selection policy belongs in a **user-composed driver branch**, not engine code. But a driver branch can't be built today: a `source_code` node's `invoke_mcp_action` is restricted to `goals`+`gates` (read-only consultation) — it can't read the backlog (`wiki`) or drive runs (`run_branch`). This closes the first half.

## This PR (slice 1/2) — wiki READ in-node

- Adds wiki reads (`read`, `search`, `list`, `since`, `lint`) to `_NODE_MCP_ACTION_ALIASES` + a `wiki` dispatch branch in `_invoke_mcp_action`, gated by the existing `tools_allowed` allowlist.
- **Read-only, enforced twice:** only the 5 reads are aliased, *and* a dispatch-time `WIKI_WRITE_ACTIONS` guard refuses any write even if one were aliased by mistake.
- **No new chatbot-facing tool / primitive.** This is purely the in-node runtime surface — `wiki` is already one of the chatbot's tools. Net connector tool count: unchanged. Universe scope resolves exactly like the existing in-node `goals`/`gates` calls (active universe).

So a driver branch can now *enumerate* the bug/patch backlog from inside the branch.

## Next (slice 2/2, separate PR)

The paced **enqueue verb** + `BranchTask.depth` + a spawn-depth cap (mirrors the existing `_runtime_max_invocation_depth` invoke-branch guard) + the §14 concurrency proof — so a driver branch can also *drive* the backlog. That's the concurrency-sensitive half; it carries an opposite-provider (Codex) review before going live.

## Tests
- node can call wiki read (dispatch + args verified)
- node cannot call wiki write (unsupported action)
- defense-in-depth: write blocked even if aliased
- existing goals/gates in-node tests still green; ruff clean; plugin mirror rebuilt + pre-commit parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)