### PR TITLE
Fix pre-existing test breakage on main (_connect caller + stale handler counts)

### DIFF
--- a/tests/test_api_market.py
+++ b/tests/test_api_market.py
@@ -110,11 +110,9 @@ def test_attribution_actions_keys():
 # ── _GOAL_ACTIONS dispatch table ────────────────────────────────────────────
 
 
-def test_goal_actions_table_has_12_handlers():
-    # 9 base actions + archive_consultation (pre-existing on main) +
-    # run_canonical (PR-127 M6 cutover Step 4) +
-    # set_selector (DESIGN-008 user-buildable selector primitive) = 12.
-    assert len(_GOAL_ACTIONS) == 12
+def test_goal_actions_table_has_14_handlers():
+    # 12 prior actions + define_protocol + get_protocol (goal-bound protocols).
+    assert len(_GOAL_ACTIONS) == 14
 
 
 def test_goal_actions_keys():
@@ -126,6 +124,8 @@ def test_goal_actions_keys():
         "run_canonical",
         # DESIGN-008 — user-buildable selector primitive.
         "set_selector",
+        # goal-bound branch protocols.
+        "define_protocol", "get_protocol",
     }
     assert set(_GOAL_ACTIONS.keys()) == expected
 
@@ -189,8 +189,8 @@ def test_goals_unknown_action_lists_directory_aliases():
 # ── _GATES_ACTIONS dispatch table ───────────────────────────────────────────
 
 
-def test_gates_actions_table_has_11_handlers():
-    assert len(_GATES_ACTIONS) == 11
+def test_gates_actions_table_has_14_handlers():
+    assert len(_GATES_ACTIONS) == 14
 
 
 def test_gates_actions_keys():
@@ -200,6 +200,9 @@ def test_gates_actions_keys():
         "stake_bonus", "unstake_bonus", "release_bonus",
         # PR-126 M5 — claim from completed run's recommended_rung_claim.
         "claim_from_branch_run",
+        # conformance packs.
+        "record_conformance_pack", "get_conformance_pack",
+        "list_conformance_packs",
     }
     assert set(_GATES_ACTIONS.keys()) == expected
 

--- a/tests/test_payments_escrow_mcp.py
+++ b/tests/test_payments_escrow_mcp.py
@@ -384,11 +384,18 @@ class TestEscrowRoundTrip:
 
 class TestPaymentsActionsUnit:
     def _conn(self, tmp_path):
+        # storage._connect is a context manager (closes on exit); these unit
+        # tests need a connection that stays open across multiple action calls,
+        # so open a raw connection to the same DB path with matching pragmas.
+        import sqlite3
+
         from workflow.daemon_server import initialize_author_server
         from workflow.payments.escrow import migrate_escrow_schema
-        from workflow.storage import _connect
+        from workflow.storage import db_path
         initialize_author_server(tmp_path)
-        conn = _connect(tmp_path)
+        conn = sqlite3.connect(db_path(tmp_path), timeout=30.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
         migrate_escrow_schema(conn)
         return conn
 


### PR DESCRIPTION
Fixes pre-existing **test-only** breakage on `main` discovered while running the payments suite.

## 1. Bare `_connect()` test caller (from `#1218`)
`#1218` made `workflow.storage._connect` a `@contextlib.contextmanager`, but `TestPaymentsActionsUnit._conn` still called it bare → `_GeneratorContextManager` has no `.execute()`. **5 failures.** Production callers already use `with`. Fixed by opening a raw connection to the same DB path.

## 2. Stale handler-count assertions in `test_api_market.py`
`_GOAL_ACTIONS` gained `define_protocol`/`get_protocol`; `_GATES_ACTIONS` gained the conformance-pack handlers — but the exact count + key-set tests were never updated. **4 failures.** Updated counts (12→14, 11→14) and key sets to match the live tables.

## Verify
`pytest tests/test_api_market.py tests/test_payments_escrow_mcp.py` → **73 passed** (was 9 failed). Test-only; no runtime changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)