### PR TITLE
loop-consent: abandonment decisions digest 2026-06-10 (5 decisions, reviewed)

### DIFF
--- a/docs/loop-decisions/2026-06-10.md
+++ b/docs/loop-decisions/2026-06-10.md
@@ -1,0 +1,65 @@
+# Loop decisions consent — 2026-06-10
+
+Generated: 2026-06-10T17:40:31.571574Z
+Decisions since: (no prior consent PR; covering all currently-terminal issues)
+
+## Summary
+
+- 1 auto-fix-exhausted (retry budget burned (Slice B))
+- 4 auto-fix-blocked (writer rejected the design as unbuildable)
+- 0 auto-fix-pr-blocked (branch pushed but PR creation blocked)
+- 0 auto-fix-branch-push-blocked (patch produced but branch push blocked)
+- 0 auto-fix-already-fixed (request already addressed, no PR needed)
+
+## Decisions
+
+### #341 — auto-fix-blocked
+
+**Title:** [WIKI-PATCH] PR-028 (proposed) ADAPTER-NW-001: native-windows-v1 runtime adapter — for legal-free retro games that run native on Windows (Cave Story original, AGS adventures, Apogee 2014 native freeware re-releases)
+**URL:** https://github.com/Jonnyton/Workflow/issues/341
+**Last touch:** 2026-05-05T22:27:40Z
+**Labels:** auto-change, auto-fix-attempted, auto-fix-blocked, auto-fix-reviewed, await-primitive-layer, checker:cross-family, daemon-request, gate-required, needs-human, payment:free-ok, request:patch, writer-pool:claude-codex
+
+To dissent: comment `reopen #341` on the consent PR before merging.
+
+### #347 — auto-fix-blocked
+
+**Title:** [WIKI-DOCS] "RetroLab Lure of the Temptress recipe — linter PASS v1"
+**URL:** https://github.com/Jonnyton/Workflow/issues/347
+**Last touch:** 2026-05-06T20:34:29Z
+**Labels:** auto-change, auto-fix-attempted, auto-fix-blocked, auto-fix-reviewed, checker:cross-family, daemon-request, gate-required, needs-human, payment:free-ok, request:docs-ops, writer-pool:claude-codex
+
+To dissent: comment `reopen #347` on the consent PR before merging.
+
+### #944 — auto-fix-blocked
+
+**Title:** [BUG-096] canon-09 §6 vs Track C local registry: one-pass audit finds 11 semantic conflicts, 3 wording drifts, 4 local-only, 6 canon-only codes; consolidated reconciliation recommended (subsumes BUG-093, BUG-095)
+**URL:** https://github.com/Jonnyton/Workflow/issues/944
+**Last touch:** 2026-05-21T23:35:22Z
+**Retry count:** 1
+**Labels:** auto-bug, auto-change, auto-fix-attempted, auto-fix-blocked, auto-fix-retries-1, auto-fix-reviewed, checker:cross-family, daemon-request, gate-required, needs-human, payment:free-ok, priority:primitive-surface, request:bug, severity:minor, writer-pool:claude-codex
+
+To dissent: comment `reopen #944` on the consent PR before merging.
+
+### #1038 — auto-fix-blocked
+
+**Title:** [WIKI-DOCS] SPLITROOT C4 contract — death + respawn loop (observer pawn, body picker, 5s timer)
+**URL:** https://github.com/Jonnyton/Workflow/issues/1038
+**Last touch:** 2026-05-24T10:17:11Z
+**Retry count:** 1
+**Labels:** auto-change, auto-fix-attempted, auto-fix-blocked, auto-fix-retries-1, auto-fix-reviewed, checker:cross-family, daemon-request, gate-required, needs-human, payment:free-ok, priority:loop-discipline, request:docs-ops, writer-pool:claude-codex
+
+To dissent: comment `reopen #1038` on the consent PR before merging.
+
+### #1090 — auto-fix-exhausted
+
+**Title:** [WIKI-DESIGN] Souled-universe consolidation program — finish the substrate's half-built universe/soul/permission surfaces into one finite domain-neutral architecture
+**URL:** https://github.com/Jonnyton/Workflow/issues/1090
+**Last touch:** 2026-05-27T17:36:26Z
+**Labels:** auto-change, auto-fix-attempted, auto-fix-auth-expired, auto-fix-auth-missing, auto-fix-codex-subscription-missing, auto-fix-exhausted, auto-fix-writer-failed, checker:cross-family, daemon-request, gate-required, payment:free-ok, priority:loop-discipline, request:project-design, writer-pool:claude-codex
+
+To dissent: comment `reopen #1090` on the consent PR before merging.
+
+---
+
+Merging this PR records host consent for all decisions above. To dissent on specific items, comment `reopen #N1 #N2 ...` on this PR and close-without-merge; the next digest will include unreopened decisions.


### PR DESCRIPTION
Records consent for the 5 abandonment decisions in `docs/loop-decisions/2026-06-10.md` (digest generated 17:40Z; the digest workflow failed to open this PR because the `loop-consent` label didn't exist — label now created, so future digests self-open).

Reviewed each decision before consenting (host delegated review 2026-06-10):

- **#341** native-windows-v1 runtime adapter — superseded: host-local Windows effect adapter work flows through PR-131 + the #914 external-write design in the live brain.
- **#347** RetroLab Lure of the Temptress recipe docs — stale May content task, writer rejected; re-enters via the live loop if still wanted.
- **#944** BUG-096 canon-09 vs Track C reconciliation — real docs-consistency bug; abandoning the auto-fix retry does not delete the wiki BUG page, it only stops the retired cheat pipeline from retrying. Proper lane can pick it up.
- **#1038** SPLITROOT C4 death+respawn contract docs — stale game-factory docs task.
- **#1090** souled-universe consolidation — the actual work landed via PR-139 (all 10 slices merged + deployed 2026-05-28); the auto-fix exhaustion is moot.

No reopens. All five are terminal states of the cheat pipeline that is slated for retirement (PR-171 / #1283); none block live-loop work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
