### PR TITLE
Fix wiki bug-page writes to reuse canonical promoted pages

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -796,25 +796,27 @@ def _wiki_write(
         parent = _wiki_pages_dir() / category
         if parent.is_dir():
             canonical = _resolve_bugs_canonical(parent, slug)
-            if canonical is not None and canonical != promoted_path:
-                _logger_wiki.warning(
-                    "wiki write alias: '%s' resolved to canonical '%s'. "
-                    "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
-                    slug + ".md",
-                    canonical.name,
-                    canonical.name if canonical.name != (slug + ".md") else slug,
-                    slug + ".md",
-                )
+            if canonical is not None:
+                if canonical != promoted_path:
+                    _logger_wiki.warning(
+                        "wiki write alias: '%s' resolved to canonical '%s'. "
+                        "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
+                        slug + ".md",
+                        canonical.name,
+                        canonical.name if canonical.name != (slug + ".md") else slug,
+                        slug + ".md",
+                    )
                 promoted_path = canonical
 
+    promoted_rel_path = _page_rel_path(promoted_path)
     if promoted_path.exists():
         try:
             promoted_path.write_text(content, encoding="utf-8")
             _append_wiki_log(
-                f"update | pages/{category}/{slug} | {log_entry or 'in-place update'}"
+                f"update | {promoted_rel_path} | {log_entry or 'in-place update'}"
             )
             return json.dumps({
-                "path": f"pages/{category}/{slug}.md",
+                "path": promoted_rel_path,
                 "status": "updated",
                 "note": "Updated existing promoted page in-place.",
             })

--- a/tests/test_wiki_file_bug.py
+++ b/tests/test_wiki_file_bug.py
@@ -412,6 +412,38 @@ class TestBug028SlugCaseRoundtrip:
             "BUG-028: write must update in-place, not create a duplicate."
         )
 
+    def test_write_updates_uppercase_bug_page_in_place(self, wiki_dir):
+        filed = json.loads(wiki(
+            action="file_bug",
+            title="Canonical Case Bug",
+            component="wiki",
+            severity="minor",
+            observed="before",
+            expected="after",
+        ))
+        assert filed.get("status") == "filed"
+        original_path = wiki_dir / filed["path"]
+        canonical_path = original_path.with_name(
+            original_path.name.replace("bug-", "BUG-", 1)
+        )
+        original_path.rename(canonical_path)
+
+        updated_content = "---\nid: BUG-001\ntitle: Canonical Update\n---\n# Canonical Update\n"
+        write_result = json.loads(wiki(
+            action="write",
+            category="bugs",
+            filename=original_path.name,
+            content=updated_content,
+        ))
+        assert write_result["status"] == "updated"
+        assert write_result["path"] == f"pages/bugs/{canonical_path.name}"
+        assert canonical_path.read_text(encoding="utf-8") == updated_content
+        assert not original_path.exists()
+        assert list((wiki_dir / "drafts" / "bugs").glob("*.md")) == []
+        assert [p.name for p in (wiki_dir / "pages" / "bugs").glob("*.md")] == [
+            canonical_path.name
+        ]
+
     def test_next_bug_id_finds_lowercase_files(self, wiki_dir):
         """_next_bug_id must find lowercase bug-NNN-... files written by file_bug."""
         bugs_dir = wiki_dir / "pages" / "bugs"

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -796,25 +796,27 @@ def _wiki_write(
         parent = _wiki_pages_dir() / category
         if parent.is_dir():
             canonical = _resolve_bugs_canonical(parent, slug)
-            if canonical is not None and canonical != promoted_path:
-                _logger_wiki.warning(
-                    "wiki write alias: '%s' resolved to canonical '%s'. "
-                    "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
-                    slug + ".md",
-                    canonical.name,
-                    canonical.name if canonical.name != (slug + ".md") else slug,
-                    slug + ".md",
-                )
+            if canonical is not None:
+                if canonical != promoted_path:
+                    _logger_wiki.warning(
+                        "wiki write alias: '%s' resolved to canonical '%s'. "
+                        "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
+                        slug + ".md",
+                        canonical.name,
+                        canonical.name if canonical.name != (slug + ".md") else slug,
+                        slug + ".md",
+                    )
                 promoted_path = canonical
 
+    promoted_rel_path = _page_rel_path(promoted_path)
     if promoted_path.exists():
         try:
             promoted_path.write_text(content, encoding="utf-8")
             _append_wiki_log(
-                f"update | pages/{category}/{slug} | {log_entry or 'in-place update'}"
+                f"update | {promoted_rel_path} | {log_entry or 'in-place update'}"
             )
             return json.dumps({
-                "path": f"pages/{category}/{slug}.md",
+                "path": promoted_rel_path,
                 "status": "updated",
                 "note": "Updated existing promoted page in-place.",
             })


### PR DESCRIPTION
Implements the requested wiki(action="write") bug-page fix. Bug-page lookup now preserves a case-insensitive canonical promoted path before deciding whether the page already exists, and updates/logs/returns that exact canonical path so alternate-case duplicates stop accumulating. Added a regression test in tests/test_wiki_file_bug.py that files a bug, rewrites it through a mismatched-case slug, and asserts the original promoted BUG page is updated in place with no duplicate page or draft created.