### PR TITLE
chore(deploy): enable optional OAuth auth mode (UNIVERSE_SERVER_AUTH=optional)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -390,6 +390,21 @@ jobs:
           ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
               "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
               "printf '%s' 'on' | sudo bash /tmp/install-workflow-env.sh set WORKFLOW_SOUL_LOOP_DISPATCH"
+          # Identity activation (2026-06-04): set optional OAuth auth mode so the
+          # daemon RESOLVES an authenticated Bearer subject into the request
+          # identity (_current_actor) when one is present, while anonymous tier-1
+          # traffic still passes unchanged (resolve-not-gate). Activates PR-165
+          # (request-scoped _current_actor, #1248) + PR-167 (OptionalOAuthProvider,
+          # #1252) end-to-end. SAFE: OptionalOAuthProvider.is_auth_required() is
+          # False, so no anonymous request is 401'd — the zero-install Forever-Rule
+          # contract is preserved. ORDERING INVARIANT: only flip once #1248 AND
+          # #1252 are merged AND deployed (release-state sha includes both).
+          # Founder/owner ENFORCEMENT is a separate follow-on (#1168 / PR-147) and
+          # is intentionally NOT enabled here. Idempotent set; reverting returns
+          # auth to dev/anonymous next deploy.
+          ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
+              "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
+              "printf '%s' 'optional' | sudo bash /tmp/install-workflow-env.sh set UNIVERSE_SERVER_AUTH"
           if [ "${HAS_CODEX_AUTH_BUNDLE}" = "true" ]; then
             echo "Deploy-visible WORKFLOW_CODEX_AUTH_JSON_B64 found; syncing subscription auth bundle."
             printf '%s' "${WORKFLOW_CODEX_AUTH_JSON_B64}" | ssh -i ~/.ssh/do_deploy -o BatchMode=yes \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -400,8 +400,13 @@ jobs:
           # contract is preserved. ORDERING INVARIANT: only flip once #1248 AND
           # #1252 are merged AND deployed (release-state sha includes both).
           # Founder/owner ENFORCEMENT is a separate follow-on (#1168 / PR-147) and
-          # is intentionally NOT enabled here. Idempotent set; reverting returns
-          # auth to dev/anonymous next deploy.
+          # is intentionally NOT enabled here. Idempotent set. ROLLBACK is NOT a
+          # plain PR revert: install-workflow-env.sh writes persistent state to
+          # /etc/workflow/env, so removing this block only stops FUTURE writes —
+          # the already-written UNIVERSE_SERVER_AUTH=optional entry persists. To
+          # roll back, a follow-up deploy must explicitly
+          # `install-workflow-env.sh set UNIVERSE_SERVER_AUTH false` (or
+          # `delete UNIVERSE_SERVER_AUTH`).
           ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
               "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
               "printf '%s' 'optional' | sudo bash /tmp/install-workflow-env.sh set UNIVERSE_SERVER_AUTH"


### PR DESCRIPTION
## Summary
Flip the droplet to `UNIVERSE_SERVER_AUTH=optional` — the resolve-not-gate auth mode added by #1252 (PR-167). The daemon resolves an authenticated Bearer subject into `_current_actor` (PR-165 / #1248) when present, while anonymous tier-1 traffic still passes (no 401s).

## Why now
PR-165 (#1248, live) + PR-167 (#1252, deployed) make optional mode possible without gating anonymous users. This flip activates them end-to-end so an authenticated founder's OAuth subject actually flows through the connector.

## Safety
- `OptionalOAuthProvider.is_auth_required()` is False → no anonymous request is 401'd → zero-install Forever-Rule contract preserved.
- Founder/owner ENFORCEMENT is a separate follow-on (#1168 / PR-147), intentionally NOT enabled here.

## Rollback (corrected per Codex ADAPT)
NOT a plain PR revert: `install-workflow-env.sh set` writes persistent `/etc/workflow/env`, so reverting this block only stops FUTURE writes — the written `UNIVERSE_SERVER_AUTH=optional` entry persists. To roll back, a follow-up deploy must explicitly `install-workflow-env.sh set UNIVERSE_SERVER_AUTH false` (or `delete UNIVERSE_SERVER_AUTH`).

## ORDERING INVARIANT (satisfied)
#1248 AND #1252 are both deployed (release-state sha 969505f6 includes both).

## Gates
Auth/config change → Codex cross-family review + explicit host merge key. Public-surface → post-merge canary (hard rule #11). Precondition for **#4 / #1168**.