### PR TITLE
feat(graph): paced in-node enqueue verb + spawn guards (slice 2/2) — ships dark, needs concurrency proof + Codex review

### DIFF
--- a/fantasy_daemon/__main__.py
+++ b/fantasy_daemon/__main__.py
@@ -852,6 +852,9 @@ def _try_execute_claimed_branch_task(
             actor=actor,
             provider_call=provider_call,
             on_node_status=on_node_status,
+            # Carry spawn depth across the queue boundary so an in-node enqueue
+            # from this run is depth+1 and the depth cap can bound the chain.
+            _invocation_depth=int(getattr(claimed_task, "depth", 0) or 0),
         )
         metadata = {
             "branch_def_id": branch_def_id,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
@@ -98,6 +98,10 @@ class BranchTask:
     heartbeat_at: str = ""
     last_progress_at: str = ""
     rung_claim_recommendations: list[dict] = field(default_factory=list)
+    # Spawn depth. 0 for user/forward-triggered tasks. A task enqueued from
+    # inside a running branch (via the in-node enqueue verb) carries
+    # parent_depth + 1; a depth cap bounds runaway self-enqueue chains.
+    depth: int = 0
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
@@ -1225,15 +1225,134 @@ _NODE_MCP_ACTION_ALIASES: dict[str, tuple[str, str]] = {
     "wiki_since": ("wiki", "since"),
     "wiki.lint": ("wiki", "lint"),
     "wiki_lint": ("wiki", "lint"),
+    # Paced ENQUEUE — append a run request to this universe's dispatcher queue.
+    # NOT a synchronous spawn: the daemon's concurrency cap + per-provider
+    # cooldown pace execution. Bounded by a spawn-depth cap + a per-run enqueue
+    # budget, and gated behind WORKFLOW_NODE_ENQUEUE_ENABLED (ships dark).
+    "enqueue_branch_run": ("dispatch", "enqueue"),
+    "dispatch.enqueue": ("dispatch", "enqueue"),
 }
+
+
+def _node_enqueue_enabled() -> bool:
+    """Capability gate for the in-node enqueue verb (ships dark, default off).
+
+    The first side-effecting in-node verb. Kept fail-closed until the
+    concurrency proof + opposite-provider review clear it for live use.
+    """
+    return os.environ.get(
+        "WORKFLOW_NODE_ENQUEUE_ENABLED", ""
+    ).strip().lower() in {"on", "1", "true", "yes"}
+
+
+def _node_enqueue_max_depth() -> int:
+    """Spawn-depth cap for queue enqueues — bounds chain LENGTH.
+
+    Default 2 (a driver at depth 0 enqueues leaf runs at depth 1; one extra
+    level of headroom), tighter than the in-graph invoke-branch cap because
+    each queue level is a full independent run. Host-tunable.
+    """
+    raw = os.environ.get("WORKFLOW_NODE_ENQUEUE_MAX_DEPTH", "").strip()
+    try:
+        val = int(raw) if raw else 2
+    except ValueError:
+        val = 2
+    return val if val >= 1 else 2
+
+
+def _node_enqueue_budget() -> int:
+    """Per-run enqueue budget — bounds branching FACTOR (default 50)."""
+    raw = os.environ.get("WORKFLOW_NODE_ENQUEUE_MAX_PER_RUN", "").strip()
+    try:
+        val = int(raw) if raw else 50
+    except ValueError:
+        val = 50
+    return val if val > 0 else 50
+
+
+def _node_enqueue_branch_run(
+    node: "NodeDefinition",
+    invocation_depth: int,
+    enqueued_count: list[int],
+    kwargs: dict[str, Any],
+) -> str:
+    """Append ONE paced run-request to this universe's dispatcher queue.
+
+    Not a synchronous spawn — the daemon's concurrency cap + cooldown pace
+    execution. Bounded three ways: a capability flag (ships dark), a spawn-
+    depth cap (chain length), and a per-run budget (branching factor). Returns
+    a JSON string so the caller's standard parse step applies.
+    """
+    if not _node_enqueue_enabled():
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: the in-node enqueue verb "
+            f"is disabled. Set WORKFLOW_NODE_ENQUEUE_ENABLED to enable."
+        )
+
+    # Guard 1 — spawn-depth cap bounds chain length (self-enqueue can't recurse
+    # forever). A task at depth D enqueues children at D+1.
+    cap = _node_enqueue_max_depth()
+    next_depth = int(invocation_depth) + 1
+    if next_depth > cap:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: spawn depth {next_depth} "
+            f"exceeds cap {cap} (WORKFLOW_NODE_ENQUEUE_MAX_DEPTH)."
+        )
+
+    # Guard 2 — per-run budget bounds branching factor (one run can't flood).
+    budget = _node_enqueue_budget()
+    if enqueued_count[0] >= budget:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: this run already enqueued "
+            f"{enqueued_count[0]} task(s) (budget {budget})."
+        )
+
+    target = str(kwargs.get("branch_def_id", "")).strip()
+    if not target:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue requires a non-empty branch_def_id."
+        )
+    run_inputs = kwargs.get("inputs") or {}
+    if not isinstance(run_inputs, dict):
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue inputs must be an object, got "
+            f"{type(run_inputs).__name__}."
+        )
+
+    from workflow.api.helpers import _default_universe, _universe_dir
+    from workflow.branch_tasks import BranchTask, append_task, new_task_id
+
+    uid = str(kwargs.get("universe_id", "")).strip() or _default_universe()
+    task = BranchTask(
+        branch_task_id=new_task_id(),
+        branch_def_id=target,
+        universe_id=uid,
+        inputs=dict(run_inputs),
+        trigger_source="owner_queued",
+        request_type=str(kwargs.get("request_type", "") or "branch_run"),
+        depth=next_depth,
+    )
+    append_task(_universe_dir(uid), task)
+    enqueued_count[0] += 1
+    return json.dumps({
+        "status": "enqueued",
+        "branch_task_id": task.branch_task_id,
+        "branch_def_id": target,
+        "universe_id": uid,
+        "depth": next_depth,
+    })
 
 
 def _build_node_mcp_invoker(
     node: NodeDefinition,
     *,
     event_sink: Callable[..., None] | None,
+    invocation_depth: int = 0,
 ) -> Callable[..., dict[str, Any]]:
     allowed = set(node.tools_allowed or [])
