### PR TITLE
Fix wiki bug writes to reuse canonical promoted bug pages

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -787,34 +787,36 @@ def _wiki_write(
     # canonical (BUG-018) cannot bypass canonical-preferring resolution.
     #
     # BUG-003: lowercase duplicate already exists alongside an uppercase
-    # canonical → we must prefer the uppercase canonical.
+    # canonical -> we must prefer the uppercase canonical.
     # BUG-028: file_bug filename is lowercase but a wrong-case canonical
-    # already exists → resolve to canonical.
+    # already exists -> resolve to canonical.
     # BUG-018: canonical filename has a trailing hyphen the slug sanitizer
-    # strips → match a "<slug>-.md" sibling as the canonical.
+    # strips -> match a "<slug>-.md" sibling as the canonical.
     if category == _BUGS_CATEGORY:
         parent = _wiki_pages_dir() / category
         if parent.is_dir():
             canonical = _resolve_bugs_canonical(parent, slug)
-            if canonical is not None and canonical != promoted_path:
-                _logger_wiki.warning(
-                    "wiki write alias: '%s' resolved to canonical '%s'. "
-                    "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
-                    slug + ".md",
-                    canonical.name,
-                    canonical.name if canonical.name != (slug + ".md") else slug,
-                    slug + ".md",
-                )
+            if canonical is not None:
+                if canonical != promoted_path:
+                    _logger_wiki.warning(
+                        "wiki write alias: '%s' resolved to canonical '%s'. "
+                        "Rename '%s' -> '%s' (or remove duplicate) to eliminate.",
+                        slug + ".md",
+                        canonical.name,
+                        canonical.name if canonical.name != (slug + ".md") else slug,
+                        slug + ".md",
+                    )
                 promoted_path = canonical
 
     if promoted_path.exists():
+        promoted_rel = _page_rel_path(promoted_path)
         try:
             promoted_path.write_text(content, encoding="utf-8")
             _append_wiki_log(
-                f"update | pages/{category}/{slug} | {log_entry or 'in-place update'}"
+                f"update | {promoted_rel.removesuffix('.md')} | {log_entry or 'in-place update'}"
             )
             return json.dumps({
-                "path": f"pages/{category}/{slug}.md",
+                "path": promoted_rel,
                 "status": "updated",
                 "note": "Updated existing promoted page in-place.",
             })

--- a/tests/test_wiki_file_bug.py
+++ b/tests/test_wiki_file_bug.py
@@ -390,27 +390,62 @@ class TestBug028SlugCaseRoundtrip:
             expected="works",
         ))
         assert filed.get("status") == "filed"
-        path_str = filed["path"]
-        filename = path_str.split("/")[-1]  # e.g. bug-001-roundtrip-test-bug.md
+        original_path = wiki_dir / filed["path"]
+        canonical_name = "BUG-001-roundtrip-test-bug.md"
+        canonical_path = original_path.with_name(canonical_name)
+        original_path.rename(canonical_path)
 
-        # Write an update to the same file using the same filename.
         updated_content = "---\nid: BUG-001\ntitle: Updated\n---\n# Updated\n"
         write_result = json.loads(wiki(
             action="write",
             category="bugs",
-            filename=filename,
+            filename=original_path.name,
             content=updated_content,
         ))
