### PR TITLE
Fix wiki_bug_sync MCP structured result parsing

### DIFF
--- a/.agents/skills/loop-uptime-maintenance/incidents/2026-05-28-wiki-bug-sync-structuredcontent.md
+++ b/.agents/skills/loop-uptime-maintenance/incidents/2026-05-28-wiki-bug-sync-structuredcontent.md
@@ -10,25 +10,27 @@ related_run: https://github.com/Jonnyton/Workflow/actions/runs/26605636623
 
 ## Symptoms
 
-Community loop watch issue #1118 stayed red after PR #1125 recovered the public MCP canary. The remaining red intake stage was `wiki-bug-sync.yml` run `26605636623`, which crashed in `scripts/wiki_bug_sync.py` while parsing `wiki action=list`.
+Community loop watch issue #1118 stayed red after PR #1125 recovered the public MCP canary. The remaining red intake stage was `wiki-bug-sync.yml` run `26605636623`, which crashed in `scripts/wiki_bug_sync.py` because the wiki result parser still assumed text-first JSON for `wiki action=list` and `wiki action=read`.
 
 ## Evidence Snapshot
 
 - `wiki-bug-sync.yml` run `26605636623` failed at 2026-05-28T22:20Z.
-- Stack trace: `json.decoder.JSONDecodeError` at `wiki_list = json.loads(_parse_text_result(list_result))`.
+- Stack trace: `json.decoder.JSONDecodeError` at the text-only wiki payload parse path (`wiki_list = json.loads(_parse_text_result(list_result))`), with the read path still carrying the same assumption.
 - The failure class matches PR #1125: MCP tool text is now a short preview and the full payload is in `structuredContent`.
 - Post-#1125 public MCP canary run `26606206467` was green, so the MCP surface itself was healthy.
 - Local live dry-run after this branch's fix: `python scripts/wiki_bug_sync.py --url https://tinyassets.io/mcp --include-community-requests --dry-run` exited 0 and found BUG-109 plus PR-144 without parser failure.
 
 ## Immediate Fix Applied
 
-`scripts/wiki_bug_sync.py` now prefers MCP `structuredContent` for wiki list/read results and keeps the old text JSON fallback. Regression tests cover preview-text plus structuredContent for both `wiki action=list` and `wiki action=read`.
+`scripts/wiki_bug_sync.py` now reuses `_extract_structured_tool_payload` through a local structured-first `_parse_json_result` helper for both wiki list/read results, while keeping text-JSON fallback when preview output still embeds the payload. Regression tests cover preview-text plus `structuredContent` and preview-text plus embedded JSON for both `wiki action=list` and `wiki action=read`.
 
 ## Verification
 
 - Reproduction tests failed before the code fix:
   - `test_sync_no_new_bugs_accepts_structured_content_list_preview`
+  - `test_sync_no_new_bugs_accepts_preview_text_json_list_payload`
   - `test_fetch_wiki_page_detail_accepts_structured_content_preview`
+  - `test_fetch_wiki_page_detail_accepts_preview_text_json_payload`
 - Focused tests after fix: `python -m pytest tests/test_wiki_bug_sync.py tests/test_canary_scripts_import_smoke.py -q` -> 88 passed.
 - Compile check: `python -m compileall -q scripts/wiki_bug_sync.py scripts/_canary_common.py` -> passed.
 - Live dry-run against `https://tinyassets.io/mcp` -> passed.
@@ -44,11 +46,11 @@ Community loop watch already noticed the intake sync stage red, but the failure 
 
 ## How Can The Loop Fix This Break Next Time, Automatically?
 
-All repo-owned MCP client scripts should share one helper for tool-result payload extraction. When one client learns a new response shape, the loop should either run a scanner for remaining text-only parse sites or open a follow-up patch automatically for each affected script.
+All repo-owned MCP client scripts should share one helper for tool-result payload extraction and wrap it with a consistent structured-first parse helper when a script expects JSON. When one client learns a new response shape, the loop should either run a scanner for remaining text-only parse sites or open a follow-up patch automatically for each affected script.
 
 ## How Can The Loop Avoid This Break In The First Place Next Time?
 
