### PR TITLE
Fail fast on unsupported body-style wiki file_bug kwargs

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1732,6 +1732,21 @@ _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
 _BUG_DEDUP_SECTION_CHAR_LIMIT = 4000
+_FILE_BUG_RUNTIME_MIRROR_KWARGS = frozenset({
+    "dry_run",
+    "similarity_threshold",
+    "max_results",
+    "offset",
+    "max_chars",
+})
+_FILE_BUG_BODY_FIELD_HINT = (
+    "Use repro, observed, expected, and workaround for filing body text."
+)
+
+
+def _is_file_bug_body_field(name: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", "", name.lower())
+    return "body" in normalized or "content" in normalized
 
 
 def _bug_token_set(text: str) -> set[str]:
@@ -1940,17 +1955,22 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
-    dropped_kwargs = sorted(
-        key for key, value in _kwargs.items()
-        if value not in ("", None, False)
-        and not (
-            (key == "dry_run" and value is True)
-            or (key == "similarity_threshold" and value == 0.25)
-            or (key == "max_results" and value == 10)
-            or (key == "offset" and value == 0)
-            or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
-        )
+    truthy_unsupported_kwargs = {
+        key: value for key, value in _kwargs.items()
+        if key not in _FILE_BUG_RUNTIME_MIRROR_KWARGS
+        and value not in ("", None, False)
+    }
+    rejected_body_kwargs = sorted(
+        key for key in truthy_unsupported_kwargs
+        if _is_file_bug_body_field(key)
     )
+    if rejected_body_kwargs:
+        return json.dumps({
+            "error": "Unsupported file_bug body field(s).",
+            "rejected_fields": rejected_body_kwargs,
+            "hint": _FILE_BUG_BODY_FIELD_HINT,
+        })
+    dropped_kwargs = sorted(truthy_unsupported_kwargs)
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",
@@ -2217,8 +2237,8 @@ def _wiki_file_bug(
         response_body["warning"] = (
             "Dropped unsupported file_bug field(s): "
             + ", ".join(dropped_kwargs)
-            + ". Use repro, observed, expected, and workaround for the filing body; "
-              "content is only for wiki write/patch actions."
+            + ". "
+            + _FILE_BUG_BODY_FIELD_HINT
         )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries

--- a/tests/test_wiki_file_bug.py
+++ b/tests/test_wiki_file_bug.py
@@ -167,6 +167,57 @@ class TestFileBugValidation:
         assert "error" in out
 
 
+class TestFileBugUnsupportedBodyFields:
+    def test_truthy_body_kwarg_is_rejected_without_creating_page(self, wiki_dir):
+        out = json.loads(
+            _wiki_file_bug(
+                component="extensions.patch_branch",
+                severity="major",
+                title="Body rejected",
+                **{"body": "this should be rejected"},
+            )
+        )
+        assert out["error"] == "Unsupported file_bug body field(s)."
+        assert out["rejected_fields"] == ["body"]
+        assert "repro, observed, expected, and workaround" in out["hint"]
+        assert list((wiki_dir / "pages" / "bugs").glob("*.md")) == []
+
+    def test_truthy_content_kwarg_is_rejected_without_creating_page(self, wiki_dir):
+        out = json.loads(
+            wiki(
+                action="file_bug",
+                component="extensions.patch_branch",
+                severity="major",
+                title="Content rejected",
+                content="this should not become a filing body",
+            )
+        )
+        assert out["error"] == "Unsupported file_bug body field(s)."
+        assert out["rejected_fields"] == ["content"]
+        assert "repro, observed, expected, and workaround" in out["hint"]
+        assert list((wiki_dir / "pages" / "bugs").glob("*.md")) == []
+
+    def test_runtime_mirror_kwargs_do_not_warn(self, wiki_dir):
+        out = json.loads(
+            _wiki_file_bug(
+                component="extensions.patch_branch",
+                severity="major",
+                title="Mirrored kwargs stay quiet",
+                observed="Y",
+                **{
+                    "dry_run": True,
+                    "similarity_threshold": 0.9,
+                    "max_results": 25,
+                    "offset": 3,
+                    "max_chars": 4096,
+                },
+            )
+        )
+        assert out["status"] == "filed"
+        assert "warning" not in out
+        assert (wiki_dir / out["path"]).exists()
+
+
 class TestFileBugWrites:
     def test_happy_path_creates_page(self, wiki_dir):
         out = json.loads(

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1732,6 +1732,21 @@ _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
 _BUG_DEDUP_SECTION_CHAR_LIMIT = 4000
+_FILE_BUG_RUNTIME_MIRROR_KWARGS = frozenset({
+    "dry_run",
+    "similarity_threshold",
+    "max_results",
+    "offset",
+    "max_chars",
+})
+_FILE_BUG_BODY_FIELD_HINT = (
+    "Use repro, observed, expected, and workaround for filing body text."
+)
+
+
+def _is_file_bug_body_field(name: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", "", name.lower())
+    return "body" in normalized or "content" in normalized
 
 
 def _bug_token_set(text: str) -> set[str]:
@@ -1940,17 +1955,22 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
-    dropped_kwargs = sorted(
-        key for key, value in _kwargs.items()
-        if value not in ("", None, False)
-        and not (
-            (key == "dry_run" and value is True)
-            or (key == "similarity_threshold" and value == 0.25)
-            or (key == "max_results" and value == 10)
-            or (key == "offset" and value == 0)
-            or (key == "max_chars" and value == _WIKI_READ_DEFAULT_MAX_CHARS)
-        )
+    truthy_unsupported_kwargs = {
+        key: value for key, value in _kwargs.items()
+        if key not in _FILE_BUG_RUNTIME_MIRROR_KWARGS
+        and value not in ("", None, False)
+    }
+    rejected_body_kwargs = sorted(
+        key for key in truthy_unsupported_kwargs
+        if _is_file_bug_body_field(key)
     )
+    if rejected_body_kwargs:
+        return json.dumps({
+            "error": "Unsupported file_bug body field(s).",
+            "rejected_fields": rejected_body_kwargs,
+            "hint": _FILE_BUG_BODY_FIELD_HINT,
+        })
+    dropped_kwargs = sorted(truthy_unsupported_kwargs)
     if not title or not component or not severity:
         return json.dumps({
             "error": "title, component, and severity are required.",
@@ -2217,8 +2237,8 @@ def _wiki_file_bug(
         response_body["warning"] = (
             "Dropped unsupported file_bug field(s): "
             + ", ".join(dropped_kwargs)
-            + ". Use repro, observed, expected, and workaround for the filing body; "
-              "content is only for wiki write/patch actions."
+            + ". "
+            + _FILE_BUG_BODY_FIELD_HINT
         )
     if trigger_block is not None:
         # FEAT-004: surface the structured trigger receipt so callers (canaries


### PR DESCRIPTION
Implements the requested `workflow/api/wiki.py` safeguard for wiki `file_bug`: truthy unsupported `body`/`content`-style kwargs now return a clear JSON error naming the rejected fields instead of silently creating an empty title-only filing. Supported runtime-mirror kwargs remain ignored without warnings, non-body unsupported kwargs still warn, and regression tests cover both the rejection path and the mirrored-kwargs success path.