### PR TITLE
Fail fast on unsupported truthy file_bug kwargs

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
@@ -121,6 +121,10 @@ framing.
     capability request, and `kind=design` for an architecture or policy
     proposal. Do not coerce these into bug wording just to enter the
     community loop.
+    For `file_bug`, put filing details in `repro`, `observed`,
+    `expected`, and `workaround`. Do not pass `content`/`body` text to
+    `file_bug`; `content` is only valid for wiki write/patch flows and
+    unsupported truthy extras are rejected.
     Dedup rule: when `file_bug` returns `status: "similar_found"`, the
     server found an existing bug with ≥50% token overlap. Default to
     `wiki action=cosign_bug bug_id=<top similar bug_id>

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1732,6 +1732,24 @@ _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
 _BUG_DEDUP_SECTION_CHAR_LIMIT = 4000
+_FILE_BUG_LEGACY_NOOP_DEFAULTS: dict[str, Any] = {
+    "dry_run": True,
+    "similarity_threshold": 0.25,
+    "max_results": 10,
+    "offset": 0,
+    "max_chars": _WIKI_READ_DEFAULT_MAX_CHARS,
+}
+
+
+def _unsupported_file_bug_kwargs(kwargs: dict[str, Any]) -> list[str]:
+    unsupported: list[str] = []
+    for key, value in kwargs.items():
+        if not value:
+            continue
+        if key in _FILE_BUG_LEGACY_NOOP_DEFAULTS and value == _FILE_BUG_LEGACY_NOOP_DEFAULTS[key]:
+            continue
+        unsupported.append(key)
+    return sorted(unsupported)
 
 
 def _bug_token_set(text: str) -> set[str]:
@@ -1940,17 +1958,20 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
-    dropped_kwargs = sorted(
-        key for key, value in _kwargs.items()
-        if value not in ("", None, False)
-        and not (
-            (key == "dry_run" and value is True)
-            or (key == "similarity_threshold" and value == 0.25)
-            or (key == "max_results" and value == 10)
-            or (key == "offset" and value == 0)
-            or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
-        )
-    )
+    unsupported_kwargs = _unsupported_file_bug_kwargs(_kwargs)
+    if unsupported_kwargs:
+        return json.dumps({
+            "error": (
+                "Unsupported file_bug field(s): "
+                + ", ".join(unsupported_kwargs)
+                + "."
+            ),
+            "unsupported_fields": unsupported_kwargs,
+            "hint": (
+                "Put filing details in repro, observed, expected, and workaround. "
+                "The content field is only valid for wiki write/patch actions."
+            ),
+        })
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",
@@ -2213,13 +2234,6 @@ def _wiki_file_bug(
         "note": "Filing sent to navigator triage pipeline. "
                 f"Use `wiki action=list category={category_dir}` to view.",
     }
-    if dropped_kwargs:
-        response_body["warning"] = (
-            "Dropped unsupported file_bug field(s): "
-            + ", ".join(dropped_kwargs)
-            + ". Use repro, observed, expected, and workaround for the filing body; "
-              "content is only for wiki write/patch actions."
-        )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries
         # / chatbots / operators) have a per-request-id join key without log

--- a/tests/test_wiki_file_bug.py
+++ b/tests/test_wiki_file_bug.py
@@ -182,6 +182,7 @@ class TestFileBugWrites:
         )
         assert out["status"] == "filed"
         assert out["bug_id"] == "BUG-001"
+        assert "warning" not in out
         path = wiki_dir / out["path"]
         assert path.exists()
         body = path.read_text(encoding="utf-8")
@@ -230,6 +231,65 @@ class TestFileBugCollisionRetry:
             )
         assert out["status"] == "filed"
         assert out["bug_id"] == "BUG-003"
+
+
+class TestFileBugExtraKwargs:
+    def test_truthy_unsupported_kwargs_rejected_before_write(self, wiki_dir):
+        out = json.loads(
+            _wiki_file_bug(
+                component="x",
+                severity="minor",
+                title="unsupported extras",
+                content="body goes here",
+                body="duplicate body",
+            )
+        )
+        assert "error" in out
+        assert out["unsupported_fields"] == ["body", "content"]
+        assert "repro, observed, expected, and workaround" in out["hint"]
+        assert "content field is only valid for wiki write/patch actions" in out["hint"]
+        assert not list((wiki_dir / "pages" / "bugs").glob("*.md"))
+
+    def test_falsey_and_legacy_noop_kwargs_still_file(self, wiki_dir):
+        out = json.loads(
+            _wiki_file_bug(
+                component="x",
+                severity="minor",
+                title="legacy extras",
+                content="",
+                body="",
+                dry_run=True,
+                similarity_threshold=0.25,
+                max_results=10,
+                offset=0,
+                max_chars=128_000,
+            )
+        )
+        assert out["status"] == "filed"
+        assert out["bug_id"] == "BUG-001"
+        assert "warning" not in out
+
+    def test_valid_call_response_shape_stays_compact(self, wiki_dir):
+        out = json.loads(
+            _wiki_file_bug(
+                component="x",
+                severity="minor",
+                title="shape parity",
+                observed="saw something",
+                expected="wanted something else",
+            )
+        )
+        assert out["status"] == "filed"
+        assert out["kind"] == "bug"
+        assert out["severity"] == "minor"
+        assert out["component"] == "x"
+        assert "warning" not in out
+        assert "unsupported_fields" not in out
+        assert "path" in out
+        assert "bug_id" in out
+        assert "investigation" in out
+        assert "effort_classification" in out
+        assert "effort_dispatch_route" in out
 
 
 class TestFileBugViaWikiDispatch:

--- a/workflow/api/prompts.py
+++ b/workflow/api/prompts.py
@@ -121,6 +121,10 @@ framing.
     capability request, and `kind=design` for an architecture or policy
     proposal. Do not coerce these into bug wording just to enter the
     community loop.
+    For `file_bug`, put filing details in `repro`, `observed`,
+    `expected`, and `workaround`. Do not pass `content`/`body` text to
+    `file_bug`; `content` is only valid for wiki write/patch flows and
+    unsupported truthy extras are rejected.
     Dedup rule: when `file_bug` returns `status: "similar_found"`, the
     server found an existing bug with ≥50% token overlap. Default to
     `wiki action=cosign_bug bug_id=<top similar bug_id>

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1732,6 +1732,24 @@ _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
 _BUG_DEDUP_SECTION_CHAR_LIMIT = 4000
