### PR TITLE
Use structured wiki payloads before text JSON in wiki_bug_sync

### DIFF
--- a/scripts/wiki_bug_sync.py
+++ b/scripts/wiki_bug_sync.py
@@ -278,13 +278,23 @@ def _parse_json_result(result: dict[str, Any]) -> dict[str, Any]:
     structured = _extract_structured_tool_payload(result)
     if structured is not None:
         return structured
+
     text = _parse_text_result(result)
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError as exc:
-        raise SyncError(
-            1, f"tool text not JSON: {exc}; preview={text[:200]!r}",
-        ) from exc
+    candidates = [text]
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and start < end:
+        embedded = text[start : end + 1]
+        if embedded != text:
+            candidates.append(embedded)
+
+    for candidate in candidates:
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+
+    raise SyncError(1, f"tool text not JSON: preview={text[:200]!r}")
 
 
 # ---------------------------------------------------------------------------
@@ -479,16 +489,10 @@ def fetch_wiki_page_detail(
     result = _mcp_call_tool(
         url, sid, "wiki", {"action": "read", "page": page}, timeout, post_fn
     )
-    structured = _extract_structured_tool_payload(result)
-    if structured is not None:
-        content = structured.get("content", "")
-    else:
-        text = _parse_text_result(result)
-        try:
-            data = json.loads(text)
-            content = data.get("content", "")
-        except (json.JSONDecodeError, AttributeError):
-            content = text
+    try:
+        content = _parse_json_result(result).get("content", "")
+    except SyncError:
+        content = _parse_text_result(result)
 
     meta, body = _split_frontmatter(content)
     return {"meta": meta, "body": body, "content": content}

--- a/tests/test_wiki_bug_sync.py
+++ b/tests/test_wiki_bug_sync.py
@@ -656,6 +656,25 @@ def test_fetch_bug_detail_reads_with_page_not_path():
     assert detail["title"] == "Bug"
 
 
+def test_fetch_bug_detail_accepts_structured_content_preview():
+    detail = fetch_bug_detail(
+        "http://fake/mcp",
+        "sid1",
+        "pages/bugs/BUG-003-new.md",
+        5.0,
+        post_fn=CapturingPost([
+            (_wiki_read_structured_resp(
+                {"title": "Bug", "severity": "high", "component": "wiki"},
+                "# Body",
+            ), "sid1"),
+        ]),
+    )
+
+    assert detail["title"] == "Bug"
+    assert detail["severity"] == "high"
+    assert detail["component"] == "wiki"
+
+
 def test_fetch_wiki_page_detail_returns_body_without_frontmatter():
     detail = fetch_wiki_page_detail(
         "http://fake/mcp",


### PR DESCRIPTION
Update `wiki_bug_sync` to prefer structured wiki tool payloads before falling back to JSON carried in text, and apply that parsing flow consistently at both wiki `action=list` and `action=read` call sites. This addresses the request to reuse the existing structured payload helper, centralize precedence in `_parse_json_result`, and add regression coverage for preview-text plus `structuredContent` responses.