-Move `_extract_structured_tool_payload` out of canary-specific naming into a general MCP client utility, then require every script that consumes MCP tool results to use that utility. Add a static test that flags direct `json.loads(_parse_text_result(...))` patterns in MCP clients unless paired with structuredContent handling.
+Keep `_extract_structured_tool_payload` in the shared MCP utility layer and require every script that consumes MCP tool results to route JSON parsing through a structured-first helper like `_parse_json_result`. Add a static test that flags direct `json.loads(_parse_text_result(...))` patterns in MCP clients unless paired with structuredContent handling.
 
 ## Substrate Improvement Filed
 

--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -632,8 +632,10 @@ Notes:
 - Source: community loop watch issue #1118 red; `wiki-bug-sync.yml` run
   26605636623 crashed because `scripts/wiki_bug_sync.py` parsed text only while
   MCP list payload now lives in `structuredContent`.
-- Purpose: port the structuredContent/text-fallback parser pattern from #1125
-  into the intake sync script and prove it with regression coverage.
+- Purpose: port the shared structured-first parser pattern from #1125 into the
+  intake sync script for both `wiki action=list` and `wiki action=read`, and
+  prove it with regression coverage for structuredContent plus preview-text
+  JSON fallback.
 - Ship condition: focused tests pass, branch pushed, PR opened, GitHub
   `wiki-bug-sync.yml` dispatch succeeds, community loop watch recovers or
   residual non-intake blockers are documented.

--- a/.claude/skills/loop-uptime-maintenance/incidents/2026-05-28-wiki-bug-sync-structuredcontent.md
+++ b/.claude/skills/loop-uptime-maintenance/incidents/2026-05-28-wiki-bug-sync-structuredcontent.md
@@ -10,25 +10,27 @@ related_run: https://github.com/Jonnyton/Workflow/actions/runs/26605636623
 
 ## Symptoms
 
-Community loop watch issue #1118 stayed red after PR #1125 recovered the public MCP canary. The remaining red intake stage was `wiki-bug-sync.yml` run `26605636623`, which crashed in `scripts/wiki_bug_sync.py` while parsing `wiki action=list`.
+Community loop watch issue #1118 stayed red after PR #1125 recovered the public MCP canary. The remaining red intake stage was `wiki-bug-sync.yml` run `26605636623`, which crashed in `scripts/wiki_bug_sync.py` because the wiki result parser still assumed text-first JSON for `wiki action=list` and `wiki action=read`.
 
 ## Evidence Snapshot
 
 - `wiki-bug-sync.yml` run `26605636623` failed at 2026-05-28T22:20Z.
-- Stack trace: `json.decoder.JSONDecodeError` at `wiki_list = json.loads(_parse_text_result(list_result))`.
+- Stack trace: `json.decoder.JSONDecodeError` at the text-only wiki payload parse path (`wiki_list = json.loads(_parse_text_result(list_result))`), with the read path still carrying the same assumption.
 - The failure class matches PR #1125: MCP tool text is now a short preview and the full payload is in `structuredContent`.
 - Post-#1125 public MCP canary run `26606206467` was green, so the MCP surface itself was healthy.
 - Local live dry-run after this branch's fix: `python scripts/wiki_bug_sync.py --url https://tinyassets.io/mcp --include-community-requests --dry-run` exited 0 and found BUG-109 plus PR-144 without parser failure.
 
 ## Immediate Fix Applied
 
-`scripts/wiki_bug_sync.py` now prefers MCP `structuredContent` for wiki list/read results and keeps the old text JSON fallback. Regression tests cover preview-text plus structuredContent for both `wiki action=list` and `wiki action=read`.
+`scripts/wiki_bug_sync.py` now reuses `_extract_structured_tool_payload` through a local structured-first `_parse_json_result` helper for both wiki list/read results, while keeping text-JSON fallback when preview output still embeds the payload. Regression tests cover preview-text plus `structuredContent` and preview-text plus embedded JSON for both `wiki action=list` and `wiki action=read`.
 
 ## Verification
 
 - Reproduction tests failed before the code fix:
   - `test_sync_no_new_bugs_accepts_structured_content_list_preview`
