### PR TITLE
[auto-change] WIKI-PATCH: _current_actor() should resolve the authenticated OAuth subject per-request, not a static env var

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/engine_helpers.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/engine_helpers.py
@@ -20,7 +20,8 @@ Public surface (back-compat re-exported via ``workflow.universe_server``):
                                        when the whitelist is unset
 
     Public action ledger trio:
-      _current_actor()               - resolve UNIVERSE_SERVER_USER (default
+      _current_actor()               - resolve request auth identity, falling
+                                       back to UNIVERSE_SERVER_USER (default
                                        'anonymous'); patched 7+ times in tests
       _append_ledger(udir, action, ..) - durable per-universe ledger writer
       _truncate(text, limit=140)     - whitespace-collapsing string truncator
@@ -176,8 +177,18 @@ def _warn_if_no_upload_whitelist() -> None:
 def _current_actor() -> str:
     """Resolve the acting user's identity for ledger attribution.
 
-    Falls back to 'anonymous' when no session identity is available.
+    Authenticated MCP requests use the OAuth subject resolved at request
+    entry. Authless paths and direct tests keep the legacy env-var fallback.
     """
+    try:
+        from workflow.auth.middleware import current_identity
+
+        identity = current_identity()
+        subject = (getattr(identity, "user_id", "") or "").strip()
+        if subject and subject != "anonymous":
+            return subject
+    except Exception:
+        logger.exception("failed to resolve request auth identity")
     return os.environ.get("UNIVERSE_SERVER_USER", "anonymous")
 
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
@@ -808,7 +808,9 @@ def get_status(universe_id: str = "") -> str:
     # Scans the activity.log for any entry within the last 30 days that
     # can be attributed to the current account user. Best-effort; never
     # raises so a log-read error doesn't break the status probe.
-    account_user = os.environ.get("UNIVERSE_SERVER_USER", "anonymous")
+    from workflow.api.engine_helpers import _current_actor
+
+    account_user = _current_actor()
     prior_session_ts: str | None = None
     try:
         if activity_tail:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/middleware.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/middleware.py
@@ -2,18 +2,15 @@
 
 Provides request-level auth resolution that works with FastMCP's
 tool execution model. Since FastMCP tools are plain functions (not
-HTTP handlers), auth is resolved via a context pattern rather than
-HTTP middleware.
-
-For now, auth state is set at the module level per-request via
-the transport layer. When FastMCP adds native auth hooks, this
-module will adapt to use them.
+HTTP handlers), auth is resolved via a context pattern set by the
+HTTP transport layer before tool execution.
 """
 
 from __future__ import annotations
 
 import logging
-import threading
+from contextvars import ContextVar, Token
+from typing import Any
 
 from workflow.auth.provider import (
     ANONYMOUS,
@@ -28,8 +25,13 @@ from workflow.auth.provider import (
 
 logger = logging.getLogger("universe_server.auth")
 
-# Thread-local storage for per-request identity
-_local = threading.local()
+# Request-local storage for per-request identity. ContextVar is required
+# because Streamable HTTP handlers run concurrently on the same event-loop
+# thread; thread-local storage would leak actors between async requests.
+_current_identity: ContextVar[Identity | None] = ContextVar(
+    "workflow_current_identity",
+    default=ANONYMOUS,
+)
 
 # Module-level provider (initialized once at startup)
 _provider: AuthProvider | None = None
@@ -64,12 +66,12 @@ def auth_middleware(token: str | None) -> Identity:
         identity = provider.resolve_token(token)
         if identity is None:
             # Invalid token — return None to signal 401
-            _local.identity = None
+            _current_identity.set(None)
             return ANONYMOUS  # Caller should check
     else:
         identity = ANONYMOUS
 
-    _local.identity = identity
+    _current_identity.set(identity)
     return identity
 
 
@@ -79,7 +81,37 @@ def current_identity() -> Identity:
     Call this from within a tool function to know who's calling.
     Returns ANONYMOUS if no auth context has been set.
     """
