### PR TITLE
Update wiki bug sync to prefer structured tool payloads

### DIFF
--- a/scripts/wiki_bug_sync.py
+++ b/scripts/wiki_bug_sync.py
@@ -277,14 +277,21 @@ def _parse_text_result(result: dict[str, Any]) -> str:
 def _parse_json_result(result: dict[str, Any]) -> dict[str, Any]:
     structured = _extract_structured_tool_payload(result)
     if structured is not None:
-        return structured
+        if isinstance(structured, dict):
+            return structured
+        raise SyncError(
+            1, f"tool structured payload not object: {type(structured).__name__}",
+        )
     text = _parse_text_result(result)
     try:
-        return json.loads(text)
+        payload = json.loads(text)
     except json.JSONDecodeError as exc:
         raise SyncError(
             1, f"tool text not JSON: {exc}; preview={text[:200]!r}",
         ) from exc
+    if not isinstance(payload, dict):
+        raise SyncError(1, f"tool JSON payload not object: {type(payload).__name__}")
+    return payload
 
 
 # ---------------------------------------------------------------------------
@@ -479,16 +486,10 @@ def fetch_wiki_page_detail(
     result = _mcp_call_tool(
         url, sid, "wiki", {"action": "read", "page": page}, timeout, post_fn
     )
-    structured = _extract_structured_tool_payload(result)
-    if structured is not None:
-        content = structured.get("content", "")
-    else:
-        text = _parse_text_result(result)
-        try:
-            data = json.loads(text)
-            content = data.get("content", "")
-        except (json.JSONDecodeError, AttributeError):
-            content = text
+    payload = _parse_json_result(result)
+    content = payload.get("content", "")
+    if not isinstance(content, str):
+        raise SyncError(1, f"wiki read content not text: {type(content).__name__}")
 
     meta, body = _split_frontmatter(content)
     return {"meta": meta, "body": body, "content": content}

--- a/tests/test_wiki_bug_sync.py
+++ b/tests/test_wiki_bug_sync.py
@@ -52,12 +52,22 @@ def _wiki_list_resp(bugs: list[dict]) -> dict:
     }
 
 
-def _wiki_list_structured_resp(bugs: list[dict]) -> dict:
+def _wiki_list_structured_resp(
+    bugs: list[dict], text_payload: dict | None = None
+) -> dict:
     """Build a wiki list response with preview text plus structuredContent."""
     promoted = [
         {"path": b["path"], "title": b.get("title", b["path"]), "type": "bug"}
         for b in bugs
     ]
+    text = (
+        json.dumps(text_payload)
+        if text_payload is not None
+        else (
+            "Tool result: promoted=%d; drafts=0. "
+            "Full payload is in structuredContent."
+        ) % len(promoted)
+    )
     return {
         "jsonrpc": "2.0",
         "id": 10,
@@ -65,10 +75,7 @@ def _wiki_list_structured_resp(bugs: list[dict]) -> dict:
             "content": [
                 {
                     "type": "text",
-                    "text": (
-                        "Tool result: promoted=%d; drafts=0. "
-                        "Full payload is in structuredContent."
-                    ) % len(promoted),
+                    "text": text,
                 }
             ],
             "structuredContent": {"promoted": promoted, "drafts": []},
@@ -91,10 +98,19 @@ def _wiki_read_resp(meta: dict, body: str = "# Body") -> dict:
     }
 
 
-def _wiki_read_structured_resp(meta: dict, body: str = "# Body") -> dict:
+def _wiki_read_structured_resp(
+    meta: dict,
+    body: str = "# Body",
+    text_payload: dict[str, str] | None = None,
+) -> dict:
     """Build a wiki read response with preview text plus structuredContent."""
     fm_lines = "\n".join(f"{k}: {v}" for k, v in meta.items())
     content = f"---\n{fm_lines}\n---\n\n{body}"
+    text = (
+        json.dumps(text_payload)
+        if text_payload is not None
+        else "Tool result: content preview. Full payload is in structuredContent."
+    )
     return {
         "jsonrpc": "2.0",
         "id": 10,
@@ -102,7 +118,7 @@ def _wiki_read_structured_resp(meta: dict, body: str = "# Body") -> dict:
             "content": [
                 {
                     "type": "text",
-                    "text": "Tool result: content preview. Full payload is in structuredContent.",
+                    "text": text,
                 }
             ],
             "structuredContent": {"content": content},
@@ -694,6 +710,28 @@ def test_fetch_wiki_page_detail_accepts_structured_content_preview():
     assert "Full payload is in structuredContent" not in detail["body"]
 
 
+def test_fetch_wiki_page_detail_structured_payload_wins_over_text_json_fallback():
+    detail = fetch_wiki_page_detail(
+        "http://fake/mcp",
+        "sid1",
+        "pages/plans/user-buildable-community-change-loop-v0-substrate-readiness-baseline.md",
+        5.0,
+        post_fn=CapturingPost([
+            (_wiki_read_structured_resp(
+                {"title": "Structured Title"},
+                "## Main finding\n\nStructured payloads win.",
+                text_payload={
+                    "content": "---\ntitle: Preview Title\n---\n\nPreview body.",
+                },
+            ), "sid1"),
+        ]),
+    )
+
+    assert detail["meta"]["title"] == "Structured Title"
+    assert "Structured payloads win." in detail["body"]
+    assert "Preview body." not in detail["body"]
+
+
 def test_format_change_issue_body_includes_bounded_source_context():
     body = format_change_issue_body(
         {"type": "plan"},
@@ -739,6 +777,32 @@ def test_sync_no_new_bugs_accepts_structured_content_list_preview(tmp_path):
             {"path": "bugs/BUG-001-a"},
             {"path": "bugs/BUG-005-e"},
         ]), "sid1"),
+    )
+    rc = sync("http://fake/mcp", 5.0, dry_run=True, cursor_path=cursor_path, post_fn=post_fn)
+    assert rc == 0
+    assert read_cursor(cursor_path) == 5
+
+
+def test_sync_list_structured_payload_wins_over_text_json_fallback(tmp_path):
+    cursor_path = tmp_path / "cursor"
+    write_cursor(5, cursor_path)
+
+    post_fn = _make_post_fn(
+        (_INIT_OK, "sid1"),
+        (_NOTIF_NONE, "sid1"),
+        (_wiki_list_structured_resp(
+            [{"path": "bugs/BUG-005-e"}],
+            text_payload={
+                "promoted": [
+                    {
+                        "path": "bugs/BUG-006-preview",
+                        "title": "Preview bug",
+                        "type": "bug",
+                    }
+                ],
+                "drafts": [],
+            },
+        ), "sid1"),
     )
     rc = sync("http://fake/mcp", 5.0, dry_run=True, cursor_path=cursor_path, post_fn=post_fn)
     assert rc == 0


### PR DESCRIPTION
This patch updates `wiki_bug_sync` to use a structured-content-first parsing path for wiki tool responses, reusing `_extract_structured_tool_payload` via the local `_parse_json_result` helper and applying that helper at both `wiki action=list` and `wiki action=read` call sites. It also adds regression coverage for list and read responses that include preview text alongside `structuredContent`, verifying the structured payload wins over text fallback as requested.