### PR TITLE
Fail fast on unsupported `file_bug` kwargs

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1940,7 +1940,7 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
-    dropped_kwargs = sorted(
+    unsupported_kwargs = sorted(
         key for key, value in _kwargs.items()
         if value not in ("", None, False)
         and not (
@@ -1951,6 +1951,20 @@ def _wiki_file_bug(
             or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
         )
     )
+    if unsupported_kwargs:
+        return json.dumps({
+            "error": (
+                "Unsupported file_bug field(s): "
+                + ", ".join(unsupported_kwargs)
+                + "."
+            ),
+            "unsupported_fields": unsupported_kwargs,
+            "hint": (
+                "Use repro, observed, expected, and workaround for filing body "
+                "content. file_bug does not accept content/body payloads; those "
+                "belong to wiki write/patch actions."
+            ),
+        })
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",
@@ -2213,13 +2227,6 @@ def _wiki_file_bug(
         "note": "Filing sent to navigator triage pipeline. "
                 f"Use `wiki action=list category={category_dir}` to view.",
     }
-    if dropped_kwargs:
-        response_body["warning"] = (
-            "Dropped unsupported file_bug field(s): "
-            + ", ".join(dropped_kwargs)
-            + ". Use repro, observed, expected, and workaround for the filing body; "
-              "content is only for wiki write/patch actions."
-        )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries
         # / chatbots / operators) have a per-request-id join key without log

--- a/tests/test_wiki_file_bug.py
+++ b/tests/test_wiki_file_bug.py
@@ -35,6 +35,7 @@ if _missing:
     )
 
 from workflow.api.wiki import (  # noqa: E402
+    _WIKI_READ_DEFAULT_MAX_CHARS,
     _next_bug_id,
     _render_bug_markdown,
     _slugify_title,
@@ -165,6 +166,38 @@ class TestFileBugValidation:
             _wiki_file_bug(component="x", severity="wombat", title="t")
         )
         assert "error" in out
+
+    @pytest.mark.parametrize("field_name", ["content", "body"])
+    def test_unsupported_truthy_kwargs_rejected_before_write(self, wiki_dir, field_name):
+        out = json.loads(
+            _wiki_file_bug(
+                component="x",
+                severity="major",
+                title="Patch request title only",
+                kind="patch_request",
+                **{field_name: "body text that should be rejected"},
+            )
+        )
+        assert out["error"] == f"Unsupported file_bug field(s): {field_name}."
+        assert out["unsupported_fields"] == [field_name]
+        assert "repro, observed, expected, and workaround" in out["hint"]
+        assert not any((wiki_dir / "pages").rglob("*.md"))
+
+    def test_benign_default_passthrough_kwargs_still_work(self, wiki_dir):
+        out = json.loads(
+            _wiki_file_bug(
+                component="x",
+                severity="major",
+                title="Supported defaults",
+                dry_run=True,
+                similarity_threshold=0.25,
+                max_results=10,
+                offset=0,
+                max_chars=_WIKI_READ_DEFAULT_MAX_CHARS,
+            )
+        )
+        assert out["status"] == "filed"
+        assert (wiki_dir / out["path"]).exists()
 
 
 class TestFileBugWrites:

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1940,7 +1940,7 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
-    dropped_kwargs = sorted(
+    unsupported_kwargs = sorted(
         key for key, value in _kwargs.items()
         if value not in ("", None, False)
         and not (
@@ -1951,6 +1951,20 @@ def _wiki_file_bug(
             or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
         )
     )
+    if unsupported_kwargs:
+        return json.dumps({
+            "error": (
+                "Unsupported file_bug field(s): "
+                + ", ".join(unsupported_kwargs)
+                + "."
+            ),
+            "unsupported_fields": unsupported_kwargs,
+            "hint": (
+                "Use repro, observed, expected, and workaround for filing body "
+                "content. file_bug does not accept content/body payloads; those "
+                "belong to wiki write/patch actions."
+            ),
+        })
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",
@@ -2213,13 +2227,6 @@ def _wiki_file_bug(
         "note": "Filing sent to navigator triage pipeline. "
                 f"Use `wiki action=list category={category_dir}` to view.",
     }
-    if dropped_kwargs:
-        response_body["warning"] = (
-            "Dropped unsupported file_bug field(s): "
-            + ", ".join(dropped_kwargs)
-            + ". Use repro, observed, expected, and workaround for the filing body; "
-              "content is only for wiki write/patch actions."
-        )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries
         # / chatbots / operators) have a per-request-id join key without log


### PR DESCRIPTION
Update `workflow/api/wiki.py` so `_wiki_file_bug` validates unsupported truthy `**_kwargs` before any write or side effect, especially `content`/`body`, and returns an error with a clear hint to use `repro`, `observed`, `expected`, and `workaround` for filing body content. This preserves the existing benign default passthrough allowlist (`dry_run=True` plus default similarity/read pagination args) and removes the old post-success warning path that could silently file a title-only patch request. Tests are updated to cover the rejection path and to confirm supported/default passthrough inputs still work.