### PR TITLE
Prefer structured wiki payloads in wiki_bug_sync

### DIFF
--- a/scripts/wiki_bug_sync.py
+++ b/scripts/wiki_bug_sync.py
@@ -276,15 +276,19 @@ def _parse_text_result(result: dict[str, Any]) -> str:
 
 def _parse_json_result(result: dict[str, Any]) -> dict[str, Any]:
     structured = _extract_structured_tool_payload(result)
-    if structured is not None:
+    if isinstance(structured, dict):
         return structured
+
     text = _parse_text_result(result)
     try:
-        return json.loads(text)
+        parsed = json.loads(text)
     except json.JSONDecodeError as exc:
         raise SyncError(
             1, f"tool text not JSON: {exc}; preview={text[:200]!r}",
         ) from exc
+    if not isinstance(parsed, dict):
+        raise SyncError(1, f"tool JSON result was not an object: {type(parsed).__name__}")
+    return parsed
 
 
 # ---------------------------------------------------------------------------
@@ -479,16 +483,11 @@ def fetch_wiki_page_detail(
     result = _mcp_call_tool(
         url, sid, "wiki", {"action": "read", "page": page}, timeout, post_fn
     )
-    structured = _extract_structured_tool_payload(result)
-    if structured is not None:
-        content = structured.get("content", "")
-    else:
-        text = _parse_text_result(result)
-        try:
-            data = json.loads(text)
-            content = data.get("content", "")
-        except (json.JSONDecodeError, AttributeError):
-            content = text
+    try:
+        data = _parse_json_result(result)
+        content = str(data.get("content", ""))
+    except SyncError:
+        content = _parse_text_result(result)
 
     meta, body = _split_frontmatter(content)
     return {"meta": meta, "body": body, "content": content}

--- a/tests/test_wiki_bug_sync.py
+++ b/tests/test_wiki_bug_sync.py
@@ -52,7 +52,10 @@ def _wiki_list_resp(bugs: list[dict]) -> dict:
     }
 
 
-def _wiki_list_structured_resp(bugs: list[dict]) -> dict:
+def _wiki_list_structured_resp(
+    bugs: list[dict],
+    preview_text: str | None = None,
+) -> dict:
     """Build a wiki list response with preview text plus structuredContent."""
     promoted = [
         {"path": b["path"], "title": b.get("title", b["path"]), "type": "bug"}
@@ -65,10 +68,12 @@ def _wiki_list_structured_resp(bugs: list[dict]) -> dict:
             "content": [
                 {
                     "type": "text",
-                    "text": (
+                    "text": preview_text
+                    or (
                         "Tool result: promoted=%d; drafts=0. "
                         "Full payload is in structuredContent."
-                    ) % len(promoted),
+                    )
+                    % len(promoted),
                 }
             ],
             "structuredContent": {"promoted": promoted, "drafts": []},
@@ -91,7 +96,11 @@ def _wiki_read_resp(meta: dict, body: str = "# Body") -> dict:
     }
 
 
-def _wiki_read_structured_resp(meta: dict, body: str = "# Body") -> dict:
+def _wiki_read_structured_resp(
+    meta: dict,
+    body: str = "# Body",
+    preview_text: str | None = None,
+) -> dict:
     """Build a wiki read response with preview text plus structuredContent."""
     fm_lines = "\n".join(f"{k}: {v}" for k, v in meta.items())
     content = f"---\n{fm_lines}\n---\n\n{body}"
@@ -102,7 +111,8 @@ def _wiki_read_structured_resp(meta: dict, body: str = "# Body") -> dict:
             "content": [
                 {
                     "type": "text",
-                    "text": "Tool result: content preview. Full payload is in structuredContent.",
+                    "text": preview_text
+                    or "Tool result: content preview. Full payload is in structuredContent.",
                 }
             ],
             "structuredContent": {"content": content},
@@ -694,6 +704,28 @@ def test_fetch_wiki_page_detail_accepts_structured_content_preview():
     assert "Full payload is in structuredContent" not in detail["body"]
 
 
+def test_fetch_wiki_page_detail_prefers_structured_content_over_preview_json():
+    detail = fetch_wiki_page_detail(
+        "http://fake/mcp",
+        "sid1",
+        "pages/plans/user-buildable-community-change-loop-v0-substrate-readiness-baseline.md",
+        5.0,
+        post_fn=CapturingPost([
+            (_wiki_read_structured_resp(
+                {"title": "Structured Title"},
+                "## Main finding\n\nStructured payloads win.",
+                preview_text=json.dumps({
+                    "content": "---\ntitle: Preview Title\n---\n\nPreview text should lose."
+                }),
+            ), "sid1"),
+        ]),
+    )
+
+    assert detail["meta"]["title"] == "Structured Title"
+    assert "Structured payloads win." in detail["body"]
+    assert "Preview text should lose." not in detail["body"]
+
+
 def test_format_change_issue_body_includes_bounded_source_context():
     body = format_change_issue_body(
         {"type": "plan"},
@@ -739,6 +771,31 @@ def test_sync_no_new_bugs_accepts_structured_content_list_preview(tmp_path):
             {"path": "bugs/BUG-001-a"},
             {"path": "bugs/BUG-005-e"},
         ]), "sid1"),
+    )
+    rc = sync("http://fake/mcp", 5.0, dry_run=True, cursor_path=cursor_path, post_fn=post_fn)
+    assert rc == 0
+    assert read_cursor(cursor_path) == 5
+
+
+def test_sync_prefers_structured_list_payload_over_preview_json(tmp_path):
+    cursor_path = tmp_path / "cursor"
+    write_cursor(5, cursor_path)
+
+    post_fn = _make_post_fn(
+        (_INIT_OK, "sid1"),
+        (_NOTIF_NONE, "sid1"),
+        (_wiki_list_structured_resp(
+            [
+                {"path": "bugs/BUG-001-a"},
+                {"path": "bugs/BUG-005-e"},
+            ],
+            preview_text=json.dumps({
+                "promoted": [
+                    {"path": "bugs/BUG-999-preview", "title": "Preview Bug", "type": "bug"}
+                ],
+                "drafts": [],
+            }),
+        ), "sid1"),
     )
     rc = sync("http://fake/mcp", 5.0, dry_run=True, cursor_path=cursor_path, post_fn=post_fn)
     assert rc == 0


### PR DESCRIPTION
Update `wiki_bug_sync` per the request to prefer `structuredContent` when parsing GitHub PR wiki tool responses, with text-to-JSON fallback only when the structured payload is absent or unusable. This reuses `_extract_structured_tool_payload`, centralizes precedence in `_parse_json_result`, applies that helper to both `wiki action=list` and `wiki action=read`, and adds regression tests proving structured payloads win over preview text in both paths.