### PR TITLE
Fix dry patch preview node-key normalization for BUG-001

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/runtime_ops.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/runtime_ops.py
@@ -203,48 +203,20 @@ def _apply_patch_ops(
     if not isinstance(ops, list):
         return None, "changes_json must be a JSON array of ops."
 
+    from workflow.api.branches import _apply_patch_op
     from workflow.branches import BranchDefinition as _BD
 
-    branch_dict = branch.to_dict()
+    staged = _BD.from_dict(branch.to_dict())
     for i, op in enumerate(ops):
         if not isinstance(op, dict):
             return None, f"Op #{i} is not an object."
-        op_name = op.get("op", "")
-        if op_name == "add_node":
-            from workflow.branches import NodeDefinition as _ND
-            try:
-                nd = _ND.from_dict(op)
-                branch_dict.setdefault("node_defs", []).append(nd.to_dict())
-            except Exception as exc:  # noqa: BLE001
-                return None, f"Op #{i} add_node failed: {exc}"
-        elif op_name == "remove_node":
-            nid = op.get("node_id", "")
-            branch_dict["node_defs"] = [
-                n for n in branch_dict.get("node_defs", [])
-                if n.get("node_id") != nid
-            ]
-        elif op_name == "update_node":
-            nid = op.get("node_id", "")
-            for nd in branch_dict.get("node_defs", []):
-                if nd.get("node_id") == nid:
-                    nd.update({k: v for k, v in op.items() if k not in ("op",)})
-        elif op_name == "add_state_field":
-            branch_dict.setdefault("state_schema", []).append({
-                "name": op.get("field_name", ""),
-                "type": op.get("field_type", "str"),
-                "reducer": op.get("reducer", ""),
-                "default": op.get("field_default", ""),
-            })
-        elif op_name == "remove_state_field":
-            fn = op.get("field_name", "")
-            branch_dict["state_schema"] = [
-                f for f in branch_dict.get("state_schema", [])
-                if f.get("name") != fn
-            ]
-        # Other ops (edges, metadata) are no-ops for structural inspection
+        err = _apply_patch_op(staged, op)
+        if err:
+            op_name = str(op.get("op") or "?")
+            return None, f"Op #{i} {op_name} failed: {err}"
 
     try:
-        return _BD.from_dict(branch_dict), None
+        return _BD.from_dict(staged.to_dict()), None
     except Exception as exc:  # noqa: BLE001
         return None, f"Patched branch could not be reconstructed: {exc}"
 

--- a/tests/test_patch_branch_node_keys.py
+++ b/tests/test_patch_branch_node_keys.py
@@ -29,6 +29,8 @@ from pathlib import Path
 import pytest
 
 from workflow.api.branches import _coerce_node_keys
+from workflow.api.runtime_ops import _apply_patch_ops
+from workflow.branches import BranchDefinition
 
 
 @pytest.fixture
@@ -89,6 +91,38 @@ def _node(branch: dict, nid: str) -> dict:
         if n["node_id"] == nid:
             return n
     raise AssertionError(f"node '{nid}' not on branch")
+
+
+def test_patch_branch_normalizes_string_key_fields_in_persisted_and_preview_paths(
+    ext_env,
+):
+    us, base = ext_env
+    bid = _build(us)
+    source_branch = BranchDefinition.from_dict(_load(us, base, bid))
+    ops = [
+        {"op": "add_state_field", "field_name": "goal", "field_type": "str"},
+        {"op": "add_state_field", "field_name": "summary", "field_type": "str"},
+        {
+            "op": "update_node",
+            "node_id": "capture",
+            "input_keys": "goal",
+            "output_keys": '["summary"]',
+        },
+    ]
+
+    res = _patch(us, bid, ops)
+    assert res.get("status") != "rejected", res
+    node = _node(_load(us, base, bid), "capture")
+    assert node["input_keys"] == ["goal"]
+    assert node["output_keys"] == ["summary"]
+
+    preview, err = _apply_patch_ops(source_branch, json.dumps(ops))
+
+    assert err is None
+    assert preview is not None
+    preview_node = _node(preview.to_dict(), "capture")
+    assert preview_node["input_keys"] == ["goal"]
+    assert preview_node["output_keys"] == ["summary"]
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/workflow/api/runtime_ops.py
+++ b/workflow/api/runtime_ops.py
@@ -203,48 +203,20 @@ def _apply_patch_ops(
     if not isinstance(ops, list):
         return None, "changes_json must be a JSON array of ops."
 
+    from workflow.api.branches import _apply_patch_op
     from workflow.branches import BranchDefinition as _BD
 
-    branch_dict = branch.to_dict()
+    staged = _BD.from_dict(branch.to_dict())
     for i, op in enumerate(ops):
         if not isinstance(op, dict):
             return None, f"Op #{i} is not an object."
-        op_name = op.get("op", "")
-        if op_name == "add_node":
-            from workflow.branches import NodeDefinition as _ND
-            try:
-                nd = _ND.from_dict(op)
-                branch_dict.setdefault("node_defs", []).append(nd.to_dict())
-            except Exception as exc:  # noqa: BLE001
-                return None, f"Op #{i} add_node failed: {exc}"
-        elif op_name == "remove_node":
-            nid = op.get("node_id", "")
-            branch_dict["node_defs"] = [
-                n for n in branch_dict.get("node_defs", [])
-                if n.get("node_id") != nid
-            ]
-        elif op_name == "update_node":
-            nid = op.get("node_id", "")
-            for nd in branch_dict.get("node_defs", []):
-                if nd.get("node_id") == nid:
-                    nd.update({k: v for k, v in op.items() if k not in ("op",)})
-        elif op_name == "add_state_field":
-            branch_dict.setdefault("state_schema", []).append({
-                "name": op.get("field_name", ""),
-                "type": op.get("field_type", "str"),
-                "reducer": op.get("reducer", ""),
-                "default": op.get("field_default", ""),
-            })
-        elif op_name == "remove_state_field":
-            fn = op.get("field_name", "")
-            branch_dict["state_schema"] = [
-                f for f in branch_dict.get("state_schema", [])
-                if f.get("name") != fn
-            ]
-        # Other ops (edges, metadata) are no-ops for structural inspection
+        err = _apply_patch_op(staged, op)
+        if err:
+            op_name = str(op.get("op") or "?")
+            return None, f"Op #{i} {op_name} failed: {err}"
 
     try:
-        return _BD.from_dict(branch_dict), None
+        return _BD.from_dict(staged.to_dict()), None
     except Exception as exc:  # noqa: BLE001
         return None, f"Patched branch could not be reconstructed: {exc}"
 


### PR DESCRIPTION
This draft PR addresses `pages/bugs/BUG-001-patch-branch-silently-corrupts-input-keys-output-keys-when-p.md`.

It reuses the existing branch patch op executor in the dry-inspect preview path so `input_keys`, `output_keys`, and related flexible node-key fields are normalized the same way for preview and persisted writes. That prevents string payloads from degrading into malformed node-key shapes during preview and returns contextual op errors instead of constructing corrupted branch data.

It also adds a regression test covering `patch_branch` with string `input_keys` / `output_keys` and asserting both the persisted branch and the previewed patched branch contain proper `list[str]` values.