+_FILE_BUG_LEGACY_NOOP_DEFAULTS: dict[str, Any] = {
+    "dry_run": True,
+    "similarity_threshold": 0.25,
+    "max_results": 10,
+    "offset": 0,
+    "max_chars": _WIKI_READ_DEFAULT_MAX_CHARS,
+}
+
+
+def _unsupported_file_bug_kwargs(kwargs: dict[str, Any]) -> list[str]:
+    unsupported: list[str] = []
+    for key, value in kwargs.items():
+        if not value:
+            continue
+        if key in _FILE_BUG_LEGACY_NOOP_DEFAULTS and value == _FILE_BUG_LEGACY_NOOP_DEFAULTS[key]:
+            continue
+        unsupported.append(key)
+    return sorted(unsupported)
 
 
 def _bug_token_set(text: str) -> set[str]:
@@ -1940,17 +1958,20 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
-    dropped_kwargs = sorted(
-        key for key, value in _kwargs.items()
-        if value not in ("", None, False)
-        and not (
-            (key == "dry_run" and value is True)
-            or (key == "similarity_threshold" and value == 0.25)
-            or (key == "max_results" and value == 10)
-            or (key == "offset" and value == 0)
-            or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
-        )
-    )
+    unsupported_kwargs = _unsupported_file_bug_kwargs(_kwargs)
+    if unsupported_kwargs:
+        return json.dumps({
+            "error": (
+                "Unsupported file_bug field(s): "
+                + ", ".join(unsupported_kwargs)
+                + "."
+            ),
+            "unsupported_fields": unsupported_kwargs,
+            "hint": (
+                "Put filing details in repro, observed, expected, and workaround. "
+                "The content field is only valid for wiki write/patch actions."
+            ),
+        })
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",
@@ -2213,13 +2234,6 @@ def _wiki_file_bug(
         "note": "Filing sent to navigator triage pipeline. "
                 f"Use `wiki action=list category={category_dir}` to view.",
     }
-    if dropped_kwargs:
-        response_body["warning"] = (
-            "Dropped unsupported file_bug field(s): "
-            + ", ".join(dropped_kwargs)
-            + ". Use repro, observed, expected, and workaround for the filing body; "
-              "content is only for wiki write/patch actions."
-        )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries
         # / chatbots / operators) have a per-request-id join key without log


### PR DESCRIPTION
Update `workflow/api/wiki.py` so `file_bug` rejects unsupported truthy extra kwargs before dedup/write/trigger work begins, instead of filing and returning a post-success warning. This keeps the current legacy no-op defaults (`dry_run=True`, default similarity/list/read pagination values, and falsey extras) while returning a clear error for fields like `content` or `body` with guidance to use `repro`, `observed`, `expected`, and `workaround`. The change also updates `file_bug` tests and the prompt/help text so runtime behavior stays consistent with the request.