### PR TITLE
Fail fast on unsupported file_bug body/content kwargs

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1940,9 +1940,29 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
+    unsupported_body_kwargs = sorted(
+        key for key, value in _kwargs.items()
+        if key in {"body", "content"}
+        and value not in ("", None, False)
+    )
+    if unsupported_body_kwargs:
+        return json.dumps({
+            "error": (
+                "wiki action=file_bug does not accept raw body/content fields: "
+                + ", ".join(unsupported_body_kwargs)
+                + "."
+            ),
+            "hint": (
+                "Use title, component, severity, and the supported filing fields "
+                "repro, observed, expected, and workaround. For raw page content, "
+                "use wiki action=write or wiki action=patch instead."
+            ),
+        })
+
     dropped_kwargs = sorted(
         key for key, value in _kwargs.items()
-        if value not in ("", None, False)
+        if key not in {"body", "content"}
+        and value not in ("", None, False)
         and not (
             (key == "dry_run" and value is True)
             or (key == "similarity_threshold" and value == 0.25)

--- a/tests/test_file_bug_compact_response.py
+++ b/tests/test_file_bug_compact_response.py
@@ -138,6 +138,42 @@ class TestWikiDispatchThreadsVerbose:
         assert "branch_task" in inv
 
 
+# ── Unsupported raw body/content kwargs now fail fast ──────────────────────
+
+
+class TestUnsupportedBodyContentKwargs:
+    def test_direct_file_bug_rejects_body_and_content_kwargs(self, wired_wiki):
+        raw = _wiki_file_bug(
+            component="probe",
+            severity="cosmetic",
+            title="reject-raw-body-content",
+            kind="feature",
+            body="raw body text",
+            content="raw markdown blob",
+        )
+        resp = json.loads(raw)
+        assert "error" in resp
+        assert "does not accept raw body/content fields" in resp["error"]
+        assert "body, content" in resp["error"]
+        assert "supported filing fields" in resp["hint"]
+        assert list((wired_wiki / "pages" / "feature-requests").glob("*.md")) == []
+
+    def test_wiki_dispatch_rejects_content_kwarg_instead_of_filing_empty_shell(self, wired_wiki):
+        raw = wiki(
+            action="file_bug",
+            component="probe",
+            severity="cosmetic",
+            title="reject-dispatch-content",
+            kind="feature",
+            content="# pasted body that used to be ignored",
+        )
+        resp = json.loads(raw)
+        assert "error" in resp
+        assert "content" in resp["error"]
+        assert resp.get("status") != "filed"
+        assert list((wired_wiki / "pages" / "feature-requests").glob("*.md")) == []
+
+
 # ── Trigger receipt block (FEAT-004) is unaffected by verbose flag ────────
 
 

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1940,9 +1940,29 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
+    unsupported_body_kwargs = sorted(
+        key for key, value in _kwargs.items()
+        if key in {"body", "content"}
+        and value not in ("", None, False)
+    )
+    if unsupported_body_kwargs:
+        return json.dumps({
+            "error": (
+                "wiki action=file_bug does not accept raw body/content fields: "
+                + ", ".join(unsupported_body_kwargs)
+                + "."
+            ),
+            "hint": (
+                "Use title, component, severity, and the supported filing fields "
+                "repro, observed, expected, and workaround. For raw page content, "
+                "use wiki action=write or wiki action=patch instead."
+            ),
+        })
+
     dropped_kwargs = sorted(
         key for key, value in _kwargs.items()
-        if value not in ("", None, False)
+        if key not in {"body", "content"}
+        and value not in ("", None, False)
         and not (
             (key == "dry_run" and value is True)
             or (key == "similarity_threshold" and value == 0.25)


### PR DESCRIPTION
## Summary
- add fail-fast validation in `_wiki_file_bug` for truthy unsupported `content`/`body` kwargs passed through `file_bug`
- keep the existing compact/verbose runtime mirror behavior and trigger receipt handling unchanged
- add regression coverage so `file_bug` no longer succeeds with a title-only empty-shell filing when callers supply `content`/`body`

## Request
This updates the `file_bug` path so unsupported body/content kwargs cannot be silently ignored, and returns a clear error with guidance for the supported `repro` / `observed` / `expected` / `workaround` usage.