-    return getattr(_local, "identity", ANONYMOUS)
+    return _current_identity.get() or ANONYMOUS
+
+
+class AuthContextMiddleware:
+    """Resolve bearer auth into request-local identity for MCP tool calls."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.app, name)
+
+    async def __call__(self, scope, receive, send):  # type: ignore[no-untyped-def]
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        previous: Token[Identity | None] = _current_identity.set(ANONYMOUS)
+        try:
+            auth_header = ""
+            for key, value in scope.get("headers", []):
+                if key.lower() == b"authorization":
+                    auth_header = value.decode("latin1")
+                    break
+            token = None
+            if auth_header.lower().startswith("bearer "):
+                token = auth_header[7:].strip()
+            auth_middleware(token)
+            await self.app(scope, receive, send)
+        finally:
+            _current_identity.reset(previous)
 
 
 def require_auth(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -1398,7 +1398,9 @@ def create_streamable_http_app() -> Starlette:
     # Substrate-fix #11 / Family A Phase 1.A: serve discovery HTML to
     # browser-style GETs on /mcp + /mcp-directory; pass MCP transport
     # requests through unchanged.
-    app = _MCPDiscoveryMiddleware(app)
+    from workflow.auth.middleware import AuthContextMiddleware
+
+    app = AuthContextMiddleware(_MCPDiscoveryMiddleware(app))
     return app
 
 

--- a/tests/test_current_actor_auth_context.py
+++ b/tests/test_current_actor_auth_context.py
@@ -1,0 +1,152 @@
+"""Regression guards for request-scoped MCP actor identity."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from workflow.auth.middleware import auth_middleware, set_provider
+from workflow.auth.provider import AuthProvider, DevAuthProvider, Identity
+
+
+class StaticAuthProvider(AuthProvider):
+    def __init__(self, identity: Identity | None) -> None:
+        self.identity = identity
+
+    def resolve_token(self, token: str) -> Identity | None:
+        return self.identity if token == "valid" else None
+
+    def is_auth_required(self) -> bool:
+        return True
+
+    def register_client(self, metadata: dict[str, Any]) -> dict[str, Any]:
+        return {"client_id": "test-client", **metadata}
+
+    def create_authorization(
+        self,
+        client_id: str,
+        redirect_uri: str,
+        scope: str,
+        state: str,
+        code_challenge: str,
+        code_challenge_method: str,
+    ) -> str:
+        return "test-code"
+
+    def exchange_code(
+        self,
+        code: str,
+        client_id: str,
+        redirect_uri: str,
+        code_verifier: str,
+    ) -> dict[str, Any] | None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _reset_auth_context() -> None:
+    set_provider(DevAuthProvider())
+    auth_middleware(None)
+    yield
+    set_provider(DevAuthProvider())
+    auth_middleware(None)
+
+
+def test_current_actor_prefers_authenticated_oauth_subject(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from workflow.api.engine_helpers import _current_actor
+
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "env-actor")
+    set_provider(StaticAuthProvider(Identity(
+        user_id="oauth-subject-123",
+        username="display-name",
+        capabilities=["workflow.universe.write"],
+    )))
+
+    auth_middleware("valid")
+
+    assert _current_actor() == "oauth-subject-123"
+
+
+def test_current_actor_falls_back_to_env_without_request_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from workflow.api.engine_helpers import _current_actor
+
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "env-actor")
+    set_provider(DevAuthProvider())
+    auth_middleware(None)
+
+    assert _current_actor() == "env-actor"
+
+
+def test_get_status_account_user_uses_authenticated_subject(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    import json
+
+    from workflow.api.status import get_status
+
+    base = tmp_path / "output"
+    universe = base / "status-uni"
+    universe.mkdir(parents=True)
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(base))
+    monkeypatch.setenv("UNIVERSE_SERVER_DEFAULT_UNIVERSE", "status-uni")
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "env-actor")
+    set_provider(StaticAuthProvider(Identity(
+        user_id="oauth-status-subject",
+        username="display-name",
+        capabilities=["workflow.universe.read"],
+    )))
+
+    auth_middleware("valid")
+
+    payload = json.loads(get_status())
+
+    assert payload["session_boundary"]["account_user"] == "oauth-status-subject"
+
+
+@pytest.mark.asyncio
+async def test_auth_context_middleware_sets_actor_for_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from workflow.api.engine_helpers import _current_actor
+    from workflow.auth.middleware import AuthContextMiddleware
+
+    seen: list[str] = []
+
+    async def app(scope, receive, send):  # type: ignore[no-untyped-def]
+        seen.append(_current_actor())
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "env-actor")
+    set_provider(StaticAuthProvider(Identity(
+        user_id="oauth-subject-456",
+        username="display-name",
+        capabilities=["workflow.universe.write"],
+    )))
+
+    middleware = AuthContextMiddleware(app)
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": [(b"authorization", b"Bearer valid")],
+    }
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    sent: list[dict[str, Any]] = []
+
+    async def send(message: dict[str, Any]) -> None:
+        sent.append(message)
+
+    await middleware(scope, receive, send)
+
+    assert seen == ["oauth-subject-456"]
+    assert _current_actor() == "env-actor"

--- a/workflow/api/engine_helpers.py
+++ b/workflow/api/engine_helpers.py
@@ -20,7 +20,8 @@ Public surface (back-compat re-exported via ``workflow.universe_server``):
                                        when the whitelist is unset
 
     Public action ledger trio:
