### PR TITLE
Prefer structured wiki payloads in wiki_bug_sync

### DIFF
--- a/scripts/wiki_bug_sync.py
+++ b/scripts/wiki_bug_sync.py
@@ -276,15 +276,20 @@ def _parse_text_result(result: dict[str, Any]) -> str:
 
 def _parse_json_result(result: dict[str, Any]) -> dict[str, Any]:
     structured = _extract_structured_tool_payload(result)
-    if structured is not None:
+    if isinstance(structured, dict):
         return structured
     text = _parse_text_result(result)
     try:
-        return json.loads(text)
+        payload = json.loads(text)
     except json.JSONDecodeError as exc:
         raise SyncError(
             1, f"tool text not JSON: {exc}; preview={text[:200]!r}",
         ) from exc
+    if not isinstance(payload, dict):
+        raise SyncError(
+            1, f"tool JSON payload not object: {type(payload).__name__}",
+        )
+    return payload
 
 
 # ---------------------------------------------------------------------------
@@ -479,16 +484,11 @@ def fetch_wiki_page_detail(
     result = _mcp_call_tool(
         url, sid, "wiki", {"action": "read", "page": page}, timeout, post_fn
     )
-    structured = _extract_structured_tool_payload(result)
-    if structured is not None:
-        content = structured.get("content", "")
-    else:
-        text = _parse_text_result(result)
-        try:
-            data = json.loads(text)
-            content = data.get("content", "")
-        except (json.JSONDecodeError, AttributeError):
-            content = text
+    try:
+        data = _parse_json_result(result)
+        content = data.get("content", "")
+    except SyncError:
+        content = _parse_text_result(result)
 
     meta, body = _split_frontmatter(content)
     return {"meta": meta, "body": body, "content": content}

--- a/tests/test_wiki_bug_sync.py
+++ b/tests/test_wiki_bug_sync.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 from wiki_bug_sync import (  # noqa: E402
     SyncError,
     _bug_number,
+    _parse_json_result,
     create_gh_change_issue,
     create_gh_issue,
     fetch_bug_detail,
@@ -654,6 +655,27 @@ def test_fetch_bug_detail_reads_with_page_not_path():
     args = post.calls[0]["params"]["arguments"]
     assert args == {"action": "read", "page": "BUG-003-new"}
     assert detail["title"] == "Bug"
+
+
+def test_parse_json_result_prefers_structured_content_over_preview_text():
+    parsed = _parse_json_result(
+        _wiki_list_structured_resp([{"path": "bugs/BUG-005-e"}])["result"]
+    )
+
+    assert parsed == {
+        "promoted": [
+            {"path": "bugs/BUG-005-e", "title": "bugs/BUG-005-e", "type": "bug"}
+        ],
+        "drafts": [],
+    }
+
+
+def test_parse_json_result_falls_back_to_text_json_payload():
+    parsed = _parse_json_result(
+        _wiki_read_resp({"title": "Bug", "severity": "high"})["result"]
+    )
+
+    assert parsed["content"].startswith("---\ntitle: Bug\nseverity: high\n---")
 
 
 def test_fetch_wiki_page_detail_returns_body_without_frontmatter():


### PR DESCRIPTION
Update `wiki_bug_sync` to prefer `structuredContent` when parsing `wiki action=list` and `wiki action=read` tool results, with text JSON used only when structured data is absent or unusable. This reuses `_extract_structured_tool_payload`, centralizes precedence in a local `_parse_json_result` helper, and adds regression coverage for preview-text-plus-structured responses while preserving text JSON fallback behavior.