### PR TITLE
test(enqueue): §14 concurrency proof + Codex review-gate row for the in-node enqueue verb

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -31,6 +31,7 @@ universe_server.py: 14012 → 972 LOC live in main. PLAN.md restructured 30→11
 |------|-------|---------|--------|
 | **#906 host merge key** — Open-brain v2 slice C cost-ledger READ surface; Claude checker APPROVED 2026-05-19 | workflow/daemon_brain.py, workflow/api/status.py + plugin mirrors | - | host-action |
 | **#907 host merge key** — Bounded autonomous spend CI writer-prompt guardrail; Claude checker APPROVED 2026-05-19 | .github/workflows/auto-fix-bug.yml, docs/ops/auto-fix-runbook.md | - | host-action |
+| **Codex review gate** — in-node paced enqueue verb #1214 (67797ba3, ships dark); §14 concurrency proof green (tests/test_node_enqueue_concurrency.py); approve depth-cap+budget+pacing before `WORKFLOW_NODE_ENQUEUE_ENABLED` flips live | workflow/graph_compiler.py, workflow/branch_tasks.py, fantasy_daemon/__main__.py | review approve/adapt | dev-ready:codex |
 | External directory acceptance — PRs landed, public canaries green 2026-05-02T12:34-07:00; needs clean ChatGPT/Claude proof + first-user evidence | packaging/registry/server.json, docs/ops/mcp-* | - | host-action |
 | OpenAI app submission hardening — docs/code never landed; chatgpt-app-submission.json absent on disk | chatgpt-app-submission.json, docs/ops/openai-app-submission-*.md | clean ChatGPT approval/mobile proof | dev-ready |
 | **#23 Arc B phase 2** — `codex/old-session-consolidation` at c967272; focused gates green | tests/, workflow/api/runs.py, fantasy_daemon/api.py | - | host-review |

--- a/tests/test_node_enqueue_concurrency.py
+++ b/tests/test_node_enqueue_concurrency.py
@@ -1,0 +1,112 @@
+"""§14 concurrency / load proof for the in-node paced enqueue verb (PR #1214).
+
+Exercises the REAL file-locked ``append_task`` under concurrent branch runs to
+prove the safety rails hold under load:
+  1. the per-run enqueue budget is enforced independently per run, even when
+     many runs enqueue at once;
+  2. concurrent appends to one universe queue lose no updates and don't corrupt
+     the JSON (the branch_tasks file lock serializes them);
+  3. every enqueued task is well-formed at the correct spawn depth, with a
+     unique task id (no id collision across concurrent appends).
+
+This is the gate the enqueue capability flag (WORKFLOW_NODE_ENQUEUE_ENABLED)
+waits on before going live.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+
+from langgraph.checkpoint.memory import InMemorySaver
+
+import workflow.api.helpers as helpers
+from workflow.branch_tasks import read_queue
+from workflow.branches import (
+    BranchDefinition,
+    EdgeDefinition,
+    GraphNodeRef,
+    NodeDefinition,
+)
+from workflow.graph_compiler import compile_branch
+
+_BUDGET = 5
+_RUNS = 8  # concurrent branch runs
+
+# Each run tries 8 enqueues; the budget caps it at 5, so each lands exactly 5.
+_SRC = (
+    "def run(state):\n"
+    "    n = 0\n"
+    "    for i in range(8):\n"
+    "        try:\n"
+    "            invoke_mcp_action('enqueue_branch_run',\n"
+    "                branch_def_id='leaf', inputs={'i': i, 'run': state['run']})\n"
+    "            n += 1\n"
+    "        except Exception:\n"
+    "            break\n"
+    "    return {'status': str(n)}\n"
+)
+
+
+def _branch() -> BranchDefinition:
+    b = BranchDefinition(name="drv", entry_point="only")
+    b.node_defs = [NodeDefinition(
+        node_id="only",
+        display_name="Only",
+        source_code=_SRC,
+        input_keys=["run"],
+        output_keys=["status"],
+        tools_allowed=["enqueue_branch_run"],
+        approved=True,
+    )]
+    b.graph_nodes = [GraphNodeRef(id="only", node_def_id="only")]
+    b.edges = [
+        EdgeDefinition(from_node="START", to_node="only"),
+        EdgeDefinition(from_node="only", to_node="END"),
+    ]
+    b.state_schema = [
+        {"name": "run", "type": "int"},
+        {"name": "status", "type": "str"},
+    ]
+    return b
+
+
+def _one_run(run_id: int) -> str:
+    compiled = compile_branch(_branch(), invocation_depth=0)
+    app = compiled.graph.compile(checkpointer=InMemorySaver())
+    out = app.invoke(
+        {"run": run_id},
+        config={"configurable": {"thread_id": f"conc-{run_id}"}},
+    )
+    return out["status"]
+
+
+def test_concurrent_enqueue_bounded_and_lock_safe(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_MAX_PER_RUN", str(_BUDGET))
+    uni = tmp_path / "uni"
+    uni.mkdir()
+    monkeypatch.setattr(helpers, "_default_universe", lambda: "uni")
+    monkeypatch.setattr(helpers, "_universe_dir", lambda uid: uni)
+
+    with ThreadPoolExecutor(max_workers=_RUNS) as ex:
+        results = list(ex.map(_one_run, range(_RUNS)))
+
+    # 1. Per-run budget held under concurrency — each run landed exactly budget.
+    assert results == [str(_BUDGET)] * _RUNS
+
+    # 2. No lost updates / no corruption — the file lock serialized every append.
+    q = read_queue(uni)
+    assert len(q) == _RUNS * _BUDGET
+
+    # 3. Well-formed at depth 1 (parent 0 + 1), correct target + tier.
+    assert all(t.depth == 1 for t in q)
+    assert all(t.branch_def_id == "leaf" for t in q)
+    assert all(t.trigger_source == "owner_queued" for t in q)
+
+    # Every run represented exactly budget times; no cross-run loss.
+    per_run = Counter(t.inputs["run"] for t in q)
+    assert per_run == {r: _BUDGET for r in range(_RUNS)}
+
+    # Unique task ids — no collision across concurrent appends.
+    assert len({t.branch_task_id for t in q}) == _RUNS * _BUDGET


### PR DESCRIPTION
Gate work for PR #1214 (paced in-node enqueue verb, merged dark).

## §14 concurrency proof
`tests/test_node_enqueue_concurrency.py` — 8 concurrent branch runs each enqueue past their budget against **one real file-locked universe queue**. Asserts:
- **per-run budget held under concurrency** — each run lands exactly `budget` (5), independently;
- **no lost updates / no corruption** — all 40 appends present, queue parses, the `branch_tasks` file lock serialized them;
- **well-formed** — every task at `depth==1`, `trigger_source==owner_queued`, **unique** task id (no collision under concurrent append).

Passes locally (`1 passed in 7.9s`).

## Codex review gate (STATUS.md)
Records the opposite-provider review gate: the enqueue verb is the first side-effecting in-node primitive, so it gets Codex review of the depth-cap + per-run-budget + dispatcher pacing **before** `WORKFLOW_NODE_ENQUEUE_ENABLED` flips live — even though the code merged dark.

With this, the two live-enable gates are: ✅ concurrency proof (this PR) · ⏳ Codex review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)