-      _current_actor()               - resolve UNIVERSE_SERVER_USER (default
+      _current_actor()               - resolve request auth identity, falling
+                                       back to UNIVERSE_SERVER_USER (default
                                        'anonymous'); patched 7+ times in tests
       _append_ledger(udir, action, ..) - durable per-universe ledger writer
       _truncate(text, limit=140)     - whitespace-collapsing string truncator
@@ -176,8 +177,18 @@ def _warn_if_no_upload_whitelist() -> None:
 def _current_actor() -> str:
     """Resolve the acting user's identity for ledger attribution.
 
-    Falls back to 'anonymous' when no session identity is available.
+    Authenticated MCP requests use the OAuth subject resolved at request
+    entry. Authless paths and direct tests keep the legacy env-var fallback.
     """
+    try:
+        from workflow.auth.middleware import current_identity
+
+        identity = current_identity()
+        subject = (getattr(identity, "user_id", "") or "").strip()
+        if subject and subject != "anonymous":
+            return subject
+    except Exception:
+        logger.exception("failed to resolve request auth identity")
     return os.environ.get("UNIVERSE_SERVER_USER", "anonymous")
 
 

--- a/workflow/api/status.py
+++ b/workflow/api/status.py
@@ -808,7 +808,9 @@ def get_status(universe_id: str = "") -> str:
     # Scans the activity.log for any entry within the last 30 days that
     # can be attributed to the current account user. Best-effort; never
     # raises so a log-read error doesn't break the status probe.
-    account_user = os.environ.get("UNIVERSE_SERVER_USER", "anonymous")
+    from workflow.api.engine_helpers import _current_actor
+
+    account_user = _current_actor()
     prior_session_ts: str | None = None
     try:
         if activity_tail:

--- a/workflow/auth/middleware.py
+++ b/workflow/auth/middleware.py
@@ -2,18 +2,15 @@
 
 Provides request-level auth resolution that works with FastMCP's
 tool execution model. Since FastMCP tools are plain functions (not
-HTTP handlers), auth is resolved via a context pattern rather than
-HTTP middleware.
-
-For now, auth state is set at the module level per-request via
-the transport layer. When FastMCP adds native auth hooks, this
-module will adapt to use them.
+HTTP handlers), auth is resolved via a context pattern set by the
+HTTP transport layer before tool execution.
 """
 
 from __future__ import annotations
 
 import logging
-import threading
+from contextvars import ContextVar, Token
+from typing import Any
 
 from workflow.auth.provider import (
     ANONYMOUS,
@@ -28,8 +25,13 @@ from workflow.auth.provider import (
 
 logger = logging.getLogger("universe_server.auth")
 
-# Thread-local storage for per-request identity
-_local = threading.local()
+# Request-local storage for per-request identity. ContextVar is required
+# because Streamable HTTP handlers run concurrently on the same event-loop
+# thread; thread-local storage would leak actors between async requests.
+_current_identity: ContextVar[Identity | None] = ContextVar(
+    "workflow_current_identity",
+    default=ANONYMOUS,
+)
 
 # Module-level provider (initialized once at startup)
 _provider: AuthProvider | None = None
@@ -64,12 +66,12 @@ def auth_middleware(token: str | None) -> Identity:
         identity = provider.resolve_token(token)
         if identity is None:
             # Invalid token — return None to signal 401
-            _local.identity = None
+            _current_identity.set(None)
             return ANONYMOUS  # Caller should check
     else:
         identity = ANONYMOUS
 
-    _local.identity = identity
+    _current_identity.set(identity)
     return identity
 
 
@@ -79,7 +81,37 @@ def current_identity() -> Identity:
     Call this from within a tool function to know who's calling.
     Returns ANONYMOUS if no auth context has been set.
     """
-    return getattr(_local, "identity", ANONYMOUS)
+    return _current_identity.get() or ANONYMOUS
+
+
+class AuthContextMiddleware:
+    """Resolve bearer auth into request-local identity for MCP tool calls."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.app, name)
+
+    async def __call__(self, scope, receive, send):  # type: ignore[no-untyped-def]
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        previous: Token[Identity | None] = _current_identity.set(ANONYMOUS)
+        try:
+            auth_header = ""
+            for key, value in scope.get("headers", []):
+                if key.lower() == b"authorization":
+                    auth_header = value.decode("latin1")
+                    break
+            token = None
+            if auth_header.lower().startswith("bearer "):
+                token = auth_header[7:].strip()
+            auth_middleware(token)
+            await self.app(scope, receive, send)
+        finally:
+            _current_identity.reset(previous)
 
 
 def require_auth(

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -1398,7 +1398,9 @@ def create_streamable_http_app() -> Starlette:
     # Substrate-fix #11 / Family A Phase 1.A: serve discovery HTML to
     # browser-style GETs on /mcp + /mcp-directory; pass MCP transport
     # requests through unchanged.
-    app = _MCPDiscoveryMiddleware(app)
+    from workflow.auth.middleware import AuthContextMiddleware
+
+    app = AuthContextMiddleware(_MCPDiscoveryMiddleware(app))
     return app
 
 


### PR DESCRIPTION
Fixes #1245

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-165-current-actor-should-resolve-the-authenticated-oauth-subject.md`
- GitHub issue: #1245
- Branch task: `auto-change/issue-1245`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.