+  - `test_sync_no_new_bugs_accepts_preview_text_json_list_payload`
   - `test_fetch_wiki_page_detail_accepts_structured_content_preview`
+  - `test_fetch_wiki_page_detail_accepts_preview_text_json_payload`
 - Focused tests after fix: `python -m pytest tests/test_wiki_bug_sync.py tests/test_canary_scripts_import_smoke.py -q` -> 88 passed.
 - Compile check: `python -m compileall -q scripts/wiki_bug_sync.py scripts/_canary_common.py` -> passed.
 - Live dry-run against `https://tinyassets.io/mcp` -> passed.
@@ -44,11 +46,11 @@ Community loop watch already noticed the intake sync stage red, but the failure 
 
 ## How Can The Loop Fix This Break Next Time, Automatically?
 
-All repo-owned MCP client scripts should share one helper for tool-result payload extraction. When one client learns a new response shape, the loop should either run a scanner for remaining text-only parse sites or open a follow-up patch automatically for each affected script.
+All repo-owned MCP client scripts should share one helper for tool-result payload extraction and wrap it with a consistent structured-first parse helper when a script expects JSON. When one client learns a new response shape, the loop should either run a scanner for remaining text-only parse sites or open a follow-up patch automatically for each affected script.
 
 ## How Can The Loop Avoid This Break In The First Place Next Time?
 
-Move `_extract_structured_tool_payload` out of canary-specific naming into a general MCP client utility, then require every script that consumes MCP tool results to use that utility. Add a static test that flags direct `json.loads(_parse_text_result(...))` patterns in MCP clients unless paired with structuredContent handling.
+Keep `_extract_structured_tool_payload` in the shared MCP utility layer and require every script that consumes MCP tool results to route JSON parsing through a structured-first helper like `_parse_json_result`. Add a static test that flags direct `json.loads(_parse_text_result(...))` patterns in MCP clients unless paired with structuredContent handling.
 
 ## Substrate Improvement Filed
 

--- a/scripts/wiki_bug_sync.py
+++ b/scripts/wiki_bug_sync.py
@@ -274,17 +274,25 @@ def _parse_text_result(result: dict[str, Any]) -> str:
     raise SyncError(1, "tool returned no text content")
 
 
+def _extract_json_object_from_text(text: str) -> dict[str, Any]:
+    decoder = json.JSONDecoder()
+    for idx, char in enumerate(text):
+        if char != "{":
+            continue
+        try:
+            payload, _ = decoder.raw_decode(text[idx:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+    raise SyncError(1, f"tool text not JSON: preview={text[:200]!r}")
+
+
 def _parse_json_result(result: dict[str, Any]) -> dict[str, Any]:
     structured = _extract_structured_tool_payload(result)
     if structured is not None:
         return structured
-    text = _parse_text_result(result)
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError as exc:
-        raise SyncError(
-            1, f"tool text not JSON: {exc}; preview={text[:200]!r}",
-        ) from exc
+    return _extract_json_object_from_text(_parse_text_result(result))
 
 
 # ---------------------------------------------------------------------------
@@ -479,16 +487,10 @@ def fetch_wiki_page_detail(
     result = _mcp_call_tool(
         url, sid, "wiki", {"action": "read", "page": page}, timeout, post_fn
     )
-    structured = _extract_structured_tool_payload(result)
-    if structured is not None:
-        content = structured.get("content", "")
-    else:
-        text = _parse_text_result(result)
-        try:
-            data = json.loads(text)
-            content = data.get("content", "")
-        except (json.JSONDecodeError, AttributeError):
-            content = text
+    try:
+        content = str(_parse_json_result(result).get("content", ""))
+    except SyncError:
+        content = _parse_text_result(result)
 
     meta, body = _split_frontmatter(content)
     return {"meta": meta, "body": body, "content": content}

--- a/tests/test_wiki_bug_sync.py
+++ b/tests/test_wiki_bug_sync.py
@@ -76,6 +76,29 @@ def _wiki_list_structured_resp(bugs: list[dict]) -> dict:
     }
 
 
+def _wiki_list_preview_json_resp(bugs: list[dict]) -> dict:
+    """Build a wiki list response with preview text wrapped around JSON."""
+    promoted = [
+        {"path": b["path"], "title": b.get("title", b["path"]), "type": "bug"}
+        for b in bugs
+    ]
+    return {
+        "jsonrpc": "2.0",
+        "id": 10,
+        "result": {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        "Tool result preview follows.\n"
+                        + json.dumps({"promoted": promoted, "drafts": []})
+                    ),
+                }
+            ]
+        },
+    }
+
+
 def _wiki_read_resp(meta: dict, body: str = "# Body") -> dict:
     """Build a mock MCP tools/call result for wiki action=read."""
     fm_lines = "\n".join(f"{k}: {v}" for k, v in meta.items())