+    # Per-run enqueue budget (mutable closure cell) — bounds branching factor:
+    # one branch run may enqueue at most _node_enqueue_budget() tasks total.
+    enqueued_count = [0]
 
     def _invoke_mcp_action(action_name: str, **kwargs: Any) -> dict[str, Any]:
         requested = str(action_name or "").strip()
@@ -1291,6 +1410,10 @@ def _build_node_mcp_invoker(
                     f"'{action}' is a write and is not exposed in-node."
                 )
             raw = wiki(action=action, **kwargs)
+        elif tool_name == "dispatch":
+            raw = _node_enqueue_branch_run(
+                node, invocation_depth, enqueued_count, kwargs,
+            )
         else:  # pragma: no cover - mapping owns the dispatch domains.
             raise CompilerError(
                 f"Node '{node.node_id}' requested unsupported MCP tool "
@@ -1318,6 +1441,7 @@ def _build_source_code_node(
     *,
     event_sink: Callable[..., None] | None,
     concurrency_tracker: ConcurrencyTracker | None = None,
+    invocation_depth: int = 0,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Return a node function that exec()s the approved source_code.
 
@@ -1328,7 +1452,9 @@ def _build_source_code_node(
     _validate_source_code(node)
     src = node.source_code
     timeout_s = float(node.timeout_seconds or 300.0)
-    invoke_mcp_action = _build_node_mcp_invoker(node, event_sink=event_sink)
+    invoke_mcp_action = _build_node_mcp_invoker(
+        node, event_sink=event_sink, invocation_depth=invocation_depth,
+    )
 
     # BUG-112: exec into a SINGLE namespace (globals == locals). With split
     # globals/locals, top-level defs land in locals, but each function's
@@ -2151,6 +2277,7 @@ def _build_node(
     if has_source:
         inner = _build_source_code_node(
             node, event_sink=event_sink, concurrency_tracker=concurrency_tracker,
+            invocation_depth=invocation_depth,
         )
         return _wrap_with_checkpoints(inner, node, event_sink)
     if has_template:

--- a/tests/test_node_enqueue_verb.py
+++ b/tests/test_node_enqueue_verb.py
@@ -1,0 +1,172 @@
+"""In-node paced enqueue verb (slice 2/2 of closing the driver-branch gap).
+
+A source_code node can append a run-request to its universe's dispatcher
+queue via ``invoke_mcp_action('enqueue_branch_run', ...)`` — NOT a synchronous
+spawn. The daemon's concurrency cap paces execution. Bounded three ways:
+a default-off capability flag, a spawn-depth cap (chain length), and a
+per-run enqueue budget (branching factor).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from langgraph.checkpoint.memory import InMemorySaver
+
+import workflow.api.helpers as helpers
+import workflow.branch_tasks as bt
+from workflow.branches import (
+    BranchDefinition,
+    EdgeDefinition,
+    GraphNodeRef,
+    NodeDefinition,
+)
+from workflow.graph_compiler import CompilerError, compile_branch
+
+ENQUEUE_ONE = (
+    "def run(state):\n"
+    "    r = invoke_mcp_action('enqueue_branch_run',\n"
+    "        branch_def_id='patch_loop', inputs={'bug_id': 'BUG-1'})\n"
+    "    return {'status': r['status']}\n"
+)
+
+ENQUEUE_TWICE = (
+    "def run(state):\n"
+    "    invoke_mcp_action('enqueue_branch_run', branch_def_id='x', inputs={})\n"
+    "    invoke_mcp_action('enqueue_branch_run', branch_def_id='y', inputs={})\n"
+    "    return {'status': 'done'}\n"
+)
+
+
+def _branch(src: str, tools_allowed: list[str]) -> BranchDefinition:
+    b = BranchDefinition(name="drv", entry_point="only")
+    b.node_defs = [NodeDefinition(
+        node_id="only",
+        display_name="Only",
+        source_code=src,
+        output_keys=["status"],
+        tools_allowed=tools_allowed,
+        approved=True,
+    )]
+    b.graph_nodes = [GraphNodeRef(id="only", node_def_id="only")]
+    b.edges = [
+        EdgeDefinition(from_node="START", to_node="only"),
+        EdgeDefinition(from_node="only", to_node="END"),
+    ]
+    b.state_schema = [{"name": "status", "type": "str"}]
+    return b
+
+
+def _patch_storage(monkeypatch) -> list:
+    captured: list = []
+    monkeypatch.setattr(helpers, "_default_universe", lambda: "u")
+    monkeypatch.setattr(helpers, "_universe_dir", lambda uid: Path(f"/fake/{uid}"))
+    monkeypatch.setattr(
+        bt, "append_task", lambda upath, task: captured.append((upath, task)),
+    )
+    return captured
+
+
+def _run(b, *, invocation_depth=0, thread="t"):
+    compiled = compile_branch(b, invocation_depth=invocation_depth)
+    app = compiled.graph.compile(checkpointer=InMemorySaver())
+    return app.invoke({}, config={"configurable": {"thread_id": thread}})
+
+
+def test_enqueue_disabled_by_default(monkeypatch):
+    # No WORKFLOW_NODE_ENQUEUE_ENABLED → fail-closed, ships dark.
+    monkeypatch.delenv("WORKFLOW_NODE_ENQUEUE_ENABLED", raising=False)
+    b = _branch(ENQUEUE_ONE, ["enqueue_branch_run"])
+    with pytest.raises(CompilerError) as exc:
+        _run(b, thread="enq-off")
+    assert "disabled" in str(exc.value)
+
+
+def test_enqueue_happy_path_appends_at_depth_1(monkeypatch):
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
+    captured = _patch_storage(monkeypatch)
+
+    b = _branch(ENQUEUE_ONE, ["enqueue_branch_run"])
+    result = _run(b, invocation_depth=0, thread="enq-ok")
+
+    assert result["status"] == "enqueued"
+    assert len(captured) == 1
+    upath, task = captured[0]
+    assert str(upath).replace("\\", "/").endswith("/fake/u")
+    assert task.branch_def_id == "patch_loop"
+    assert task.inputs == {"bug_id": "BUG-1"}
+    assert task.universe_id == "u"
+    assert task.trigger_source == "owner_queued"
+    assert task.depth == 1  # parent depth 0 + 1
+
+
+def test_enqueue_carries_parent_depth_plus_one(monkeypatch):
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_MAX_DEPTH", "5")
+    captured = _patch_storage(monkeypatch)
+
+    b = _branch(ENQUEUE_ONE, ["enqueue_branch_run"])
+    _run(b, invocation_depth=3, thread="enq-depth")
+
+    assert captured[0][1].depth == 4  # parent 3 + 1
+
+
+def test_enqueue_depth_cap_refuses(monkeypatch):
+    # Default cap is 2; a run already at depth 2 would enqueue at depth 3.
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
+    monkeypatch.delenv("WORKFLOW_NODE_ENQUEUE_MAX_DEPTH", raising=False)
+    captured = _patch_storage(monkeypatch)
+
+    b = _branch(ENQUEUE_ONE, ["enqueue_branch_run"])
+    with pytest.raises(CompilerError) as exc:
+        _run(b, invocation_depth=2, thread="enq-cap")
+    assert "exceeds cap" in str(exc.value)
+    assert captured == []  # never appended
+
+
+def test_enqueue_per_run_budget_refuses_second(monkeypatch):
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_MAX_PER_RUN", "1")
+    captured = _patch_storage(monkeypatch)
+
+    b = _branch(ENQUEUE_TWICE, ["enqueue_branch_run"])
+    with pytest.raises(CompilerError) as exc:
+        _run(b, thread="enq-budget")
+    assert "budget" in str(exc.value)
+    assert len(captured) == 1  # first appended, second refused
+
+
+def test_enqueue_requires_tools_allowed(monkeypatch):
+    # Even enabled, the node must declare the verb in tools_allowed.
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
+    b = _branch(ENQUEUE_ONE, [])  # not declared
+    with pytest.raises(CompilerError) as exc:
+        _run(b, thread="enq-gate")
+    assert "not allowed" in str(exc.value)
+
+
+def test_enqueue_requires_branch_def_id(monkeypatch):
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
+    _patch_storage(monkeypatch)
+    src = (
+        "def run(state):\n"
+        "    invoke_mcp_action('enqueue_branch_run', inputs={})\n"
+        "    return {'status': 'x'}\n"
+    )
+    b = _branch(src, ["enqueue_branch_run"])
+    with pytest.raises(CompilerError) as exc:
+        _run(b, thread="enq-nobranch")
+    assert "branch_def_id" in str(exc.value)
+
+
+def test_branch_task_depth_field_roundtrips():
+    # Migration-safe: new field defaults to 0 and survives to_dict/from_dict.
+    t = bt.BranchTask(branch_task_id="x", branch_def_id="b", universe_id="u")
+    assert t.depth == 0
+    assert bt.BranchTask.from_dict(t.to_dict()).depth == 0
+    assert bt.BranchTask.from_dict({**t.to_dict(), "depth": 3}).depth == 3
+    # Old rows without the field still load.
+    assert bt.BranchTask.from_dict(
+        {"branch_task_id": "y", "branch_def_id": "b", "universe_id": "u"}
+    ).depth == 0

--- a/workflow/branch_tasks.py
+++ b/workflow/branch_tasks.py
@@ -98,6 +98,10 @@ class BranchTask:
     heartbeat_at: str = ""
     last_progress_at: str = ""
     rung_claim_recommendations: list[dict] = field(default_factory=list)
+    # Spawn depth. 0 for user/forward-triggered tasks. A task enqueued from
+    # inside a running branch (via the in-node enqueue verb) carries
+    # parent_depth + 1; a depth cap bounds runaway self-enqueue chains.
+    depth: int = 0
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/workflow/graph_compiler.py
+++ b/workflow/graph_compiler.py
@@ -1225,15 +1225,134 @@ _NODE_MCP_ACTION_ALIASES: dict[str, tuple[str, str]] = {
     "wiki_since": ("wiki", "since"),
     "wiki.lint": ("wiki", "lint"),
     "wiki_lint": ("wiki", "lint"),
+    # Paced ENQUEUE — append a run request to this universe's dispatcher queue.
+    # NOT a synchronous spawn: the daemon's concurrency cap + per-provider
+    # cooldown pace execution. Bounded by a spawn-depth cap + a per-run enqueue
+    # budget, and gated behind WORKFLOW_NODE_ENQUEUE_ENABLED (ships dark).
+    "enqueue_branch_run": ("dispatch", "enqueue"),
+    "dispatch.enqueue": ("dispatch", "enqueue"),
 }
+
+
+def _node_enqueue_enabled() -> bool:
+    """Capability gate for the in-node enqueue verb (ships dark, default off).
+
+    The first side-effecting in-node verb. Kept fail-closed until the
+    concurrency proof + opposite-provider review clear it for live use.
+    """
+    return os.environ.get(
+        "WORKFLOW_NODE_ENQUEUE_ENABLED", ""
+    ).strip().lower() in {"on", "1", "true", "yes"}
+
+
+def _node_enqueue_max_depth() -> int:
+    """Spawn-depth cap for queue enqueues — bounds chain LENGTH.
+
+    Default 2 (a driver at depth 0 enqueues leaf runs at depth 1; one extra
+    level of headroom), tighter than the in-graph invoke-branch cap because
+    each queue level is a full independent run. Host-tunable.
+    """
+    raw = os.environ.get("WORKFLOW_NODE_ENQUEUE_MAX_DEPTH", "").strip()
+    try:
+        val = int(raw) if raw else 2
+    except ValueError:
+        val = 2
+    return val if val >= 1 else 2
+
+
+def _node_enqueue_budget() -> int:
+    """Per-run enqueue budget — bounds branching FACTOR (default 50)."""
+    raw = os.environ.get("WORKFLOW_NODE_ENQUEUE_MAX_PER_RUN", "").strip()
+    try:
+        val = int(raw) if raw else 50
+    except ValueError:
+        val = 50
+    return val if val > 0 else 50
+
+
+def _node_enqueue_branch_run(
+    node: "NodeDefinition",
+    invocation_depth: int,
+    enqueued_count: list[int],
+    kwargs: dict[str, Any],
+) -> str:
+    """Append ONE paced run-request to this universe's dispatcher queue.
+
+    Not a synchronous spawn — the daemon's concurrency cap + cooldown pace
+    execution. Bounded three ways: a capability flag (ships dark), a spawn-
+    depth cap (chain length), and a per-run budget (branching factor). Returns
+    a JSON string so the caller's standard parse step applies.
+    """
+    if not _node_enqueue_enabled():
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: the in-node enqueue verb "
+            f"is disabled. Set WORKFLOW_NODE_ENQUEUE_ENABLED to enable."
+        )
+
+    # Guard 1 — spawn-depth cap bounds chain length (self-enqueue can't recurse
+    # forever). A task at depth D enqueues children at D+1.
+    cap = _node_enqueue_max_depth()
+    next_depth = int(invocation_depth) + 1
+    if next_depth > cap:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: spawn depth {next_depth} "
+            f"exceeds cap {cap} (WORKFLOW_NODE_ENQUEUE_MAX_DEPTH)."
+        )
+
+    # Guard 2 — per-run budget bounds branching factor (one run can't flood).
+    budget = _node_enqueue_budget()
+    if enqueued_count[0] >= budget:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: this run already enqueued "
+            f"{enqueued_count[0]} task(s) (budget {budget})."
+        )
+
+    target = str(kwargs.get("branch_def_id", "")).strip()
+    if not target:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue requires a non-empty branch_def_id."
+        )
+    run_inputs = kwargs.get("inputs") or {}
+    if not isinstance(run_inputs, dict):
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue inputs must be an object, got "
+            f"{type(run_inputs).__name__}."
+        )
+
+    from workflow.api.helpers import _default_universe, _universe_dir
+    from workflow.branch_tasks import BranchTask, append_task, new_task_id
+
+    uid = str(kwargs.get("universe_id", "")).strip() or _default_universe()
+    task = BranchTask(
+        branch_task_id=new_task_id(),
+        branch_def_id=target,
+        universe_id=uid,
+        inputs=dict(run_inputs),
+        trigger_source="owner_queued",
+        request_type=str(kwargs.get("request_type", "") or "branch_run"),
+        depth=next_depth,
+    )
+    append_task(_universe_dir(uid), task)
+    enqueued_count[0] += 1
+    return json.dumps({
+        "status": "enqueued",
+        "branch_task_id": task.branch_task_id,
+        "branch_def_id": target,
+        "universe_id": uid,
+        "depth": next_depth,
+    })
 
 
 def _build_node_mcp_invoker(
     node: NodeDefinition,
     *,
     event_sink: Callable[..., None] | None,
+    invocation_depth: int = 0,
 ) -> Callable[..., dict[str, Any]]:
     allowed = set(node.tools_allowed or [])
+    # Per-run enqueue budget (mutable closure cell) — bounds branching factor:
+    # one branch run may enqueue at most _node_enqueue_budget() tasks total.
+    enqueued_count = [0]
 
     def _invoke_mcp_action(action_name: str, **kwargs: Any) -> dict[str, Any]:
         requested = str(action_name or "").strip()
@@ -1291,6 +1410,10 @@ def _build_node_mcp_invoker(
                     f"'{action}' is a write and is not exposed in-node."
                 )
             raw = wiki(action=action, **kwargs)
+        elif tool_name == "dispatch":
+            raw = _node_enqueue_branch_run(
+                node, invocation_depth, enqueued_count, kwargs,
+            )
         else:  # pragma: no cover - mapping owns the dispatch domains.
             raise CompilerError(
                 f"Node '{node.node_id}' requested unsupported MCP tool "
@@ -1318,6 +1441,7 @@ def _build_source_code_node(
     *,
     event_sink: Callable[..., None] | None,
     concurrency_tracker: ConcurrencyTracker | None = None,
+    invocation_depth: int = 0,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Return a node function that exec()s the approved source_code.
 
@@ -1328,7 +1452,9 @@ def _build_source_code_node(
     _validate_source_code(node)
     src = node.source_code
     timeout_s = float(node.timeout_seconds or 300.0)
-    invoke_mcp_action = _build_node_mcp_invoker(node, event_sink=event_sink)
+    invoke_mcp_action = _build_node_mcp_invoker(
+        node, event_sink=event_sink, invocation_depth=invocation_depth,
+    )
 
     # BUG-112: exec into a SINGLE namespace (globals == locals). With split
     # globals/locals, top-level defs land in locals, but each function's
@@ -2151,6 +2277,7 @@ def _build_node(
     if has_source:
         inner = _build_source_code_node(
             node, event_sink=event_sink, concurrency_tracker=concurrency_tracker,
+            invocation_depth=invocation_depth,
         )
         return _wrap_with_checkpoints(inner, node, event_sink)
     if has_template:


### PR DESCRIPTION
## Context

Slice 2/2 of closing the **driver-branch gap** (slice 1 = wiki-read, #1213, merged). Together these let a user *compose* the backlog-driver from primitives instead of it living in engine code (the backfill we cut in #1212).

## What this adds

A `source_code` node can append a run-request to its universe's dispatcher queue:
```python
invoke_mcp_action('enqueue_branch_run', branch_def_id='patch_loop', inputs={'bug_id': 'BUG-1'})
```
**Paced, not spawned** — it appends to `branch_tasks.json`; the daemon's concurrency cap + per-provider cooldown pace execution (the mechanism that kept the old backfill safe). No synchronous `run_branch`, no blocking, no direct fork-bomb.

## Safety — three bounds, fail-closed

| Bound | Env | Default | Protects against |
|---|---|---|---|
| Capability flag | `WORKFLOW_NODE_ENQUEUE_ENABLED` | **off** | ships dark until proven |
| Spawn-depth cap | `WORKFLOW_NODE_ENQUEUE_MAX_DEPTH` | 2 | chain length (infinite self-enqueue) |
| Per-run budget | `WORKFLOW_NODE_ENQUEUE_MAX_PER_RUN` | 50 | branching factor (one run flooding) |

Depth is carried across the queue boundary via a new `BranchTask.depth` field (migration-safe): the dispatcher passes `claimed_task.depth` into `execute_branch(_invocation_depth=...)`, threaded through `compile_branch → _build_node → _build_source_code_node →` the node MCP invoker, so an enqueue is always `parent_depth + 1`. Mirrors the existing invoke-branch depth guard. `tools_allowed` gating + universe resolution match the existing in-node `goals`/`gates`/`wiki` calls; `trigger_source` is forced to `owner_queued` (no arbitrary tiers).

## Tests
enqueue happy path (appends at parent_depth+1) · default-off flag · depth-cap refusal (never appends) · per-run-budget refusal (first appends, second refused) · `tools_allowed` gating · missing `branch_def_id` · `BranchTask.depth` migration roundtrip. ruff clean; mirror rebuilt; full `test_branch_runner` (48) green. (Pre-existing unrelated `test_dispatcher_queue` host-actor failures exist on clean main too.)

## ⚠️ Gates before this goes LIVE (not before merge — it ships dark)
1. **§14 concurrency / load-test proof** — validate the depth cap + per-run budget + dispatcher pacing under concurrent enqueue load.
2. **Opposite-provider (Codex) review** — per the substrate-change rule; this is the first side-effecting in-node verb.

Merging the code is low-risk (flag default off). Enabling `WORKFLOW_NODE_ENQUEUE_ENABLED` is gated on 1+2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)