### PR TITLE
chore(deploy): flip WORKFLOW_NODE_ENQUEUE_ENABLED on (HOLD until #1221 deployed)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -363,6 +363,20 @@ jobs:
           ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
               "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
               "printf '%s' '0ca6e9c97f65' | sudo bash /tmp/install-workflow-env.sh set WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID"
+          # Enqueue go-live (2026-06-03): turn ON the in-node paced enqueue verb
+          # so a user-built driver branch can append run-requests to its own
+          # universe's dispatcher queue. The verb shipped dark in #1214 and was
+          # hardened in #1221 (trusted-universe targeting, global + per-origin
+          # queue caps, target-branch authority, forced request_type=branch_run).
+          # Codex cleared the review gate round-3 APPROVE (2026-06-03).
+          # ORDERING INVARIANT: this line is only safe once #1221 is merged AND
+          # deployed — flipping it while prod runs the pre-#1221 (un-contained)
+          # verb would enable the unguarded path. Do not merge this PR until the
+          # release-state sha includes #1221. Idempotent set; reverting this
+          # block returns the verb to fail-closed dark on the next deploy.
+          ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
+              "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
+              "printf '%s' 'on' | sudo bash /tmp/install-workflow-env.sh set WORKFLOW_NODE_ENQUEUE_ENABLED"
           if [ "${HAS_CODEX_AUTH_BUNDLE}" = "true" ]; then
             echo "Deploy-visible WORKFLOW_CODEX_AUTH_JSON_B64 found; syncing subscription auth bundle."
             printf '%s' "${WORKFLOW_CODEX_AUTH_JSON_B64}" | ssh -i ~/.ssh/do_deploy -o BatchMode=yes \


### PR DESCRIPTION
## ⛔ HOLD — do not merge until PR #1221 is merged AND deployed

Draft on purpose. This is the **go-live** switch for the in-node paced enqueue verb.

## What

Sets `WORKFLOW_NODE_ENQUEUE_ENABLED=on` on the droplet (same idempotent `install-workflow-env.sh set` pattern as the bug-investigation cutover line). That turns the verb live so a user-built **driver branch** can enqueue run-requests to its own universe's dispatcher queue — the last gate before the user-buildable patch-request loop runs end-to-end.

## Gate status

Codex cleared the review **round-3 APPROVE** (2026-06-03), after the #1221 hardening closed all five concerns: trusted-universe targeting, global + per-origin queue caps, target-branch authority, lineage/migration, and forced `request_type=branch_run`. Trail: `docs/audits/2026-06-02-in-node-enqueue-adapt-rereview.md`.

## ⚠️ Ordering invariant (why this is a draft)

Production currently runs `67797ba3` (#1214) — the verb **without** any #1221 hardening. Flipping the flag now would enable the **un-contained** path (no universe guard, no caps, no authority check, spoofable request_type).

**Merge order, strictly:**
1. Merge **#1221** → prod auto-deploys the hardened verb.
2. Confirm the release-state sha includes #1221 (`get_status` → `release_state.git_sha`).
3. **Then** mark this ready + merge → deploy flips the flag.
4. Post-deploy: public canary + a host-watched live driver run.

Reverting this block returns the verb to fail-closed dark on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)