### PR TITLE
Fix wiki bug-page writes to resolve canonical mixed-case paths

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -781,6 +781,7 @@ def _wiki_write(
     if slug_error:
         return json.dumps({"error": slug_error})
     promoted_path = _wiki_pages_dir() / category / (slug + ".md")
+    promoted_rel_path = f"pages/{category}/{slug}.md"
 
     # Alias-resolution for the bugs category. Runs BEFORE the .exists() check
     # so a pre-existing lowercase-duplicate (BUG-003) or trailing-hyphen
@@ -796,25 +797,27 @@ def _wiki_write(
         parent = _wiki_pages_dir() / category
         if parent.is_dir():
             canonical = _resolve_bugs_canonical(parent, slug)
-            if canonical is not None and canonical != promoted_path:
-                _logger_wiki.warning(
-                    "wiki write alias: '%s' resolved to canonical '%s'. "
-                    "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
-                    slug + ".md",
-                    canonical.name,
-                    canonical.name if canonical.name != (slug + ".md") else slug,
-                    slug + ".md",
-                )
+            if canonical is not None:
+                if canonical != promoted_path:
+                    _logger_wiki.warning(
+                        "wiki write alias: '%s' resolved to canonical '%s'. "
+                        "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
+                        slug + ".md",
+                        canonical.name,
+                        canonical.name if canonical.name != (slug + ".md") else slug,
+                        slug + ".md",
+                    )
                 promoted_path = canonical
+                promoted_rel_path = _page_rel_path(canonical)
 
     if promoted_path.exists():
         try:
             promoted_path.write_text(content, encoding="utf-8")
             _append_wiki_log(
-                f"update | pages/{category}/{slug} | {log_entry or 'in-place update'}"
+                f"update | {promoted_rel_path.removesuffix('.md')} | {log_entry or 'in-place update'}"
             )
             return json.dumps({
-                "path": f"pages/{category}/{slug}.md",
+                "path": promoted_rel_path,
                 "status": "updated",
                 "note": "Updated existing promoted page in-place.",
             })

--- a/tests/test_wiki_file_bug.py
+++ b/tests/test_wiki_file_bug.py
@@ -412,6 +412,28 @@ class TestBug028SlugCaseRoundtrip:
             "BUG-028: write must update in-place, not create a duplicate."
         )
 
+    def test_write_updates_mixed_case_bug_slug_in_place(self, wiki_dir):
+        """Lowercase bug writes must resolve to the canonical mixed-case page path."""
+        canonical = wiki_dir / "pages" / "bugs" / "BUG-001-mixed-case-bug.md"
+        canonical.write_text("old body\n", encoding="utf-8")
+
+        updated_content = "---\nid: BUG-001\ntitle: Mixed Case Updated\n---\n# Updated\n"
+        write_result = json.loads(wiki(
+            action="write",
+            category="bugs",
+            filename="bug-001-mixed-case-bug.md",
+            content=updated_content,
+        ))
+        assert write_result == {
+            "path": "pages/bugs/BUG-001-mixed-case-bug.md",
+            "status": "updated",
+            "note": "Updated existing promoted page in-place.",
+        }
+        assert canonical.read_text(encoding="utf-8") == updated_content
+        assert not (wiki_dir / "drafts" / "bugs" / "bug-001-mixed-case-bug.md").exists()
+        bug_files = list((wiki_dir / "pages" / "bugs").glob("*.md"))
+        assert [path.name for path in bug_files] == ["BUG-001-mixed-case-bug.md"]
+
     def test_next_bug_id_finds_lowercase_files(self, wiki_dir):
         """_next_bug_id must find lowercase bug-NNN-... files written by file_bug."""
         bugs_dir = wiki_dir / "pages" / "bugs"

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -781,6 +781,7 @@ def _wiki_write(
     if slug_error:
         return json.dumps({"error": slug_error})
     promoted_path = _wiki_pages_dir() / category / (slug + ".md")
+    promoted_rel_path = f"pages/{category}/{slug}.md"
 
     # Alias-resolution for the bugs category. Runs BEFORE the .exists() check
     # so a pre-existing lowercase-duplicate (BUG-003) or trailing-hyphen
@@ -796,25 +797,27 @@ def _wiki_write(
         parent = _wiki_pages_dir() / category
         if parent.is_dir():
             canonical = _resolve_bugs_canonical(parent, slug)
-            if canonical is not None and canonical != promoted_path:
-                _logger_wiki.warning(
-                    "wiki write alias: '%s' resolved to canonical '%s'. "
-                    "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
-                    slug + ".md",
-                    canonical.name,
-                    canonical.name if canonical.name != (slug + ".md") else slug,
-                    slug + ".md",
-                )
+            if canonical is not None:
+                if canonical != promoted_path:
+                    _logger_wiki.warning(
+                        "wiki write alias: '%s' resolved to canonical '%s'. "
+                        "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
+                        slug + ".md",
+                        canonical.name,
+                        canonical.name if canonical.name != (slug + ".md") else slug,
+                        slug + ".md",
+                    )
                 promoted_path = canonical
+                promoted_rel_path = _page_rel_path(canonical)
 
     if promoted_path.exists():
         try:
             promoted_path.write_text(content, encoding="utf-8")
             _append_wiki_log(
-                f"update | pages/{category}/{slug} | {log_entry or 'in-place update'}"
+                f"update | {promoted_rel_path.removesuffix('.md')} | {log_entry or 'in-place update'}"
             )
             return json.dumps({
-                "path": f"pages/{category}/{slug}.md",
+                "path": promoted_rel_path,
                 "status": "updated",
                 "note": "Updated existing promoted page in-place.",
             })


### PR DESCRIPTION
Update `workflow/api/wiki.py` so `wiki(action="write")` resolves bug-page targets to the canonical on-disk bug page before deciding whether to update `pages/` or create a draft. This prevents lowercase `bug-...md` writes from missing an existing mixed-case `pages/bugs/BUG-...md` page and creating a stale duplicate draft instead of updating in place. The response now returns the canonical `pages/bugs/...` path when a mixed-case bug page is updated. Regression coverage was added in `tests/test_wiki_file_bug.py` for updating an existing mixed-case bug slug without creating a draft duplicate, per the request.