### PR TITLE
Normalize wiki write slugs for bug pages before update/create checks

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -443,6 +443,35 @@ def _sanitize_slug(name: str) -> str:
     return re.sub(r"[^a-z0-9-]", "-", clean.lower()).strip("-")
 
 
+def _canonical_write_slug(category: str, requested: str) -> str:
+    """Normalize action=write slugs to the same canonical form used at creation.
+
+    Bug filings created via ``file_bug`` use a stricter ``<id>-<slugified-title>``
+    format than the generic write-path sanitizer. Reuse that shape here so a
+    write against an existing filing updates the canonical page instead of
+    creating a stale duplicate whose slug differs only by punctuation or case.
+    """
+    slug = _sanitize_slug(requested)
+    if category != _BUGS_CATEGORY:
+        return slug
+
+    clean = requested.removesuffix(".md").strip()
+    kind_prefixes = {prefix.lower() for _, prefix in _KIND_ROUTING.values()}
+    match = re.match(r"^([a-z]+)[-_\s]+(\d{3,})(.*)$", clean, re.IGNORECASE)
+    if not match:
+        return slug
+
+    prefix = match.group(1).lower()
+    if prefix not in kind_prefixes:
+        return slug
+
+    suffix_source = match.group(3).strip(" -_:")
+    canonical_id = f"{prefix}-{int(match.group(2)):03d}"
+    if not suffix_source:
+        return canonical_id
+    return f"{canonical_id}-{_slugify_title(suffix_source)}"
+
+
 def _wiki_write_slug(category: str, filename: str) -> tuple[str, str | None]:
     """Normalize action=write filename input to a page slug.
 
@@ -467,7 +496,7 @@ def _wiki_write_slug(category: str, filename: str) -> tuple[str, str | None]:
     elif len(parts) == 2 and parts[0] == category:
         requested = parts[1]
 
-    slug = _sanitize_slug(requested)
+    slug = _canonical_write_slug(category, requested)
     if not slug:
         return "", "filename must resolve to a non-empty slug."
     return slug, None

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -443,6 +443,35 @@ def _sanitize_slug(name: str) -> str:
     return re.sub(r"[^a-z0-9-]", "-", clean.lower()).strip("-")
 
 
+def _canonical_write_slug(category: str, requested: str) -> str:
+    """Normalize action=write slugs to the same canonical form used at creation.
+
+    Bug filings created via ``file_bug`` use a stricter ``<id>-<slugified-title>``
+    format than the generic write-path sanitizer. Reuse that shape here so a
+    write against an existing filing updates the canonical page instead of
+    creating a stale duplicate whose slug differs only by punctuation or case.
+    """
+    slug = _sanitize_slug(requested)
+    if category != _BUGS_CATEGORY:
+        return slug
+
+    clean = requested.removesuffix(".md").strip()
+    kind_prefixes = {prefix.lower() for _, prefix in _KIND_ROUTING.values()}
+    match = re.match(r"^([a-z]+)[-_\s]+(\d{3,})(.*)$", clean, re.IGNORECASE)
+    if not match:
+        return slug
+
+    prefix = match.group(1).lower()
+    if prefix not in kind_prefixes:
+        return slug
+
+    suffix_source = match.group(3).strip(" -_:")
+    canonical_id = f"{prefix}-{int(match.group(2)):03d}"
+    if not suffix_source:
+        return canonical_id
+    return f"{canonical_id}-{_slugify_title(suffix_source)}"
+
+
 def _wiki_write_slug(category: str, filename: str) -> tuple[str, str | None]:
     """Normalize action=write filename input to a page slug.
 
@@ -467,7 +496,7 @@ def _wiki_write_slug(category: str, filename: str) -> tuple[str, str | None]:
     elif len(parts) == 2 and parts[0] == category:
         requested = parts[1]
 
-    slug = _sanitize_slug(requested)
+    slug = _canonical_write_slug(category, requested)
     if not slug:
         return "", "filename must resolve to a non-empty slug."
     return slug, None


### PR DESCRIPTION
## Summary
- update the `wiki action=write` slug normalization so bug-page writes use the same canonical slug format as `file_bug`
- normalize requested wiki page titles/paths before checking for existing promoted or draft pages
- keep the returned/stored page identifier on the canonical slug to avoid stale duplicates caused by slug/case mismatches

## Request addressed
Update the wiki write path so page lookup and update use the same canonical slug normalization as page creation. In the `action=write` flow, normalize the requested wiki page title/path to the `file_bug` page slug format before checking for an existing page, and use that canonical slug consistently when deciding whether to update versus create. If an existing page is found only via the normalized slug, update that page instead of creating a new one, and ensure the stored/returned page identifier also uses the canonical slug so stale duplicate pages do not accumulate because of slug-case mismatches.
