### PR TITLE
test(bug-investigation): pin effort fields in stable-payload key set

### DIFF
--- a/tests/test_bug_investigation.py
+++ b/tests/test_bug_investigation.py
@@ -88,10 +88,12 @@ class TestBuildRunPayload:
         assert payload["request_text"] == "custom request body"
 
     def test_payload_keys_are_stable(self):
-        """The 9 canonical fields plus request_text are always present."""
+        """The canonical fields (incl. effort classification) plus request_text
+        are always present."""
         payload = self._call({})
         assert set(payload.keys()) == {
             "bug_id", "title", "component", "severity", "kind",
+            "effort_class", "effort_attention", "effort_dispatch_lane",
             "observed", "expected", "repro", "workaround", "request_text",
         }
 


### PR DESCRIPTION
## What

`test_payload_keys_are_stable` was failing on `main` (flagged by Codex during the post-merge #1212 review as a pre-existing, non-#1212 red).

`build_run_payload({})` now always emits three effort fields — `effort_class`, `effort_attention`, `effort_dispatch_lane` — because they're part of `_PAYLOAD_KEYS` as of the effort-classification work (PR-1018 lineage). The test still pinned the old 10-key set, so it failed with 3 unexpected keys.

This updates the expected key set to match the canonical payload contract. **Test-only — no runtime change.**

## Why pin them rather than ignore them

The test is a deliberate contract guard: it pins the exact payload shape so a silent change to `_PAYLOAD_KEYS` trips it. The effort fields are now a real, permanent part of that shape, so they belong in the pinned set.

## Verification

- `tests/test_bug_investigation.py` → **26 passed** (was 1 failed)
- adjacent: `test_bug_investigation_wiring.py test_bug_investigation_canonical_cutover.py test_bug_investigation_dispatcher.py` → **55 passed**
- `ruff check tests/test_bug_investigation.py` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)