### PR TITLE
[auto-change] WIKI-PATCH: Add a wiki write-back effector so a loop can publish its result packet back onto the filing

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/__init__.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/__init__.py
@@ -30,6 +30,10 @@ from workflow.effectors.github_search import (
     register_search_repo_files,
     search_repo_files,
 )
+from workflow.effectors.wiki_write_back import (
+    EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+    run_wiki_write_back_effector,
+)
 from workflow.effectors.windows_desktop import (
     EXTERNAL_WRITE_SINK_WINDOWS_DESKTOP_CLASSIC_GAME,
     run_windows_desktop_effector,
@@ -43,11 +47,13 @@ register_search_repo_files()
 __all__ = [
     "EXTERNAL_WRITE_SINK_GITHUB_PR",
     "EXTERNAL_WRITE_SINK_WINDOWS_DESKTOP_CLASSIC_GAME",
+    "EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK",
     "read_repo_files",
     "register_read_repo_files",
     "search_repo_files",
     "register_search_repo_files",
     "run_github_pr_effector",
     "run_windows_desktop_effector",
+    "run_wiki_write_back_effector",
     "run_effects_for_branch",
 ]

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_pr.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_pr.py
@@ -1575,6 +1575,29 @@ def run_effects_for_branch(
                         "error_kind": "effector_crashed",
                     }
                 per_node[sink] = result
+            elif sink == "wiki_write_back":
+                try:
+                    from workflow.effectors.wiki_write_back import (
+                        run_wiki_write_back_effector,
+                    )
+
+                    result = run_wiki_write_back_effector(
+                        node_id=node_id,
+                        output_keys=output_keys,
+                        run_state=run_state,
+                        base_path=base_path,
+                        run_id=run_id,
+                    )
+                except Exception as exc:  # defensive — never raise
+                    logger.exception(
+                        "wiki_write_back effector crashed for node %s",
+                        node_id,
+                    )
+                    result = {
+                        "error": f"effector crashed: {exc}",
+                        "error_kind": "effector_crashed",
+                    }
+                per_node[sink] = result
             else:
                 per_node[sink] = {
                     "error": f"unknown effect sink '{sink}'",

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/wiki_write_back.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/wiki_write_back.py
@@ -1,0 +1,500 @@
+"""Wiki write-back external-write effector — PR-166.
+
+Consumes a branch-declared ``external_write_packet`` and appends the result
+packet back onto a same-universe wiki page. This is an explicit effect sink:
+the dispatcher does not auto-publish loop output.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+from workflow.effectors.authority import DENIED as SOUL_AUTHORITY_DENIED
+from workflow.effectors.authority import resolve_soul_effect_authority
+
+logger = logging.getLogger(__name__)
+
+EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK = "wiki_write_back"
+
+_IDEMPOTENCY_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,200}$")
+
+
+def _parse_packet(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        packet = value
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped or not stripped.startswith("{"):
+            return None
+        try:
+            packet = json.loads(stripped)
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(packet, dict):
+            return None
+    else:
+        return None
+    if packet.get("sink") != EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK:
+        return None
+    return packet
+
+
+def _find_packet(
+    *,
+    output_keys: list[str],
+    run_state: dict[str, Any],
+) -> tuple[str | None, dict[str, Any] | None]:
+    for key in output_keys or []:
+        if not isinstance(key, str) or key not in run_state:
+            continue
+        packet = _parse_packet(run_state.get(key))
+        if packet is not None:
+            return key, packet
+    return None, None
+
+
+def _destination(packet: dict[str, Any]) -> str:
+    value = packet.get("destination") or packet.get("target_page")
+    if isinstance(value, str):
+        return value.strip().replace("\\", "/")
+    return ""
+
+
+def _idempotency_hint(packet: dict[str, Any]) -> str:
+    for key in ("idempotency_hint", "idempotency_key"):
+        value = packet.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _payload_text(packet: dict[str, Any]) -> tuple[str, str]:
+    payload = packet.get("payload")
+    if not isinstance(payload, dict):
+        return "", "packet.payload must be a JSON object"
+    body = payload.get("body") or payload.get("result_packet")
+    if not isinstance(body, str) or not body.strip():
+        return "", "packet.payload.body is required"
+    return body.strip(), ""
+
+
+def _payload_heading(packet: dict[str, Any]) -> str:
+    payload = packet.get("payload")
+    raw = payload.get("heading") if isinstance(payload, dict) else None
+    if not isinstance(raw, str) or not raw.strip():
+        return "Workflow result packet"
+    heading = " ".join(raw.replace("#", "").split())
+    return heading[:120] or "Workflow result packet"
+
+
+def _universe_dir(base_path: str | Path | None) -> Path | None:
+    if base_path is None:
+        return None
+    try:
+        return Path(base_path)
+    except (TypeError, ValueError):
+        return None
+
+
+def _wiki_root_for_universe(universe_dir: Path | None) -> Path | None:
+    if universe_dir is None:
+        return None
+    return universe_dir / "wiki"
+
+
+def _resolve_target_page(wiki_root: Path, destination: str) -> tuple[Path | None, str]:
+    requested = destination.strip().replace("\\", "/")
+    if not requested:
+        return None, "destination is required"
+    parts = requested.split("/")
+    if (
+        requested.startswith("/")
+        or any(part in {"", ".", ".."} for part in parts)
+        or len(parts) < 3
+        or parts[0] not in {"pages", "drafts"}
+        or not requested.endswith(".md")
+    ):
+        return None, (
+            "destination must be an exact wiki-relative page path like "
+            "pages/<category>/<slug>.md or drafts/<category>/<slug>.md"
+        )
+    candidate = (wiki_root / requested).resolve()
+    root = wiki_root.resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None, "destination escapes the wiki root"
+    if not candidate.exists() or not candidate.is_file():
+        return None, f"Page not found: {requested}"
+    return candidate, ""
+
+
+def _check_consent(universe_dir: Path | None, destination: str) -> bool:
+    if universe_dir is None or not destination:
+        return False
+    try:
+        from workflow.storage.effector_consents import is_consent_active
+
+        return is_consent_active(
+            universe_dir,
+            sink=EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+            destination=destination,
+        )
+    except Exception:
+        logger.exception("wiki write-back consent lookup crashed")
+        return False
+
+
+def _try_reserve(
+    universe_dir: Path | None,
+    *,
+    idempotency_hint: str,
+    run_id: str,
+) -> dict[str, Any]:
+    if universe_dir is None or not idempotency_hint:
+        return {"status": "no_hint"}
+    from workflow.storage.external_write_receipts import try_reserve_receipt
+
+    return try_reserve_receipt(
+        universe_dir,
+        idempotency_hint=idempotency_hint,
+        sink=EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+        run_id=run_id or "",
+    )
+
+
+def _finalize_receipt(
+    universe_dir: Path | None,
+    *,
+    idempotency_hint: str,
+    evidence: dict[str, Any],
+    run_id: str,
+) -> bool:
+    if universe_dir is None or not idempotency_hint:
+        return False
+    try:
+        from workflow.storage.external_write_receipts import finalize_receipt
+
+        return finalize_receipt(
+            universe_dir,
+            idempotency_hint=idempotency_hint,
+            sink=EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+            evidence=evidence,
+            run_id=run_id or "",
+        )
+    except Exception:
+        logger.exception("failed to finalize wiki write-back receipt")
+        return False
+
+
+def _release_reservation(
+    universe_dir: Path | None,
+    *,
+    idempotency_hint: str,
+    run_id: str,
+) -> None:
+    if universe_dir is None or not idempotency_hint:
+        return
+    try:
+        from workflow.storage.external_write_receipts import release_reservation
+
+        release_reservation(
+            universe_dir,
+            idempotency_hint=idempotency_hint,
+            sink=EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+            run_id=run_id or "",
+            mark_failed=True,
+        )
+    except Exception:
+        logger.exception("failed to release wiki write-back reservation")
+
+
+def _is_lock_error(exc: BaseException) -> bool:
+    if not isinstance(exc, sqlite3.OperationalError):
+        return False
+    msg = str(exc).lower()
+    return any(token in msg for token in ("locked", "busy", "deadlock", "timeout"))
+
+
+def _render_section(*, packet: dict[str, Any], idem_hint: str) -> tuple[str, str]:
+    body, error = _payload_text(packet)
+    if error:
+        return "", error
+    if not _IDEMPOTENCY_RE.fullmatch(idem_hint):
+        return "", "idempotency_hint contains unsupported characters"
+    heading = _payload_heading(packet)
+    marker = f"workflow-wiki-write-back:{idem_hint}"
+    return (
+        f"<!-- {marker} -->\n"
+        f"## {heading}\n\n"
+        f"{body}\n"
+        f"<!-- /{marker} -->",
+        "",
+    )
+
+
+def _append_or_update_section(path: Path, section: str, idem_hint: str) -> dict[str, Any]:
+    from workflow.api.wiki import _append_wiki_log, _page_rel_path
+
+    text = path.read_text(encoding="utf-8")
+    old_sha = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    marker = f"workflow-wiki-write-back:{idem_hint}"
+    start = f"<!-- {marker} -->"
+    end = f"<!-- /{marker} -->"
+    start_idx = text.find(start)
+    end_idx = text.find(end)
+    if start_idx >= 0 and end_idx >= start_idx:
+        end_idx += len(end)
+        new_text = text[:start_idx] + section + text[end_idx:]
+        status = "updated"
+    else:
+        new_text = text.rstrip() + "\n\n" + section + "\n"
+        status = "written"
+    new_sha = hashlib.sha256(new_text.encode("utf-8")).hexdigest()
+    path.write_text(new_text, encoding="utf-8")
+    rel = _page_rel_path(path)
+    _append_wiki_log(f"wiki_write_back | {rel} | idempotency_hint={idem_hint}")
+    return {
+        "status": status,
+        "path": rel,
+        "old_sha256": old_sha,
+        "new_sha256": new_sha,
+        "old_total_chars": len(text),
+        "new_total_chars": len(new_text),
+    }
+
+
+def run_wiki_write_back_effector(
+    *,
+    node_id: str,
+    output_keys: list[str],
+    run_state: dict[str, Any],
+    base_path: str | Path | None = None,
+    run_id: str = "",
+) -> dict[str, Any]:
+    """Append/update one wiki result-packet section.
+
+    The function never raises to the run-completion path. All refusal and
+    failure states are returned as structured evidence.
+    """
+    matched_key, packet = _find_packet(output_keys=output_keys, run_state=run_state)
+    if packet is None:
+        return {
+            "error": (
+                f"node '{node_id}' declared effects=["
+                f"{EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK}] but no output_key held "
+                "a parseable wiki write-back packet"
+            ),
+            "error_kind": "no_matching_packet",
+        }
+
+    destination = _destination(packet)
+    universe_dir = _universe_dir(base_path)
+    wiki_root = _wiki_root_for_universe(universe_dir)
+    idem_hint = _idempotency_hint(packet)
+
+    if not destination:
+        return {
+            "error": "packet.destination is required",
+            "error_kind": "invalid_destination",
+            "phase": "phase_2",
+            "matched_output_key": matched_key,
+        }
+
+    authority = resolve_soul_effect_authority(
+        universe_dir,
+        EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+        destination,
+    )
+    if authority == SOUL_AUTHORITY_DENIED:
+        return {
+            "dry_run": True,
+            "phase": "phase_2",
+            "reason": "soul_authority_denied",
+            "destination": destination,
+            "matched_output_key": matched_key,
+            "intent": packet,
+        }
+
+    if not _check_consent(universe_dir, destination):
+        return {
+            "dry_run": True,
+            "phase": "phase_2",
+            "reason": "missing_consent",
+            "destination": destination,
+            "matched_output_key": matched_key,
+            "intent": packet,
+            "hint": (
+                "Call extensions action=grant_effector_consent "
+                f"sink={EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK} "
+                f"destination={destination} before dispatching wiki write-back "
+                "effects."
+            ),
+        }
+
+    if not idem_hint:
+        return {
+            "dry_run": True,
+            "phase": "phase_2",
+            "reason": "missing_idempotency_hint",
+            "destination": destination,
+            "matched_output_key": matched_key,
+            "intent": packet,
+        }
+
+    section, render_error = _render_section(packet=packet, idem_hint=idem_hint)
+    if render_error:
+        return {
+            "error": render_error,
+            "error_kind": "invalid_payload",
+            "phase": "phase_2",
+            "destination": destination,
+            "matched_output_key": matched_key,
+        }
+
+    if wiki_root is None:
+        return {
+            "error": "base_path is required for wiki write-back effects",
+            "error_kind": "missing_universe_context",
+            "phase": "phase_2",
+            "destination": destination,
+            "matched_output_key": matched_key,
+        }
+
+    from workflow.api.wiki import _ensure_wiki_scaffold, _scoped_wiki_root
+
+    try:
+        _ensure_wiki_scaffold(wiki_root)
+    except OSError as exc:
+        return {
+            "error": f"Wiki scaffold failed at {wiki_root}: {exc}",
+            "error_kind": "wiki_scaffold_failed",
+            "phase": "phase_2",
+            "destination": destination,
+            "matched_output_key": matched_key,
+        }
+
+    with _scoped_wiki_root(wiki_root):
+        target, destination_error = _resolve_target_page(wiki_root, destination)
+        if destination_error or target is None:
+            return {
+                "error": destination_error or "Page not found.",
+                "error_kind": "invalid_destination",
+                "phase": "phase_2",
+                "destination": destination,
+                "matched_output_key": matched_key,
+            }
+
+        try:
+            reservation = _try_reserve(
+                universe_dir,
+                idempotency_hint=idem_hint,
+                run_id=run_id,
+            )
+        except sqlite3.OperationalError as exc:
+            return {
+                "error": (
+                    "receipt store unavailable; refusing wiki write-back to "
+                    f"avoid duplicate writes: {exc}"
+                ),
+                "error_kind": (
+                    "receipt_store_locked"
+                    if _is_lock_error(exc) else "receipt_store_error"
+                ),
+                "phase": "phase_2",
+                "destination": destination,
+                "idempotency_hint": idem_hint,
+                "matched_output_key": matched_key,
+            }
+
+        status = reservation.get("status")
+        if status == "duplicate":
+            recorded = reservation.get("row") or {}
+            return {
+                "idempotency_dedup_hit": True,
+                "phase": "phase_2",
+                "destination": destination,
+                "matched_output_key": matched_key,
+                "evidence": recorded.get("evidence") or {},
+                "recorded_run_id": recorded.get("run_id"),
+                "recorded_at": recorded.get("created_at"),
+                "idempotency_hint": idem_hint,
+            }
+        if status == "in_flight":
+            held = reservation.get("row") or {}
+            return {
+                "dry_run": True,
+                "phase": "phase_2",
+                "reason": "concurrent_in_flight",
+                "destination": destination,
+                "idempotency_hint": idem_hint,
+                "matched_output_key": matched_key,
+                "held_by_run_id": held.get("run_id"),
+                "reservation_created_at": held.get("created_at"),
+                "intent": packet,
+            }
+        if status not in (
+            "reserved",
+            "reserved_after_stale",
+            "reserved_after_failed",
+        ):
+            return {
+                "dry_run": True,
+                "phase": "phase_2",
+                "reason": "reservation_unknown_state",
+                "destination": destination,
+                "idempotency_hint": idem_hint,
+                "reservation_status": str(status),
+                "matched_output_key": matched_key,
+                "intent": packet,
+            }
+
+        try:
+            evidence = _append_or_update_section(target, section, idem_hint)
+        except Exception as exc:
+            _release_reservation(
+                universe_dir,
+                idempotency_hint=idem_hint,
+                run_id=run_id,
+            )
+            return {
+                "error": f"wiki write-back failed: {exc}",
+                "error_kind": "wiki_write_back_failed",
+                "phase": "phase_2",
+                "destination": destination,
+                "idempotency_hint": idem_hint,
+                "reservation_released": bool(idem_hint),
+                "matched_output_key": matched_key,
+            }
+
+        evidence.update({
+            "phase": "phase_2",
+            "destination": destination,
+            "matched_output_key": matched_key,
+            "idempotency_hint": idem_hint,
+            "recorded_at": time.time(),
+        })
+        if status in ("reserved_after_stale", "reserved_after_failed"):
+            evidence["reservation_origin"] = status
+
+        if not _finalize_receipt(
+            universe_dir,
+            idempotency_hint=idem_hint,
+            evidence=evidence,
+            run_id=run_id,
+        ):
+            evidence["receipt_finalize_failed"] = True
+        return evidence
+
+
+__all__ = [
+    "EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK",
+    "run_wiki_write_back_effector",
+]

--- a/tests/test_wiki_write_back_effector.py
+++ b/tests/test_wiki_write_back_effector.py
@@ -1,0 +1,208 @@
+"""PR-166 wiki write-back external-write effector tests."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from workflow.api.wiki import _ensure_wiki_scaffold
+from workflow.branches import NodeDefinition
+from workflow.effectors import (
+    EXTERNAL_WRITE_SINK_GITHUB_PR,
+    EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+    read_repo_files,
+    run_effects_for_branch,
+    run_wiki_write_back_effector,
+    search_repo_files,
+)
+from workflow.storage.effector_consents import grant_consent
+from workflow.storage.external_write_receipts import (
+    STATUS_SUCCEEDED,
+    lookup_receipt,
+)
+
+
+def _wiki_env(tmp_path):
+    wiki_root = tmp_path / "wiki"
+    _ensure_wiki_scaffold(wiki_root)
+    target = wiki_root / "pages" / "patch-requests" / "pr-166-test.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        "---\ntitle: PR-166 Test\ntype: patch_request\n---\n\n# PR-166 Test\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+def _packet(**overrides):
+    packet = {
+        "sink": EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+        "destination": "pages/patch-requests/pr-166-test.md",
+        "payload": {
+            "heading": "Loop result packet",
+            "body": (
+                "Decision: KEEP\n\n"
+                "Evidence: open_pr dry-run produced a proposed patch."
+            ),
+        },
+        "idempotency_hint": "pr-166-loop-result-run-1",
+    }
+    packet.update(overrides)
+    return packet
+
+
+def test_effectors_package_preserves_existing_exports():
+    assert EXTERNAL_WRITE_SINK_GITHUB_PR == "github_pull_request"
+    assert callable(read_repo_files)
+    assert callable(search_repo_files)
+    assert callable(run_wiki_write_back_effector)
+
+
+def test_wiki_write_back_without_consent_dry_runs_before_write(tmp_path):
+    target = _wiki_env(tmp_path)
+    before = target.read_text(encoding="utf-8")
+
+    result = run_wiki_write_back_effector(
+        node_id="publish",
+        output_keys=["packet"],
+        run_state={"packet": _packet()},
+        base_path=tmp_path,
+        run_id="run-no-consent",
+    )
+
+    assert result["dry_run"] is True
+    assert result["reason"] == "missing_consent"
+    assert result["destination"] == "pages/patch-requests/pr-166-test.md"
+    assert target.read_text(encoding="utf-8") == before
+
+
+def test_wiki_write_back_rejects_packet_controlled_path_escape(tmp_path):
+    _wiki_env(tmp_path)
+    grant_consent(
+        tmp_path,
+        sink=EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+        destination="../outside.md",
+        granted_by="tester",
+    )
+
+    result = run_wiki_write_back_effector(
+        node_id="publish",
+        output_keys=["packet"],
+        run_state={"packet": _packet(destination="../outside.md")},
+        base_path=tmp_path,
+        run_id="run-path-escape",
+    )
+
+    assert result["error_kind"] == "invalid_destination"
+    assert not (tmp_path / "outside.md").exists()
+
+
+def test_wiki_write_back_requires_idempotency_hint_for_real_write(tmp_path):
+    target = _wiki_env(tmp_path)
+    grant_consent(
+        tmp_path,
+        sink=EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+        destination="pages/patch-requests/pr-166-test.md",
+        granted_by="tester",
+    )
+
+    result = run_wiki_write_back_effector(
+        node_id="publish",
+        output_keys=["packet"],
+        run_state={"packet": _packet(idempotency_hint="")},
+        base_path=tmp_path,
+        run_id="run-no-idem",
+    )
+
+    assert result["dry_run"] is True
+    assert result["reason"] == "missing_idempotency_hint"
+    assert "Loop result packet" not in target.read_text(encoding="utf-8")
+
+
+def test_wiki_write_back_appends_section_and_records_receipt(tmp_path):
+    target = _wiki_env(tmp_path)
+    grant_consent(
+        tmp_path,
+        sink=EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+        destination="pages/patch-requests/pr-166-test.md",
+        granted_by="tester",
+    )
+
+    result = run_wiki_write_back_effector(
+        node_id="publish",
+        output_keys=["packet"],
+        run_state={"packet": json.dumps(_packet())},
+        base_path=tmp_path,
+        run_id="run-ok",
+    )
+
+    assert result["phase"] == "phase_2"
+    assert result["status"] == "written"
+    assert result["path"] == "pages/patch-requests/pr-166-test.md"
+    text = target.read_text(encoding="utf-8")
+    assert "## Loop result packet" in text
+    assert "Decision: KEEP" in text
+    assert "workflow-wiki-write-back:pr-166-loop-result-run-1" in text
+
+    receipt = lookup_receipt(
+        tmp_path,
+        idempotency_hint="pr-166-loop-result-run-1",
+        sink=EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+    )
+    assert receipt is not None
+    assert receipt["status"] == STATUS_SUCCEEDED
+    assert receipt["evidence"]["path"] == "pages/patch-requests/pr-166-test.md"
+
+
+def test_wiki_write_back_idempotency_dedup_does_not_append_twice(tmp_path):
+    target = _wiki_env(tmp_path)
+    grant_consent(
+        tmp_path,
+        sink=EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+        destination="pages/patch-requests/pr-166-test.md",
+        granted_by="tester",
+    )
+
+    first = run_wiki_write_back_effector(
+        node_id="publish",
+        output_keys=["packet"],
+        run_state={"packet": _packet()},
+        base_path=tmp_path,
+        run_id="run-first",
+    )
+    second = run_wiki_write_back_effector(
+        node_id="publish",
+        output_keys=["packet"],
+        run_state={"packet": _packet()},
+        base_path=tmp_path,
+        run_id="run-second",
+    )
+
+    assert first["status"] == "written"
+    assert second["idempotency_dedup_hit"] is True
+    text = target.read_text(encoding="utf-8")
+    assert text.count("## Loop result packet") == 1
+
+
+def test_branch_dispatch_routes_wiki_write_back_sink(tmp_path):
+    _wiki_env(tmp_path)
+    branch = SimpleNamespace(
+        node_defs=[
+            NodeDefinition(
+                node_id="publish",
+                display_name="Publish",
+                output_keys=["packet"],
+                effects=[EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK],
+            ),
+        ],
+    )
+
+    ev_map = run_effects_for_branch(
+        branch=branch,
+        run_state={"packet": _packet()},
+        base_path=tmp_path,
+        run_id="run-dispatch",
+    )
+
+    ev = ev_map["publish"][EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK]
+    assert ev["reason"] == "missing_consent"

--- a/workflow/effectors/__init__.py
+++ b/workflow/effectors/__init__.py
@@ -30,6 +30,10 @@ from workflow.effectors.github_search import (
     register_search_repo_files,
     search_repo_files,
 )
+from workflow.effectors.wiki_write_back import (
+    EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+    run_wiki_write_back_effector,
+)
 from workflow.effectors.windows_desktop import (
     EXTERNAL_WRITE_SINK_WINDOWS_DESKTOP_CLASSIC_GAME,
     run_windows_desktop_effector,
@@ -43,11 +47,13 @@ register_search_repo_files()
 __all__ = [
     "EXTERNAL_WRITE_SINK_GITHUB_PR",
     "EXTERNAL_WRITE_SINK_WINDOWS_DESKTOP_CLASSIC_GAME",
+    "EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK",
     "read_repo_files",
     "register_read_repo_files",
     "search_repo_files",
     "register_search_repo_files",
     "run_github_pr_effector",
     "run_windows_desktop_effector",
+    "run_wiki_write_back_effector",
     "run_effects_for_branch",
 ]

--- a/workflow/effectors/github_pr.py
+++ b/workflow/effectors/github_pr.py
@@ -1575,6 +1575,29 @@ def run_effects_for_branch(
                         "error_kind": "effector_crashed",
                     }
                 per_node[sink] = result
+            elif sink == "wiki_write_back":
+                try:
+                    from workflow.effectors.wiki_write_back import (
+                        run_wiki_write_back_effector,
+                    )
+
+                    result = run_wiki_write_back_effector(
+                        node_id=node_id,
+                        output_keys=output_keys,
+                        run_state=run_state,
+                        base_path=base_path,
+                        run_id=run_id,
+                    )
+                except Exception as exc:  # defensive — never raise
+                    logger.exception(
+                        "wiki_write_back effector crashed for node %s",
+                        node_id,
+                    )
+                    result = {
+                        "error": f"effector crashed: {exc}",
+                        "error_kind": "effector_crashed",
+                    }
+                per_node[sink] = result
             else:
                 per_node[sink] = {
                     "error": f"unknown effect sink '{sink}'",

--- a/workflow/effectors/wiki_write_back.py
+++ b/workflow/effectors/wiki_write_back.py
@@ -1,0 +1,500 @@
+"""Wiki write-back external-write effector — PR-166.
+
+Consumes a branch-declared ``external_write_packet`` and appends the result
+packet back onto a same-universe wiki page. This is an explicit effect sink:
+the dispatcher does not auto-publish loop output.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+from workflow.effectors.authority import DENIED as SOUL_AUTHORITY_DENIED
+from workflow.effectors.authority import resolve_soul_effect_authority
+
+logger = logging.getLogger(__name__)
+
+EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK = "wiki_write_back"
+
+_IDEMPOTENCY_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,200}$")
+
+
+def _parse_packet(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        packet = value
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped or not stripped.startswith("{"):
+            return None
+        try:
+            packet = json.loads(stripped)
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(packet, dict):
+            return None
+    else:
+        return None
+    if packet.get("sink") != EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK:
+        return None
+    return packet
+
+
+def _find_packet(
+    *,
+    output_keys: list[str],
+    run_state: dict[str, Any],
+) -> tuple[str | None, dict[str, Any] | None]:
+    for key in output_keys or []:
+        if not isinstance(key, str) or key not in run_state:
+            continue
+        packet = _parse_packet(run_state.get(key))
+        if packet is not None:
+            return key, packet
+    return None, None
+
+
+def _destination(packet: dict[str, Any]) -> str:
+    value = packet.get("destination") or packet.get("target_page")
+    if isinstance(value, str):
+        return value.strip().replace("\\", "/")
+    return ""
+
+
+def _idempotency_hint(packet: dict[str, Any]) -> str:
+    for key in ("idempotency_hint", "idempotency_key"):
+        value = packet.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _payload_text(packet: dict[str, Any]) -> tuple[str, str]:
+    payload = packet.get("payload")
+    if not isinstance(payload, dict):
+        return "", "packet.payload must be a JSON object"
+    body = payload.get("body") or payload.get("result_packet")
+    if not isinstance(body, str) or not body.strip():
+        return "", "packet.payload.body is required"
+    return body.strip(), ""
+
+
+def _payload_heading(packet: dict[str, Any]) -> str:
+    payload = packet.get("payload")
+    raw = payload.get("heading") if isinstance(payload, dict) else None
+    if not isinstance(raw, str) or not raw.strip():
+        return "Workflow result packet"
+    heading = " ".join(raw.replace("#", "").split())
+    return heading[:120] or "Workflow result packet"
+
+
+def _universe_dir(base_path: str | Path | None) -> Path | None:
+    if base_path is None:
+        return None
+    try:
+        return Path(base_path)
+    except (TypeError, ValueError):
+        return None
+
+
+def _wiki_root_for_universe(universe_dir: Path | None) -> Path | None:
+    if universe_dir is None:
+        return None
+    return universe_dir / "wiki"
+
+
+def _resolve_target_page(wiki_root: Path, destination: str) -> tuple[Path | None, str]:
+    requested = destination.strip().replace("\\", "/")
+    if not requested:
+        return None, "destination is required"
+    parts = requested.split("/")
+    if (
+        requested.startswith("/")
+        or any(part in {"", ".", ".."} for part in parts)
+        or len(parts) < 3
+        or parts[0] not in {"pages", "drafts"}
+        or not requested.endswith(".md")
+    ):
+        return None, (
+            "destination must be an exact wiki-relative page path like "
+            "pages/<category>/<slug>.md or drafts/<category>/<slug>.md"
+        )
+    candidate = (wiki_root / requested).resolve()
+    root = wiki_root.resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None, "destination escapes the wiki root"
+    if not candidate.exists() or not candidate.is_file():
+        return None, f"Page not found: {requested}"
+    return candidate, ""
+
+
+def _check_consent(universe_dir: Path | None, destination: str) -> bool:
+    if universe_dir is None or not destination:
+        return False
+    try:
+        from workflow.storage.effector_consents import is_consent_active
+
+        return is_consent_active(
+            universe_dir,
+            sink=EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+            destination=destination,
+        )
+    except Exception:
+        logger.exception("wiki write-back consent lookup crashed")
+        return False
+
+
+def _try_reserve(
+    universe_dir: Path | None,
+    *,
+    idempotency_hint: str,
+    run_id: str,
+) -> dict[str, Any]:
+    if universe_dir is None or not idempotency_hint:
+        return {"status": "no_hint"}
+    from workflow.storage.external_write_receipts import try_reserve_receipt
+
+    return try_reserve_receipt(
+        universe_dir,
+        idempotency_hint=idempotency_hint,
+        sink=EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+        run_id=run_id or "",
+    )
+
+
+def _finalize_receipt(
+    universe_dir: Path | None,
+    *,
+    idempotency_hint: str,
+    evidence: dict[str, Any],
+    run_id: str,
+) -> bool:
+    if universe_dir is None or not idempotency_hint:
+        return False
+    try:
+        from workflow.storage.external_write_receipts import finalize_receipt
+
+        return finalize_receipt(
+            universe_dir,
+            idempotency_hint=idempotency_hint,
+            sink=EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+            evidence=evidence,
+            run_id=run_id or "",
+        )
+    except Exception:
+        logger.exception("failed to finalize wiki write-back receipt")
+        return False
+
+
+def _release_reservation(
+    universe_dir: Path | None,
+    *,
+    idempotency_hint: str,
+    run_id: str,
+) -> None:
+    if universe_dir is None or not idempotency_hint:
+        return
+    try:
+        from workflow.storage.external_write_receipts import release_reservation
+
+        release_reservation(
+            universe_dir,
+            idempotency_hint=idempotency_hint,
+            sink=EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+            run_id=run_id or "",
+            mark_failed=True,
+        )
+    except Exception:
+        logger.exception("failed to release wiki write-back reservation")
+
+
+def _is_lock_error(exc: BaseException) -> bool:
+    if not isinstance(exc, sqlite3.OperationalError):
+        return False
+    msg = str(exc).lower()
+    return any(token in msg for token in ("locked", "busy", "deadlock", "timeout"))
+
+
+def _render_section(*, packet: dict[str, Any], idem_hint: str) -> tuple[str, str]:
+    body, error = _payload_text(packet)
+    if error:
+        return "", error
+    if not _IDEMPOTENCY_RE.fullmatch(idem_hint):
+        return "", "idempotency_hint contains unsupported characters"
+    heading = _payload_heading(packet)
+    marker = f"workflow-wiki-write-back:{idem_hint}"
+    return (
+        f"<!-- {marker} -->\n"
+        f"## {heading}\n\n"
+        f"{body}\n"
+        f"<!-- /{marker} -->",
+        "",
+    )
+
+
+def _append_or_update_section(path: Path, section: str, idem_hint: str) -> dict[str, Any]:
+    from workflow.api.wiki import _append_wiki_log, _page_rel_path
+
+    text = path.read_text(encoding="utf-8")
+    old_sha = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    marker = f"workflow-wiki-write-back:{idem_hint}"
+    start = f"<!-- {marker} -->"
+    end = f"<!-- /{marker} -->"
+    start_idx = text.find(start)
+    end_idx = text.find(end)
+    if start_idx >= 0 and end_idx >= start_idx:
+        end_idx += len(end)
+        new_text = text[:start_idx] + section + text[end_idx:]
+        status = "updated"
+    else:
+        new_text = text.rstrip() + "\n\n" + section + "\n"
+        status = "written"
+    new_sha = hashlib.sha256(new_text.encode("utf-8")).hexdigest()
+    path.write_text(new_text, encoding="utf-8")
+    rel = _page_rel_path(path)
+    _append_wiki_log(f"wiki_write_back | {rel} | idempotency_hint={idem_hint}")
+    return {
+        "status": status,
+        "path": rel,
+        "old_sha256": old_sha,
+        "new_sha256": new_sha,
+        "old_total_chars": len(text),
+        "new_total_chars": len(new_text),
+    }
+
+
+def run_wiki_write_back_effector(
+    *,
+    node_id: str,
+    output_keys: list[str],
+    run_state: dict[str, Any],
+    base_path: str | Path | None = None,
+    run_id: str = "",
+) -> dict[str, Any]:
+    """Append/update one wiki result-packet section.
+
+    The function never raises to the run-completion path. All refusal and
+    failure states are returned as structured evidence.
+    """
+    matched_key, packet = _find_packet(output_keys=output_keys, run_state=run_state)
+    if packet is None:
+        return {
+            "error": (
+                f"node '{node_id}' declared effects=["
+                f"{EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK}] but no output_key held "
+                "a parseable wiki write-back packet"
+            ),
+            "error_kind": "no_matching_packet",
+        }
+
+    destination = _destination(packet)
+    universe_dir = _universe_dir(base_path)
+    wiki_root = _wiki_root_for_universe(universe_dir)
+    idem_hint = _idempotency_hint(packet)
+
+    if not destination:
+        return {
+            "error": "packet.destination is required",
+            "error_kind": "invalid_destination",
+            "phase": "phase_2",
+            "matched_output_key": matched_key,
+        }
+
+    authority = resolve_soul_effect_authority(
+        universe_dir,
+        EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
+        destination,
+    )
+    if authority == SOUL_AUTHORITY_DENIED:
+        return {
+            "dry_run": True,
+            "phase": "phase_2",
+            "reason": "soul_authority_denied",
+            "destination": destination,
+            "matched_output_key": matched_key,
+            "intent": packet,
+        }
+
+    if not _check_consent(universe_dir, destination):
+        return {
+            "dry_run": True,
+            "phase": "phase_2",
+            "reason": "missing_consent",
+            "destination": destination,
+            "matched_output_key": matched_key,
+            "intent": packet,
+            "hint": (
+                "Call extensions action=grant_effector_consent "
+                f"sink={EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK} "
+                f"destination={destination} before dispatching wiki write-back "
+                "effects."
+            ),
+        }
+
+    if not idem_hint:
+        return {
+            "dry_run": True,
+            "phase": "phase_2",
+            "reason": "missing_idempotency_hint",
+            "destination": destination,
+            "matched_output_key": matched_key,
+            "intent": packet,
+        }
+
+    section, render_error = _render_section(packet=packet, idem_hint=idem_hint)
+    if render_error:
+        return {
+            "error": render_error,
+            "error_kind": "invalid_payload",
+            "phase": "phase_2",
+            "destination": destination,
+            "matched_output_key": matched_key,
+        }
+
+    if wiki_root is None:
+        return {
+            "error": "base_path is required for wiki write-back effects",
+            "error_kind": "missing_universe_context",
+            "phase": "phase_2",
+            "destination": destination,
+            "matched_output_key": matched_key,
+        }
+
+    from workflow.api.wiki import _ensure_wiki_scaffold, _scoped_wiki_root
+
+    try:
+        _ensure_wiki_scaffold(wiki_root)
+    except OSError as exc:
+        return {
+            "error": f"Wiki scaffold failed at {wiki_root}: {exc}",
+            "error_kind": "wiki_scaffold_failed",
+            "phase": "phase_2",
+            "destination": destination,
+            "matched_output_key": matched_key,
+        }
+
+    with _scoped_wiki_root(wiki_root):
+        target, destination_error = _resolve_target_page(wiki_root, destination)
+        if destination_error or target is None:
+            return {
+                "error": destination_error or "Page not found.",
+                "error_kind": "invalid_destination",
+                "phase": "phase_2",
+                "destination": destination,
+                "matched_output_key": matched_key,
+            }
+
+        try:
+            reservation = _try_reserve(
+                universe_dir,
+                idempotency_hint=idem_hint,
+                run_id=run_id,
+            )
+        except sqlite3.OperationalError as exc:
+            return {
+                "error": (
+                    "receipt store unavailable; refusing wiki write-back to "
+                    f"avoid duplicate writes: {exc}"
+                ),
+                "error_kind": (
+                    "receipt_store_locked"
+                    if _is_lock_error(exc) else "receipt_store_error"
+                ),
+                "phase": "phase_2",
+                "destination": destination,
+                "idempotency_hint": idem_hint,
+                "matched_output_key": matched_key,
+            }
+
+        status = reservation.get("status")
+        if status == "duplicate":
+            recorded = reservation.get("row") or {}
+            return {
+                "idempotency_dedup_hit": True,
+                "phase": "phase_2",
+                "destination": destination,
+                "matched_output_key": matched_key,
+                "evidence": recorded.get("evidence") or {},
+                "recorded_run_id": recorded.get("run_id"),
+                "recorded_at": recorded.get("created_at"),
+                "idempotency_hint": idem_hint,
+            }
+        if status == "in_flight":
+            held = reservation.get("row") or {}
+            return {
+                "dry_run": True,
+                "phase": "phase_2",
+                "reason": "concurrent_in_flight",
+                "destination": destination,
+                "idempotency_hint": idem_hint,
+                "matched_output_key": matched_key,
+                "held_by_run_id": held.get("run_id"),
+                "reservation_created_at": held.get("created_at"),
+                "intent": packet,
+            }
+        if status not in (
+            "reserved",
+            "reserved_after_stale",
+            "reserved_after_failed",
+        ):
+            return {
+                "dry_run": True,
+                "phase": "phase_2",
+                "reason": "reservation_unknown_state",
+                "destination": destination,
+                "idempotency_hint": idem_hint,
+                "reservation_status": str(status),
+                "matched_output_key": matched_key,
+                "intent": packet,
+            }
+
+        try:
+            evidence = _append_or_update_section(target, section, idem_hint)
+        except Exception as exc:
+            _release_reservation(
+                universe_dir,
+                idempotency_hint=idem_hint,
+                run_id=run_id,
+            )
+            return {
+                "error": f"wiki write-back failed: {exc}",
+                "error_kind": "wiki_write_back_failed",
+                "phase": "phase_2",
+                "destination": destination,
+                "idempotency_hint": idem_hint,
+                "reservation_released": bool(idem_hint),
+                "matched_output_key": matched_key,
+            }
+
+        evidence.update({
+            "phase": "phase_2",
+            "destination": destination,
+            "matched_output_key": matched_key,
+            "idempotency_hint": idem_hint,
+            "recorded_at": time.time(),
+        })
+        if status in ("reserved_after_stale", "reserved_after_failed"):
+            evidence["reservation_origin"] = status
+
+        if not _finalize_receipt(
+            universe_dir,
+            idempotency_hint=idem_hint,
+            evidence=evidence,
+            run_id=run_id,
+        ):
+            evidence["receipt_finalize_failed"] = True
+        return evidence
+
+
+__all__ = [
+    "EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK",
+    "run_wiki_write_back_effector",
+]


### PR DESCRIPTION
Fixes #1246

## Request artifact reconciliation

- Wiki page: `pages/patch-requests/pr-166-add-a-wiki-write-back-effector-so-a-loop-can-publish-its-res.md`
- GitHub issue: #1246
- Branch task: `auto-change/issue-1246`
- PR artifact: this PR

Writer family: Codex
Required checker family: Claude

Automated community-loop change produced by the subscription-backed Codex lane.