### PR TITLE
Fail fast on unsupported wiki file_bug fields

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1732,6 +1732,19 @@ _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
 _BUG_DEDUP_SECTION_CHAR_LIMIT = 4000
+_FILE_BUG_ALLOWED_RUNTIME_MIRROR_KWARGS: dict[str, Any] = {
+    "dry_run": True,
+    "similarity_threshold": 0.25,
+    "max_results": 10,
+    "offset": 0,
+    "max_chars": _WIKI_READ_DEFAULT_MAX_CHARS,
+}
+_FILE_BUG_SUPPORTED_FIELDS_HINT = (
+    "Supported file_bug fields: title, component, observed, expected, repro, "
+    "severity, kind, workaround, tags, cross_reference_count, force_new, "
+    "verbose, universe_id. Allowed runtime-mirror kwargs: dry_run, "
+    "similarity_threshold, max_results, offset, max_chars."
+)
 
 
 def _bug_token_set(text: str) -> set[str]:
@@ -1940,17 +1953,16 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
-    dropped_kwargs = sorted(
+    unsupported_kwargs = sorted(
         key for key, value in _kwargs.items()
         if value not in ("", None, False)
-        and not (
-            (key == "dry_run" and value is True)
-            or (key == "similarity_threshold" and value == 0.25)
-            or (key == "max_results" and value == 10)
-            or (key == "offset" and value == 0)
-            or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
-        )
+        and _FILE_BUG_ALLOWED_RUNTIME_MIRROR_KWARGS.get(key) != value
     )
+    if unsupported_kwargs:
+        return json.dumps({
+            "error": "Unsupported file_bug field(s): " + ", ".join(unsupported_kwargs),
+            "hint": _FILE_BUG_SUPPORTED_FIELDS_HINT,
+        })
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",
@@ -2213,13 +2225,6 @@ def _wiki_file_bug(
         "note": "Filing sent to navigator triage pipeline. "
                 f"Use `wiki action=list category={category_dir}` to view.",
     }
-    if dropped_kwargs:
-        response_body["warning"] = (
-            "Dropped unsupported file_bug field(s): "
-            + ", ".join(dropped_kwargs)
-            + ". Use repro, observed, expected, and workaround for the filing body; "
-              "content is only for wiki write/patch actions."
-        )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries
         # / chatbots / operators) have a per-request-id join key without log

--- a/tests/test_wiki_file_bug.py
+++ b/tests/test_wiki_file_bug.py
@@ -166,6 +166,37 @@ class TestFileBugValidation:
         )
         assert "error" in out
 
+    @pytest.mark.parametrize("field_name", ["body", "content"])
+    def test_truthy_unsupported_fields_rejected_with_hint(self, wiki_dir, field_name):
+        out = json.loads(
+            _wiki_file_bug(
+                component="x",
+                severity="major",
+                title="t",
+                **{field_name: "non-empty"},
+            )
+        )
+        assert out["error"] == f"Unsupported file_bug field(s): {field_name}"
+        assert "Supported file_bug fields:" in out["hint"]
+        assert "title, component, observed, expected, repro, severity, kind" in out["hint"]
+        assert "dry_run, similarity_threshold, max_results, offset, max_chars" in out["hint"]
+
+    def test_supported_runtime_mirror_kwargs_still_succeed(self, wiki_dir):
+        out = json.loads(
+            _wiki_file_bug(
+                component="extensions.patch_branch",
+                severity="major",
+                title="runtime mirror parity",
+                dry_run=True,
+                similarity_threshold=0.25,
+                max_results=10,
+                offset=0,
+                max_chars=128_000,
+            )
+        )
+        assert out["status"] == "filed"
+        assert out["bug_id"] == "BUG-001"
+
 
 class TestFileBugWrites:
     def test_happy_path_creates_page(self, wiki_dir):

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1732,6 +1732,19 @@ _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
 _BUG_DEDUP_SECTION_CHAR_LIMIT = 4000
+_FILE_BUG_ALLOWED_RUNTIME_MIRROR_KWARGS: dict[str, Any] = {
+    "dry_run": True,
+    "similarity_threshold": 0.25,
+    "max_results": 10,
+    "offset": 0,
+    "max_chars": _WIKI_READ_DEFAULT_MAX_CHARS,
+}
+_FILE_BUG_SUPPORTED_FIELDS_HINT = (
+    "Supported file_bug fields: title, component, observed, expected, repro, "
+    "severity, kind, workaround, tags, cross_reference_count, force_new, "
+    "verbose, universe_id. Allowed runtime-mirror kwargs: dry_run, "
+    "similarity_threshold, max_results, offset, max_chars."
+)
 
 
 def _bug_token_set(text: str) -> set[str]:
@@ -1940,17 +1953,16 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
-    dropped_kwargs = sorted(
+    unsupported_kwargs = sorted(
         key for key, value in _kwargs.items()
         if value not in ("", None, False)
-        and not (
-            (key == "dry_run" and value is True)
-            or (key == "similarity_threshold" and value == 0.25)
-            or (key == "max_results" and value == 10)
-            or (key == "offset" and value == 0)
-            or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
-        )
+        and _FILE_BUG_ALLOWED_RUNTIME_MIRROR_KWARGS.get(key) != value
     )
+    if unsupported_kwargs:
+        return json.dumps({
+            "error": "Unsupported file_bug field(s): " + ", ".join(unsupported_kwargs),
+            "hint": _FILE_BUG_SUPPORTED_FIELDS_HINT,
+        })
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",
@@ -2213,13 +2225,6 @@ def _wiki_file_bug(
         "note": "Filing sent to navigator triage pipeline. "
                 f"Use `wiki action=list category={category_dir}` to view.",
     }
-    if dropped_kwargs:
-        response_body["warning"] = (
-            "Dropped unsupported file_bug field(s): "
-            + ", ".join(dropped_kwargs)
-            + ". Use repro, observed, expected, and workaround for the filing body; "
-              "content is only for wiki write/patch actions."
-        )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries
         # / chatbots / operators) have a per-request-id join key without log


### PR DESCRIPTION
This patch updates `workflow/api/wiki.py` so `action=file_bug` rejects truthy unsupported kwargs instead of silently filing and returning a post-hoc dropped-fields warning. It keeps the existing runtime-mirror parity for the currently allowed mirror kwargs at their accepted values, preserves falsy extra kwargs, and returns the structured error path with a clear supported-fields hint when callers pass unsupported inputs like `body` or `content`.

It also updates `tests/test_wiki_file_bug.py` to cover rejection of truthy `body`/`content`, confirm the approved runtime-mirror kwargs still succeed, and keep the existing `file_bug` behavior exercised by the current suite.

Requested change: make `file_bug` fail fast on truthy unsupported kwargs and remove the old success-with-warning behavior.