### PR TITLE
Fix wiki bug-page writes to reuse canonical BUG paths

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -793,28 +793,32 @@ def _wiki_write(
     # BUG-018: canonical filename has a trailing hyphen the slug sanitizer
     # strips → match a "<slug>-.md" sibling as the canonical.
     if category == _BUGS_CATEGORY:
-        parent = _wiki_pages_dir() / category
+        parent = promoted_path.parent
         if parent.is_dir():
             canonical = _resolve_bugs_canonical(parent, slug)
-            if canonical is not None and canonical != promoted_path:
-                _logger_wiki.warning(
-                    "wiki write alias: '%s' resolved to canonical '%s'. "
-                    "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
-                    slug + ".md",
-                    canonical.name,
-                    canonical.name if canonical.name != (slug + ".md") else slug,
-                    slug + ".md",
-                )
+            if canonical is not None:
+                if canonical != promoted_path:
+                    _logger_wiki.warning(
+                        "wiki write alias: '%s' resolved to canonical '%s'. "
+                        "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
+                        slug + ".md",
+                        canonical.name,
+                        canonical.name if canonical.name != (slug + ".md") else slug,
+                        slug + ".md",
+                    )
                 promoted_path = canonical
+
+    promoted_rel_path = _page_rel_path(promoted_path)
+    promoted_log_path = promoted_rel_path.removesuffix(".md")
 
     if promoted_path.exists():
         try:
             promoted_path.write_text(content, encoding="utf-8")
             _append_wiki_log(
-                f"update | pages/{category}/{slug} | {log_entry or 'in-place update'}"
+                f"update | {promoted_log_path} | {log_entry or 'in-place update'}"
             )
             return json.dumps({
-                "path": f"pages/{category}/{slug}.md",
+                "path": promoted_rel_path,
                 "status": "updated",
                 "note": "Updated existing promoted page in-place.",
             })

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -793,28 +793,32 @@ def _wiki_write(
     # BUG-018: canonical filename has a trailing hyphen the slug sanitizer
     # strips → match a "<slug>-.md" sibling as the canonical.
     if category == _BUGS_CATEGORY:
-        parent = _wiki_pages_dir() / category
+        parent = promoted_path.parent
         if parent.is_dir():
             canonical = _resolve_bugs_canonical(parent, slug)
-            if canonical is not None and canonical != promoted_path:
-                _logger_wiki.warning(
-                    "wiki write alias: '%s' resolved to canonical '%s'. "
-                    "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
-                    slug + ".md",
-                    canonical.name,
-                    canonical.name if canonical.name != (slug + ".md") else slug,
-                    slug + ".md",
-                )
+            if canonical is not None:
+                if canonical != promoted_path:
+                    _logger_wiki.warning(
+                        "wiki write alias: '%s' resolved to canonical '%s'. "
+                        "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
+                        slug + ".md",
+                        canonical.name,
+                        canonical.name if canonical.name != (slug + ".md") else slug,
+                        slug + ".md",
+                    )
                 promoted_path = canonical
+
+    promoted_rel_path = _page_rel_path(promoted_path)
+    promoted_log_path = promoted_rel_path.removesuffix(".md")
 
     if promoted_path.exists():
         try:
             promoted_path.write_text(content, encoding="utf-8")
             _append_wiki_log(
-                f"update | pages/{category}/{slug} | {log_entry or 'in-place update'}"
+                f"update | {promoted_log_path} | {log_entry or 'in-place update'}"
             )
             return json.dumps({
-                "path": f"pages/{category}/{slug}.md",
+                "path": promoted_rel_path,
                 "status": "updated",
                 "note": "Updated existing promoted page in-place.",
             })


### PR DESCRIPTION
## Summary
Fix `wiki action=write` for `category="bugs"` so writes reuse the existing canonical `pages/bugs/*.md` file even when the requested filename arrives with a different slug case.

## What changed
- Normalize the requested filename to a slug as before.
- Resolve that slug against existing bug pages case-insensitively before the `exists()` check.
- Prefer the canonical existing `BUG-...` page path over creating a lowercase alias or draft.
- When an existing canonical page is updated, log and return the canonical path so repeated writes stay pinned to the real file.

## Request addressed
This implements the requested behavior for bug-page writes where a caller may send `bug-001-...` while the actual file on disk is `BUG-001-...`.
