### PR TITLE
Close SQLite connections in storage and idempotency helpers

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/idempotency.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/idempotency.py
@@ -22,6 +22,7 @@ wrapped function again.
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import json
 import logging
@@ -46,12 +47,17 @@ class IdempotencyStore:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._init_db()
 
-    def _connect(self) -> sqlite3.Connection:
+    @contextlib.contextmanager
+    def _connect(self):
         conn = sqlite3.connect(str(self._path), timeout=30.0)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode = WAL")
-        conn.execute("PRAGMA busy_timeout = 30000")
-        return conn
+        try:
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode = WAL")
+            conn.execute("PRAGMA busy_timeout = 30000")
+            with conn:
+                yield conn
+        finally:
+            conn.close()
 
     def _now(self) -> str:
         return datetime.now(timezone.utc).isoformat()

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/storage/__init__.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/storage/__init__.py
@@ -31,6 +31,7 @@ intermediate file.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import sqlite3
@@ -571,15 +572,20 @@ def universe_id_from_path(universe_path: str | Path) -> str:
 # -------------------------------------------------------------------
 
 
-def _connect(base_path: str | Path) -> sqlite3.Connection:
+@contextlib.contextmanager
+def _connect(base_path: str | Path):
     path = db_path(base_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path, timeout=30.0)
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA foreign_keys = ON")
-    conn.execute("PRAGMA journal_mode = WAL")
-    conn.execute("PRAGMA busy_timeout = 30000")
-    return conn
+    try:
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA busy_timeout = 30000")
+        with conn:
+            yield conn
+    finally:
+        conn.close()
 
 
 __all__ = [

--- a/workflow/idempotency.py
+++ b/workflow/idempotency.py
@@ -22,6 +22,7 @@ wrapped function again.
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import json
 import logging
@@ -46,12 +47,17 @@ class IdempotencyStore:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._init_db()
 
-    def _connect(self) -> sqlite3.Connection:
+    @contextlib.contextmanager
+    def _connect(self):
         conn = sqlite3.connect(str(self._path), timeout=30.0)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode = WAL")
-        conn.execute("PRAGMA busy_timeout = 30000")
-        return conn
+        try:
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode = WAL")
+            conn.execute("PRAGMA busy_timeout = 30000")
+            with conn:
+                yield conn
+        finally:
+            conn.close()
 
     def _now(self) -> str:
         return datetime.now(timezone.utc).isoformat()

--- a/workflow/storage/__init__.py
+++ b/workflow/storage/__init__.py
@@ -31,6 +31,7 @@ intermediate file.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import sqlite3
@@ -571,15 +572,20 @@ def universe_id_from_path(universe_path: str | Path) -> str:
 # -------------------------------------------------------------------
 
 
-def _connect(base_path: str | Path) -> sqlite3.Connection:
+@contextlib.contextmanager
+def _connect(base_path: str | Path):
     path = db_path(base_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path, timeout=30.0)
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA foreign_keys = ON")
-    conn.execute("PRAGMA journal_mode = WAL")
-    conn.execute("PRAGMA busy_timeout = 30000")
-    return conn
+    try:
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA busy_timeout = 30000")
+        with conn:
+            yield conn
+    finally:
+        conn.close()
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- wrap the shared SQLite `_connect(...)` helpers in context managers that close connections in `finally`
- preserve existing sqlite transaction commit/rollback behavior by nesting `with conn:` inside the helper
- leave existing `with _connect(...) as conn:` call sites unchanged while stopping WAL/file descriptor leaks on account/auth and idempotency paths

## Request reference
Implements the requested change to update the SQLite connection helpers so `with _connect(...) as conn:` always closes the underlying connection after use.