### PR TITLE
Fix wiki bug write resolution for canonical BUG filenames

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -516,6 +516,31 @@ def _resolve_bugs_canonical(parent: Path, slug: str) -> Path | None:
     return candidates[0]
 
 
+def _wiki_write_promoted_path(category: str, slug: str) -> Path:
+    """Resolve the promoted write target, honoring canonical bug-page filenames."""
+    promoted_path = _wiki_pages_dir() / category / (slug + ".md")
+    if category != _BUGS_CATEGORY:
+        return promoted_path
+
+    parent = promoted_path.parent
+    if not parent.is_dir():
+        return promoted_path
+
+    canonical = _resolve_bugs_canonical(parent, slug)
+    if canonical is None:
+        return promoted_path
+    if canonical != promoted_path:
+        _logger_wiki.warning(
+            "wiki write alias: '%s' resolved to canonical '%s'. "
+            "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
+            slug + ".md",
+            canonical.name,
+            canonical.name if canonical.name != (slug + ".md") else slug,
+            slug + ".md",
+        )
+    return canonical
+
+
 # ---------------------------------------------------------------------------
 # Wiki action implementations
 # ---------------------------------------------------------------------------
@@ -780,41 +805,22 @@ def _wiki_write(
     slug, slug_error = _wiki_write_slug(category, filename)
     if slug_error:
         return json.dumps({"error": slug_error})
-    promoted_path = _wiki_pages_dir() / category / (slug + ".md")
-
-    # Alias-resolution for the bugs category. Runs BEFORE the .exists() check
-    # so a pre-existing lowercase-duplicate (BUG-003) or trailing-hyphen
-    # canonical (BUG-018) cannot bypass canonical-preferring resolution.
-    #
-    # BUG-003: lowercase duplicate already exists alongside an uppercase
-    # canonical → we must prefer the uppercase canonical.
-    # BUG-028: file_bug filename is lowercase but a wrong-case canonical
-    # already exists → resolve to canonical.
-    # BUG-018: canonical filename has a trailing hyphen the slug sanitizer
-    # strips → match a "<slug>-.md" sibling as the canonical.
-    if category == _BUGS_CATEGORY:
-        parent = _wiki_pages_dir() / category
-        if parent.is_dir():
-            canonical = _resolve_bugs_canonical(parent, slug)
-            if canonical is not None and canonical != promoted_path:
-                _logger_wiki.warning(
-                    "wiki write alias: '%s' resolved to canonical '%s'. "
-                    "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
-                    slug + ".md",
-                    canonical.name,
-                    canonical.name if canonical.name != (slug + ".md") else slug,
-                    slug + ".md",
-                )
-                promoted_path = canonical
+    promoted_path = _wiki_write_promoted_path(category, slug)
+    promoted_response_path = _page_rel_path(promoted_path)
+    promoted_log_path = (
+        promoted_response_path
+        if category == _BUGS_CATEGORY
+        else f"pages/{category}/{slug}"
+    )
 
     if promoted_path.exists():
         try:
             promoted_path.write_text(content, encoding="utf-8")
             _append_wiki_log(
-                f"update | pages/{category}/{slug} | {log_entry or 'in-place update'}"
+                f"update | {promoted_log_path} | {log_entry or 'in-place update'}"
             )
             return json.dumps({
-                "path": f"pages/{category}/{slug}.md",
+                "path": promoted_response_path,
                 "status": "updated",
                 "note": "Updated existing promoted page in-place.",
             })

--- a/tests/test_wiki_file_bug.py
+++ b/tests/test_wiki_file_bug.py
@@ -412,6 +412,30 @@ class TestBug028SlugCaseRoundtrip:
             "BUG-028: write must update in-place, not create a duplicate."
         )
 
+    def test_write_updates_uppercase_canonical_bug_page_in_place(self, wiki_dir):
+        """Lowercase bug slugs must update the canonical BUG-NNN page in-place."""
+        canonical_path = wiki_dir / "pages" / "bugs" / "BUG-001-case-sensitive.md"
+        canonical_path.write_text(
+            "---\nid: BUG-001\ntitle: Original\n---\n# Original\n",
+            encoding="utf-8",
+        )
+
+        updated_content = "---\nid: BUG-001\ntitle: Updated\n---\n# Updated\n"
+        write_result = json.loads(wiki(
+            action="write",
+            category="bugs",
+            filename="bug-001-case-sensitive.md",
+            content=updated_content,
+            log_entry="canonical bug rewrite",
+        ))
+        assert write_result["status"] == "updated"
+        assert write_result["path"] == "pages/bugs/BUG-001-case-sensitive.md"
+        assert canonical_path.read_text(encoding="utf-8") == updated_content
+        assert not (wiki_dir / "pages" / "bugs" / "bug-001-case-sensitive.md").exists()
+        assert not (wiki_dir / "drafts" / "bugs" / "bug-001-case-sensitive.md").exists()
+        log = (wiki_dir / "log.md").read_text(encoding="utf-8")
+        assert "update | pages/bugs/BUG-001-case-sensitive.md | canonical bug rewrite" in log
+
     def test_next_bug_id_finds_lowercase_files(self, wiki_dir):
         """_next_bug_id must find lowercase bug-NNN-... files written by file_bug."""
         bugs_dir = wiki_dir / "pages" / "bugs"

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -516,6 +516,31 @@ def _resolve_bugs_canonical(parent: Path, slug: str) -> Path | None:
     return candidates[0]
 
 
