### PR TITLE
Expose uploaded universe sources in the surface ledger and daemon API

### DIFF
--- a/fantasy_daemon/api.py
+++ b/fantasy_daemon/api.py
@@ -1641,6 +1641,82 @@ def list_canon_sources(
     }
 
 
+@app.get("/v1/universes/{uid}/canon/sources/{filename}")
+def get_canon_source_file(
+    uid: str, filename: str, _user: str = Depends(_require_auth),
+) -> dict[str, Any]:
+    """Read a specific uploaded source file with integrity checksums."""
+    import hashlib
+
+    udir = _validate_universe_id(uid)
+    canon_dir = udir / "canon"
+    sources_dir = canon_dir / "sources"
+
+    safe_name = Path(filename).name
+    if not safe_name or safe_name != filename:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Invalid filename. Use list_sources to discover available "
+                "source files."
+            ),
+        )
+
+    target = sources_dir / safe_name
+    if not target.exists():
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"Source file not found: {filename}. Use list_sources to "
+                "inspect available source files."
+            ),
+        )
+    if not target.is_file():
+        raise HTTPException(
+            status_code=400,
+            detail="Path is not a file. Use list_sources to inspect available source files.",
+        )
+
+    manifest_data: dict[str, Any] = {}
+    manifest_path = canon_dir / ".manifest.json"
+    if manifest_path.exists():
+        try:
+            manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    try:
+        raw = target.read_bytes()
+        content = raw.decode("utf-8")
+        stat = target.stat()
+    except UnicodeDecodeError:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Source file is not valid UTF-8 text. Use list_sources to "
+                "inspect available source files."
+            ),
+        )
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Failed to read source file: {e}")
+
+    entry = manifest_data.get(safe_name, {})
+    synth_docs = entry.get("synthesized_docs", [])
+    return {
+        "filename": safe_name,
+        "content": content,
+        "byte_count": len(raw),
+        "sha256": hashlib.sha256(raw).hexdigest(),
+        "modified_at": datetime.fromtimestamp(
+            stat.st_mtime, tz=timezone.utc,
+        ).isoformat(),
+        "file_type": entry.get("file_type", "unknown"),
+        "synthesized_docs": synth_docs,
+        "synthesis_complete": len(synth_docs) > 0,
+        "synthesis_failed": bool(entry.get("synthesis_failed")),
+    }
+
+
 @app.get("/v1/universes/{uid}/canon/{filename}")
 def get_canon_file(
     uid: str, filename: str, _user: str = Depends(_require_auth),

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
@@ -164,8 +164,8 @@ this connector do?", "what tools do I have?", or "show me everything",
 enumerate ALL FIVE. Don't list extensions actions and forget the rest.
 
 1. **`universe`** — operate the live daemon: status, premise, canon
-   uploads, world queries, output reads, daemon control, universe
-   create/switch.
+   uploads, uploaded source browsing, world queries, output reads,
+   daemon control, universe create/switch.
 2. **`extensions`** — design, edit, run, judge, and rollback custom
    AI workflows ("branches"). Largest action surface — node/edge
    builds, runs, judgments, lineage.
@@ -234,7 +234,9 @@ enumerate ALL FIVE. Don't list extensions actions and forget the rest.
    | Check daemon memory status     | `universe` action="daemon_memory_status"|
    | Query world state              | `universe` action="query_world"         |
    | Read produced output           | `universe` action="read_output"         |
-   | Browse source / canon docs     | `universe` action="list_canon"          |
+   | Browse canon docs              | `universe` action="list_canon"          |
+   | Browse uploaded source docs    | `universe` action="list_sources"        |
+   | Read uploaded source doc       | `universe` action="read_source"         |
    | Create a new universe          | `universe` action="create_universe"     |
    | Switch active universe         | `universe` action="switch_universe"     |
    | Pause / resume the daemon      | `universe` action="control_daemon"      |

--- a/workflow/api/prompts.py
+++ b/workflow/api/prompts.py
@@ -164,8 +164,8 @@ this connector do?", "what tools do I have?", or "show me everything",
 enumerate ALL FIVE. Don't list extensions actions and forget the rest.
 
 1. **`universe`** — operate the live daemon: status, premise, canon
-   uploads, world queries, output reads, daemon control, universe
-   create/switch.
+   uploads, uploaded source browsing, world queries, output reads,
+   daemon control, universe create/switch.
 2. **`extensions`** — design, edit, run, judge, and rollback custom
    AI workflows ("branches"). Largest action surface — node/edge
    builds, runs, judgments, lineage.
@@ -234,7 +234,9 @@ enumerate ALL FIVE. Don't list extensions actions and forget the rest.
    | Check daemon memory status     | `universe` action="daemon_memory_status"|
    | Query world state              | `universe` action="query_world"         |
    | Read produced output           | `universe` action="read_output"         |
-   | Browse source / canon docs     | `universe` action="list_canon"          |
+   | Browse canon docs              | `universe` action="list_canon"          |
+   | Browse uploaded source docs    | `universe` action="list_sources"        |
+   | Read uploaded source doc       | `universe` action="read_source"         |
    | Create a new universe          | `universe` action="create_universe"     |
    | Switch active universe         | `universe` action="switch_universe"     |
    | Pause / resume the daemon      | `universe` action="control_daemon"      |


### PR DESCRIPTION
Implements the patch request from `pages/feature-requests/feat-011-feat-add-list-sources-read-source-to-universe-surface-ledger.md`.

This change updates the universe surface ledger so uploaded source browsing is explicitly advertised with `universe action="list_sources"` and `universe action="read_source"` alongside the existing canon actions. It also adds the missing daemon HTTP read endpoint for a single file under `canon/sources/`, reusing the existing bare-filename safety rules, UTF-8 decoding, checksum/size metadata, and source-listing guidance for callers.

Bug/Request ID: `pages/feature-requests/feat-011-feat-add-list-sources-read-source-to-universe-surface-ledger.md`