### PR TITLE
Fail fast on unsupported wiki file_bug passthrough fields

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1822,6 +1822,30 @@ def _scan_existing_bugs(bugs_dir: Path) -> list[dict[str, Any]]:
     return results
 
 
+_FILE_BUG_ALLOWED_DEFAULT_KWARGS: dict[str, Any] = {
+    "dry_run": True,
+    "similarity_threshold": 0.25,
+    "max_results": 10,
+    "offset": 0,
+    "max_chars": _WIKI_READ_DEFAULT_MAX_CHARS,
+}
+
+
+def _validate_file_bug_passthrough_kwargs(kwargs: dict[str, Any]) -> None:
+    rejected = sorted(
+        key for key, value in kwargs.items()
+        if value and _FILE_BUG_ALLOWED_DEFAULT_KWARGS.get(key) != value
+    )
+    if rejected:
+        rejected_fields = ", ".join(rejected)
+        raise ValueError(
+            "Unsupported file_bug field(s): "
+            f"{rejected_fields}. "
+            "file_bug currently files title-only requests; use repro, observed, "
+            "expected, and workaround for details."
+        )
+
+
 def _wiki_cosign_bug(
     bug_id: str = "",
     reporter_context: str = "",
@@ -1940,17 +1964,7 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
-    dropped_kwargs = sorted(
-        key for key, value in _kwargs.items()
-        if value not in ("", None, False)
-        and not (
-            (key == "dry_run" and value is True)
-            or (key == "similarity_threshold" and value == 0.25)
-            or (key == "max_results" and value == 10)
-            or (key == "offset" and value == 0)
-            or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
-        )
-    )
+    _validate_file_bug_passthrough_kwargs(_kwargs)
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",
@@ -2213,13 +2227,6 @@ def _wiki_file_bug(
         "note": "Filing sent to navigator triage pipeline. "
                 f"Use `wiki action=list category={category_dir}` to view.",
     }
-    if dropped_kwargs:
-        response_body["warning"] = (
-            "Dropped unsupported file_bug field(s): "
-            + ", ".join(dropped_kwargs)
-            + ". Use repro, observed, expected, and workaround for the filing body; "
-              "content is only for wiki write/patch actions."
-        )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries
         # / chatbots / operators) have a per-request-id join key without log

--- a/tests/test_wiki_file_bug.py
+++ b/tests/test_wiki_file_bug.py
@@ -166,6 +166,21 @@ class TestFileBugValidation:
         )
         assert "error" in out
 
+    def test_truthy_body_and_content_rejected_without_writes(self, wiki_dir):
+        log_before = (wiki_dir / "log.md").read_text(encoding="utf-8")
+
+        with pytest.raises(ValueError, match="body, content"):
+            _wiki_file_bug(
+                component="x",
+                severity="major",
+                title="t",
+                body="details",
+                content="extra details",
+            )
+
+        assert list((wiki_dir / "pages" / "bugs").glob("*.md")) == []
+        assert (wiki_dir / "log.md").read_text(encoding="utf-8") == log_before
+
 
 class TestFileBugWrites:
     def test_happy_path_creates_page(self, wiki_dir):
@@ -187,6 +202,40 @@ class TestFileBugWrites:
         body = path.read_text(encoding="utf-8")
         assert "BUG-001" in body
         assert "First bug" in body
+
+    def test_falsey_and_default_passthrough_kwargs_are_allowed(self, wiki_dir):
+        out = json.loads(
+            _wiki_file_bug(
+                component="x",
+                severity="minor",
+                title="passthrough defaults",
+                body="",
+                content="",
+                page="",
+                dry_run=True,
+                similarity_threshold=0.25,
+                max_results=10,
+                offset=0,
+                max_chars=128000,
+            )
+        )
+        assert out["status"] == "filed"
+        assert out["path"] == "pages/bugs/bug-001-passthrough-defaults.md"
+        assert "warning" not in out
+
+    def test_title_only_filing_path_and_response_preserved(self, wiki_dir):
+        out = json.loads(
+            _wiki_file_bug(
+                component="x",
+                severity="minor",
+                title="Title only",
+            )
+        )
+        assert out["status"] == "filed"
+        assert out["bug_id"] == "BUG-001"
+        assert out["path"] == "pages/bugs/bug-001-title-only.md"
+        assert out["kind"] == "bug"
+        assert "warning" not in out
 
     def test_log_appended(self, wiki_dir):
         _wiki_file_bug(

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1822,6 +1822,30 @@ def _scan_existing_bugs(bugs_dir: Path) -> list[dict[str, Any]]:
     return results
 
 
+_FILE_BUG_ALLOWED_DEFAULT_KWARGS: dict[str, Any] = {
+    "dry_run": True,
+    "similarity_threshold": 0.25,
+    "max_results": 10,
+    "offset": 0,
+    "max_chars": _WIKI_READ_DEFAULT_MAX_CHARS,
+}
+
+
+def _validate_file_bug_passthrough_kwargs(kwargs: dict[str, Any]) -> None:
+    rejected = sorted(
+        key for key, value in kwargs.items()
+        if value and _FILE_BUG_ALLOWED_DEFAULT_KWARGS.get(key) != value
+    )
+    if rejected:
+        rejected_fields = ", ".join(rejected)
+        raise ValueError(
+            "Unsupported file_bug field(s): "
+            f"{rejected_fields}. "
+            "file_bug currently files title-only requests; use repro, observed, "
+            "expected, and workaround for details."
+        )
+
+
 def _wiki_cosign_bug(
     bug_id: str = "",
     reporter_context: str = "",
@@ -1940,17 +1964,7 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
-    dropped_kwargs = sorted(
-        key for key, value in _kwargs.items()
-        if value not in ("", None, False)
-        and not (
-            (key == "dry_run" and value is True)
-            or (key == "similarity_threshold" and value == 0.25)
-            or (key == "max_results" and value == 10)
-            or (key == "offset" and value == 0)
-            or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
-        )
-    )
+    _validate_file_bug_passthrough_kwargs(_kwargs)
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",
@@ -2213,13 +2227,6 @@ def _wiki_file_bug(
         "note": "Filing sent to navigator triage pipeline. "
                 f"Use `wiki action=list category={category_dir}` to view.",
     }
-    if dropped_kwargs:
-        response_body["warning"] = (
-            "Dropped unsupported file_bug field(s): "
-            + ", ".join(dropped_kwargs)
-            + ". Use repro, observed, expected, and workaround for the filing body; "
-              "content is only for wiki write/patch actions."
-        )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries
         # / chatbots / operators) have a per-request-id join key without log


### PR DESCRIPTION
## Summary
- add a `_wiki_file_bug` passthrough validator that raises on truthy unsupported fields before any file or log writes
- allow falsey passthrough values and the known default transport kwargs used by the wiki dispatcher
- add regression coverage for rejected `body`/`content`, allowed default passthrough kwargs, and the existing title-only filing path

## Request
Implements the requested `workflow/api/wiki.py` change so `file_bug` no longer silently drops unsupported payload fields, and adds the matching regression tests in `tests/test_wiki_file_bug.py`.