### PR TITLE
Backup: two-tier nightly (consistent brain archive + live-tolerant full tar) + pruner foreign-file fix

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -48,6 +48,7 @@ universe_server.py: 14012 → 972 LOC live in main. PLAN.md restructured 30→11
 | Mark-branch canonical decision (Task #33 phase 0) | live MCP `goals action=propose/bind/set_canonical` | host | host-decision |
 | Host decision: BUG-018 canonical filename trailing-hyphen — rename canonical to drop, or `wiki action=promote` draft to overwrite? | wiki | - | host-decision |
 | Fire DR drill #3 via workflow_dispatch | `.github/workflows/dr-drill.yml` | - | host or lead-with-PAT |
+| Host-action: provision real offsite BACKUP_DEST (DO Spaces or Hetzner Storage Box creds + rclone config on droplet) — current dest is droplet-local; GH releases are the only true offsite (runbook "Current droplet reality") | /etc/workflow/env on droplet | - | host-action |
 | Host-action: re-register `Workflow DEV` ChatGPT connector as workspace admin | OpenAI workspace admin | - | host-action |
 | Memory-scope Stage 2c flag | - | 30d clean | monitoring |
 | Remove provider+DO keys from persistent uptime surfaces | `deploy/*` | host Qs answered | host->e2e |

--- a/STATUS.md
+++ b/STATUS.md
@@ -11,6 +11,7 @@ Live steering only. **Budget 4 KB / 60 lines.** Concerns/Work = one line each; l
 - [filed:2026-04-24] Task #9 host Qs: GROQ/GEMINI/XAI GH Actions secrets present + rotation e2e validated after deploy step ships.
 - **[P1 filed:2026-04-30]** Castles II live run `28479d8ddfb44488` failed `provider_exhausted` at `candidate_discovery` (see BUG-038); blocks branch-run proof. Companion: BUG-039 (Echoes intake same root cause).
 - [filed:2026-04-30 reframed:2026-05-19] Classic-game v0 desktop shortcut concern: now PR-131 in dispatcher queue (`bc6ed9df-e764-495a-b466-c5c86d7e0e2e`); user-canary packet `tiberian_sun_host_local_effect_packet_v1` built with correct idempotency_key + asset policy. First consumer of #914 external-write design.
+- [filed:2026-06-10] Droplet `/opt/workflow` checkout is stale (c1380fa) + dirty (compose.yml, vector-entrypoint.sh local edits); systemd units run scripts from it. Needs deliberate sync strategy — NOT `git pull` (would drag local edits live).
 - [filed:2026-05-19] Wiki has shifted toward multi-agent shared scratch space — 81% of post-2026-05-01 notes (495 of 614) are Codex/Cowork/Claude agent-coordination. Volume risks drowning out chatbot discovery/remix. Worth a host conversation on whether to split coordination off the knowledge wiki.
 
 ## Approved Specs
@@ -29,6 +30,7 @@ universe_server.py: 14012 → 972 LOC live in main. PLAN.md restructured 30→11
 
 | Task | Files | Depends | Status |
 |------|-------|---------|--------|
+| **#1307 host merge key** — backup two-tier fix (consistent brain archive + live-tolerant full tar + pruner foreign-file fix); rolled out on droplet + e2e-proven 2026-06-10; offsite starvation since 05-28 closed | deploy/backup.sh, deploy/workflow-backup.timer, scripts/backup_prune.py, docs/ops/backup-restore-runbook.md, tests/test_backup_script.py | - | host-action |
 | **#906 host merge key** — Open-brain v2 slice C cost-ledger READ surface; Claude checker APPROVED 2026-05-19 | workflow/daemon_brain.py, workflow/api/status.py + plugin mirrors | - | host-action |
 | **#907 host merge key** — Bounded autonomous spend CI writer-prompt guardrail; Claude checker APPROVED 2026-05-19 | .github/workflows/auto-fix-bug.yml, docs/ops/auto-fix-runbook.md | - | host-action |
 | **Codex verdict ADAPT** — in-node enqueue #1214 stays dark; before flag flip add current-universe context, queue/lineage cap, branch target validation | workflow/graph_compiler.py, workflow/branch_tasks.py, fantasy_daemon/__main__.py, tests/test_node_enqueue_*.py | verdict filed in `docs/audits/2026-05-30-in-node-enqueue-codex-review.md` | dev-ready |

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -4,12 +4,25 @@
 # Self-host migration Row J per
 # docs/exec-plans/active/2026-04-20-selfhost-uptime-migration.md.
 #
-# Tars the Docker named volume's backing directory + uploads to any
-# rclone-compatible remote. Retention: 7 daily + 4 weekly + 6 monthly,
-# pruned at the end of each run.
+# Two tiers per run (2026-06-10 redesign — see
+# docs/ops/backup-restore-runbook.md "Two-tier design"):
 #
-# Triggered by backup.service (systemd oneshot) from
-# backup.timer (nightly 02:00 UTC).
+#   1. BRAIN tier (strict): wiki/, daemon_wikis/, top-level ledgers and
+#      SQLite DBs, staged to a quiesced temp dir with SQLite files copied
+#      through python3's sqlite3 backup API for transactional consistency.
+#      Small (MBs). This archive MUST succeed — it carries the
+#      irreplaceable knowledge state.
+#   2. FULL tier (best-effort): whole-volume tar including multi-GB
+#      rebuildable LanceDB indexes, taken live. GNU tar exit 1 ("file
+#      changed as we read it") is EXPECTED on a hot volume and tolerated;
+#      exit >= 2 is fatal. Before 2026-06-10 this exit-1 case failed the
+#      whole unit nightly and silently starved the offsite history.
+#
+# Retention: 7 daily + 4 weekly + 6 monthly per tier, pruned at the end
+# of each run (scripts/backup_prune.py).
+#
+# Triggered by workflow-backup.service (systemd oneshot) from
+# workflow-backup.timer (nightly 03:00 UTC).
 #
 # Required env (from /etc/workflow/env, sourced by the systemd unit):
 #   BACKUP_DEST   rclone destination URL, e.g.:
@@ -26,16 +39,18 @@
 #   DRY_RUN                set to "1" — print plan, no tar/upload/prune
 #   BACKUP_LOG             append log to this file (default: /var/log/workflow-backup.log)
 #   GH_TOKEN               GitHub token for offsite upload to BACKUP_GH_REPO.
-#                          When set, tarball is also shipped as a GH release asset.
+#                          When set, both tarballs are also shipped as GH
+#                          release assets.
 #   BACKUP_GH_REPO         GitHub repo for offsite releases (default: Jonnyton/workflow-backups).
 #   BACKUP_GH_RETAIN       GH releases to keep (default: 30).
 #
 # Exit codes:
 #   0  upload + prune succeeded (or DRY_RUN=1 — no mutations).
 #   1  BACKUP_DEST not set.
-#   2  tar failed (source volume missing or unreadable).
-#   3  rclone upload failed.
-#   4  retention prune failed (non-fatal; upload itself succeeded).
+#   2  tar/staging failed (source volume missing, brain stage failed, or
+#      full tar exited >= 2).
+#   3  rclone upload failed (either tier).
+#   4  retention prune failed (non-fatal; uploads themselves succeeded).
 
 set -euo pipefail
 
@@ -87,61 +102,125 @@ fi
 log "source: ${VOLUME_DIR}"
 log "dest:   ${BACKUP_DEST}"
 
-# ----- 3. tar the volume ------------------------------------------------
-
 TS="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+
+# ----- 3. brain tier — consistent archive of the irreplaceable subset ---
+
+BRAIN_NAME="workflow-brain-${TS}.tar.gz"
+BRAIN_PATH="/tmp/${BRAIN_NAME}"
+BRAIN_STAGE="$(mktemp -d /tmp/workflow-brain-stage.XXXXXX)"
+trap 'rm -rf "${BRAIN_STAGE}"' EXIT
+
+log "staging brain tier (wiki, daemon_wikis, ledgers, SQLite DBs)..."
+for d in wiki daemon_wikis; do
+    if [[ -d "${VOLUME_DIR}/${d}" ]]; then
+        if ! cp -a "${VOLUME_DIR}/${d}" "${BRAIN_STAGE}/"; then
+            log "ERROR: brain stage copy failed: ${d}"
+            exit 2
+        fi
+    fi
+done
+for f in "${VOLUME_DIR}"/*.json; do
+    [[ -f "${f}" ]] && cp -a "${f}" "${BRAIN_STAGE}/"
+done
+for db in "${VOLUME_DIR}"/*.db; do
+    [[ -f "${db}" ]] || continue
+    if ! python3 - "${db}" "${BRAIN_STAGE}/$(basename "${db}")" <<'PY'
+import sqlite3
+import sys
+
+src = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
+dst = sqlite3.connect(sys.argv[2])
+src.backup(dst)
+dst.close()
+src.close()
+PY
+    then
+        log "ERROR: consistent sqlite copy failed: $(basename "${db}")"
+        exit 2
+    fi
+done
+
+log "creating brain archive ${BRAIN_PATH}..."
+if ! tar -czf "${BRAIN_PATH}" -C "${BRAIN_STAGE}" .; then
+    log "ERROR: brain tar failed"
+    rm -f "${BRAIN_PATH}"
+    exit 2
+fi
+log "  brain archive size: $(stat -c %s "${BRAIN_PATH}" 2>/dev/null || echo '?') bytes"
+
+log "uploading brain tier to ${BACKUP_DEST}/${BRAIN_NAME}..."
+if ! rclone copyto --contimeout 60s --timeout 900s \
+        "${BRAIN_PATH}" "${BACKUP_DEST}/${BRAIN_NAME}"; then
+    log "ERROR: brain rclone upload failed"
+    rm -f "${BRAIN_PATH}"
+    exit 3
+fi
+log "  brain upload OK"
+
+# ----- 4. full tier — whole volume, live (tar exit 1 tolerated) ---------
+
 TAR_NAME="workflow-data-${TS}.tar.gz"
 TAR_PATH="/tmp/${TAR_NAME}"
 
 log "creating archive ${TAR_PATH}..."
-if ! tar -czf "${TAR_PATH}" -C "$(dirname "${VOLUME_DIR}")" "$(basename "${VOLUME_DIR}")"; then
-    log "ERROR: tar failed"
-    rm -f "${TAR_PATH}"
+set +e
+tar -czf "${TAR_PATH}" --warning=no-file-changed \
+    -C "$(dirname "${VOLUME_DIR}")" "$(basename "${VOLUME_DIR}")"
+tar_rc=$?
+set -e
+if [[ "${tar_rc}" -ge 2 ]]; then
+    log "ERROR: tar failed (rc=${tar_rc})"
+    rm -f "${TAR_PATH}" "${BRAIN_PATH}"
     exit 2
+elif [[ "${tar_rc}" -eq 1 ]]; then
+    log "  tar rc=1 (files changed during live read) — expected on a hot volume; archive kept (brain tier carries the strict-consistency guarantee)"
 fi
 TAR_SIZE="$(stat -c %s "${TAR_PATH}" 2>/dev/null || echo '?')"
 log "  archive size: ${TAR_SIZE} bytes"
-
-# ----- 4. upload --------------------------------------------------------
 
 log "uploading to ${BACKUP_DEST}/${TAR_NAME}..."
 if ! rclone copyto --contimeout 60s --timeout 900s \
         "${TAR_PATH}" "${BACKUP_DEST}/${TAR_NAME}"; then
     log "ERROR: rclone upload failed"
-    rm -f "${TAR_PATH}"
+    rm -f "${TAR_PATH}" "${BRAIN_PATH}"
     exit 3
 fi
 log "  upload OK"
 
 # ----- 5. offsite upload (GH release assets) ----------------------------
 # Best-effort; failure is non-fatal so local backup still counts as done.
-# Activated only when GH_TOKEN is set.
+# Activated only when GH_TOKEN is set. Ships both tiers.
 
 SHIP_SCRIPT="$(dirname "$(realpath "$0")")/../scripts/backup_ship_gh.py"
 if [[ -n "${GH_TOKEN:-}" ]]; then
-    log "shipping to GitHub releases (${BACKUP_GH_REPO:-Jonnyton/workflow-backups})..."
-    set +e
-    python3 "${SHIP_SCRIPT}" "${TAR_PATH}" 2>&1 | while IFS= read -r line; do
-        log "  gh-ship: ${line}"
+    for ship_path in "${TAR_PATH}" "${BRAIN_PATH}"; do
+        log "shipping $(basename "${ship_path}") to GitHub releases (${BACKUP_GH_REPO:-Jonnyton/workflow-backups})..."
+        set +e
+        python3 "${SHIP_SCRIPT}" "${ship_path}" 2>&1 | while IFS= read -r line; do
+            log "  gh-ship: ${line}"
+        done
+        ship_status=$?
+        set -e
+        if [[ "${ship_status}" -ne 0 ]]; then
+            log "WARN: GH offsite ship exited ${ship_status} for $(basename "${ship_path}") (local backup succeeded)"
+        fi
     done
-    ship_status=$?
-    set -e
-    if [[ "${ship_status}" -ne 0 ]]; then
-        log "WARN: GH offsite ship exited ${ship_status} (local backup succeeded)"
-    fi
 else
     log "GH_TOKEN not set — skipping offsite GH release upload"
 fi
 
-rm -f "${TAR_PATH}"
+rm -f "${TAR_PATH}" "${BRAIN_PATH}"
 
 # ----- 6. retention prune ----------------------------------------------
 
-# Keep:
+# Keep, per tier prefix (workflow-data-, workflow-brain-):
 #   - last BACKUP_RETAIN_DAILY daily archives (most recent N)
 #   - first archive of each week for last BACKUP_RETAIN_WEEKLY weeks
 #   - first archive of each month for last BACKUP_RETAIN_MONTHLY months
-# Prune is best-effort; failure is non-fatal.
+# Prune is best-effort; failure is non-fatal. backup_prune.py only ever
+# emits names matching the tier prefixes — unknown files at the
+# destination are never deleted.
 #
 # Python replaces awk here: mawk (Debian default) lacks the 3-arg match()
 # and gensub() extensions used by GNU awk. Python 3 is guaranteed present

--- a/deploy/workflow-backup.service
+++ b/deploy/workflow-backup.service
@@ -4,8 +4,9 @@
 # docs/exec-plans/active/2026-04-20-selfhost-uptime-migration.md.
 #
 # Triggered by workflow-backup.timer nightly at 03:00 UTC. Invokes
-# deploy/backup.sh to tar the workflow-data named volume + rclone-
-# upload to Hetzner Storage Box. Retention pruned in the same run.
+# deploy/backup.sh: brain-tier + full-tier archives of the workflow-data
+# named volume, rclone-uploaded to BACKUP_DEST and shipped to GitHub
+# release assets when GH_TOKEN is set. Retention pruned in the same run.
 #
 # Runs as root because:
 #   1. /var/lib/docker/volumes/ is only root-readable by default.
@@ -18,7 +19,7 @@
 # reads STORAGEBOX_* from the process env.
 
 [Unit]
-Description=Workflow daemon state backup (nightly snapshot to Hetzner Storage Box)
+Description=Workflow daemon state backup (nightly two-tier snapshot to BACKUP_DEST + GH releases)
 Documentation=https://github.com/Jonnyton/Workflow/blob/main/deploy/HETZNER-DEPLOY.md
 After=docker.service network-online.target
 Wants=network-online.target

--- a/deploy/workflow-backup.timer
+++ b/deploy/workflow-backup.timer
@@ -11,7 +11,7 @@ Requires=workflow-backup.service
 # 03:00 UTC nightly. Low-traffic window for most regions; 3h before
 # the 07:17 UTC tier-3 OSS clone nightly (so backup completes before
 # CI hits the box).
-OnCalendar=02:00 UTC
+OnCalendar=03:00 UTC
 AccuracySec=5min
 # Persistent=true so a missed backup (box was off at 02:00) runs on
 # next boot. State backup is a scheduled batch job, unlike the

--- a/docs/ops/backup-restore-runbook.md
+++ b/docs/ops/backup-restore-runbook.md
@@ -39,6 +39,19 @@ indexes are rebuildable from canon, and run state is resumable. Retention is
 applied **per tier prefix** by `scripts/backup_prune.py`; unrecognized
 filenames at the destination are never pruned.
 
+### Current droplet reality (verified 2026-06-10)
+
+Despite the Hetzner narrative elsewhere in this runbook, the production
+droplet has **`BACKUP_DEST=/var/backups/workflow` — a local directory on the
+same disk as the data it backs up**. No rclone remote was ever configured.
+The **GitHub release assets in `Jonnyton/workflow-backups` are the only true
+offsite copy.** Until a real remote is provisioned (host action: DO Spaces or
+Hetzner Storage Box credentials + `rclone config` on the droplet), treat the
+GH tier as primary offsite, keep `GH_TOKEN` valid in `/etc/workflow/env`, and
+keep local retention tight (`BACKUP_RETAIN_DAILY=3 / WEEKLY=2 / MONTHLY=2`
+set 2026-06-10) so the local mirror cannot fill the 50 GB root disk at
+~1.5 GB/night.
+
 **Retention schedule:**
 
 | Window | Count | Default env var |

--- a/docs/ops/backup-restore-runbook.md
+++ b/docs/ops/backup-restore-runbook.md
@@ -13,12 +13,31 @@ State backup for the DO Droplet's `/data` volume. Row J per
 
 ## Architecture
 
-- **Script:** `deploy/backup.sh` — tars the `workflow-data` Docker volume and uploads to any
+- **Script:** `deploy/backup.sh` — two archives per run (see "Two-tier design"), uploaded to any
   rclone-compatible remote.
 - **Restore:** `deploy/backup-restore.sh` — pulls a snapshot and restores it in-place.
-- **Schedule:** `deploy/backup.timer` (systemd) — fires nightly at **02:00 UTC**.
+- **Schedule:** `deploy/workflow-backup.timer` (systemd) — fires nightly at **03:00 UTC**.
 - **Offsite options:** DO Spaces (`s3://`), Hetzner Storage Box (`sftp://`), AWS S3, etc. — any
   rclone remote works. `BACKUP_DEST` is the single config variable.
+
+### Two-tier design (2026-06-10)
+
+A live volume cannot be tarred consistently: the daemon writes during the
+~7-minute archive, GNU tar exits 1 ("file changed as we read it"), and the
+pre-2026-06-10 script treated that as fatal — every nightly run from
+2026-05-28 to 2026-06-10 failed this way, silently starving offsite history
+(the only successes were nights quiet enough to win the race). The redesign:
+
+| Tier | Archive | Contents | Consistency | Failure policy |
+|------|---------|----------|-------------|----------------|
+| **Brain** | `workflow-brain-<ts>.tar.gz` (MBs) | `wiki/`, `daemon_wikis/`, top-level `*.json` ledgers, top-level `*.db` | Strict — staged to a temp dir; SQLite copied via python3 `sqlite3.backup()` API | Any failure is fatal (exit 2/3) |
+| **Full** | `workflow-data-<ts>.tar.gz` (GBs) | whole volume incl. rebuildable per-universe `lancedb/` indexes + universe canon/output | Best-effort — tarred live; tar rc=1 tolerated, rc≥2 fatal | Upload failure fatal (exit 3) |
+
+The brain tier is the irreplaceable knowledge state and must always land.
+The full tier may contain torn copies of files that were mid-write; LanceDB
+indexes are rebuildable from canon, and run state is resumable. Retention is
+applied **per tier prefix** by `scripts/backup_prune.py`; unrecognized
+filenames at the destination are never pruned.
 
 **Retention schedule:**
 
@@ -126,6 +145,20 @@ Example output:
   workflow-data-2026-04-21T02-00-00Z.tar.gz
   workflow-data-2026-04-20T02-00-00Z.tar.gz
   workflow-data-2026-04-19T02-00-00Z.tar.gz
+```
+
+---
+
+## Restore the brain tier only
+
+The brain archive's contents are relative to the volume root (`./wiki`,
+`./daemon_wikis`, `./ledger.json`, `./*.db`). To restore just the knowledge
+state over an existing volume:
+
+```bash
+systemctl stop workflow-daemon   # or: docker compose -f /opt/workflow/deploy/compose.yml stop daemon
+tar -xzf /tmp/workflow-brain-<ts>.tar.gz -C /var/lib/docker/volumes/workflow-data/_data
+systemctl start workflow-daemon
 ```
 
 ---

--- a/scripts/backup_prune.py
+++ b/scripts/backup_prune.py
@@ -19,14 +19,23 @@ import argparse
 import re
 import sys
 
+# Tier prefixes managed by this pruner. Names not matching one of these
+# patterns are NEVER deleted — the destination may hold files we don't
+# own. (Before 2026-06-10 the delete set was computed as all-names minus
+# kept, which would have deleted any unrecognized file at the dest.)
+TIER_PATTERNS = (
+    r"^workflow-data-\d.*\.tar\.gz$",
+    r"^workflow-brain-\d.*\.tar\.gz$",
+)
 
-def _apply_retention(
+
+def _apply_retention_one_tier(
     names: list[str],
     keep_daily: int,
     keep_weekly: int,
     keep_monthly: int,
 ) -> list[str]:
-    """Return names that should be deleted (oldest first)."""
+    """Return names within one tier that should be deleted (oldest first)."""
     keep: set[str] = set()
     week_seen: dict[str, bool] = {}
     month_seen: dict[str, bool] = {}
@@ -35,8 +44,6 @@ def _apply_retention(
     monthly_count = 0
 
     for name in sorted(names, reverse=True):
-        if not re.match(r"^workflow-data-\d.*\.tar\.gz$", name):
-            continue
         daily_count += 1
         if daily_count <= keep_daily:
             keep.add(name)
@@ -61,8 +68,28 @@ def _apply_retention(
                 keep.add(name)
                 continue
 
-    to_delete = sorted(set(names) - keep)
-    return to_delete
+    return sorted(set(names) - keep)
+
+
+def _apply_retention(
+    names: list[str],
+    keep_daily: int,
+    keep_weekly: int,
+    keep_monthly: int,
+) -> list[str]:
+    """Return names that should be deleted (oldest first).
+
+    Retention is applied independently per tier prefix so brain archives
+    never crowd out full-volume archives (or vice versa). Unrecognized
+    names are never returned.
+    """
+    to_delete: list[str] = []
+    for pattern in TIER_PATTERNS:
+        tier_names = [n for n in names if re.match(pattern, n)]
+        to_delete.extend(
+            _apply_retention_one_tier(tier_names, keep_daily, keep_weekly, keep_monthly)
+        )
+    return sorted(to_delete)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_backup_script.py
+++ b/tests/test_backup_script.py
@@ -347,6 +347,49 @@ def test_retention_monthly_anchor_kept():
     assert march_kept, f"At least one March archive should be kept; all deleted: {to_delete}"
 
 
+def test_retention_never_deletes_unrecognized_names():
+    """Foreign files at the destination must never be emitted for deletion.
+
+    Regression: before 2026-06-10 the delete set was computed as
+    all-names-minus-kept, so any file not matching the workflow-data
+    pattern was deleted on every successful prune.
+    """
+    foreign = ["README.txt", "manual-snapshot.tar.gz", "somebody-elses-file.bin"]
+    dates = [f"2026-04-{d:02d}" for d in range(1, 15)]
+    names = _make_archives(dates) + foreign
+    to_delete = _retention_set(names, keep_daily=1, keep_weekly=1, keep_monthly=1)
+    assert set(foreign).isdisjoint(to_delete), (
+        f"Foreign names must never be pruned: {to_delete & set(foreign)}"
+    )
+
+
+def test_retention_per_tier_independent():
+    """Brain and data archives get independent retention windows."""
+    dates = [f"2026-04-{d:02d}" for d in range(1, 11)]
+    data_names = _make_archives(dates)
+    brain_names = [f"workflow-brain-{d}T03-00-00Z.tar.gz" for d in dates]
+    to_delete = _retention_set(
+        data_names + brain_names, keep_daily=7, keep_weekly=4, keep_monthly=6
+    )
+    # Same policy as test_prune_script_subprocess_emits_deletions, applied
+    # per tier: only the Apr 01 archive of EACH tier is pruned.
+    assert to_delete == {
+        "workflow-data-2026-04-01T02-00-00Z.tar.gz",
+        "workflow-brain-2026-04-01T03-00-00Z.tar.gz",
+    }, f"Expected per-tier Apr 01 pruning; got: {to_delete}"
+
+
+def test_backup_sh_has_brain_tier_and_tolerates_live_tar():
+    """Structural anchors for the 2026-06-10 two-tier redesign."""
+    text = BACKUP_SH.read_text(encoding="utf-8")
+    assert "workflow-brain-" in text, "brain-tier archive missing from backup.sh"
+    assert "--warning=no-file-changed" in text, "live-tar warning suppression missing"
+    assert 'tar_rc' in text and '-ge 2' in text, (
+        "full-tier tar must tolerate rc=1 and fail only on rc>=2"
+    )
+    assert "src.backup(dst)" in text, "consistent sqlite copy (sqlite3 backup API) missing"
+
+
 def test_prune_script_subprocess_emits_deletions():
     """backup_prune.py via subprocess: 10 archives, daily=7 → correct prune set.
 


### PR DESCRIPTION
## Backup pipeline: silent 14-day offsite starvation — three bugs found, fixed, live-proven

**Discovery (2026-06-10, Fable session, spec §15 D1-2 brain-backup verification):** every nightly backup since 2026-05-28 failed with `tar: file changed as we read it` — the live daemon mutates the 17 GB volume during the ~7-minute archive, GNU tar exits 1, `backup.sh` treated that as fatal. Last offsite snapshot: **2026-05-27**. The May "successes" were nights quiet enough to win the race.

**Bug 2 (pruner):** `backup_prune.py` computed deletions as all-names-minus-kept, so any destination file not matching `workflow-data-*` gets deleted on every successful prune. **Demonstrated live during rollout:** the first service run with the new script but old pruner deleted the brain archive it had uploaded 4 seconds earlier.

**Bug 3 (config reality, not in this diff):** production `BACKUP_DEST=/var/backups/workflow` — a **local directory on the same droplet disk**. The "Hetzner" narrative in the unit description was never wired; the GitHub releases in `Jonnyton/workflow-backups` were the only true offsite copy all along. Runbook now documents this; STATUS has a host-action row to provision a real rclone remote.

### The fix (two tiers per run)

| Tier | Contents | Consistency | Failure |
|---|---|---|---|
| **Brain** `workflow-brain-<ts>.tar.gz` (~3.4 MB) | wiki/, daemon_wikis/, top-level ledgers + SQLite DBs | Strict — temp-dir staging; SQLite via python3 `sqlite3.backup()` | fatal |
| **Full** `workflow-data-<ts>.tar.gz` (~1.5 GB) | whole volume (incl. rebuildable per-universe lancedb/) | Best-effort — live tar, rc=1 tolerated, rc≥2 fatal | upload fatal |

- Pruner: per-tier retention windows; unrecognized destination files never pruned (regression-tested).
- Timer: `OnCalendar` 02:00 → 03:00 UTC, matching unit comments + installed droplet reality.
- Service: Description no longer claims Hetzner.
- Runbook: two-tier design, brain-only restore, "Current droplet reality" section.

### Evidence (all 2026-06-10)

- **End-to-end production proof:** second `systemctl start workflow-backup.service` run with all fixes installed → `Result=success`, `backup complete.`, brain archive survived prune, both tiers shipped to GH releases: `workflow-data-2026-06-10T17-22-30Z` + `workflow-brain-2026-06-10T17-22-30Z` (journal 17:31Z).
- The 14-day offsite gap is closed: today's brain + full archives are on GitHub (true offsite).
- `pytest tests/test_backup_script.py`: 15 passed, 2 skipped (shellcheck absent locally). New tests: foreign-name protection, per-tier retention, structural anchors. `ruff` clean.
- Droplet rollout was targeted file copies (old script kept as `backup.sh.pre-2026-06-10`); `/opt/workflow` checkout is stale+dirty — separate STATUS concern, no `git pull` performed.
- Local mirror bounded: `BACKUP_RETAIN_DAILY=3/WEEKLY=2/MONTHLY=2` set in `/etc/workflow/env` so the local-disk dest can't fill the 50 GB root at ~1.5 GB/night.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
