### PR TITLE
Fail fast on unsupported wiki file_bug body kwargs

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1728,10 +1728,23 @@ def _render_bug_markdown(
 
 
 _VALID_BUG_KINDS = frozenset({"bug", "feature", "design", "patch_request"})
+_UNSUPPORTED_FILE_BUG_BODY_KWARGS = frozenset({
+    "body",
+    "content",
+    "description",
+    "details",
+})
 _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
 _BUG_DEDUP_SECTION_CHAR_LIMIT = 4000
+
+
+def _unsupported_file_bug_body_kwargs(kwargs: dict[str, Any]) -> list[str]:
+    return sorted(
+        key for key, value in kwargs.items()
+        if key in _UNSUPPORTED_FILE_BUG_BODY_KWARGS and value not in ("", None, False)
+    )
 
 
 def _bug_token_set(text: str) -> set[str]:
@@ -1940,9 +1953,25 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
+    unsupported_body_kwargs = _unsupported_file_bug_body_kwargs(_kwargs)
+    if unsupported_body_kwargs:
+        return json.dumps({
+            "error": (
+                "Unsupported file_bug field(s): "
+                + ", ".join(unsupported_body_kwargs)
+                + "."
+            ),
+            "hint": (
+                "Use title for the summary and repro, observed, expected, and "
+                "workaround for the filing body. body/content-style fields are "
+                "not supported by file_bug."
+            ),
+        })
+
     dropped_kwargs = sorted(
         key for key, value in _kwargs.items()
-        if value not in ("", None, False)
+        if key not in _UNSUPPORTED_FILE_BUG_BODY_KWARGS
+        and value not in ("", None, False)
         and not (
             (key == "dry_run" and value is True)
             or (key == "similarity_threshold" and value == 0.25)

--- a/tests/test_wiki_file_bug.py
+++ b/tests/test_wiki_file_bug.py
@@ -166,6 +166,20 @@ class TestFileBugValidation:
         )
         assert "error" in out
 
+    def test_truthy_unsupported_body_kwargs_rejected(self, wiki_dir):
+        out = json.loads(
+            _wiki_file_bug(
+                component="x",
+                severity="major",
+                title="t",
+                content="Observed body that would be dropped",
+                body="More dropped details",
+            )
+        )
+        assert out["error"] == "Unsupported file_bug field(s): body, content."
+        assert "repro, observed, expected, and workaround" in out["hint"]
+        assert list((wiki_dir / "pages" / "bugs").glob("*.md")) == []
+
 
 class TestFileBugWrites:
     def test_happy_path_creates_page(self, wiki_dir):
@@ -187,6 +201,19 @@ class TestFileBugWrites:
         body = path.read_text(encoding="utf-8")
         assert "BUG-001" in body
         assert "First bug" in body
+
+    def test_falsy_unsupported_body_kwargs_still_allowed(self, wiki_dir):
+        out = json.loads(
+            _wiki_file_bug(
+                component="x",
+                severity="minor",
+                title="still files",
+                content="",
+                body=None,
+            )
+        )
+        assert out["status"] == "filed"
+        assert out["bug_id"] == "BUG-001"
 
     def test_log_appended(self, wiki_dir):
         _wiki_file_bug(

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1728,10 +1728,23 @@ def _render_bug_markdown(
 
 
 _VALID_BUG_KINDS = frozenset({"bug", "feature", "design", "patch_request"})
+_UNSUPPORTED_FILE_BUG_BODY_KWARGS = frozenset({
+    "body",
+    "content",
+    "description",
+    "details",
+})
 _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
 _BUG_DEDUP_SECTION_CHAR_LIMIT = 4000
+
+
+def _unsupported_file_bug_body_kwargs(kwargs: dict[str, Any]) -> list[str]:
+    return sorted(
+        key for key, value in kwargs.items()
+        if key in _UNSUPPORTED_FILE_BUG_BODY_KWARGS and value not in ("", None, False)
+    )
 
 
 def _bug_token_set(text: str) -> set[str]:
@@ -1940,9 +1953,25 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
+    unsupported_body_kwargs = _unsupported_file_bug_body_kwargs(_kwargs)
+    if unsupported_body_kwargs:
+        return json.dumps({
+            "error": (
+                "Unsupported file_bug field(s): "
+                + ", ".join(unsupported_body_kwargs)
+                + "."
+            ),
+            "hint": (
+                "Use title for the summary and repro, observed, expected, and "
+                "workaround for the filing body. body/content-style fields are "
+                "not supported by file_bug."
+            ),
+        })
+
     dropped_kwargs = sorted(
         key for key, value in _kwargs.items()
-        if value not in ("", None, False)
+        if key not in _UNSUPPORTED_FILE_BUG_BODY_KWARGS
+        and value not in ("", None, False)
         and not (
             (key == "dry_run" and value is True)
             or (key == "similarity_threshold" and value == 0.25)


### PR DESCRIPTION
## Summary
- add fail-fast validation in the wiki `file_bug` path for truthy unsupported body/content-style kwargs that were previously dropped
- keep absent and falsy unsupported kwargs allowed so runtime mirror parity stays intact
- extend `file_bug` tests to cover the rejection case and confirm valid behavior is unchanged

## Request
This implements the requested `file_bug` change so `_wiki_file_bug` no longer silently ignores unsupported body/content-style kwargs and instead returns a clear error with guidance toward `title`, `repro`, `observed`, `expected`, and `workaround`.