### PR TITLE
Fail fast on unsupported file_bug body kwargs

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1731,7 +1731,14 @@ def _render_bug_markdown(
 
 
 _VALID_BUG_KINDS = frozenset({"bug", "feature", "design", "patch_request"})
-_UNSUPPORTED_FILE_BUG_BODY_KWARGS = frozenset({"body", "content"})
+_UNSUPPORTED_FILE_BUG_BODY_KWARGS = frozenset({
+    "body",
+    "body_format",
+    "body_style",
+    "content",
+    "content_format",
+    "content_type",
+})
 _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
@@ -1953,12 +1960,13 @@ def _wiki_file_bug(
         return json.dumps({
             "error": (
                 "Unsupported file_bug field(s): "
-                f"{fields}. file_bug only accepts title plus structured body fields "
-                "(repro, observed, expected, workaround); content/body are not supported here."
+                f"{fields}. file_bug only supports the title-only shell plus "
+                "structured body fields (repro, observed, expected, workaround); "
+                "body/content-style kwargs must be omitted here."
             ),
             "hint": (
-                "Use wiki(action=\"file_bug\", title=..., component=..., severity=...) "
-                "and optionally repro/observed/expected/workaround."
+                "Keep title/component/severity and either omit those kwargs or map "
+                "their content into repro/observed/expected/workaround."
             ),
         })
     dropped_kwargs = sorted(

--- a/tests/api/test_wiki_file_bug_kwargs.py
+++ b/tests/api/test_wiki_file_bug_kwargs.py
@@ -1,0 +1,80 @@
+import json
+
+from workflow.api.helpers import _scoped_wiki_root
+from workflow.api.wiki import _ensure_wiki_scaffold, _wiki_file_bug
+
+
+def _make_wiki_root(tmp_path):
+    wiki_root = tmp_path / "wiki"
+    _ensure_wiki_scaffold(wiki_root)
+    return wiki_root
+
+
+def test_file_bug_title_only_shell_still_files(tmp_path):
+    wiki_root = _make_wiki_root(tmp_path)
+
+    with _scoped_wiki_root(wiki_root):
+        response = json.loads(
+            _wiki_file_bug(
+                component="wiki.shell",
+                severity="minor",
+                title="Title only filing",
+            )
+        )
+
+    assert response["status"] == "filed"
+    assert response["bug_id"].startswith("BUG-")
+    bug_path = wiki_root / response["path"]
+    assert bug_path.exists()
+    bug_text = bug_path.read_text(encoding="utf-8")
+    assert "## What happened\n\n_not specified_" in bug_text
+    assert "## What was expected\n\n_not specified_" in bug_text
+    assert "warning" not in response
+
+
+def test_file_bug_falsey_unsupported_body_kwargs_do_not_block_title_only_shell(tmp_path):
+    wiki_root = _make_wiki_root(tmp_path)
+
+    with _scoped_wiki_root(wiki_root):
+        response = json.loads(
+            _wiki_file_bug(
+                component="wiki.shell",
+                severity="minor",
+                title="Falsey unsupported kwargs stay ignored",
+                body="",
+                content=None,
+                body_style=False,
+            )
+        )
+
+    assert response["status"] == "filed"
+    assert (wiki_root / response["path"]).exists()
+    assert "warning" not in response
+
+
+def test_file_bug_rejects_truthy_unsupported_body_kwargs(tmp_path):
+    wiki_root = _make_wiki_root(tmp_path)
+
+    with _scoped_wiki_root(wiki_root):
+        response = json.loads(
+            _wiki_file_bug(
+                component="wiki.shell",
+                severity="minor",
+                title="Truthy unsupported kwargs fail fast",
+                body="unexpected markdown body",
+                body_style="markdown",
+                content_type="text/markdown",
+            )
+        )
+
+    assert response["error"] == (
+        "Unsupported file_bug field(s): body, body_style, content_type. "
+        "file_bug only supports the title-only shell plus structured body fields "
+        "(repro, observed, expected, workaround); body/content-style kwargs must "
+        "be omitted here."
+    )
+    assert response["hint"] == (
+        "Keep title/component/severity and either omit those kwargs or map their "
+        "content into repro/observed/expected/workaround."
+    )
+    assert list((wiki_root / "pages" / "bugs").glob("*.md")) == []

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1731,7 +1731,14 @@ def _render_bug_markdown(
 
 
 _VALID_BUG_KINDS = frozenset({"bug", "feature", "design", "patch_request"})
-_UNSUPPORTED_FILE_BUG_BODY_KWARGS = frozenset({"body", "content"})
+_UNSUPPORTED_FILE_BUG_BODY_KWARGS = frozenset({
+    "body",
+    "body_format",
+    "body_style",
+    "content",
+    "content_format",
+    "content_type",
+})
 _BUG_DEDUP_THRESHOLD = 0.5
 _BUG_DEDUP_CONTAINMENT_THRESHOLD = 0.8
 _BUG_DEDUP_MIN_SHARED_TOKENS = 6
@@ -1953,12 +1960,13 @@ def _wiki_file_bug(
         return json.dumps({
             "error": (
                 "Unsupported file_bug field(s): "
-                f"{fields}. file_bug only accepts title plus structured body fields "
-                "(repro, observed, expected, workaround); content/body are not supported here."
+                f"{fields}. file_bug only supports the title-only shell plus "
+                "structured body fields (repro, observed, expected, workaround); "
+                "body/content-style kwargs must be omitted here."
             ),
             "hint": (
-                "Use wiki(action=\"file_bug\", title=..., component=..., severity=...) "
-                "and optionally repro/observed/expected/workaround."
+                "Keep title/component/severity and either omit those kwargs or map "
+                "their content into repro/observed/expected/workaround."
             ),
         })
     dropped_kwargs = sorted(


### PR DESCRIPTION
Implements the requested wiki/file_bug change in the shared `_wiki_file_bug` path so truthy unsupported content/body-style kwargs no longer get silently ignored. Valid calls keep the existing title-only behavior and runtime mirror shape, while unsupported truthy `body`/`content`-style kwargs now return a clear error with a hint to use the supported title-only shell plus structured fields.

This PR also adds focused tests covering:
- the existing title-only filing shell still succeeding
- falsey unsupported kwargs remaining non-blocking
- truthy unsupported body/content-style kwargs now failing fast

Request reference: update the GitHub PR wiki/file-bug implementation so unsupported content/body-style kwargs are rejected instead of silently ignored, while preserving valid title-only behavior.