### PR TITLE
Fail fast on unsupported file_bug body/content kwargs

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1728,6 +1728,12 @@ def _render_bug_markdown(
 
 
 _VALID_BUG_KINDS = frozenset({"bug", "feature", "design", "patch_request"})
+_UNSUPPORTED_FILE_BUG_BODY_KWARGS = frozenset({
+    "body",
+    "content",
+    "description",
+    "markdown_body",
+})
 _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
@@ -1940,9 +1946,29 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
+    unsupported_body_kwargs = sorted(
+        key for key, value in _kwargs.items()
+        if key in _UNSUPPORTED_FILE_BUG_BODY_KWARGS
+        and value not in ("", None, False)
+    )
+    if unsupported_body_kwargs:
+        fields = ", ".join(unsupported_body_kwargs)
+        return json.dumps({
+            "error": (
+                "wiki action=file_bug currently supports title-only bug filing "
+                "for generic body/content kwargs."
+            ),
+            "unsupported_fields": unsupported_body_kwargs,
+            "hint": (
+                "Remove the unsupported field(s) "
+                f"({fields}) or use the supported file_bug interface with repro, "
+                "observed, expected, and workaround."
+            ),
+        })
     dropped_kwargs = sorted(
         key for key, value in _kwargs.items()
-        if value not in ("", None, False)
+        if key not in _UNSUPPORTED_FILE_BUG_BODY_KWARGS
+        and value not in ("", None, False)
         and not (
             (key == "dry_run" and value is True)
             or (key == "similarity_threshold" and value == 0.25)

--- a/tests/test_wiki_file_bug.py
+++ b/tests/test_wiki_file_bug.py
@@ -188,6 +188,50 @@ class TestFileBugWrites:
         assert "BUG-001" in body
         assert "First bug" in body
 
+    def test_title_only_success_path_uses_placeholders(self, wiki_dir):
+        out = json.loads(
+            _wiki_file_bug(
+                component="extensions.patch_branch",
+                severity="major",
+                title="Title only bug",
+            )
+        )
+        assert out["status"] == "filed"
+        path = wiki_dir / out["path"]
+        body = path.read_text(encoding="utf-8")
+        assert "## What happened\n\n_not specified_" in body
+        assert "## What was expected\n\n_not specified_" in body
+        assert "## Workaround\n\n_none_" in body
+
+    def test_falsey_content_kwarg_preserves_dispatch_behavior(self, wiki_dir):
+        out = json.loads(
+            wiki(
+                action="file_bug",
+                component="extensions.patch_branch",
+                severity="major",
+                title="Dispatch title only",
+                content="",
+            )
+        )
+        assert out["status"] == "filed"
+        path = wiki_dir / out["path"]
+        assert path.exists()
+
+    def test_truthy_content_kwarg_returns_clear_error(self, wiki_dir):
+        out = json.loads(
+            wiki(
+                action="file_bug",
+                component="extensions.patch_branch",
+                severity="major",
+                title="Body kwarg should fail",
+                content="free-form bug body",
+            )
+        )
+        assert "error" in out
+        assert "title-only bug filing" in out["error"]
+        assert "content" in out["hint"]
+        assert list((wiki_dir / "pages" / "bugs").glob("*.md")) == []
+
     def test_log_appended(self, wiki_dir):
         _wiki_file_bug(
             component="x",

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1728,6 +1728,12 @@ def _render_bug_markdown(
 
 
 _VALID_BUG_KINDS = frozenset({"bug", "feature", "design", "patch_request"})
+_UNSUPPORTED_FILE_BUG_BODY_KWARGS = frozenset({
+    "body",
+    "content",
+    "description",
+    "markdown_body",
+})
 _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
@@ -1940,9 +1946,29 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
+    unsupported_body_kwargs = sorted(
+        key for key, value in _kwargs.items()
+        if key in _UNSUPPORTED_FILE_BUG_BODY_KWARGS
+        and value not in ("", None, False)
+    )
+    if unsupported_body_kwargs:
+        fields = ", ".join(unsupported_body_kwargs)
+        return json.dumps({
+            "error": (
+                "wiki action=file_bug currently supports title-only bug filing "
+                "for generic body/content kwargs."
+            ),
+            "unsupported_fields": unsupported_body_kwargs,
+            "hint": (
+                "Remove the unsupported field(s) "
+                f"({fields}) or use the supported file_bug interface with repro, "
+                "observed, expected, and workaround."
+            ),
+        })
     dropped_kwargs = sorted(
         key for key, value in _kwargs.items()
-        if value not in ("", None, False)
+        if key not in _UNSUPPORTED_FILE_BUG_BODY_KWARGS
+        and value not in ("", None, False)
         and not (
             (key == "dry_run" and value is True)
             or (key == "similarity_threshold" and value == 0.25)


### PR DESCRIPTION
Implements the requested `file_bug` change so the internal `_wiki_file_bug` path no longer silently ignores unsupported body/content-style kwargs. Truthy unsupported body/content fields now fail fast with a clear JSON error that explains this path currently supports title-only bug filing for generic body/content inputs and points callers to remove those kwargs or use the supported `repro`/`observed`/`expected`/`workaround` interface. Falsey/omitted unsupported kwargs still preserve the current runtime and mirror behavior. Tests were updated to cover the prior silent-discard case, the new validation error, and the title-only success path.