+def _wiki_write_promoted_path(category: str, slug: str) -> Path:
+    """Resolve the promoted write target, honoring canonical bug-page filenames."""
+    promoted_path = _wiki_pages_dir() / category / (slug + ".md")
+    if category != _BUGS_CATEGORY:
+        return promoted_path
+
+    parent = promoted_path.parent
+    if not parent.is_dir():
+        return promoted_path
+
+    canonical = _resolve_bugs_canonical(parent, slug)
+    if canonical is None:
+        return promoted_path
+    if canonical != promoted_path:
+        _logger_wiki.warning(
+            "wiki write alias: '%s' resolved to canonical '%s'. "
+            "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
+            slug + ".md",
+            canonical.name,
+            canonical.name if canonical.name != (slug + ".md") else slug,
+            slug + ".md",
+        )
+    return canonical
+
+
 # ---------------------------------------------------------------------------
 # Wiki action implementations
 # ---------------------------------------------------------------------------
@@ -780,41 +805,22 @@ def _wiki_write(
     slug, slug_error = _wiki_write_slug(category, filename)
     if slug_error:
         return json.dumps({"error": slug_error})
-    promoted_path = _wiki_pages_dir() / category / (slug + ".md")
-
-    # Alias-resolution for the bugs category. Runs BEFORE the .exists() check
-    # so a pre-existing lowercase-duplicate (BUG-003) or trailing-hyphen
-    # canonical (BUG-018) cannot bypass canonical-preferring resolution.
-    #
-    # BUG-003: lowercase duplicate already exists alongside an uppercase
-    # canonical → we must prefer the uppercase canonical.
-    # BUG-028: file_bug filename is lowercase but a wrong-case canonical
-    # already exists → resolve to canonical.
-    # BUG-018: canonical filename has a trailing hyphen the slug sanitizer
-    # strips → match a "<slug>-.md" sibling as the canonical.
-    if category == _BUGS_CATEGORY:
-        parent = _wiki_pages_dir() / category
-        if parent.is_dir():
-            canonical = _resolve_bugs_canonical(parent, slug)
-            if canonical is not None and canonical != promoted_path:
-                _logger_wiki.warning(
-                    "wiki write alias: '%s' resolved to canonical '%s'. "
-                    "Rename '%s' → '%s' (or remove duplicate) to eliminate.",
-                    slug + ".md",
-                    canonical.name,
-                    canonical.name if canonical.name != (slug + ".md") else slug,
-                    slug + ".md",
-                )
-                promoted_path = canonical
+    promoted_path = _wiki_write_promoted_path(category, slug)
+    promoted_response_path = _page_rel_path(promoted_path)
+    promoted_log_path = (
+        promoted_response_path
+        if category == _BUGS_CATEGORY
+        else f"pages/{category}/{slug}"
+    )
 
     if promoted_path.exists():
         try:
             promoted_path.write_text(content, encoding="utf-8")
             _append_wiki_log(
-                f"update | pages/{category}/{slug} | {log_entry or 'in-place update'}"
+                f"update | {promoted_log_path} | {log_entry or 'in-place update'}"
             )
             return json.dumps({
-                "path": f"pages/{category}/{slug}.md",
+                "path": promoted_response_path,
                 "status": "updated",
                 "note": "Updated existing promoted page in-place.",
             })


### PR DESCRIPTION
Implements the requested wiki `action=write` bug-page fix. The write path now resolves existing `pages/bugs/BUG-...md` files case-insensitively before deciding whether to update `pages/` or create a draft, and it returns/logs the canonical page path when an existing bug page is updated. Non-bug category behavior stays unchanged. Regression coverage was added to prove a lowercase slug updates an existing mixed-case canonical bug page in place without creating duplicate lowercase page or draft files.