### PR TITLE
Fix wiki bug slug truncation to preserve whole-word boundaries

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/wiki.py
@@ -1656,7 +1656,15 @@ def _next_bug_id(bugs_pages_dir: Path) -> str:
 
 def _slugify_title(title: str, max_len: int = 60) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
-    return slug[:max_len] or "untitled"
+    if not slug:
+        return "untitled"
+    if len(slug) <= max_len:
+        return slug
+    cut = slug[:max_len]
+    boundary = cut.rfind("-")
+    if boundary <= 0:
+        return cut
+    return cut[:boundary]
 
 
 def _render_bug_markdown(

--- a/tests/test_wiki_file_bug.py
+++ b/tests/test_wiki_file_bug.py
@@ -98,6 +98,16 @@ class TestSlugifyTitle:
         long = "a" * 100
         assert len(_slugify_title(long, max_len=60)) == 60
 
+    def test_truncates_at_word_boundary(self):
+        title = "Wiki slug generation truncates mid word instead of at word boundary"
+        assert _slugify_title(title, max_len=55) == (
+            "wiki-slug-generation-truncates-mid-word-instead-of"
+        )
+
+    def test_long_first_token_falls_back_to_hard_cut(self):
+        title = "supercalifragilisticexpialidocious trailing words"
+        assert _slugify_title(title, max_len=12) == "supercalifra"
+
     def test_empty_returns_untitled(self):
         assert _slugify_title("") == "untitled"
         assert _slugify_title("!!!") == "untitled"

--- a/workflow/api/wiki.py
+++ b/workflow/api/wiki.py
@@ -1656,7 +1656,15 @@ def _next_bug_id(bugs_pages_dir: Path) -> str:
 
 def _slugify_title(title: str, max_len: int = 60) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
-    return slug[:max_len] or "untitled"
+    if not slug:
+        return "untitled"
+    if len(slug) <= max_len:
+        return slug
+    cut = slug[:max_len]
+    boundary = cut.rfind("-")
+    if boundary <= 0:
+        return cut
+    return cut[:boundary]
 
 
 def _render_bug_markdown(


### PR DESCRIPTION
Implements the requested fix for `pages/patch-requests/pr-002-wiki-slug-generation-truncates-mid-word-instead-of-at-word-b.md`.

This change updates `workflow/api/wiki.py` so `_slugify_title()` keeps the existing normalization behavior but, when truncation is needed, cuts at the last complete hyphen-delimited word boundary at or before `max_len` instead of leaving a partial trailing word. If the first token itself exceeds `max_len`, it now falls back to a hard cut of that token rather than returning an empty slug.

It also adds regression coverage in `tests/test_wiki_file_bug.py` to verify both word-boundary truncation and the long-first-token fallback.