### PR TITLE
Fail fast on unsupported `file_bug` body kwargs

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1602,6 +1602,20 @@ _KIND_FEATURES_DIR = "feature-requests"
 _KIND_DESIGNS_DIR = "design-proposals"
 _KIND_PATCH_REQUESTS_DIR = "patch-requests"
 _VALID_SEVERITIES = ("critical", "major", "minor", "cosmetic")
+_FILE_BUG_UNSUPPORTED_BODY_KWARGS = frozenset({
+    "body",
+    "body_markdown",
+    "content",
+    "content_markdown",
+    "description",
+    "details",
+    "markdown",
+})
+_FILE_BUG_SUPPORTED_ARGS_HINT = (
+    "Use repro, observed, expected, and workaround for filing details; "
+    "supported metadata args are title, component, severity, kind, tags, "
+    "cross_reference_count, force_new, verbose, and universe_id."
+)
 
 # Per-kind routing: kind -> (category-dir-name, ID-prefix). Each prefix has its
 # own independent NNN counter. New filings route per kind; existing pages stay
@@ -1940,9 +1954,25 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
+    unsupported_body_kwargs = sorted(
+        key for key, value in _kwargs.items()
+        if key in _FILE_BUG_UNSUPPORTED_BODY_KWARGS
+        and value not in ("", None, False)
+    )
+    if unsupported_body_kwargs:
+        return json.dumps({
+            "error": (
+                "Unsupported file_bug body/content argument(s): "
+                + ", ".join(unsupported_body_kwargs)
+                + "."
+            ),
+            "hint": _FILE_BUG_SUPPORTED_ARGS_HINT,
+        })
+
     dropped_kwargs = sorted(
         key for key, value in _kwargs.items()
-        if value not in ("", None, False)
+        if key not in _FILE_BUG_UNSUPPORTED_BODY_KWARGS
+        and value not in ("", None, False)
         and not (
             (key == "dry_run" and value is True)
             or (key == "similarity_threshold" and value == 0.25)
@@ -2217,8 +2247,8 @@ def _wiki_file_bug(
         response_body["warning"] = (
             "Dropped unsupported file_bug field(s): "
             + ", ".join(dropped_kwargs)
-            + ". Use repro, observed, expected, and workaround for the filing body; "
-              "content is only for wiki write/patch actions."
+            + ". "
+            + _FILE_BUG_SUPPORTED_ARGS_HINT
         )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries

--- a/tests/api/test_wiki_file_bug.py
+++ b/tests/api/test_wiki_file_bug.py
@@ -1,0 +1,53 @@
+import json
+
+from workflow.api.helpers import _scoped_wiki_root
+from workflow.api.wiki import _ensure_wiki_scaffold, _wiki_file_bug
+
+
+def test_wiki_file_bug_rejects_truthy_unsupported_body_kwargs(tmp_path):
+    with _scoped_wiki_root(tmp_path):
+        _ensure_wiki_scaffold(tmp_path)
+        response = json.loads(
+            _wiki_file_bug(
+                title="Body kwargs should fail fast",
+                component="workflow.api",
+                severity="major",
+                **{
+                    "content": "Observed details routed through the wrong field.",
+                    "body": "Alternate body field should also fail.",
+                },
+            )
+        )
+
+    assert response["error"] == "Unsupported file_bug body/content argument(s): body, content."
+    assert "Use repro, observed, expected, and workaround" in response["hint"]
+    assert list((tmp_path / "pages" / "bugs").glob("*.md")) == []
+
+
+def test_wiki_file_bug_supported_fields_still_file(tmp_path):
+    with _scoped_wiki_root(tmp_path):
+        _ensure_wiki_scaffold(tmp_path)
+        response = json.loads(
+            _wiki_file_bug(
+                title="Bug filing keeps supported body fields",
+                component="workflow.api",
+                severity="major",
+                repro="1. Open file_bug\n2. Provide supported fields",
+                observed="The filing should capture observed details.",
+                expected="The filing should still succeed.",
+                workaround="Use the supported arguments directly.",
+            )
+        )
+
+    assert response["status"] == "filed"
+    assert response["kind"] == "bug"
+    assert "warning" not in response
+
+    bug_path = tmp_path / response["path"]
+    assert bug_path.exists()
+
+    bug_text = bug_path.read_text(encoding="utf-8")
+    assert "## What happened\n\nThe filing should capture observed details." in bug_text
+    assert "## What was expected\n\nThe filing should still succeed." in bug_text
+    assert "## Repro\n\n1. Open file_bug\n2. Provide supported fields" in bug_text
+    assert "## Workaround\n\nUse the supported arguments directly." in bug_text

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1602,6 +1602,20 @@ _KIND_FEATURES_DIR = "feature-requests"
 _KIND_DESIGNS_DIR = "design-proposals"
 _KIND_PATCH_REQUESTS_DIR = "patch-requests"
 _VALID_SEVERITIES = ("critical", "major", "minor", "cosmetic")
+_FILE_BUG_UNSUPPORTED_BODY_KWARGS = frozenset({
+    "body",
+    "body_markdown",
+    "content",
+    "content_markdown",
+    "description",
+    "details",
+    "markdown",
+})
+_FILE_BUG_SUPPORTED_ARGS_HINT = (
+    "Use repro, observed, expected, and workaround for filing details; "
+    "supported metadata args are title, component, severity, kind, tags, "
+    "cross_reference_count, force_new, verbose, and universe_id."
+)
 
 # Per-kind routing: kind -> (category-dir-name, ID-prefix). Each prefix has its
 # own independent NNN counter. New filings route per kind; existing pages stay
@@ -1940,9 +1954,25 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
+    unsupported_body_kwargs = sorted(
+        key for key, value in _kwargs.items()
+        if key in _FILE_BUG_UNSUPPORTED_BODY_KWARGS
+        and value not in ("", None, False)
+    )
+    if unsupported_body_kwargs:
+        return json.dumps({
+            "error": (
+                "Unsupported file_bug body/content argument(s): "
+                + ", ".join(unsupported_body_kwargs)
+                + "."
+            ),
+            "hint": _FILE_BUG_SUPPORTED_ARGS_HINT,
+        })
+
     dropped_kwargs = sorted(
         key for key, value in _kwargs.items()
-        if value not in ("", None, False)
+        if key not in _FILE_BUG_UNSUPPORTED_BODY_KWARGS
+        and value not in ("", None, False)
         and not (
             (key == "dry_run" and value is True)
             or (key == "similarity_threshold" and value == 0.25)
@@ -2217,8 +2247,8 @@ def _wiki_file_bug(
         response_body["warning"] = (
             "Dropped unsupported file_bug field(s): "
             + ", ".join(dropped_kwargs)
-            + ". Use repro, observed, expected, and workaround for the filing body; "
-              "content is only for wiki write/patch actions."
+            + ". "
+            + _FILE_BUG_SUPPORTED_ARGS_HINT
         )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries


### PR DESCRIPTION
## Summary
- update `_wiki_file_bug` to reject truthy unsupported body/content-style kwargs instead of silently dropping them
- keep the existing runtime-mirror behavior for supported `file_bug` calls and other ignorable mirrored defaults
- add tests covering the new rejection path and confirming supported `file_bug` inputs still file successfully

## Request
Update the wiki bug-filing implementation so `file_bug` no longer silently accepts unsupported content/body-style kwargs and returns a misleading title-only success.