### PR TITLE
Fail fast on unsupported file_bug body kwargs

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1728,6 +1728,7 @@ def _render_bug_markdown(
 
 
 _VALID_BUG_KINDS = frozenset({"bug", "feature", "design", "patch_request"})
+_UNSUPPORTED_FILE_BUG_BODY_KWARGS = frozenset({"body", "content"})
 _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
@@ -1940,9 +1941,27 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
+    unsupported_body_kwargs = sorted(
+        key for key, value in _kwargs.items()
+        if key in _UNSUPPORTED_FILE_BUG_BODY_KWARGS and value not in ("", None, False)
+    )
+    if unsupported_body_kwargs:
+        fields = ", ".join(unsupported_body_kwargs)
+        return json.dumps({
+            "error": (
+                "Unsupported file_bug field(s): "
+                f"{fields}. file_bug only accepts title plus structured body fields "
+                "(repro, observed, expected, workaround); content/body are not supported here."
+            ),
+            "hint": (
+                "Use wiki(action=\"file_bug\", title=..., component=..., severity=...) "
+                "and optionally repro/observed/expected/workaround."
+            ),
+        })
     dropped_kwargs = sorted(
         key for key, value in _kwargs.items()
         if value not in ("", None, False)
+        and key not in _UNSUPPORTED_FILE_BUG_BODY_KWARGS
         and not (
             (key == "dry_run" and value is True)
             or (key == "similarity_threshold" and value == 0.25)

--- a/tests/test_api_wiki.py
+++ b/tests/test_api_wiki.py
@@ -17,6 +17,7 @@ from workflow.api.wiki import (
     _BUG_DEDUP_THRESHOLD,
     _BUGS_CATEGORY,
     _KIND_ROUTING,
+    _UNSUPPORTED_FILE_BUG_BODY_KWARGS,
     _VALID_BUG_KINDS,
     _VALID_SEVERITIES,
     _WIKI_CATEGORIES,
@@ -675,6 +676,21 @@ def test_wiki_file_bug_files_clean_when_no_dups(wiki_env):
     assert res["bug_id"].startswith("BUG-")
 
 
+def test_wiki_file_bug_title_only_path_still_succeeds(wiki_env):
+    res = json.loads(
+        wiki(
+            action="file_bug",
+            component="api.wiki",
+            severity="minor",
+            title="Title only filing still works",
+            force_new=True,
+        )
+    )
+
+    assert res["status"] == "filed"
+    assert res["bug_id"].startswith("BUG-")
+
+
 def test_wiki_file_bug_rejects_unsupported_body_field(wiki_env):
     res = json.loads(
         wiki(
@@ -688,6 +704,8 @@ def test_wiki_file_bug_rejects_unsupported_body_field(wiki_env):
 
     assert "error" in res
     assert "content" in res["error"]
+    assert "repro, observed, expected, workaround" in res["error"]
+    assert "title=..., component=..., severity=..." in res["hint"]
     assert not list((wiki_env / "pages" / "bugs").glob("bug-*.md"))
 
 
@@ -703,6 +721,8 @@ def test_wiki_file_bug_rejects_unknown_direct_kwarg(wiki_env):
 
     assert "error" in res
     assert "body" in res["error"]
+    assert "content/body are not supported here" in res["error"]
+    assert set(_UNSUPPORTED_FILE_BUG_BODY_KWARGS) == {"body", "content"}
     assert not list((wiki_env / "pages" / "bugs").glob("bug-*.md"))
 
 

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1728,6 +1728,7 @@ def _render_bug_markdown(
 
 
 _VALID_BUG_KINDS = frozenset({"bug", "feature", "design", "patch_request"})
+_UNSUPPORTED_FILE_BUG_BODY_KWARGS = frozenset({"body", "content"})
 _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
@@ -1940,9 +1941,27 @@ def _wiki_file_bug(
     When omitted, a token-overlap similarity score ≥ 0.5 against an existing
     bug's title+body returns {status: "similar_found"} instead of filing.
     """
+    unsupported_body_kwargs = sorted(
+        key for key, value in _kwargs.items()
+        if key in _UNSUPPORTED_FILE_BUG_BODY_KWARGS and value not in ("", None, False)
+    )
+    if unsupported_body_kwargs:
+        fields = ", ".join(unsupported_body_kwargs)
+        return json.dumps({
+            "error": (
+                "Unsupported file_bug field(s): "
+                f"{fields}. file_bug only accepts title plus structured body fields "
+                "(repro, observed, expected, workaround); content/body are not supported here."
+            ),
+            "hint": (
+                "Use wiki(action=\"file_bug\", title=..., component=..., severity=...) "
+                "and optionally repro/observed/expected/workaround."
+            ),
+        })
     dropped_kwargs = sorted(
         key for key, value in _kwargs.items()
         if value not in ("", None, False)
+        and key not in _UNSUPPORTED_FILE_BUG_BODY_KWARGS
         and not (
             (key == "dry_run" and value is True)
             or (key == "similarity_threshold" and value == 0.25)


### PR DESCRIPTION
Update the GitHub PR cowork/file-bug path so unsupported content/body-style kwargs are no longer silently ignored. This change makes `_wiki_file_bug` reject truthy unsupported body/content kwargs with a clear error and a title-focused usage hint, while preserving the existing valid filing path. Tests were adjusted to cover both rejection and the unchanged title-only success path.