### PR TITLE
Fail fast on unsupported file_bug body kwargs

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1728,10 +1728,27 @@ def _render_bug_markdown(
 
 
 _VALID_BUG_KINDS = frozenset({"bug", "feature", "design", "patch_request"})
+_UNSUPPORTED_FILE_BUG_BODY_KEYS = frozenset({"body", "content"})
 _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
 _BUG_DEDUP_SECTION_CHAR_LIMIT = 4000
+
+
+def _validate_file_bug_kwargs(kwargs: dict[str, Any]) -> None:
+    rejected = sorted(
+        key for key, value in kwargs.items()
+        if value not in ("", None, False)
+        and (key in _UNSUPPORTED_FILE_BUG_BODY_KEYS or key.startswith("body_"))
+    )
+    if not rejected:
+        return
+    raise ValueError(
+        "file_bug does not accept unsupported body/content field(s): "
+        + ", ".join(rejected)
+        + ". Use title for the summary and repro, observed, expected, and "
+          "workaround for the filing body."
+    )
 
 
 def _bug_token_set(text: str) -> set[str]:
@@ -1940,17 +1957,7 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
-    dropped_kwargs = sorted(
-        key for key, value in _kwargs.items()
-        if value not in ("", None, False)
-        and not (
-            (key == "dry_run" and value is True)
-            or (key == "similarity_threshold" and value == 0.25)
-            or (key == "max_results" and value == 10)
-            or (key == "offset" and value == 0)
-            or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
-        )
-    )
+    _validate_file_bug_kwargs(_kwargs)
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",
@@ -2213,13 +2220,6 @@ def _wiki_file_bug(
         "note": "Filing sent to navigator triage pipeline. "
                 f"Use `wiki action=list category={category_dir}` to view.",
     }
-    if dropped_kwargs:
-        response_body["warning"] = (
-            "Dropped unsupported file_bug field(s): "
-            + ", ".join(dropped_kwargs)
-            + ". Use repro, observed, expected, and workaround for the filing body; "
-              "content is only for wiki write/patch actions."
-        )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries
         # / chatbots / operators) have a per-request-id join key without log

--- a/tests/test_wiki_file_bug.py
+++ b/tests/test_wiki_file_bug.py
@@ -166,6 +166,26 @@ class TestFileBugValidation:
         )
         assert "error" in out
 
+    def test_truthy_content_kwarg_rejected(self, wiki_dir):
+        with pytest.raises(ValueError, match="content"):
+            _wiki_file_bug(
+                component="x",
+                severity="major",
+                title="t",
+                content="ignored body",
+            )
+        assert not list((wiki_dir / "pages" / "bugs").glob("*.md"))
+
+    def test_truthy_body_style_kwarg_rejected(self, wiki_dir):
+        with pytest.raises(ValueError, match="body_markdown"):
+            _wiki_file_bug(
+                component="x",
+                severity="major",
+                title="t",
+                body_markdown="ignored body",
+            )
+        assert not list((wiki_dir / "pages" / "bugs").glob("*.md"))
+
 
 class TestFileBugWrites:
     def test_happy_path_creates_page(self, wiki_dir):
@@ -247,6 +267,17 @@ class TestFileBugViaWikiDispatch:
         )
         assert out["status"] == "filed"
         assert out["bug_id"] == "BUG-001"
+
+    def test_dispatch_rejects_truthy_content_kwarg(self, wiki_dir):
+        with pytest.raises(ValueError, match="content"):
+            wiki(
+                action="file_bug",
+                component="extensions.patch_branch",
+                severity="major",
+                title="Dispatched",
+                content="discarded body",
+            )
+        assert not list((wiki_dir / "pages" / "bugs").glob("*.md"))
 
     def test_bugs_in_valid_categories(self):
         """Smoke test that 'bugs' is registered via patch (a)."""

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1728,10 +1728,27 @@ def _render_bug_markdown(
 
 
 _VALID_BUG_KINDS = frozenset({"bug", "feature", "design", "patch_request"})
+_UNSUPPORTED_FILE_BUG_BODY_KEYS = frozenset({"body", "content"})
 _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
 _BUG_DEDUP_SECTION_CHAR_LIMIT = 4000
+
+
+def _validate_file_bug_kwargs(kwargs: dict[str, Any]) -> None:
+    rejected = sorted(
+        key for key, value in kwargs.items()
+        if value not in ("", None, False)
+        and (key in _UNSUPPORTED_FILE_BUG_BODY_KEYS or key.startswith("body_"))
+    )
+    if not rejected:
+        return
+    raise ValueError(
+        "file_bug does not accept unsupported body/content field(s): "
+        + ", ".join(rejected)
+        + ". Use title for the summary and repro, observed, expected, and "
+          "workaround for the filing body."
+    )
 
 
 def _bug_token_set(text: str) -> set[str]:
@@ -1940,17 +1957,7 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
-    dropped_kwargs = sorted(
-        key for key, value in _kwargs.items()
-        if value not in ("", None, False)
-        and not (
-            (key == "dry_run" and value is True)
-            or (key == "similarity_threshold" and value == 0.25)
-            or (key == "max_results" and value == 10)
-            or (key == "offset" and value == 0)
-            or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
-        )
-    )
+    _validate_file_bug_kwargs(_kwargs)
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",
@@ -2213,13 +2220,6 @@ def _wiki_file_bug(
         "note": "Filing sent to navigator triage pipeline. "
                 f"Use `wiki action=list category={category_dir}` to view.",
     }
-    if dropped_kwargs:
-        response_body["warning"] = (
-            "Dropped unsupported file_bug field(s): "
-            + ", ".join(dropped_kwargs)
-            + ". Use repro, observed, expected, and workaround for the filing body; "
-              "content is only for wiki write/patch actions."
-        )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries
         # / chatbots / operators) have a per-request-id join key without log


### PR DESCRIPTION
Update the GitHub PR bug-filing path so `file_bug` no longer silently ignores truthy unsupported content/body-style kwargs. This change adds explicit validation in `_wiki_file_bug` that rejects those inputs with a clear error naming the offending keys and pointing callers to the supported filing fields (`title`, `repro`, `observed`, `expected`, `workaround`). It preserves the existing behavior for valid calls and adds tests for the rejection path so `file_bug` no longer reports success when body/content kwargs were discarded.

This addresses the request to fail fast in `_wiki_file_bug` instead of returning a success response with a title-only empty shell.