### PR TITLE
chore(deploy): flip WORKFLOW_SOUL_LOOP_DISPATCH on (soul-loop go-live)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -377,6 +377,19 @@ jobs:
           ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
               "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
               "printf '%s' 'on' | sudo bash /tmp/install-workflow-env.sh set WORKFLOW_NODE_ENQUEUE_ENABLED"
+          # Soul-loop go-live (2026-06-03): turn ON soul-declared loop dispatch
+          # so the daemon runs a souled universe's declared loop_branch_def_id
+          # (a user-built branch) via execute_branch instead of the fantasy
+          # cycle. Shipped dark in #1223, Codex round-2 APPROVE (2026-06-03).
+          # SAFE because it is inert until a souled universe with a declared
+          # loop exists; soulless/legacy universes are untouched. The pick is
+          # active in this mode so child tasks the driver enqueues drain (no
+          # starvation). ORDERING INVARIANT: only flip once #1223 is merged AND
+          # deployed (release-state sha includes #1223). Idempotent set;
+          # reverting returns soul-loop dispatch to fail-closed dark next deploy.
+          ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
+              "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
+              "printf '%s' 'on' | sudo bash /tmp/install-workflow-env.sh set WORKFLOW_SOUL_LOOP_DISPATCH"
           if [ "${HAS_CODEX_AUTH_BUNDLE}" = "true" ]; then
             echo "Deploy-visible WORKFLOW_CODEX_AUTH_JSON_B64 found; syncing subscription auth bundle."
             printf '%s' "${WORKFLOW_CODEX_AUTH_JSON_B64}" | ssh -i ~/.ssh/do_deploy -o BatchMode=yes \


### PR DESCRIPTION
## What

Go-live switch for **soul-loop dispatch** (#1223): sets `WORKFLOW_SOUL_LOOP_DISPATCH=on` on the droplet (same idempotent `install-workflow-env.sh set` pattern as the enqueue flag). The daemon then runs a souled universe's declared `loop_branch_def_id` (a user-built branch) via `execute_branch` instead of the fantasy cycle.

## Why it's safe to merge now

- **Ordering invariant satisfied:** #1223 is merged AND deployed — live `release_state.git_sha = fae9ee19`, canary green.
- **Inert until a souled universe exists.** No universe currently has a soul, so flipping this changes nothing until step 2 of the runbook (create a fresh souled universe with a declared loop). Soulless/legacy universes are untouched.
- **No starvation** — the dispatcher pick is active in soul-loop mode, so child tasks the driver enqueues drain on later cycles (Codex round-2 confirmed).
- Reverting returns soul-loop dispatch to fail-closed dark on the next deploy.

## After this merges

Per the activation runbook (`docs/design-notes/2026-06-03-soul-loop-dispatch-activation-plan.md`):
1. Deploy this (note: a workflow-only change may need a manual `deploy-prod` dispatch pinned to the current image, as with #1222).
2. `create_universe` a fresh souled universe with `loop_branch_def_id=cca3c93b632e` (the approved driver) and `effect_authority=()` (dry-run).
3. Watch it run end-to-end → driver scans the backlog → enqueues canonical patch-loop runs through the live enqueue verb → children drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)