### PR TITLE
Use structured wiki tool payloads before text JSON fallback

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -36,6 +36,23 @@ Format for future entries:
 
 ---
 
+## 2026-06-04 00:00 - create wiki-bug-sync-structured-first
+
+- Provider: codex-gpt5
+- Branch: patch-loop/wiki-bug-sync-structured-first
+- Lane state: Active lane
+- Worktree: /app
+- STATUS/Issue/PR: request to update `scripts/wiki_bug_sync.py` structuredContent parsing
+- PLAN refs: community loop intake sync; MCP structured payload parsing
+- Purpose: reuse `_extract_structured_tool_payload` precedence for wiki list/read responses and add regression coverage.
+- _PURPOSE.md: missing - retrofit before pickup
+- Memory refs: none
+- Related implications: `scripts/wiki_bug_sync.py`; `tests/test_wiki_bug_sync.py`
+- Idea feed refs: none
+- Ship/abandon: draft PR to Jonnyton/Workflow pending review
+
+---
+
 ## 2026-05-27 12:00 - create pr139-universe-state
 
 - Provider: codex-gpt5-desktop

--- a/scripts/wiki_bug_sync.py
+++ b/scripts/wiki_bug_sync.py
@@ -479,16 +479,11 @@ def fetch_wiki_page_detail(
     result = _mcp_call_tool(
         url, sid, "wiki", {"action": "read", "page": page}, timeout, post_fn
     )
-    structured = _extract_structured_tool_payload(result)
-    if structured is not None:
-        content = structured.get("content", "")
-    else:
-        text = _parse_text_result(result)
-        try:
-            data = json.loads(text)
-            content = data.get("content", "")
-        except (json.JSONDecodeError, AttributeError):
-            content = text
+    try:
+        data = _parse_json_result(result)
+        content = str(data.get("content", ""))
+    except SyncError:
+        content = _parse_text_result(result)
 
     meta, body = _split_frontmatter(content)
     return {"meta": meta, "body": body, "content": content}

--- a/tests/test_wiki_bug_sync.py
+++ b/tests/test_wiki_bug_sync.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 from wiki_bug_sync import (  # noqa: E402
     SyncError,
     _bug_number,
+    _parse_json_result,
     create_gh_change_issue,
     create_gh_issue,
     fetch_bug_detail,
@@ -139,6 +140,29 @@ class CapturingPost:
     def __call__(self, url, sid, payload, timeout):
         self.calls.append(payload)
         return self._responses.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# _parse_json_result
+# ---------------------------------------------------------------------------
+
+
+def test_parse_json_result_prefers_structured_content_for_list_preview():
+    parsed = _parse_json_result(
+        _wiki_list_structured_resp([{"path": "bugs/BUG-006-new"}])["result"]
+    )
+
+    assert parsed["promoted"] == [
+        {"path": "bugs/BUG-006-new", "title": "bugs/BUG-006-new", "type": "bug"}
+    ]
+
+
+def test_parse_json_result_prefers_structured_content_for_read_preview():
+    parsed = _parse_json_result(
+        _wiki_read_structured_resp({"title": "Bug"}, "# Body")["result"]
+    )
+
+    assert parsed["content"].startswith("---\ntitle: Bug\n---\n")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements the requested `wiki_bug_sync` parser update.

This change reuses `_extract_structured_tool_payload` through the local `_parse_json_result` helper so wiki tool results prefer `structuredContent` and only fall back to JSON embedded in text when needed. It applies that precedence at both wiki call sites (`action=list` and `action=read`), adds regression coverage for preview-text-plus-`structuredContent` responses in both payload shapes, and records the lane in the worktree inventory mirror.