@@ -106,6 +129,27 @@ def _wiki_read_structured_resp(meta: dict, body: str = "# Body") -> dict:
                 }
             ],
             "structuredContent": {"content": content},
+        },
+    }
+
+
+def _wiki_read_preview_json_resp(meta: dict, body: str = "# Body") -> dict:
+    """Build a wiki read response with preview text wrapped around JSON."""
+    fm_lines = "\n".join(f"{k}: {v}" for k, v in meta.items())
+    content = f"---\n{fm_lines}\n---\n\n{body}"
+    return {
+        "jsonrpc": "2.0",
+        "id": 10,
+        "result": {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        "Tool result preview follows.\n"
+                        + json.dumps({"content": content})
+                    ),
+                }
+            ]
         },
     }
 
@@ -694,6 +738,25 @@ def test_fetch_wiki_page_detail_accepts_structured_content_preview():
     assert "Full payload is in structuredContent" not in detail["body"]
 
 
+def test_fetch_wiki_page_detail_accepts_preview_text_json_payload():
+    detail = fetch_wiki_page_detail(
+        "http://fake/mcp",
+        "sid1",
+        "pages/plans/user-buildable-community-change-loop-v0-substrate-readiness-baseline.md",
+        5.0,
+        post_fn=CapturingPost([
+            (_wiki_read_preview_json_resp(
+                {"title": "User-Buildable Community Change Loop"},
+                "## Main finding\n\nPreview text still contains the JSON payload.",
+            ), "sid1"),
+        ]),
+    )
+
+    assert detail["meta"]["title"] == "User-Buildable Community Change Loop"
+    assert "Preview text still contains the JSON payload." in detail["body"]
+    assert "Tool result preview follows." not in detail["body"]
+
+
 def test_format_change_issue_body_includes_bounded_source_context():
     body = format_change_issue_body(
         {"type": "plan"},
@@ -736,6 +799,23 @@ def test_sync_no_new_bugs_accepts_structured_content_list_preview(tmp_path):
         (_INIT_OK, "sid1"),
         (_NOTIF_NONE, "sid1"),
         (_wiki_list_structured_resp([
+            {"path": "bugs/BUG-001-a"},
+            {"path": "bugs/BUG-005-e"},
+        ]), "sid1"),
+    )
+    rc = sync("http://fake/mcp", 5.0, dry_run=True, cursor_path=cursor_path, post_fn=post_fn)
+    assert rc == 0
+    assert read_cursor(cursor_path) == 5
+
+
+def test_sync_no_new_bugs_accepts_preview_text_json_list_payload(tmp_path):
+    cursor_path = tmp_path / "cursor"
+    write_cursor(5, cursor_path)
+
+    post_fn = _make_post_fn(
+        (_INIT_OK, "sid1"),
+        (_NOTIF_NONE, "sid1"),
+        (_wiki_list_preview_json_resp([
             {"path": "bugs/BUG-001-a"},
             {"path": "bugs/BUG-005-e"},
         ]), "sid1"),


### PR DESCRIPTION
Update the `wiki_bug_sync` PR-check script to reuse `_extract_structured_tool_payload` from `scripts/_canary_common.py`, harden local JSON-result parsing so structured payloads win over preview text, and apply that parser at both `wiki action=list` and `wiki action=read`. This also adds regression coverage for preview-text plus `structuredContent` and preview-text plus embedded JSON fallback, and refreshes the mirrored incident/worktree notes that track the fix.

Request reference: fix MCP wiki result parsing in `wiki_bug_sync` with structured-first parsing and mirrored docs updates.