### PR TITLE
feat(graph): contain the in-node enqueue verb before live enable (Codex adapt)

### DIFF
--- a/docs/audits/2026-06-02-in-node-enqueue-adapt-rereview.md
+++ b/docs/audits/2026-06-02-in-node-enqueue-adapt-rereview.md
@@ -1,0 +1,98 @@
+# In-node enqueue verb — ADAPT re-review brief (Codex, round 2)
+
+**Writer:** claude-code (claude-opus-4-8) · **Reviewer family:** Codex
+(opposite-provider) · **Date:** 2026-06-02
+
+This is the re-review gate after the **ADAPT** verdict in
+`2026-05-30-in-node-enqueue-codex-review.md` (recorded via PR #1217). The verb
+still ships **dark** behind `WORKFLOW_NODE_ENQUEUE_ENABLED` (default off). A
+Codex **approve** here is the gate to flip that flag on in production — it does
+**not** gate the merge.
+
+## What to review
+
+- **PR #1221**, branch `claude/enqueue-adapt`, head `658d126a`.
+- It closes the three ADAPT items. The two findings Codex marked ACCEPTABLE
+  (Q2 cross-process lock, Q5 depth integrity) are unchanged; the Q6 failed-
+  enqueue audit-record note is left as an explicit follow-up, not done here.
+
+## Files / symbols
+
+- `workflow/graph_compiler.py`
+  - `NodeEnqueueContext` (new) — trusted, server-set `universe_id`, `actor`,
+    `parent_branch_task_id`, `origin_branch_task_id`.
+  - `_node_enqueue_branch_run` (rewritten) — Fixes 1+2+3.
+  - `_node_enqueue_max_queue` / `_node_enqueue_max_lineage` (new env readers).
+  - context threaded through `_build_node_mcp_invoker` → `_build_source_code_node`
+    → `_build_node` → `compile_branch` (parallel to `invocation_depth`).
+- `workflow/branch_tasks.py` — `BranchTask.parent_branch_task_id` /
+  `origin_branch_task_id` (new, migration-safe); `QueueCapExceeded` +
+  `append_task_capped` (atomic count-then-append under one lock).
+- `workflow/runs.py` — `execute_branch` accepts `_enqueue_universe_id`
+  `_parent_branch_task_id` `_origin_branch_task_id`, builds the context, threads
+  it via `_invoke_graph` → `compile_branch`.
+- `fantasy_daemon/__main__.py` — dispatcher passes `claimed_task.universe_id` /
+  `.branch_task_id` / `.origin_branch_task_id` at the `execute_branch` call.
+- Tests: `tests/test_node_enqueue_verb.py`, `tests/test_node_enqueue_concurrency.py`.
+
+## How each ADAPT item was addressed
+
+1. **Universe targeting (was Q3).** The queue write targets the run's own
+   trusted `context.universe_id` only. A branch-supplied `universe_id` may only
+   echo it (mismatch → refused). Empty trusted universe → fail closed
+   (in-node enqueue is for dispatched runs; the async/MCP path passes no
+   context and therefore cannot enqueue).
+2. **Queue growth (was Q1).** Global active cap
+   `WORKFLOW_NODE_ENQUEUE_MAX_QUEUE` (default 500) + per-origin lineage cap
+   `WORKFLOW_NODE_ENQUEUE_MAX_LINEAGE` (default 200), both enforced inside
+   `append_task_capped` under a single file lock (count + append atomic — no
+   TOCTOU). Lineage = `origin_branch_task_id`, propagated server-side; a root
+   run's first enqueue becomes its own origin.
+3. **Branch authority (was Q4).** No new policy — reuses the existing
+   public/private visibility model. Before append: `get_branch_definition`
+   (KeyError → "does not exist", refused before any append); private branch
+   runnable only when `author == context.actor`; public by any actor. (Host
+   steer: scenario-specific authority — e.g. same-goal — is composed by the
+   loop author, not baked into the primitive.)
+
+## Re-review questions (don't rubber-stamp)
+
+1. **Each ADAPT item fully closed?** Confirm Fix 1/2/3 actually hold and there
+   is no remaining path to (a) target a non-current universe, (b) grow the
+   queue past the caps, or (c) enqueue a non-existent / unauthorized branch.
+2. **Spoof resistance.** A node controls `inputs` and its own kwargs. Confirm
+   it cannot influence `universe_id`, `actor`, `parent_branch_task_id`, or
+   `origin_branch_task_id` — all must come from `NodeEnqueueContext` (trusted),
+   never kwargs/inputs. Check the kwargs→task field flow specifically.
+3. **Cap atomicity.** Confirm `append_task_capped` counts and appends under one
+   lock so concurrent enqueues cannot overshoot a cap. Is counting
+   pending+running the right active-set definition? Is the per-origin scan over
+   the full queue acceptable cost at the 500/200 ceilings?
+4. **Fail-closed completeness.** Confirm no trusted context (async/MCP run,
+   direct `execute_branch`, or a future caller) ⇒ refuse, never a silent
+   default-universe write. Is "in-node enqueue only for dispatched runs" an
+   acceptable boundary, or should the interactive path get a trusted context
+   too?
+5. **Authority reuse correctness.** Is `get_branch_definition` +
+   author/visibility the right existing check to reuse, matching what
+   `run_branch` enforces? Any visibility states beyond public/private (e.g.
+   unlisted/archived) that this misses?
+6. **Migration safety.** Confirm old `BranchTask` rows without the new fields
+   load (default ""), and the new fields can't break the dispatcher claim path.
+
+## Required output
+
+Append a `## Verdict (codex round 2, YYYY-MM-DD)` section to THIS file:
+**approve** / **adapt** / **reject**, reasoning per question. On **approve**,
+the flag flip is unblocked. On **adapt**, list the concrete required changes.
+
+## Evidence pointers
+
+- enqueue verb + concurrency suites: 19 passed (new tests per fix incl. real
+  `append_task_capped` global + per-origin enforcement).
+- broader suites: 0 new failures. The 4 `test_dispatcher_queue` reds + 1
+  `test_payload_keys_are_stable` red are pre-existing on clean origin/main
+  (latter fixed by PR #1220), confirmed by running them without this branch.
+- ruff clean; plugin mirror parity green; import probe ok.
+- Prior verdict: `docs/audits/2026-05-30-in-node-enqueue-codex-review.md`
+  (PR #1217).

--- a/docs/audits/2026-06-02-in-node-enqueue-adapt-rereview.md
+++ b/docs/audits/2026-06-02-in-node-enqueue-adapt-rereview.md
@@ -194,3 +194,36 @@ Verification (claude-code, 2026-06-03):
 
 Append a `## Verdict (codex round 3, YYYY-MM-DD)` section: approve / adapt /
 reject.
+
+## Verdict (codex round 3, 2026-06-03)
+
+**approve** - the round-2 blocker is closed, and flipping
+`WORKFLOW_NODE_ENQUEUE_ENABLED` on is unblocked from this review gate.
+
+Round-3 answers:
+
+1. `request_type` is now fully server-controlled for this verb. Both the source
+   helper and packaged runtime mirror force `request_type="branch_run"` and no
+   longer read `request_type` from branch-authored kwargs. `branch_run` is the
+   correct sole scheduler class for an `enqueue_branch_run` primitive; other
+   classes such as `bug_investigation` or `paid_market` need their own reviewed
+   primitives or server-side routing policy.
+2. No other branch-authored kwarg reaches a scheduler-class or privileged
+   side-effect task field. The remaining caller-controlled surface is
+   `branch_def_id` (required, existence-validated, and checked against
+   public/private branch authority), `inputs` (the intended opaque payload for
+   the target branch), and an optional `universe_id` echo that is refused unless
+   it matches the trusted run universe.
+3. With the original universe targeting, queue cap, target-branch authority,
+   lineage/migration, and now request-type containment checks in place, this
+   review gate is approved for production flag enablement.
+
+Verification run by Codex:
+
+- `python -m pytest tests/test_node_enqueue_verb.py tests/test_node_enqueue_concurrency.py -q`
+  -> 20 passed.
+- `python -m pytest tests/test_branch_runner.py::test_execute_branch_end_to_end tests/test_branch_runner.py::test_async_run_completes_successfully tests/test_api_runs.py::test_compile_failure_records_actionable_run_error -q`
+  -> 3 passed.
+- GitHub PR #1221 at head `d472abe8379bf8fb45510595de71b81958ee4074` was
+  open, mergeable, and green/pass for policy, import probe, and Docker smoke;
+  tagged-release pack was skipped as expected.

--- a/docs/audits/2026-06-02-in-node-enqueue-adapt-rereview.md
+++ b/docs/audits/2026-06-02-in-node-enqueue-adapt-rereview.md
@@ -96,3 +96,64 @@ the flag flip is unblocked. On **adapt**, list the concrete required changes.
 - ruff clean; plugin mirror parity green; import probe ok.
 - Prior verdict: `docs/audits/2026-05-30-in-node-enqueue-codex-review.md`
   (PR #1217).
+
+## Verdict (codex round 2, 2026-06-03)
+
+**adapt** - do not flip `WORKFLOW_NODE_ENQUEUE_ENABLED` on in production yet.
+
+The three original ADAPT items are substantially closed: enqueue now uses a
+trusted universe context, refuses foreign or absent universe context, validates
+target branch existence before append, enforces private-branch owner checks, and
+does global active-queue plus per-origin lineage counting inside the
+`branch_tasks.json` file lock. Migration of old `BranchTask` rows is also safe:
+the new lineage fields default to `""` and `from_dict` still filters unknowns.
+
+The remaining blocker is a new spoof-resistance issue in the kwargs-to-task
+flow: `_node_enqueue_branch_run` copies branch-authored `request_type` from
+kwargs into the queued `BranchTask`. `request_type` is not just metadata. The
+dispatcher uses it for claim filtering, and `fantasy_daemon.__main__` treats
+`bug_investigation` as a direct-execution type with special input shaping and
+post-run patch-packet attachment. That lets source-code nodes steer scheduler
+class / downstream side effects through an untrusted field, even though this
+verb is named and scoped as `enqueue_branch_run`.
+
+Question answers:
+
+1. Original ADAPT closure: universe targeting, queue caps, and target branch
+   validation are closed for the intended daemon-dispatched path. The new
+   branch-authored `request_type` routing hole remains.
+2. Spoof resistance: `universe_id`, `actor`, `parent_branch_task_id`, and
+   `origin_branch_task_id` are trusted-context-only. `request_type` is still
+   kwargs-controlled and should not be.
+3. Cap atomicity: `append_task_capped` counts and appends under one lock. The
+   pending+running active set is the right global queue pressure metric, and
+   the full-file per-origin scan is acceptable at the 500/200 defaults.
+4. Fail-closed completeness: no trusted context fails closed, including async
+   MCP/direct run paths. That daemon-dispatch-only boundary is acceptable for
+   this flag flip, but should be documented as the live operating envelope.
+5. Authority reuse: branch storage normalizes visibility to public/private, and
+   enqueue's private-owner check is stricter than the current `run_branch`
+   exact-ID path. That is acceptable here, with a separate follow-up to align
+   `run_branch` visibility semantics if desired.
+6. Migration safety: old queue rows load with default lineage fields; the
+   dispatcher claim path reads them safely.
+
+Required change before approve:
+
+- Make in-node `enqueue_branch_run` force `request_type="branch_run"` for all
+  tasks it creates, or reject any caller-supplied `request_type` unless there is
+  a deliberately reviewed server-side allowlist for each non-branch-run class.
+- Add a regression test proving branch-authored kwargs cannot create
+  `request_type="bug_investigation"`, `paid_market`, or any other scheduler
+  class through this verb.
+
+Verification run by Codex:
+
+- `python -m pytest tests/test_node_enqueue_verb.py tests/test_node_enqueue_concurrency.py -q`
+  -> 19 passed.
+- `python -m pytest tests/test_branch_runner.py::test_execute_branch_end_to_end tests/test_branch_runner.py::test_execute_branch_fails_on_compiler_error tests/test_branch_runner.py::test_async_run_completes_successfully -q`
+  -> 3 passed.
+- `python -m pytest tests/test_api_runs.py::test_compile_failure_records_actionable_run_error tests/test_api_runs.py::test_action_run_branch_missing_branch_def_id_returns_error -q`
+  -> 2 passed.
+- GitHub checks for PR #1221 at head `f94e7da71907a9043a5ce976e3e2c41501fdcfa6`
+  were green/pass, with the tagged-release pack job skipped as expected.

--- a/docs/audits/2026-06-02-in-node-enqueue-adapt-rereview.md
+++ b/docs/audits/2026-06-02-in-node-enqueue-adapt-rereview.md
@@ -157,3 +157,40 @@ Verification run by Codex:
   -> 2 passed.
 - GitHub checks for PR #1221 at head `f94e7da71907a9043a5ce976e3e2c41501fdcfa6`
   were green/pass, with the tagged-release pack job skipped as expected.
+
+## Round 3 — request_type blocker addressed (claude-code, 2026-06-03)
+
+The single round-2 ADAPT blocker is fixed in commit `2fbc10af` (on top of the
+verdict commit `d5d18adf`):
+
+- `_node_enqueue_branch_run` now **forces `request_type="branch_run"`** and no
+  longer reads `request_type` from branch-authored kwargs. A source node can no
+  longer steer scheduler class / privileged downstream handling (e.g.
+  `bug_investigation` direct-execution + patch-packet attachment, `paid_market`)
+  through this verb.
+- New regression test `test_enqueue_ignores_branch_authored_request_type`
+  asserts a node-supplied `request_type='bug_investigation'` is ignored and the
+  queued task stays `request_type='branch_run'`.
+
+No other behavior changed; the round-2 ACCEPTABLE findings and the now-closed
+Fix 1/2/3 are untouched. `request_type` was the last kwargs→task field; with it
+forced, every task field is now either trusted context (universe/actor/parent/
+origin), validated (branch_def_id), the intended payload (inputs), or a
+server-set constant.
+
+Verification (claude-code, 2026-06-03):
+- `tests/test_node_enqueue_verb.py tests/test_node_enqueue_concurrency.py` -> 20 passed.
+- ruff clean; plugin mirror parity verified; import probe ok.
+
+### Confirm questions for Codex (round 3 — narrow)
+
+1. Is `request_type` now fully server-controlled (forced `"branch_run"`, no
+   kwargs path) and is `branch_run` the correct sole class for this verb?
+2. Is any OTHER branch-authored kwarg still reaching a task field with
+   scheduler/side-effect significance, or is `inputs` (opaque payload) +
+   validated `branch_def_id` the complete remaining caller-controlled surface?
+3. With this closed, is the verdict **approve** to flip
+   `WORKFLOW_NODE_ENQUEUE_ENABLED` on?
+
+Append a `## Verdict (codex round 3, YYYY-MM-DD)` section: approve / adapt /
+reject.

--- a/fantasy_daemon/__main__.py
+++ b/fantasy_daemon/__main__.py
@@ -855,6 +855,18 @@ def _try_execute_claimed_branch_task(
             # Carry spawn depth across the queue boundary so an in-node enqueue
             # from this run is depth+1 and the depth cap can bound the chain.
             _invocation_depth=int(getattr(claimed_task, "depth", 0) or 0),
+            # Trusted enqueue context (Codex review 2026-05-30): the run's own
+            # universe + spawn lineage, server-set from the claimed task so an
+            # in-node enqueue targets THIS universe and the per-origin cap can
+            # bound the whole spawn chain. origin falls back to this task when
+            # it starts a new chain (resolved in the enqueue helper).
+            _enqueue_universe_id=str(getattr(claimed_task, "universe_id", "") or ""),
+            _parent_branch_task_id=str(
+                getattr(claimed_task, "branch_task_id", "") or ""
+            ),
+            _origin_branch_task_id=str(
+                getattr(claimed_task, "origin_branch_task_id", "") or ""
+            ),
         )
         metadata = {
             "branch_def_id": branch_def_id,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
@@ -102,6 +102,12 @@ class BranchTask:
     # inside a running branch (via the in-node enqueue verb) carries
     # parent_depth + 1; a depth cap bounds runaway self-enqueue chains.
     depth: int = 0
+    # Spawn lineage for the per-origin enqueue cap (Codex enqueue review,
+    # 2026-05-30). ``parent`` = the task whose run enqueued this one; ``origin``
+    # = the root of the whole spawn chain. Both are server-set from trusted
+    # dispatch context, never from branch-authored inputs.
+    parent_branch_task_id: str = ""
+    origin_branch_task_id: str = ""
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -245,6 +251,63 @@ def append_task(universe_path: Path, task: BranchTask) -> None:
     qp = queue_path(universe_path)
     with _file_lock(universe_path):
         raw = _read_raw(qp)
+        raw.append(task.to_dict())
+        _write_raw(qp, raw)
+
+
+class QueueCapExceeded(RuntimeError):
+    """A queue-growth cap (global active or per-origin lineage) would be
+    exceeded. The task was NOT appended."""
+
+
+def append_task_capped(
+    universe_path: Path,
+    task: BranchTask,
+    *,
+    max_active: int | None = None,
+    max_lineage: int | None = None,
+) -> None:
+    """File-locked append with atomic queue-growth containment.
+
+    Under a SINGLE lock: count the current queue, enforce a global
+    active-task cap and a per-origin spawn-lineage cap, then append. This is
+    race-free — no read-then-append TOCTOU, so concurrent enqueues cannot
+    overshoot a cap. Raises :class:`QueueCapExceeded` (task not appended)
+    when a cap would be exceeded.
+
+    Caps are skipped when their argument is ``None``. The lineage cap only
+    applies when ``task.origin_branch_task_id`` is set.
+    """
+    if task.trigger_source not in VALID_TRIGGER_SOURCES:
+        raise ValueError(f"Invalid trigger_source: {task.trigger_source}")
+    if task.status not in VALID_STATUSES:
+        raise ValueError(f"Invalid status: {task.status}")
+    if not task.queued_at:
+        task.queued_at = _now_iso()
+    qp = queue_path(universe_path)
+    with _file_lock(universe_path):
+        raw = _read_raw(qp)
+        if max_active is not None:
+            active = sum(
+                1 for r in raw
+                if isinstance(r, dict)
+                and r.get("status") in ("pending", "running")
+            )
+            if active >= max_active:
+                raise QueueCapExceeded(
+                    f"queue has {active} active task(s) (cap {max_active})"
+                )
+        if max_lineage is not None and task.origin_branch_task_id:
+            lineage = sum(
+                1 for r in raw
+                if isinstance(r, dict)
+                and r.get("origin_branch_task_id") == task.origin_branch_task_id
+            )
+            if lineage >= max_lineage:
+                raise QueueCapExceeded(
+                    f"spawn lineage '{task.origin_branch_task_id}' already has "
+                    f"{lineage} task(s) (cap {max_lineage})"
+                )
         raw.append(task.to_dict())
         _write_raw(qp, raw)
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
@@ -1444,7 +1444,13 @@ def _node_enqueue_branch_run(
         universe_id=uid,
         inputs=dict(run_inputs),
         trigger_source="owner_queued",
-        request_type=str(kwargs.get("request_type", "") or "branch_run"),
+        # request_type is FORCED to "branch_run" — never from kwargs. It is not
+        # mere metadata: the dispatcher filters claims on it and the daemon
+        # treats classes like "bug_investigation" as direct-execution with
+        # special input shaping + post-run side effects. Letting a source node
+        # name it would let an enqueue_branch_run verb steer scheduler class /
+        # privileged downstream behavior (Codex round-2 review, 2026-06-03).
+        request_type="branch_run",
         depth=next_depth,
         parent_branch_task_id=parent,
         origin_branch_task_id=origin,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
@@ -1270,19 +1270,74 @@ def _node_enqueue_budget() -> int:
     return val if val > 0 else 50
 
 
+def _node_enqueue_max_queue() -> int:
+    """Global active-queue cap — bounds TOTAL queue growth (default 500).
+
+    Depth + per-run budget bound a single run's shape, but not the total pile
+    across a whole spawn tree (worst case depth*budget). This is the absolute
+    ceiling on pending+running tasks one enqueue may grow the queue to.
+    """
+    raw = os.environ.get("WORKFLOW_NODE_ENQUEUE_MAX_QUEUE", "").strip()
+    try:
+        val = int(raw) if raw else 500
+    except ValueError:
+        val = 500
+    return val if val > 0 else 500
+
+
+def _node_enqueue_max_lineage() -> int:
+    """Per-origin spawn-lineage cap — bounds one origin run's total descendants
+    across all depths (default 200). Stops a single driver chain from consuming
+    the whole global queue and starving other work.
+    """
+    raw = os.environ.get("WORKFLOW_NODE_ENQUEUE_MAX_LINEAGE", "").strip()
+    try:
+        val = int(raw) if raw else 200
+    except ValueError:
+        val = 200
+    return val if val > 0 else 200
+
+
+@dataclass(frozen=True)
+class NodeEnqueueContext:
+    """Trusted, server-set execution context for the in-node enqueue verb.
+
+    Carries the *current run's* universe, actor, and spawn lineage from the
+    dispatcher down to the enqueue helper. None of it is branch-authored — a
+    node controls its ``inputs``, never this context — so it is the trusted
+    basis for universe targeting (Fix 1), branch authority (Fix 3), and the
+    per-origin lineage cap (Fix 2).
+    """
+
+    universe_id: str = ""
+    actor: str = ""
+    parent_branch_task_id: str = ""
+    origin_branch_task_id: str = ""
+
+
 def _node_enqueue_branch_run(
     node: "NodeDefinition",
     invocation_depth: int,
     enqueued_count: list[int],
     kwargs: dict[str, Any],
+    *,
+    base_path: str | Path | None = None,
+    context: "NodeEnqueueContext | None" = None,
 ) -> str:
-    """Append ONE paced run-request to this universe's dispatcher queue.
+    """Append ONE paced run-request to this run's universe dispatcher queue.
 
     Not a synchronous spawn — the daemon's concurrency cap + cooldown pace
-    execution. Bounded three ways: a capability flag (ships dark), a spawn-
-    depth cap (chain length), and a per-run budget (branching factor). Returns
-    a JSON string so the caller's standard parse step applies.
+    execution. Containment (Codex enqueue review, 2026-05-30):
+      * capability flag (ships dark);
+      * spawn-depth cap (chain length) + per-run budget (branching factor);
+      * trusted current-universe targeting — never a branch-named universe
+        (Fix 1);
+      * global active-queue cap + per-origin spawn-lineage cap (Fix 2);
+      * target branch must exist and be runnable by the actor under the
+        existing public/private visibility model (Fix 3).
+    Returns a JSON string so the caller's standard parse step applies.
     """
+    ctx = context or NodeEnqueueContext()
     if not _node_enqueue_enabled():
         raise CompilerError(
             f"Node '{node.node_id}' enqueue refused: the in-node enqueue verb "
@@ -1319,27 +1374,102 @@ def _node_enqueue_branch_run(
             f"{type(run_inputs).__name__}."
         )
 
-    from workflow.api.helpers import _default_universe, _universe_dir
-    from workflow.branch_tasks import BranchTask, append_task, new_task_id
+    # Fix 1 — universe targeting. A queue write is side-effecting, so it goes
+    # ONLY to the run's own trusted universe (set server-side from the claimed
+    # task), never a branch-named one. A caller-supplied universe_id may only
+    # echo the trusted one; anything else is refused. Absent trusted context
+    # we fail closed — in-node enqueue is for dispatched runs.
+    trusted_uid = str(ctx.universe_id or "").strip()
+    if not trusted_uid:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: no trusted universe "
+            f"context. In-node enqueue is available only for dispatched runs."
+        )
+    requested_uid = str(kwargs.get("universe_id", "")).strip()
+    if requested_uid and requested_uid != trusted_uid:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: cannot target universe "
+            f"'{requested_uid}'; this run executes in '{trusted_uid}'."
+        )
+    uid = trusted_uid
 
-    uid = str(kwargs.get("universe_id", "")).strip() or _default_universe()
+    from workflow.api.helpers import _universe_dir
+    from workflow.branch_tasks import (
+        BranchTask,
+        QueueCapExceeded,
+        append_task_capped,
+        new_task_id,
+    )
+
+    # Fix 3 — target branch authority. Reuse the existing visibility model
+    # (no new policy): the branch must exist, and a private branch is runnable
+    # only by its author. Public branches: any actor. Existence is validated
+    # BEFORE append so an unknown id can't land a doomed task.
+    if base_path is None:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: no run context available "
+            f"to validate the target branch."
+        )
+    from workflow.daemon_server import get_branch_definition
+
+    try:
+        target_meta = get_branch_definition(base_path, branch_def_id=target)
+    except KeyError:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: target branch '{target}' "
+            f"does not exist."
+        ) from None
+    visibility = str(target_meta.get("visibility", "public") or "public").strip().lower()
+    target_author = str(target_meta.get("author", "") or "")
+    actor = str(ctx.actor or "").strip()
+    if visibility == "private" and target_author != actor:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: target branch '{target}' "
+            f"is private; only its owner may run it."
+        )
+
+    # Fix 2 — lineage. parent = the current run's task; origin = the root of
+    # the spawn chain (propagated, or this task when it starts a new chain).
+    # Sourced from trusted context, never inputs.
+    new_id = new_task_id()
+    parent = str(ctx.parent_branch_task_id or "").strip()
+    origin = (
+        str(ctx.origin_branch_task_id or "").strip()
+        or parent
+        or new_id
+    )
     task = BranchTask(
-        branch_task_id=new_task_id(),
+        branch_task_id=new_id,
         branch_def_id=target,
         universe_id=uid,
         inputs=dict(run_inputs),
         trigger_source="owner_queued",
         request_type=str(kwargs.get("request_type", "") or "branch_run"),
         depth=next_depth,
+        parent_branch_task_id=parent,
+        origin_branch_task_id=origin,
     )
-    append_task(_universe_dir(uid), task)
+    # Fix 2 — global active-queue cap + per-origin lineage cap, enforced
+    # atomically under one lock (no read-then-append race).
+    try:
+        append_task_capped(
+            _universe_dir(uid),
+            task,
+            max_active=_node_enqueue_max_queue(),
+            max_lineage=_node_enqueue_max_lineage(),
+        )
+    except QueueCapExceeded as exc:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: {exc}."
+        ) from exc
     enqueued_count[0] += 1
     return json.dumps({
         "status": "enqueued",
-        "branch_task_id": task.branch_task_id,
+        "branch_task_id": new_id,
         "branch_def_id": target,
         "universe_id": uid,
         "depth": next_depth,
+        "origin_branch_task_id": origin,
     })
 
 
@@ -1348,6 +1478,8 @@ def _build_node_mcp_invoker(
     *,
     event_sink: Callable[..., None] | None,
     invocation_depth: int = 0,
+    base_path: str | Path | None = None,
+    enqueue_context: "NodeEnqueueContext | None" = None,
 ) -> Callable[..., dict[str, Any]]:
     allowed = set(node.tools_allowed or [])
     # Per-run enqueue budget (mutable closure cell) — bounds branching factor:
@@ -1413,6 +1545,7 @@ def _build_node_mcp_invoker(
         elif tool_name == "dispatch":
             raw = _node_enqueue_branch_run(
                 node, invocation_depth, enqueued_count, kwargs,
+                base_path=base_path, context=enqueue_context,
             )
         else:  # pragma: no cover - mapping owns the dispatch domains.
             raise CompilerError(
@@ -1442,6 +1575,8 @@ def _build_source_code_node(
     event_sink: Callable[..., None] | None,
     concurrency_tracker: ConcurrencyTracker | None = None,
     invocation_depth: int = 0,
+    base_path: str | Path | None = None,
+    enqueue_context: "NodeEnqueueContext | None" = None,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Return a node function that exec()s the approved source_code.
 
@@ -1454,6 +1589,7 @@ def _build_source_code_node(
     timeout_s = float(node.timeout_seconds or 300.0)
     invoke_mcp_action = _build_node_mcp_invoker(
         node, event_sink=event_sink, invocation_depth=invocation_depth,
+        base_path=base_path, enqueue_context=enqueue_context,
     )
 
     # BUG-112: exec into a SINGLE namespace (globals == locals). With split
@@ -2251,6 +2387,7 @@ def _build_node(
     base_path: str | Path | None = None,
     parent_run_id: str = "",
     invocation_depth: int = 0,
+    enqueue_context: "NodeEnqueueContext | None" = None,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Dispatch a NodeDefinition to the right adapter.
 
@@ -2278,6 +2415,7 @@ def _build_node(
         inner = _build_source_code_node(
             node, event_sink=event_sink, concurrency_tracker=concurrency_tracker,
             invocation_depth=invocation_depth,
+            base_path=base_path, enqueue_context=enqueue_context,
         )
         return _wrap_with_checkpoints(inner, node, event_sink)
     if has_template:
@@ -2432,6 +2570,7 @@ def compile_branch(
     base_path: str | Path | None = None,
     parent_run_id: str = "",
     invocation_depth: int = 0,
+    enqueue_context: "NodeEnqueueContext | None" = None,
 ) -> CompiledBranch:
     """Compile a validated BranchDefinition into a StateGraph.
 
@@ -2545,6 +2684,7 @@ def compile_branch(
             base_path=base_path,
             parent_run_id=parent_run_id,
             invocation_depth=invocation_depth,
+            enqueue_context=enqueue_context,
         )
         graph.add_node(gn.id, fn)
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/runs.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/runs.py
@@ -40,6 +40,7 @@ from workflow.branches import BranchDefinition
 from workflow.graph_compiler import (
     CompilerError,
     EmptyResponseError,
+    NodeEnqueueContext,
     NodeTimeoutError,
     UnapprovedNodeError,
     compile_branch,
@@ -2047,6 +2048,7 @@ def _invoke_graph(
     concurrency_budget_override: int | None = None,
     on_node_status: Callable[[str, str], None] | None = None,
     invocation_depth: int = 0,
+    enqueue_context: "NodeEnqueueContext | None" = None,
 ) -> RunOutcome:
     """Compile + invoke the graph for an already-prepared run_id.
 
@@ -2189,6 +2191,7 @@ def _invoke_graph(
             base_path=base_path,
             parent_run_id=run_id,
             invocation_depth=invocation_depth,
+            enqueue_context=enqueue_context,
         )
     except (UnapprovedNodeError, CompilerError) as exc:
         update_run_status(
@@ -2660,6 +2663,9 @@ def execute_branch(
     concurrency_budget_override: int | None = None,
     on_node_status: Callable[[str, str], None] | None = None,
     _invocation_depth: int = 0,
+    _enqueue_universe_id: str = "",
+    _parent_branch_task_id: str = "",
+    _origin_branch_task_id: str = "",
 ) -> RunOutcome:
     """Synchronous end-to-end execution.
 
@@ -2681,6 +2687,12 @@ def execute_branch(
         branch=branch, inputs=inputs,
         run_name=run_name, actor=actor,
     )
+    enqueue_context = NodeEnqueueContext(
+        universe_id=_enqueue_universe_id,
+        actor=actor,
+        parent_branch_task_id=_parent_branch_task_id,
+        origin_branch_task_id=_origin_branch_task_id,
+    )
     return _invoke_graph(
         base_path,
         run_id=run_id, branch=branch, inputs=inputs,
@@ -2689,6 +2701,7 @@ def execute_branch(
         concurrency_budget_override=concurrency_budget_override,
         on_node_status=on_node_status,
         invocation_depth=_invocation_depth,
+        enqueue_context=enqueue_context,
     )
 
 

--- a/tests/test_node_enqueue_concurrency.py
+++ b/tests/test_node_enqueue_concurrency.py
@@ -21,6 +21,7 @@ from concurrent.futures import ThreadPoolExecutor
 from langgraph.checkpoint.memory import InMemorySaver
 
 import workflow.api.helpers as helpers
+import workflow.daemon_server as ds
 from workflow.branch_tasks import read_queue
 from workflow.branches import (
     BranchDefinition,
@@ -28,7 +29,7 @@ from workflow.branches import (
     GraphNodeRef,
     NodeDefinition,
 )
-from workflow.graph_compiler import compile_branch
+from workflow.graph_compiler import NodeEnqueueContext, compile_branch
 
 _BUDGET = 5
 _RUNS = 8  # concurrent branch runs
@@ -72,7 +73,17 @@ def _branch() -> BranchDefinition:
 
 
 def _one_run(run_id: int) -> str:
-    compiled = compile_branch(_branch(), invocation_depth=0)
+    # Each run is its own dispatched task → its own trusted universe context.
+    # Distinct origin per run (parent empty → origin = the run's own enqueued
+    # task), so the per-origin lineage cap never trips here.
+    ctx = NodeEnqueueContext(
+        universe_id="uni", actor="anyone",
+        parent_branch_task_id="", origin_branch_task_id="",
+    )
+    compiled = compile_branch(
+        _branch(), invocation_depth=0,
+        base_path="/fake/base", enqueue_context=ctx,
+    )
     app = compiled.graph.compile(checkpointer=InMemorySaver())
     out = app.invoke(
         {"run": run_id},
@@ -86,8 +97,13 @@ def test_concurrent_enqueue_bounded_and_lock_safe(tmp_path, monkeypatch):
     monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_MAX_PER_RUN", str(_BUDGET))
     uni = tmp_path / "uni"
     uni.mkdir()
-    monkeypatch.setattr(helpers, "_default_universe", lambda: "uni")
     monkeypatch.setattr(helpers, "_universe_dir", lambda uid: uni)
+    # Stub the target-branch existence/visibility check as a public branch so
+    # the real append path (file lock + caps) is what's under test here.
+    monkeypatch.setattr(
+        ds, "get_branch_definition",
+        lambda base_path, *, branch_def_id: {"visibility": "public", "author": "anyone"},
+    )
 
     with ThreadPoolExecutor(max_workers=_RUNS) as ex:
         results = list(ex.map(_one_run, range(_RUNS)))

--- a/tests/test_node_enqueue_verb.py
+++ b/tests/test_node_enqueue_verb.py
@@ -2,9 +2,15 @@
 
 A source_code node can append a run-request to its universe's dispatcher
 queue via ``invoke_mcp_action('enqueue_branch_run', ...)`` — NOT a synchronous
-spawn. The daemon's concurrency cap paces execution. Bounded three ways:
-a default-off capability flag, a spawn-depth cap (chain length), and a
-per-run enqueue budget (branching factor).
+spawn. The daemon's concurrency cap paces execution.
+
+Containment (Codex enqueue review, 2026-05-30):
+  * default-off capability flag (ships dark);
+  * spawn-depth cap (chain length) + per-run budget (branching factor);
+  * trusted current-universe targeting — never a branch-named universe (Fix 1);
+  * global active-queue cap + per-origin spawn-lineage cap (Fix 2);
+  * target branch must exist and be runnable by the actor under the existing
+    public/private visibility model (Fix 3).
 """
 
 from __future__ import annotations
@@ -16,13 +22,18 @@ from langgraph.checkpoint.memory import InMemorySaver
 
 import workflow.api.helpers as helpers
 import workflow.branch_tasks as bt
+import workflow.daemon_server as ds
 from workflow.branches import (
     BranchDefinition,
     EdgeDefinition,
     GraphNodeRef,
     NodeDefinition,
 )
-from workflow.graph_compiler import CompilerError, compile_branch
+from workflow.graph_compiler import (
+    CompilerError,
+    NodeEnqueueContext,
+    compile_branch,
+)
 
 ENQUEUE_ONE = (
     "def run(state):\n"
@@ -36,6 +47,13 @@ ENQUEUE_TWICE = (
     "    invoke_mcp_action('enqueue_branch_run', branch_def_id='x', inputs={})\n"
     "    invoke_mcp_action('enqueue_branch_run', branch_def_id='y', inputs={})\n"
     "    return {'status': 'done'}\n"
+)
+
+ENQUEUE_FOREIGN_UNIVERSE = (
+    "def run(state):\n"
+    "    invoke_mcp_action('enqueue_branch_run', branch_def_id='x',\n"
+    "        inputs={}, universe_id='other')\n"
+    "    return {'status': 'x'}\n"
 )
 
 
@@ -58,18 +76,42 @@ def _branch(src: str, tools_allowed: list[str]) -> BranchDefinition:
     return b
 
 
-def _patch_storage(monkeypatch) -> list:
+def _patch_storage(monkeypatch, *, branch_meta=None) -> list:
+    """Capture enqueued tasks; stub the target-branch lookup as public.
+
+    The helper calls ``append_task_capped`` (not ``append_task``) and
+    ``get_branch_definition`` for the existence/visibility check — both are
+    imported lazily, so patching the module attribute is enough.
+    """
     captured: list = []
-    monkeypatch.setattr(helpers, "_default_universe", lambda: "u")
     monkeypatch.setattr(helpers, "_universe_dir", lambda uid: Path(f"/fake/{uid}"))
     monkeypatch.setattr(
-        bt, "append_task", lambda upath, task: captured.append((upath, task)),
+        bt, "append_task_capped",
+        lambda upath, task, **caps: captured.append((upath, task)),
+    )
+    meta = branch_meta if branch_meta is not None else {
+        "visibility": "public", "author": "anyone",
+    }
+    monkeypatch.setattr(
+        ds, "get_branch_definition",
+        lambda base_path, *, branch_def_id: dict(meta),
     )
     return captured
 
 
-def _run(b, *, invocation_depth=0, thread="t"):
-    compiled = compile_branch(b, invocation_depth=invocation_depth)
+def _ctx(**kw) -> NodeEnqueueContext:
+    base = {"universe_id": "u", "actor": "anyone"}
+    base.update(kw)
+    return NodeEnqueueContext(**base)
+
+
+def _run(b, *, invocation_depth=0, thread="t", context=None, base_path="/fake/base"):
+    if context is None:
+        context = _ctx()
+    compiled = compile_branch(
+        b, invocation_depth=invocation_depth,
+        base_path=base_path, enqueue_context=context,
+    )
     app = compiled.graph.compile(checkpointer=InMemorySaver())
     return app.invoke({}, config={"configurable": {"thread_id": thread}})
 
@@ -99,6 +141,9 @@ def test_enqueue_happy_path_appends_at_depth_1(monkeypatch):
     assert task.universe_id == "u"
     assert task.trigger_source == "owner_queued"
     assert task.depth == 1  # parent depth 0 + 1
+    # A root run starts a new spawn chain: origin == this task, no parent.
+    assert task.parent_branch_task_id == ""
+    assert task.origin_branch_task_id == task.branch_task_id
 
 
 def test_enqueue_carries_parent_depth_plus_one(monkeypatch):
@@ -160,13 +205,149 @@ def test_enqueue_requires_branch_def_id(monkeypatch):
     assert "branch_def_id" in str(exc.value)
 
 
-def test_branch_task_depth_field_roundtrips():
-    # Migration-safe: new field defaults to 0 and survives to_dict/from_dict.
+# ── Fix 1: universe targeting ────────────────────────────────────────────────
+
+def test_enqueue_refuses_without_trusted_universe(monkeypatch):
+    # Absent trusted context (e.g. a direct, non-dispatched run) → fail closed.
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
+    captured = _patch_storage(monkeypatch)
+    b = _branch(ENQUEUE_ONE, ["enqueue_branch_run"])
+    with pytest.raises(CompilerError) as exc:
+        _run(b, thread="enq-nouni", context=_ctx(universe_id=""))
+    assert "trusted universe" in str(exc.value)
+    assert captured == []
+
+
+def test_enqueue_refuses_foreign_universe(monkeypatch):
+    # A node may not target a universe other than the run's own.
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
+    captured = _patch_storage(monkeypatch)
+    b = _branch(ENQUEUE_FOREIGN_UNIVERSE, ["enqueue_branch_run"])
+    with pytest.raises(CompilerError) as exc:
+        _run(b, thread="enq-foreign")
+    assert "cannot target universe" in str(exc.value)
+    assert captured == []
+
+
+# ── Fix 3: target branch authority (reuses existing visibility model) ─────────
+
+def test_enqueue_refuses_unknown_branch(monkeypatch):
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
+    captured = _patch_storage(monkeypatch)
+
+    def _missing(base_path, *, branch_def_id):
+        raise KeyError(branch_def_id)
+
+    monkeypatch.setattr(ds, "get_branch_definition", _missing)
+    b = _branch(ENQUEUE_ONE, ["enqueue_branch_run"])
+    with pytest.raises(CompilerError) as exc:
+        _run(b, thread="enq-missing")
+    assert "does not exist" in str(exc.value)
+    assert captured == []  # validated BEFORE append
+
+
+def test_enqueue_refuses_private_branch_non_owner(monkeypatch):
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
+    captured = _patch_storage(
+        monkeypatch, branch_meta={"visibility": "private", "author": "someone_else"},
+    )
+    b = _branch(ENQUEUE_ONE, ["enqueue_branch_run"])
+    with pytest.raises(CompilerError) as exc:
+        _run(b, thread="enq-priv", context=_ctx(actor="me"))
+    assert "private" in str(exc.value)
+    assert captured == []
+
+
+def test_enqueue_allows_private_branch_owner(monkeypatch):
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
+    captured = _patch_storage(
+        monkeypatch, branch_meta={"visibility": "private", "author": "me"},
+    )
+    b = _branch(ENQUEUE_ONE, ["enqueue_branch_run"])
+    result = _run(b, thread="enq-priv-ok", context=_ctx(actor="me"))
+    assert result["status"] == "enqueued"
+    assert len(captured) == 1
+
+
+# ── Fix 2: spawn lineage stamping + cap surfacing ────────────────────────────
+
+def test_enqueue_stamps_parent_and_origin(monkeypatch):
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_MAX_DEPTH", "5")
+    captured = _patch_storage(monkeypatch)
+    b = _branch(ENQUEUE_ONE, ["enqueue_branch_run"])
+    _run(
+        b, invocation_depth=1, thread="enq-lineage",
+        context=_ctx(parent_branch_task_id="P1", origin_branch_task_id="O1"),
+    )
+    task = captured[0][1]
+    assert task.parent_branch_task_id == "P1"
+    assert task.origin_branch_task_id == "O1"  # propagated, not reset
+
+
+def test_enqueue_surfaces_queue_cap_as_compiler_error(monkeypatch):
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
+    _patch_storage(monkeypatch)
+
+    def _raise(upath, task, **caps):
+        raise bt.QueueCapExceeded("queue has 500 active task(s) (cap 500)")
+
+    monkeypatch.setattr(bt, "append_task_capped", _raise)
+    b = _branch(ENQUEUE_ONE, ["enqueue_branch_run"])
+    with pytest.raises(CompilerError) as exc:
+        _run(b, thread="enq-cap-surface")
+    assert "cap 500" in str(exc.value)
+
+
+# ── BranchTask migration-safety ──────────────────────────────────────────────
+
+def test_branch_task_lineage_fields_roundtrip():
+    # Migration-safe: new fields default to "" and survive to_dict/from_dict.
     t = bt.BranchTask(branch_task_id="x", branch_def_id="b", universe_id="u")
     assert t.depth == 0
-    assert bt.BranchTask.from_dict(t.to_dict()).depth == 0
-    assert bt.BranchTask.from_dict({**t.to_dict(), "depth": 3}).depth == 3
-    # Old rows without the field still load.
-    assert bt.BranchTask.from_dict(
+    assert t.parent_branch_task_id == ""
+    assert t.origin_branch_task_id == ""
+    rt = bt.BranchTask.from_dict({
+        **t.to_dict(), "depth": 3,
+        "parent_branch_task_id": "P", "origin_branch_task_id": "O",
+    })
+    assert (rt.depth, rt.parent_branch_task_id, rt.origin_branch_task_id) == (3, "P", "O")
+    # Old rows without the new fields still load.
+    old = bt.BranchTask.from_dict(
         {"branch_task_id": "y", "branch_def_id": "b", "universe_id": "u"}
-    ).depth == 0
+    )
+    assert (old.depth, old.parent_branch_task_id, old.origin_branch_task_id) == (0, "", "")
+
+
+# ── append_task_capped: atomic queue-growth containment (Fix 2 core) ──────────
+
+def _task(tid, origin="", status="pending"):
+    return bt.BranchTask(
+        branch_task_id=tid, branch_def_id="b", universe_id="u",
+        trigger_source="owner_queued", status=status,
+        origin_branch_task_id=origin,
+    )
+
+
+def test_append_task_capped_allows_under_caps(tmp_path):
+    bt.append_task_capped(tmp_path, _task("t1", origin="O"), max_active=5, max_lineage=5)
+    assert len(bt.read_queue(tmp_path)) == 1
+
+
+def test_append_task_capped_global_active_cap(tmp_path):
+    bt.append_task_capped(tmp_path, _task("t1"), max_active=1)
+    with pytest.raises(bt.QueueCapExceeded) as exc:
+        bt.append_task_capped(tmp_path, _task("t2"), max_active=1)
+    assert "active" in str(exc.value)
+    assert len(bt.read_queue(tmp_path)) == 1  # second never landed
+
+
+def test_append_task_capped_per_origin_lineage_cap(tmp_path):
+    bt.append_task_capped(tmp_path, _task("t1", origin="O"), max_lineage=1)
+    # Same origin → refused.
+    with pytest.raises(bt.QueueCapExceeded) as exc:
+        bt.append_task_capped(tmp_path, _task("t2", origin="O"), max_lineage=1)
+    assert "lineage" in str(exc.value)
+    # Different origin → still allowed (cap is per-origin, not global).
+    bt.append_task_capped(tmp_path, _task("t3", origin="O2"), max_lineage=1)
+    assert len(bt.read_queue(tmp_path)) == 2

--- a/tests/test_node_enqueue_verb.py
+++ b/tests/test_node_enqueue_verb.py
@@ -285,6 +285,24 @@ def test_enqueue_stamps_parent_and_origin(monkeypatch):
     assert task.origin_branch_task_id == "O1"  # propagated, not reset
 
 
+def test_enqueue_ignores_branch_authored_request_type(monkeypatch):
+    # request_type steers scheduler class + privileged downstream handling
+    # (e.g. bug_investigation direct-execution). A source node must NOT be able
+    # to pick it through enqueue_branch_run — it's forced to "branch_run".
+    monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
+    captured = _patch_storage(monkeypatch)
+    src = (
+        "def run(state):\n"
+        "    invoke_mcp_action('enqueue_branch_run', branch_def_id='x',\n"
+        "        inputs={}, request_type='bug_investigation')\n"
+        "    return {'status': 'x'}\n"
+    )
+    b = _branch(src, ["enqueue_branch_run"])
+    _run(b, thread="enq-reqtype")
+    assert len(captured) == 1
+    assert captured[0][1].request_type == "branch_run"  # not 'bug_investigation'
+
+
 def test_enqueue_surfaces_queue_cap_as_compiler_error(monkeypatch):
     monkeypatch.setenv("WORKFLOW_NODE_ENQUEUE_ENABLED", "on")
     _patch_storage(monkeypatch)

--- a/workflow/branch_tasks.py
+++ b/workflow/branch_tasks.py
@@ -102,6 +102,12 @@ class BranchTask:
     # inside a running branch (via the in-node enqueue verb) carries
     # parent_depth + 1; a depth cap bounds runaway self-enqueue chains.
     depth: int = 0
+    # Spawn lineage for the per-origin enqueue cap (Codex enqueue review,
+    # 2026-05-30). ``parent`` = the task whose run enqueued this one; ``origin``
+    # = the root of the whole spawn chain. Both are server-set from trusted
+    # dispatch context, never from branch-authored inputs.
+    parent_branch_task_id: str = ""
+    origin_branch_task_id: str = ""
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -245,6 +251,63 @@ def append_task(universe_path: Path, task: BranchTask) -> None:
     qp = queue_path(universe_path)
     with _file_lock(universe_path):
         raw = _read_raw(qp)
+        raw.append(task.to_dict())
+        _write_raw(qp, raw)
+
+
+class QueueCapExceeded(RuntimeError):
+    """A queue-growth cap (global active or per-origin lineage) would be
+    exceeded. The task was NOT appended."""
+
+
+def append_task_capped(
+    universe_path: Path,
+    task: BranchTask,
+    *,
+    max_active: int | None = None,
+    max_lineage: int | None = None,
+) -> None:
+    """File-locked append with atomic queue-growth containment.
+
+    Under a SINGLE lock: count the current queue, enforce a global
+    active-task cap and a per-origin spawn-lineage cap, then append. This is
+    race-free — no read-then-append TOCTOU, so concurrent enqueues cannot
+    overshoot a cap. Raises :class:`QueueCapExceeded` (task not appended)
+    when a cap would be exceeded.
+
+    Caps are skipped when their argument is ``None``. The lineage cap only
+    applies when ``task.origin_branch_task_id`` is set.
+    """
+    if task.trigger_source not in VALID_TRIGGER_SOURCES:
+        raise ValueError(f"Invalid trigger_source: {task.trigger_source}")
+    if task.status not in VALID_STATUSES:
+        raise ValueError(f"Invalid status: {task.status}")
+    if not task.queued_at:
+        task.queued_at = _now_iso()
+    qp = queue_path(universe_path)
+    with _file_lock(universe_path):
+        raw = _read_raw(qp)
+        if max_active is not None:
+            active = sum(
+                1 for r in raw
+                if isinstance(r, dict)
+                and r.get("status") in ("pending", "running")
+            )
+            if active >= max_active:
+                raise QueueCapExceeded(
+                    f"queue has {active} active task(s) (cap {max_active})"
+                )
+        if max_lineage is not None and task.origin_branch_task_id:
+            lineage = sum(
+                1 for r in raw
+                if isinstance(r, dict)
+                and r.get("origin_branch_task_id") == task.origin_branch_task_id
+            )
+            if lineage >= max_lineage:
+                raise QueueCapExceeded(
+                    f"spawn lineage '{task.origin_branch_task_id}' already has "
+                    f"{lineage} task(s) (cap {max_lineage})"
+                )
         raw.append(task.to_dict())
         _write_raw(qp, raw)
 

--- a/workflow/graph_compiler.py
+++ b/workflow/graph_compiler.py
@@ -1444,7 +1444,13 @@ def _node_enqueue_branch_run(
         universe_id=uid,
         inputs=dict(run_inputs),
         trigger_source="owner_queued",
-        request_type=str(kwargs.get("request_type", "") or "branch_run"),
+        # request_type is FORCED to "branch_run" — never from kwargs. It is not
+        # mere metadata: the dispatcher filters claims on it and the daemon
+        # treats classes like "bug_investigation" as direct-execution with
+        # special input shaping + post-run side effects. Letting a source node
+        # name it would let an enqueue_branch_run verb steer scheduler class /
+        # privileged downstream behavior (Codex round-2 review, 2026-06-03).
+        request_type="branch_run",
         depth=next_depth,
         parent_branch_task_id=parent,
         origin_branch_task_id=origin,

--- a/workflow/graph_compiler.py
+++ b/workflow/graph_compiler.py
@@ -1270,19 +1270,74 @@ def _node_enqueue_budget() -> int:
     return val if val > 0 else 50
 
 
+def _node_enqueue_max_queue() -> int:
+    """Global active-queue cap — bounds TOTAL queue growth (default 500).
+
+    Depth + per-run budget bound a single run's shape, but not the total pile
+    across a whole spawn tree (worst case depth*budget). This is the absolute
+    ceiling on pending+running tasks one enqueue may grow the queue to.
+    """
+    raw = os.environ.get("WORKFLOW_NODE_ENQUEUE_MAX_QUEUE", "").strip()
+    try:
+        val = int(raw) if raw else 500
+    except ValueError:
+        val = 500
+    return val if val > 0 else 500
+
+
+def _node_enqueue_max_lineage() -> int:
+    """Per-origin spawn-lineage cap — bounds one origin run's total descendants
+    across all depths (default 200). Stops a single driver chain from consuming
+    the whole global queue and starving other work.
+    """
+    raw = os.environ.get("WORKFLOW_NODE_ENQUEUE_MAX_LINEAGE", "").strip()
+    try:
+        val = int(raw) if raw else 200
+    except ValueError:
+        val = 200
+    return val if val > 0 else 200
+
+
+@dataclass(frozen=True)
+class NodeEnqueueContext:
+    """Trusted, server-set execution context for the in-node enqueue verb.
+
+    Carries the *current run's* universe, actor, and spawn lineage from the
+    dispatcher down to the enqueue helper. None of it is branch-authored — a
+    node controls its ``inputs``, never this context — so it is the trusted
+    basis for universe targeting (Fix 1), branch authority (Fix 3), and the
+    per-origin lineage cap (Fix 2).
+    """
+
+    universe_id: str = ""
+    actor: str = ""
+    parent_branch_task_id: str = ""
+    origin_branch_task_id: str = ""
+
+
 def _node_enqueue_branch_run(
     node: "NodeDefinition",
     invocation_depth: int,
     enqueued_count: list[int],
     kwargs: dict[str, Any],
+    *,
+    base_path: str | Path | None = None,
+    context: "NodeEnqueueContext | None" = None,
 ) -> str:
-    """Append ONE paced run-request to this universe's dispatcher queue.
+    """Append ONE paced run-request to this run's universe dispatcher queue.
 
     Not a synchronous spawn — the daemon's concurrency cap + cooldown pace
-    execution. Bounded three ways: a capability flag (ships dark), a spawn-
-    depth cap (chain length), and a per-run budget (branching factor). Returns
-    a JSON string so the caller's standard parse step applies.
+    execution. Containment (Codex enqueue review, 2026-05-30):
+      * capability flag (ships dark);
+      * spawn-depth cap (chain length) + per-run budget (branching factor);
+      * trusted current-universe targeting — never a branch-named universe
+        (Fix 1);
+      * global active-queue cap + per-origin spawn-lineage cap (Fix 2);
+      * target branch must exist and be runnable by the actor under the
+        existing public/private visibility model (Fix 3).
+    Returns a JSON string so the caller's standard parse step applies.
     """
+    ctx = context or NodeEnqueueContext()
     if not _node_enqueue_enabled():
         raise CompilerError(
             f"Node '{node.node_id}' enqueue refused: the in-node enqueue verb "
@@ -1319,27 +1374,102 @@ def _node_enqueue_branch_run(
             f"{type(run_inputs).__name__}."
         )
 
-    from workflow.api.helpers import _default_universe, _universe_dir
-    from workflow.branch_tasks import BranchTask, append_task, new_task_id
+    # Fix 1 — universe targeting. A queue write is side-effecting, so it goes
+    # ONLY to the run's own trusted universe (set server-side from the claimed
+    # task), never a branch-named one. A caller-supplied universe_id may only
+    # echo the trusted one; anything else is refused. Absent trusted context
+    # we fail closed — in-node enqueue is for dispatched runs.
+    trusted_uid = str(ctx.universe_id or "").strip()
+    if not trusted_uid:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: no trusted universe "
+            f"context. In-node enqueue is available only for dispatched runs."
+        )
+    requested_uid = str(kwargs.get("universe_id", "")).strip()
+    if requested_uid and requested_uid != trusted_uid:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: cannot target universe "
+            f"'{requested_uid}'; this run executes in '{trusted_uid}'."
+        )
+    uid = trusted_uid
 
-    uid = str(kwargs.get("universe_id", "")).strip() or _default_universe()
+    from workflow.api.helpers import _universe_dir
+    from workflow.branch_tasks import (
+        BranchTask,
+        QueueCapExceeded,
+        append_task_capped,
+        new_task_id,
+    )
+
+    # Fix 3 — target branch authority. Reuse the existing visibility model
+    # (no new policy): the branch must exist, and a private branch is runnable
+    # only by its author. Public branches: any actor. Existence is validated
+    # BEFORE append so an unknown id can't land a doomed task.
+    if base_path is None:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: no run context available "
+            f"to validate the target branch."
+        )
+    from workflow.daemon_server import get_branch_definition
+
+    try:
+        target_meta = get_branch_definition(base_path, branch_def_id=target)
+    except KeyError:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: target branch '{target}' "
+            f"does not exist."
+        ) from None
+    visibility = str(target_meta.get("visibility", "public") or "public").strip().lower()
+    target_author = str(target_meta.get("author", "") or "")
+    actor = str(ctx.actor or "").strip()
+    if visibility == "private" and target_author != actor:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: target branch '{target}' "
+            f"is private; only its owner may run it."
+        )
+
+    # Fix 2 — lineage. parent = the current run's task; origin = the root of
+    # the spawn chain (propagated, or this task when it starts a new chain).
+    # Sourced from trusted context, never inputs.
+    new_id = new_task_id()
+    parent = str(ctx.parent_branch_task_id or "").strip()
+    origin = (
+        str(ctx.origin_branch_task_id or "").strip()
+        or parent
+        or new_id
+    )
     task = BranchTask(
-        branch_task_id=new_task_id(),
+        branch_task_id=new_id,
         branch_def_id=target,
         universe_id=uid,
         inputs=dict(run_inputs),
         trigger_source="owner_queued",
         request_type=str(kwargs.get("request_type", "") or "branch_run"),
         depth=next_depth,
+        parent_branch_task_id=parent,
+        origin_branch_task_id=origin,
     )
-    append_task(_universe_dir(uid), task)
+    # Fix 2 — global active-queue cap + per-origin lineage cap, enforced
+    # atomically under one lock (no read-then-append race).
+    try:
+        append_task_capped(
+            _universe_dir(uid),
+            task,
+            max_active=_node_enqueue_max_queue(),
+            max_lineage=_node_enqueue_max_lineage(),
+        )
+    except QueueCapExceeded as exc:
+        raise CompilerError(
+            f"Node '{node.node_id}' enqueue refused: {exc}."
+        ) from exc
     enqueued_count[0] += 1
     return json.dumps({
         "status": "enqueued",
-        "branch_task_id": task.branch_task_id,
+        "branch_task_id": new_id,
         "branch_def_id": target,
         "universe_id": uid,
         "depth": next_depth,
+        "origin_branch_task_id": origin,
     })
 
 
@@ -1348,6 +1478,8 @@ def _build_node_mcp_invoker(
     *,
     event_sink: Callable[..., None] | None,
     invocation_depth: int = 0,
+    base_path: str | Path | None = None,
+    enqueue_context: "NodeEnqueueContext | None" = None,
 ) -> Callable[..., dict[str, Any]]:
     allowed = set(node.tools_allowed or [])
     # Per-run enqueue budget (mutable closure cell) — bounds branching factor:
@@ -1413,6 +1545,7 @@ def _build_node_mcp_invoker(
         elif tool_name == "dispatch":
             raw = _node_enqueue_branch_run(
                 node, invocation_depth, enqueued_count, kwargs,
+                base_path=base_path, context=enqueue_context,
             )
         else:  # pragma: no cover - mapping owns the dispatch domains.
             raise CompilerError(
@@ -1442,6 +1575,8 @@ def _build_source_code_node(
     event_sink: Callable[..., None] | None,
     concurrency_tracker: ConcurrencyTracker | None = None,
     invocation_depth: int = 0,
+    base_path: str | Path | None = None,
+    enqueue_context: "NodeEnqueueContext | None" = None,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Return a node function that exec()s the approved source_code.
 
@@ -1454,6 +1589,7 @@ def _build_source_code_node(
     timeout_s = float(node.timeout_seconds or 300.0)
     invoke_mcp_action = _build_node_mcp_invoker(
         node, event_sink=event_sink, invocation_depth=invocation_depth,
+        base_path=base_path, enqueue_context=enqueue_context,
     )
 
     # BUG-112: exec into a SINGLE namespace (globals == locals). With split
@@ -2251,6 +2387,7 @@ def _build_node(
     base_path: str | Path | None = None,
     parent_run_id: str = "",
     invocation_depth: int = 0,
+    enqueue_context: "NodeEnqueueContext | None" = None,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Dispatch a NodeDefinition to the right adapter.
 
@@ -2278,6 +2415,7 @@ def _build_node(
         inner = _build_source_code_node(
             node, event_sink=event_sink, concurrency_tracker=concurrency_tracker,
             invocation_depth=invocation_depth,
+            base_path=base_path, enqueue_context=enqueue_context,
         )
         return _wrap_with_checkpoints(inner, node, event_sink)
     if has_template:
@@ -2432,6 +2570,7 @@ def compile_branch(
     base_path: str | Path | None = None,
     parent_run_id: str = "",
     invocation_depth: int = 0,
+    enqueue_context: "NodeEnqueueContext | None" = None,
 ) -> CompiledBranch:
     """Compile a validated BranchDefinition into a StateGraph.
 
@@ -2545,6 +2684,7 @@ def compile_branch(
             base_path=base_path,
             parent_run_id=parent_run_id,
             invocation_depth=invocation_depth,
+            enqueue_context=enqueue_context,
         )
         graph.add_node(gn.id, fn)
 

--- a/workflow/runs.py
+++ b/workflow/runs.py
@@ -40,6 +40,7 @@ from workflow.branches import BranchDefinition
 from workflow.graph_compiler import (
     CompilerError,
     EmptyResponseError,
+    NodeEnqueueContext,
     NodeTimeoutError,
     UnapprovedNodeError,
     compile_branch,
@@ -2047,6 +2048,7 @@ def _invoke_graph(
     concurrency_budget_override: int | None = None,
     on_node_status: Callable[[str, str], None] | None = None,
     invocation_depth: int = 0,
+    enqueue_context: "NodeEnqueueContext | None" = None,
 ) -> RunOutcome:
     """Compile + invoke the graph for an already-prepared run_id.
 
@@ -2189,6 +2191,7 @@ def _invoke_graph(
             base_path=base_path,
             parent_run_id=run_id,
             invocation_depth=invocation_depth,
+            enqueue_context=enqueue_context,
         )
     except (UnapprovedNodeError, CompilerError) as exc:
         update_run_status(
@@ -2660,6 +2663,9 @@ def execute_branch(
     concurrency_budget_override: int | None = None,
     on_node_status: Callable[[str, str], None] | None = None,
     _invocation_depth: int = 0,
+    _enqueue_universe_id: str = "",
+    _parent_branch_task_id: str = "",
+    _origin_branch_task_id: str = "",
 ) -> RunOutcome:
     """Synchronous end-to-end execution.
 
@@ -2681,6 +2687,12 @@ def execute_branch(
         branch=branch, inputs=inputs,
         run_name=run_name, actor=actor,
     )
+    enqueue_context = NodeEnqueueContext(
+        universe_id=_enqueue_universe_id,
+        actor=actor,
+        parent_branch_task_id=_parent_branch_task_id,
+        origin_branch_task_id=_origin_branch_task_id,
+    )
     return _invoke_graph(
         base_path,
         run_id=run_id, branch=branch, inputs=inputs,
@@ -2689,6 +2701,7 @@ def execute_branch(
         concurrency_budget_override=concurrency_budget_override,
         on_node_status=on_node_status,
         invocation_depth=_invocation_depth,
+        enqueue_context=enqueue_context,
     )
 
 


### PR DESCRIPTION
## What

Closes the three containment gaps Codex's 2026-05-30 review (verdict **ADAPT**) required before `WORKFLOW_NODE_ENQUEUE_ENABLED` can flip on. The verb **stays dark** — this is the hardening slice that earns the flag-flip. Verdict record: `docs/audits/2026-05-30-in-node-enqueue-codex-review.md` (PR #1217).

## Shared spine

Thread trusted, **server-set** run context — universe + spawn lineage + actor — from the dispatcher through `execute_branch → _invoke_graph → compile_branch →` the source-node MCP invoker, parallel to the existing `invocation_depth` threading. A node controls its `inputs`, never this context, so it's the trusted basis for all three fixes.

## The three fixes (mapped to Codex's questions)

**Fix 1 — universe targeting (Q3).** A queue write goes ONLY to the run's own trusted universe. A branch-supplied `universe_id` may only echo it; anything else is refused. No trusted context ⇒ fail closed (in-node enqueue is for dispatched runs, not direct interactive runs).

**Fix 2 — queue growth (Q1).** Depth + per-run budget bound one run's *shape*, not total *volume*. Adds:
- global active-queue cap — `WORKFLOW_NODE_ENQUEUE_MAX_QUEUE` (default 500)
- per-origin spawn-lineage cap — `WORKFLOW_NODE_ENQUEUE_MAX_LINEAGE` (default 200)

Both enforced **atomically under one lock** via new `branch_tasks.append_task_capped` (no read-then-append TOCTOU). New `BranchTask.parent_branch_task_id` / `origin_branch_task_id` carry the lineage (server-set, migration-safe via `from_dict` filtering).

**Fix 3 — branch authority (Q4).** Reuses the **existing** public/private visibility model — *no new policy* (per host steer: scenario-specific authority is composed by the loop author, not baked into the platform). Before append: the target branch must exist (`get_branch_definition`) and a private branch is runnable only by its author; public by any actor. Validated **before** append so an unknown id can't land a doomed task.

Codex's two ACCEPTABLE findings (cross-process lock safety Q2, depth-spoof integrity Q5) needed no change; the failure-mode audit note (Q6) is left as a follow-up option.

## Verification

- `tests/test_node_enqueue_verb.py` + `tests/test_node_enqueue_concurrency.py` → **19 passed** (existing depth/budget/lock/concurrency tests updated to pass trusted context + kept; new tests for universe defaulting/foreign-refusal, unknown/private-branch refusal-before-append, lineage stamping, cap surfacing, and real `append_task_capped` global + per-origin enforcement)
- broader suites (`branch_tasks`, `branch_runner`, `bug_investigation`, dispatcher) → no new failures. The 4 `test_dispatcher_queue` reds + 1 `test_payload_keys_are_stable` red are pre-existing on clean origin/main (the latter fixed by #1220), confirmed by running them without this branch's changes.
- `ruff check` clean; plugin mirror rebuilt (parity gate green); import probe ok.

## Gate

Flag stays **dark**. Back to Codex for re-review → approve → **then** flip `WORKFLOW_NODE_ENQUEUE_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)