-        assert write_result.get("status") in ("updated", "drafted", "draft-update"), (
-            f"Expected an update, got: {write_result}"
-        )
-        # Verify only one file exists for this bug (no duplicate).
-        bugs_dir = wiki_dir / "pages" / "bugs"
-        bug_files = list(bugs_dir.glob("*.md"))
-        assert len(bug_files) == 1, (
-            f"Expected exactly 1 bug file, got {[f.name for f in bug_files]}. "
-            "BUG-028: write must update in-place, not create a duplicate."
-        )
+        assert write_result == {
+            "path": f"pages/bugs/{canonical_name}",
+            "status": "updated",
+            "note": "Updated existing promoted page in-place.",
+        }
+        assert canonical_path.read_text(encoding="utf-8") == updated_content
+        assert not original_path.exists()
+        assert not (wiki_dir / "drafts" / "bugs" / original_path.name).exists()
+        bug_files = sorted(p.name for p in (wiki_dir / "pages" / "bugs").glob("*.md"))
+        assert bug_files == [canonical_name]
+
+    def test_file_bug_write_resolves_trailing_hyphen_canonical(self, wiki_dir):
+        """Writes must reuse canonical BUG filenames even when the disk name keeps a trailing hyphen."""
+        filed = json.loads(wiki(
+            action="file_bug",
+            title="Trailing Hyphen Alias",
+            component="wiki",
+            severity="minor",
+            observed="broken",
+            expected="works",
+        ))
+        assert filed.get("status") == "filed"
+        original_path = wiki_dir / filed["path"]
+        canonical_name = "BUG-001-trailing-hyphen-alias-.md"
+        canonical_path = original_path.with_name(canonical_name)
+        original_path.rename(canonical_path)
+
+        updated_content = "---\nid: BUG-001\ntitle: Trailing Updated\n---\n# Updated\n"
+        write_result = json.loads(wiki(
+            action="write",
+            category="bugs",
+            filename=original_path.name,
+            content=updated_content,
+        ))
+        assert write_result == {
+            "path": f"pages/bugs/{canonical_name}",
+            "status": "updated",
+            "note": "Updated existing promoted page in-place.",
+        }
+        assert canonical_path.read_text(encoding="utf-8") == updated_content
+        assert not original_path.exists()
+        assert not (wiki_dir / "drafts" / "bugs" / original_path.name).exists()
+        bug_files = sorted(p.name for p in (wiki_dir / "pages" / "bugs").glob("*.md"))
+        assert bug_files == [canonical_name]
 
     def test_next_bug_id_finds_lowercase_files(self, wiki_dir):
         """_next_bug_id must find lowercase bug-NNN-... files written by file_bug."""

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -787,34 +787,36 @@ def _wiki_write(
     # canonical (BUG-018) cannot bypass canonical-preferring resolution.
     #
     # BUG-003: lowercase duplicate already exists alongside an uppercase
-    # canonical → we must prefer the uppercase canonical.
+    # canonical -> we must prefer the uppercase canonical.
     # BUG-028: file_bug filename is lowercase but a wrong-case canonical
-    # already exists → resolve to canonical.
+    # already exists -> resolve to canonical.
     # BUG-018: canonical filename has a trailing hyphen the slug sanitizer
-    # strips → match a "<slug>-.md" sibling as the canonical.
+    # strips -> match a "<slug>-.md" sibling as the canonical.
     if category == _BUGS_CATEGORY:
         parent = _wiki_pages_dir() / category
         if parent.is_dir():
             canonical = _resolve_bugs_canonical(parent, slug)
-            if canonical is not None and canonical != promoted_path:
-                _logger_wiki.warning(
-                    "wiki write alias: '%s' resolved to canonical '%s'. "
-                    "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
-                    slug + ".md",
-                    canonical.name,
-                    canonical.name if canonical.name != (slug + ".md") else slug,
-                    slug + ".md",
-                )
+            if canonical is not None:
+                if canonical != promoted_path:
+                    _logger_wiki.warning(
+                        "wiki write alias: '%s' resolved to canonical '%s'. "
+                        "Rename '%s' -> '%s' (or remove duplicate) to eliminate.",
+                        slug + ".md",
+                        canonical.name,
+                        canonical.name if canonical.name != (slug + ".md") else slug,
+                        slug + ".md",
+                    )
                 promoted_path = canonical
 
     if promoted_path.exists():
+        promoted_rel = _page_rel_path(promoted_path)
         try:
             promoted_path.write_text(content, encoding="utf-8")
             _append_wiki_log(
-                f"update | pages/{category}/{slug} | {log_entry or 'in-place update'}"
+                f"update | {promoted_rel.removesuffix('.md')} | {log_entry or 'in-place update'}"
             )
             return json.dumps({
-                "path": f"pages/{category}/{slug}.md",
+                "path": promoted_rel,
                 "status": "updated",
                 "note": "Updated existing promoted page in-place.",
             })


### PR DESCRIPTION
This patch updates `wiki(action="write")` to resolve bug-page writes against the existing canonical file in `pages/bugs` before draft fallback, even when the requested slug differs only by case or when the canonical filename keeps a trailing hyphen. It prefers the standard uppercase `BUG-` filename when aliases exist, writes in place to that canonical path, and returns/logs the real on-disk path. It also adds regression coverage for `file_bug`-created pages to verify writes update the promoted canonical file and do not leave lowercase duplicates behind in `pages/bugs` or `drafts/bugs`, including the trailing-hyphen alias case.

Request referenced: fix `workflow/api/wiki.py` so bug writes reuse canonical promoted bug pages instead of creating lowercase duplicates, and add regression coverage in `tests/test_wiki_file_bug.py`.