### PR TITLE
Loop telemetry: supervisor heartbeat + healthcheck/autoheal + lease reaper + model stamps on receipts

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -189,6 +189,19 @@ services:
     depends_on:
       daemon:
         condition: service_healthy
+    # Liveness watchdog (docs/specs/daemon-liveness-watchdog.md §1): the
+    # supervisor writes <universe>/.worker_supervisor.json beats; this
+    # check fails when beats go stale or pickable work sits unclaimed
+    # (the 2026-06 dormancy class: container "healthy" 37h while no
+    # claims happened). NOTE: compose does NOT restart unhealthy
+    # containers by itself — deploy/workflow-autoheal.timer on the host
+    # restarts any workflow container that reports unhealthy.
+    healthcheck:
+      test: ["CMD", "python", "-m", "workflow.cloud_worker_healthcheck"]
+      interval: 60s
+      timeout: 15s
+      retries: 3
+      start_period: 120s
     labels:
       org.workflow.component: worker
       org.workflow.role: node-executor

--- a/deploy/workflow-autoheal.service
+++ b/deploy/workflow-autoheal.service
@@ -1,0 +1,19 @@
+# Workflow autoheal — restart unhealthy workflow containers.
+#
+# docs/specs/daemon-liveness-watchdog.md §1 acceptance: a failing
+# healthcheck must lead to a restart. Docker Compose does not restart
+# unhealthy containers on its own (restart policies act on exit, not
+# health), so this host-side oneshot closes the loop without granting
+# any container docker.sock access.
+#
+# Triggered by workflow-autoheal.timer (every 2 minutes).
+
+[Unit]
+Description=Restart unhealthy workflow containers (liveness watchdog)
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c 'unhealthy=$(docker ps -q --filter "health=unhealthy" --filter "label=org.workflow.component"); if [ -n "$unhealthy" ]; then for c in $unhealthy; do name=$(docker inspect -f "{{.Name}}" "$c"); echo "autoheal: restarting unhealthy $name"; docker restart "$c"; done; else exit 0; fi'
+SyslogIdentifier=workflow-autoheal

--- a/deploy/workflow-autoheal.timer
+++ b/deploy/workflow-autoheal.timer
@@ -1,0 +1,17 @@
+# Workflow autoheal timer — pairs with workflow-autoheal.service.
+#
+# Every 2 minutes: with the worker healthcheck at interval 60s /
+# retries 3, a wedged worker is marked unhealthy within ~4 minutes and
+# restarted within ~6 — versus the 7 DAYS the 2026-06 dormancy lasted.
+
+[Unit]
+Description=Timer for workflow autoheal (restart unhealthy containers)
+Requires=workflow-autoheal.service
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=2min
+Unit=workflow-autoheal.service
+
+[Install]
+WantedBy=timers.target

--- a/fantasy_daemon/__main__.py
+++ b/fantasy_daemon/__main__.py
@@ -369,7 +369,7 @@ def _try_dispatcher_pick(
     tolerated by LangGraph's initial_state.
     """
     try:
-        from workflow.branch_tasks import claim_task
+        from workflow.branch_tasks import claim_task, reclaim_expired_leases
         from workflow.dispatcher import (
             dispatcher_enabled,
             load_dispatcher_config,
@@ -386,6 +386,16 @@ def _try_dispatcher_pick(
             or _soul_loop_dispatch_enabled()
         ):
             return None, {}
+        # BUG-011 Phase C: sweep expired leases before every pick so a
+        # wedged worker's claim is reaped at the next dispatch attempt
+        # instead of the next daemon restart. Live claims refresh their
+        # leases and are never touched.
+        reclaimed = reclaim_expired_leases(universe_path)
+        if reclaimed:
+            logger.info(
+                "dispatcher_pick: reclaimed %d expired-lease task(s)",
+                reclaimed,
+            )
         cfg = load_dispatcher_config(universe_path)
         picked = select_next_task(universe_path, config=cfg)
         if picked is None:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
@@ -543,8 +543,11 @@ def _compute_supervisor_liveness(
     if out["stale_running_tasks"]:
         out["warnings"].append(
             f"{len(out['stale_running_tasks'])} stale running task(s) "
-            "(heartbeat past threshold or lease expired). BUG-011 "
-            "Phase C reclaim would reclaim these once shipped."
+            "(heartbeat past threshold or lease expired). "
+            "branch_tasks.reclaim_expired_leases sweeps these at every "
+            "dispatcher pick (BUG-011 Phase C, shipped 2026-06-10); a "
+            "persistent entry here means no picks are happening — check "
+            "worker_liveness in universe inspect."
         )
 
     return out

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -939,10 +939,47 @@ def _daemon_liveness(udir: Path, status: dict[str, Any] | None) -> dict[str, Any
         "has_work": has_work,
         "last_activity_at": last_activity,
         "staleness": staleness,
+        "worker_liveness": _worker_liveness(udir),
         "word_count": word_count,
         "word_count_sample": word_count_sample,
         "accept_rate": accept_rate,
         "accept_rate_sample": accept_sample,
+    }
+
+
+def _worker_liveness(udir: Path) -> dict[str, Any]:
+    """Supervisor-heartbeat liveness, distinct from content activity.
+
+    ``last_activity_at`` answers "when did the daemon last DO something"
+    (activity.log / .runtime_status.json mtimes) — it goes stale both
+    when the worker is wedged AND when there is simply nothing to do.
+    This field answers "is the worker process alive right now" from the
+    ``.worker_supervisor.json`` beat the cloud_worker supervisor writes
+    (docs/specs/daemon-liveness-watchdog.md). Consumers (the activity
+    canary) use it to page on wedge and stay quiet on idle.
+    """
+    beat_path = udir / ".worker_supervisor.json"
+    if not beat_path.exists():
+        return {"present": False}
+    try:
+        beat = json.loads(beat_path.read_text(encoding="utf-8"))
+        ts = datetime.strptime(
+            str(beat.get("ts", "")), "%Y-%m-%dT%H:%M:%SZ",
+        ).replace(tzinfo=timezone.utc)
+    except (OSError, ValueError, TypeError):  # noqa: BLE001 — probe, not gate
+        return {"present": True, "parse_error": True}
+    age_s = max(0.0, (datetime.now(timezone.utc) - ts).total_seconds())
+    planned_sleep = float(beat.get("planned_sleep_s") or 0.0)
+    allowed = max(300.0, planned_sleep + 120.0)
+    return {
+        "present": True,
+        "alive": age_s <= allowed,
+        "beat_age_s": round(age_s, 1),
+        "phase": beat.get("phase", ""),
+        "subprocess_alive": bool(beat.get("subprocess_alive", False)),
+        "consec_crashes": beat.get("consec_crashes", 0),
+        "total_spawns": beat.get("total_spawns", 0),
+        "last_exit_rc": beat.get("last_exit_rc"),
     }
 
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
@@ -526,6 +526,72 @@ def recover_claimed_tasks(universe_path: Path) -> int:
     return count
 
 
+def reclaim_expired_leases(
+    universe_path: Path,
+    *,
+    now: datetime | None = None,
+) -> int:
+    """Lease-aware reclaim: reset ``running`` rows whose lease expired.
+
+    BUG-011 Phase C / daemon-liveness-watchdog spec: ``claim_task``
+    stamps a lease window and the runner refreshes it via
+    ``refresh_task_heartbeat`` while alive — so a ``running`` row with
+    an expired lease means its worker wedged or died mid-task. Unlike
+    :func:`recover_claimed_tasks` (startup-only blanket reset), this is
+    safe to call while OTHER workers are healthy: live claims keep
+    their leases fresh and are never touched. Intended call site is the
+    dispatcher claim path, so every claim attempt sweeps first and a
+    wedged claim is reaped on the next pick instead of the next daemon
+    restart. Returns the count reclaimed.
+    """
+    current = now or datetime.now(timezone.utc)
+    qp = queue_path(universe_path)
+    if not qp.exists():
+        return 0
+    count = 0
+    with _file_lock(universe_path):
+        raw = _read_raw(qp)
+        for row in raw:
+            if not isinstance(row, dict) or row.get("status") != "running":
+                continue
+            lease_raw = str(row.get("lease_expires_at") or "")
+            if not lease_raw:
+                # Pre-lease-era claim: no lease to judge by; leave it
+                # for startup recovery rather than guessing.
+                continue
+            lease_at = _parse_iso_utc(lease_raw)
+            if lease_at is None or lease_at > current:
+                continue
+            logger.warning(
+                "branch_tasks reclaim: lease expired %s ago on %s "
+                "(claimed_by=%s heartbeat_at=%s) — resetting to pending",
+                current - lease_at,
+                row.get("branch_task_id"),
+                row.get("claimed_by"),
+                row.get("heartbeat_at"),
+            )
+            row["status"] = "pending"
+            row["claimed_by"] = ""
+            row["worker_owner_id"] = ""
+            row["lease_expires_at"] = ""
+            row["heartbeat_at"] = ""
+            count += 1
+        if count:
+            _write_raw(qp, raw)
+    return count
+
+
+def _parse_iso_utc(value: str) -> datetime | None:
+    """Parse an ISO timestamp; assume UTC when naive. None on failure."""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
 def garbage_collect(
     universe_path: Path,
     *,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker.py
@@ -63,6 +63,7 @@ Stdlib only.
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import signal
@@ -70,6 +71,7 @@ import socket
 import subprocess
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -301,9 +303,13 @@ class SupervisorState:
         self.total_spawns = 0
         self.total_clean_exits = 0
         self.total_crashes = 0
+        self.started_at = _utcnow_iso()
+        self.last_spawn_at = ""
+        self.last_exit_rc: int | None = None
 
     def record_exit(self, returncode: int) -> None:
         self.total_spawns += 1
+        self.last_exit_rc = returncode
         if returncode == 0:
             self.crash_count = 0
             self.clean_exit_count += 1
@@ -320,6 +326,58 @@ class SupervisorState:
             f"crashes={self.total_crashes} "
             f"consec={self.crash_count}"
         )
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# Heartbeat file the supervisor writes into the universe dir. Liveness
+# consumers (workflow.api.universe worker_liveness, the activity canary,
+# workflow.cloud_worker_healthcheck) read it to distinguish "worker wedged"
+# from "idle, nothing queued" — the gap behind the 2026-06 dormancy
+# (docs/specs/daemon-liveness-watchdog.md). Deliberately NOT activity.log:
+# that file's mtime is the daemon last-activity source, and supervisor
+# ticks freshening it would mask a wedged subprocess.
+SUPERVISOR_HEARTBEAT_FILENAME = ".worker_supervisor.json"
+
+
+def write_supervisor_heartbeat(
+    universe: Path,
+    state: SupervisorState,
+    *,
+    iteration: int,
+    phase: str,
+    subprocess_pid: int | None = None,
+    subprocess_alive: bool = False,
+    planned_sleep_s: float = 0.0,
+) -> None:
+    """Atomically write the supervisor liveness beat. Best-effort.
+
+    A probe write must never take down the supervisor (the loop IS the
+    uptime surface), so failures log loudly and return.
+    """
+    beat = {
+        "ts": _utcnow_iso(),
+        "phase": phase,
+        "iteration": iteration,
+        "supervisor_started_at": state.started_at,
+        "last_spawn_at": state.last_spawn_at,
+        "last_exit_rc": state.last_exit_rc,
+        "total_spawns": state.total_spawns,
+        "total_crashes": state.total_crashes,
+        "consec_crashes": state.crash_count,
+        "subprocess_pid": subprocess_pid,
+        "subprocess_alive": subprocess_alive,
+        "planned_sleep_s": planned_sleep_s,
+    }
+    target = universe / SUPERVISOR_HEARTBEAT_FILENAME
+    tmp = universe / (SUPERVISOR_HEARTBEAT_FILENAME + ".tmp")
+    try:
+        tmp.write_text(json.dumps(beat), encoding="utf-8")
+        tmp.replace(target)
+    except OSError:
+        logger.exception("cloud_worker: heartbeat write failed at %s", target)
 
 
 def run_supervisor(
@@ -399,8 +457,17 @@ def run_supervisor(
             )
             logger.info("cloud_worker: backoff %.1fs after spawn failure (consec=%d)",
                         delay, state.crash_count)
+            write_supervisor_heartbeat(
+                universe, state, iteration=iteration, phase="spawn_failed",
+                planned_sleep_s=delay,
+            )
             sleep_fn(delay)
             continue
+        state.last_spawn_at = _utcnow_iso()
+        write_supervisor_heartbeat(
+            universe, state, iteration=iteration, phase="spawned",
+            subprocess_pid=getattr(proc, "pid", None), subprocess_alive=True,
+        )
 
         # Poll until subprocess exits, while respecting stop signal.
         returncode: int | None = None
@@ -411,7 +478,15 @@ def run_supervisor(
         # loop. Start the producer clock now and only restart if the task is
         # still pickable after one poll interval.
         last_producer_poll = time.monotonic()
+        last_beat = time.monotonic()
         while True:
+            if time.monotonic() - last_beat >= 15.0:
+                last_beat = time.monotonic()
+                write_supervisor_heartbeat(
+                    universe, state, iteration=iteration, phase="polling",
+                    subprocess_pid=getattr(proc, "pid", None),
+                    subprocess_alive=True,
+                )
             if stopping["flag"]:
                 logger.info("cloud_worker: terminating subprocess on stop signal")
                 try:
@@ -498,8 +573,15 @@ def run_supervisor(
                 base=crash_backoff, mult=backoff_mult, ceiling=max_backoff,
             )
         logger.info("cloud_worker: sleeping %.1fs before next spawn", delay)
+        write_supervisor_heartbeat(
+            universe, state, iteration=iteration, phase="backoff",
+            planned_sleep_s=delay,
+        )
         sleep_fn(delay)
 
+    write_supervisor_heartbeat(
+        universe, state, iteration=iteration, phase="stopped",
+    )
     return state
 
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker_healthcheck.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker_healthcheck.py
@@ -1,0 +1,113 @@
+"""Container healthcheck asserting the daemon is ALIVE, not just running.
+
+docs/specs/daemon-liveness-watchdog.md §1: the stock ``docker inspect``
+healthcheck is a false positive — it reports "container alive" when the
+condition that matters is "container alive AND the supervisor is beating
+AND pickable work is actually being picked up". The 2026-06 dormancy
+(worker wedged June 3-10, container "healthy" throughout) is the failure
+class this closes: with ``restart: unless-stopped`` plus this check, a
+wedged worker self-heals via container restart instead of waiting for a
+human to notice.
+
+Exit codes:
+    0  healthy (supervisor beating; no stuck pickable work).
+    1  unhealthy — one-line reason on stderr.
+
+Wire-up (deploy/compose.yml ``worker`` service):
+
+    healthcheck:
+      test: ["CMD", "python", "-m", "workflow.cloud_worker_healthcheck"]
+      interval: 60s
+      timeout: 15s
+      retries: 3
+      start_period: 120s
+
+Stdlib only; read-only against the universe dir.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Beat older than this is always unhealthy, regardless of planned sleep
+# floor — matches the spec's "no supervisor heartbeat for >5min" rule.
+STALE_FLOOR_S = 300.0
+# Grace added on top of the supervisor's own declared backoff sleep.
+PLANNED_SLEEP_GRACE_S = 120.0
+# With pickable work present the supervisor must beat at least this often
+# (it polls at sub-second granularity while a subprocess runs, and a fresh
+# spawn beats immediately). Catches "work arrived mid-backoff and the
+# supervisor is sleeping through it" as well as a wedged supervisor.
+PICKABLE_STALE_S = 180.0
+
+
+def _parse_ts(value: str) -> datetime | None:
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc,
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def check(universe: Path, *, now: datetime | None = None) -> tuple[bool, str]:
+    """Return (healthy, reason). Pure logic — testable without a container."""
+    from workflow.cloud_worker import SUPERVISOR_HEARTBEAT_FILENAME
+
+    now = now or datetime.now(timezone.utc)
+    beat_path = universe / SUPERVISOR_HEARTBEAT_FILENAME
+    if not beat_path.exists():
+        return False, f"no supervisor heartbeat at {beat_path}"
+    try:
+        beat = json.loads(beat_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return False, f"unreadable supervisor heartbeat: {exc}"
+
+    ts = _parse_ts(str(beat.get("ts", "")))
+    if ts is None:
+        return False, f"heartbeat has no parseable ts: {beat.get('ts')!r}"
+    age_s = (now - ts).total_seconds()
+
+    planned_sleep = float(beat.get("planned_sleep_s") or 0.0)
+    allowed = max(STALE_FLOOR_S, planned_sleep + PLANNED_SLEEP_GRACE_S)
+    if age_s > allowed:
+        return False, (
+            f"supervisor beat stale: age={age_s:.0f}s allowed={allowed:.0f}s "
+            f"phase={beat.get('phase')}"
+        )
+
+    try:
+        from workflow.cloud_worker import _has_pickable_branch_task
+
+        pickable = _has_pickable_branch_task(universe)
+    except Exception as exc:  # noqa: BLE001 — probe must report, not crash
+        return False, f"queue probe failed: {exc}"
+    if pickable and age_s > PICKABLE_STALE_S:
+        return False, (
+            f"pickable work waiting but supervisor beat is {age_s:.0f}s old "
+            f"(phase={beat.get('phase')})"
+        )
+
+    return True, (
+        f"ok: beat age={age_s:.0f}s phase={beat.get('phase')} "
+        f"pickable={pickable}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    from workflow.cloud_worker import _resolve_universe_path
+
+    universe = _resolve_universe_path()
+    healthy, reason = check(universe)
+    if healthy:
+        print(reason)
+        return 0
+    print(reason, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/graph_compiler.py
@@ -220,7 +220,7 @@ def _call_policy_router_with_retry(
     prompt: str,
     system: str,
     policy: dict[str, Any],
-) -> tuple[str, str]:
+) -> tuple[str, str, dict]:
     """Retry policy-aware provider dispatch on transient chain exhaustion."""
     attempts = len(_POLICY_PROVIDER_RETRY_BACKOFF_SECONDS) + 1
     for attempt_index in range(attempts):
@@ -1053,6 +1053,7 @@ def _build_prompt_template_node(
             concurrency_tracker.acquire()
         try:
             provider_served: str = "unknown"
+            provider_meta: dict[str, Any] = {}
             if provider_call is None:
                 response = f"[Mock response for {node.node_id}]"
                 provider_served = "mock"
@@ -1067,7 +1068,7 @@ def _build_prompt_template_node(
                         router_providers is None or bool(router_providers)
                     )
                     if _policy_router is not None and router_has_providers:
-                        def _policy_call() -> tuple[str, str]:
+                        def _policy_call() -> tuple[str, str, dict]:
                             return _call_policy_router_with_retry(
                                 _policy_router,
                                 role=role,
@@ -1080,7 +1081,7 @@ def _build_prompt_template_node(
                             timeout_s=timeout_s,
                             node_id=node.node_id,
                         )
-                        response, provider_served = text_and_name
+                        response, provider_served, provider_meta = text_and_name
                     else:
                         # Router unavailable or empty — fall through to the
                         # run_branch-injected provider bridge.
@@ -1136,11 +1137,20 @@ def _build_prompt_template_node(
 
         if event_sink is not None:
             try:
+                _meta_detail = {}
+                if provider_meta:
+                    _meta_detail = {
+                        "provider_model": provider_meta.get("model", ""),
+                        "provider_latency_ms": provider_meta.get("latency_ms"),
+                        "provider_attempts": provider_meta.get("attempts"),
+                        "provider_degraded": provider_meta.get("degraded", False),
+                    }
                 event_sink(
                     node_id=node.node_id,
                     phase="ran",
                     prompt=prompt, response=response, role=role,
                     provider_served=provider_served,
+                    **_meta_detail,
                 )
             except Exception as exc:
                 if _is_cancel_exception(exc):

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/router.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/router.py
@@ -441,6 +441,23 @@ class ProviderRouter:
     # Policy-aware routing (per-node llm_policy override)
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _call_meta(resp, attempts: int) -> dict:
+        """Telemetry for one routed call: model identity, latency, attempts.
+
+        Persisted onto run receipts (runs.provider_used/model columns and the
+        per-run ``provider_calls`` event) so receipts can answer "which model
+        produced this, how long did it take, after how many tries" — spec
+        §11.3 model-stamp requirement.
+        """
+        return {
+            "model": getattr(resp, "model", "") or "",
+            "family": getattr(resp, "family", "") or "",
+            "latency_ms": getattr(resp, "latency_ms", None),
+            "degraded": bool(getattr(resp, "degraded", False)),
+            "attempts": attempts,
+        }
+
     async def call_with_policy(
         self,
         role: str,
@@ -449,10 +466,11 @@ class ProviderRouter:
         policy: dict | None,
         config: ModelConfig | None = None,
         difficulty: str = "",
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, dict]:
         """Route a call honouring an explicit llm_policy dict.
 
-        Returns ``(response_text, provider_name_used)``.
+        Returns ``(response_text, provider_name_used, call_meta)`` where
+        ``call_meta`` is :meth:`_call_meta` telemetry for the winning call.
 
         Policy resolution order:
         1. ``preferred`` provider — try first.
@@ -467,14 +485,14 @@ class ProviderRouter:
            through to the standard role-based ``call()`` method.
 
         When ``call()`` is reached it returns a ``ProviderResponse``; this
-        method extracts ``.text`` and returns (text, provider_name). For
+        method extracts ``.text`` and returns (text, provider_name, meta). For
         the policy path we track the name explicitly.
         """
         cfg = config or _default_config()
 
         if not policy:
             resp = await self.call(role, prompt, system, cfg)
-            return resp.text, resp.provider
+            return resp.text, resp.provider, self._call_meta(resp, attempts=1)
 
         # Build ordered attempt list from policy
         attempt_order: list[str] = []
@@ -532,6 +550,7 @@ class ProviderRouter:
         attempt_order = auth_filtered_order
 
         # Try policy-derived providers
+        tried = 0
         for provider_name in attempt_order:
             provider = self._providers.get(provider_name)
             if provider is None:
@@ -546,10 +565,11 @@ class ProviderRouter:
             logger.info(
                 "Trying policy provider %s for role=%s", provider_name, role,
             )
+            tried += 1
             try:
                 resp = await provider.complete(prompt, system, cfg)
                 self._quota.record_success(provider_name)
-                return resp.text, provider_name
+                return resp.text, provider_name, self._call_meta(resp, attempts=tried)
             except ProviderUnavailableError:
                 self._quota.cooldown(provider_name, COOLDOWN_UNAVAILABLE)
                 logger.warning(
@@ -578,7 +598,7 @@ class ProviderRouter:
             role,
         )
         resp = await self.call(role, prompt, system, cfg)
-        return resp.text, resp.provider
+        return resp.text, resp.provider, self._call_meta(resp, attempts=tried + 1)
 
     def call_with_policy_sync(
         self,
@@ -588,12 +608,12 @@ class ProviderRouter:
         policy: dict | None,
         config: ModelConfig | None = None,
         difficulty: str = "",
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, dict]:
         """Synchronous wrapper for :meth:`call_with_policy`."""
         cfg = config or _default_config()
         sync_timeout = cfg.timeout + 30
 
-        def _run() -> tuple[str, str]:
+        def _run() -> tuple[str, str, dict]:
             loop = asyncio.new_event_loop()
             try:
                 return loop.run_until_complete(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/runs.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/runs.py
@@ -2057,7 +2057,11 @@ def _invoke_graph(
     """
     thread_id = run_id
     execution_cursor = {"step": 0}
-    provider_tracker: dict[str, str | None] = {"last": None}
+    # Telemetry accumulator: "last" feeds runs.provider_used (legacy
+    # last-wins), "model" feeds the runs.model column, "calls" becomes a
+    # per-run ``provider_calls`` system event (one entry per provider-served
+    # node: provider, model, latency, attempts).
+    provider_tracker: dict[str, Any] = {"last": None, "model": None, "calls": []}
 
     def _emit_node_status(node_id: str, status: str) -> None:
         if on_node_status is None:
@@ -2128,6 +2132,18 @@ def _invoke_graph(
         served = detail.get("provider_served")
         if served:
             provider_tracker["last"] = str(served)
+            model = detail.get("provider_model")
+            if model:
+                provider_tracker["model"] = str(model)
+            provider_tracker["calls"].append({
+                "node_id": node_id,
+                "provider": str(served),
+                "model": str(model or ""),
+                "latency_ms": detail.get("provider_latency_ms"),
+                "attempts": detail.get("provider_attempts"),
+                "degraded": bool(detail.get("provider_degraded", False)),
+                "at": _now(),
+            })
         record_event(base_path, RunStepEvent(
             run_id=run_id,
             step_index=step + _PENDING_OFFSET,
@@ -2453,6 +2469,21 @@ def _invoke_graph(
             detail=stats,
         ))
 
+    # Model-stamp telemetry (spec §11.3 / PR-172): one system event with the
+    # full per-call list so receipts can answer "which model, how long, how
+    # many tries" per provider-served node.
+    if provider_tracker["calls"]:
+        step = execution_cursor["step"]
+        execution_cursor["step"] += 1
+        record_event(base_path, RunStepEvent(
+            run_id=run_id,
+            step_index=step + _PENDING_OFFSET,
+            node_id="__system__",
+            status="provider_calls",
+            started_at=_now(),
+            detail={"calls": provider_tracker["calls"]},
+        ))
+
     # PR-122 Phase 1 — external-write effectors.
     # After a successful run, walk node_defs that declared an ``effects``
     # list and route their outputs to the matching effector (today only
@@ -2481,6 +2512,7 @@ def _invoke_graph(
         output=output,
         finished_at=_now(),
         provider_used=provider_tracker["last"],
+        model=provider_tracker["model"],
     )
     return RunOutcome(
         run_id=run_id, status=RUN_STATUS_COMPLETED,
@@ -3213,7 +3245,7 @@ def _invoke_graph_resume(
 ) -> RunOutcome:
     """Compile branch + invoke with None inputs to resume from checkpoint."""
     execution_cursor = {"step": 1000}  # offset so resume events don't collide
-    provider_tracker: dict[str, str | None] = {"last": None}
+    provider_tracker: dict[str, Any] = {"last": None, "model": None, "calls": []}
 
     def _on_node(node_id: str, **detail: Any) -> None:
         phase = detail.pop("phase", "ran")
@@ -3223,6 +3255,18 @@ def _invoke_graph_resume(
             served = detail.get("provider_served")
             if served:
                 provider_tracker["last"] = served
+                model = detail.get("provider_model")
+                if model:
+                    provider_tracker["model"] = str(model)
+                provider_tracker["calls"].append({
+                    "node_id": node_id,
+                    "provider": str(served),
+                    "model": str(model or ""),
+                    "latency_ms": detail.get("provider_latency_ms"),
+                    "attempts": detail.get("provider_attempts"),
+                    "degraded": bool(detail.get("provider_degraded", False)),
+                    "at": _now(),
+                })
 
         if phase == "starting":
             record_event(base_path, RunStepEvent(
@@ -3347,6 +3391,7 @@ def _invoke_graph_resume(
         output=output,
         finished_at=_now(),
         provider_used=provider_tracker["last"],
+        model=provider_tracker["model"],
     )
     return RunOutcome(
         run_id=run_id, status=RUN_STATUS_COMPLETED,

--- a/scripts/last_activity_canary.py
+++ b/scripts/last_activity_canary.py
@@ -270,6 +270,33 @@ def run_canary(
             f"(freshness gate suspended while {reason})"
         )
 
+    # Worker-liveness preference (daemon-liveness-watchdog spec): the
+    # supervisor heartbeat distinguishes the two states content-activity
+    # mtimes conflate. A dead/stale beat is a wedge — page with that as
+    # the reason instead of the vaguer "activity stale". A live beat
+    # with no queued work is healthy idleness — don't page just because
+    # nothing has needed doing lately. A live beat with work present
+    # falls through to the freshness gate (the daemon should be making
+    # progress, and last_activity measures exactly that).
+    liveness = daemon.get("worker_liveness")
+    if isinstance(liveness, dict) and liveness.get("present"):
+        alive = liveness.get("alive")
+        if alive is False:
+            return 2, (
+                "STALE (worker_wedged): supervisor heartbeat is "
+                f"{liveness.get('beat_age_s')}s old "
+                f"(phase={liveness.get('phase')!r}, "
+                f"consec_crashes={liveness.get('consec_crashes')}); "
+                "worker is wedged or dead — restart the worker container"
+            )
+        if alive is True and not daemon.get("has_work", False):
+            return 0, (
+                "FRESH (worker alive, no active work): supervisor beat "
+                f"{liveness.get('beat_age_s')}s old; "
+                f"last_activity_at={daemon.get('last_activity_at')!r} "
+                "staleness reflects idleness, not a wedge"
+            )
+
     last_activity_iso = daemon.get("last_activity_at")
     return classify_freshness(last_activity_iso, current_now, threshold_min)
 

--- a/tests/test_cloud_worker.py
+++ b/tests/test_cloud_worker.py
@@ -451,7 +451,13 @@ def test_supervisor_restarts_idle_subprocess_for_still_pending_task_after_grace(
             trigger_source="owner_queued",
         ),
     )
-    times = iter([100.0, 131.0])
+    # Supervisor consumes monotonic() for the producer clock, the
+    # heartbeat clock, and per-tick beat checks; only the producer-poll
+    # comparison needs to see the 31s jump, so feed 100.0 until the
+    # producer check and 131.0 from there on.
+    import itertools
+
+    times = itertools.chain([100.0, 100.0, 100.0], itertools.repeat(131.0))
     monkeypatch.setattr(cw.time, "monotonic", lambda: next(times))
     _sleep_calls, sleep_fn = _make_sleep_recorder()
     spawned: list[FakeProc] = []

--- a/tests/test_llm_policy_override.py
+++ b/tests/test_llm_policy_override.py
@@ -128,7 +128,7 @@ def _mock_router_for_policy(
             raise raises_on_preferred
     else:
         def _side_effect(role, prompt, system, policy, config=None, difficulty=""):
-            return preferred_response, preferred_provider
+            return preferred_response, preferred_provider, {}
 
     mock_router.call_with_policy_sync.side_effect = _side_effect
     return mock_router
@@ -248,7 +248,7 @@ def test_node_policy_overrides_branch_default():
     calls: list[dict] = []
     def _mock_policy_call(role, prompt, system, policy, config=None, difficulty=""):
         calls.append({"policy": policy})
-        return "node-policy-response", "codex"
+        return "node-policy-response", "codex", {}
 
     mock_router = MagicMock()
     mock_router.call_with_policy_sync.side_effect = _mock_policy_call
@@ -317,7 +317,7 @@ def test_policy_dispatch_retries_transient_provider_exhaustion(monkeypatch):
         AllProvidersExhaustedError(
             "All providers exhausted for role=writer. Daemon should retry with backoff."
         ),
-        ("success after retry", "groq-free"),
+        ("success after retry", "groq-free", {}),
     ]
 
     monkeypatch.setattr(
@@ -354,7 +354,7 @@ def test_difficulty_override_passed_through():
     calls: list[dict] = []
     def _mock_call(role, prompt, system, policy, config=None, difficulty=""):
         calls.append({"difficulty": difficulty})
-        return "hard-response", "claude-code"
+        return "hard-response", "claude-code", {}
 
     mock_router = MagicMock()
     mock_router.call_with_policy_sync.side_effect = _mock_call

--- a/tests/test_loop_telemetry.py
+++ b/tests/test_loop_telemetry.py
@@ -1,0 +1,371 @@
+"""Tests for the 2026-06-10 loop-telemetry slice.
+
+Covers:
+  - branch_tasks.reclaim_expired_leases (lease-aware reaper, BUG-011 Phase C)
+  - cloud_worker supervisor heartbeat file
+  - cloud_worker_healthcheck.check decision logic
+  - api.universe._worker_liveness beat interpretation
+  - last_activity_canary worker_liveness preference
+  - ProviderRouter._call_meta shape + call_with_policy 3-tuple
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from workflow.branch_tasks import (
+    BranchTask,
+    append_task,
+    claim_task,
+    new_task_id,
+    read_queue,
+    reclaim_expired_leases,
+)
+from workflow.cloud_worker import (
+    SUPERVISOR_HEARTBEAT_FILENAME,
+    SupervisorState,
+    run_supervisor,
+    write_supervisor_heartbeat,
+)
+from workflow.cloud_worker_healthcheck import check as healthcheck_check
+
+
+def _utc(offset_s: float = 0.0) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(seconds=offset_s)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _make_task(universe: Path) -> BranchTask:
+    task = BranchTask(
+        branch_task_id=new_task_id(),
+        branch_def_id="def-telemetry-test",
+        universe_id="u-telemetry-test",
+        trigger_source="owner_queued",
+    )
+    append_task(universe, task)
+    return task
+
+
+# ---------------------------------------------------------------------------
+# reclaim_expired_leases
+# ---------------------------------------------------------------------------
+
+
+def test_reclaim_resets_expired_lease(tmp_path):
+    task = _make_task(tmp_path)
+    claimed = claim_task(tmp_path, task.branch_task_id, "daemon::test::1")
+    assert claimed is not None
+
+    future = _utc(offset_s=10_000)
+    count = reclaim_expired_leases(tmp_path, now=future)
+    assert count == 1
+    rows = {t.branch_task_id: t for t in read_queue(tmp_path)}
+    row = rows[task.branch_task_id]
+    assert row.status == "pending"
+    assert row.claimed_by == ""
+    assert row.lease_expires_at == ""
+
+
+def test_reclaim_leaves_fresh_lease_alone(tmp_path):
+    task = _make_task(tmp_path)
+    claimed = claim_task(tmp_path, task.branch_task_id, "daemon::test::1")
+    assert claimed is not None
+
+    count = reclaim_expired_leases(tmp_path)
+    assert count == 0
+    rows = {t.branch_task_id: t for t in read_queue(tmp_path)}
+    assert rows[task.branch_task_id].status == "running"
+
+
+def test_reclaim_skips_leaseless_running_rows(tmp_path):
+    # Pre-lease-era claim: running but no lease stamp. The reaper must
+    # not guess — startup recovery owns that case.
+    task = _make_task(tmp_path)
+    claimed = claim_task(tmp_path, task.branch_task_id, "daemon::test::1")
+    assert claimed is not None
+    from workflow.branch_tasks import _read_raw, _write_raw, queue_path
+
+    qp = queue_path(tmp_path)
+    raw = _read_raw(qp)
+    for row in raw:
+        row["lease_expires_at"] = ""
+    _write_raw(qp, raw)
+
+    count = reclaim_expired_leases(tmp_path, now=_utc(offset_s=10_000))
+    assert count == 0
+
+
+def test_reclaim_ignores_pending_rows(tmp_path):
+    _make_task(tmp_path)
+    assert reclaim_expired_leases(tmp_path, now=_utc(offset_s=10_000)) == 0
+
+
+# ---------------------------------------------------------------------------
+# supervisor heartbeat
+# ---------------------------------------------------------------------------
+
+
+def test_write_supervisor_heartbeat_atomic_shape(tmp_path):
+    state = SupervisorState()
+    state.record_exit(0)
+    write_supervisor_heartbeat(
+        tmp_path, state, iteration=3, phase="backoff", planned_sleep_s=42.0,
+    )
+    beat = json.loads(
+        (tmp_path / SUPERVISOR_HEARTBEAT_FILENAME).read_text(encoding="utf-8")
+    )
+    assert beat["phase"] == "backoff"
+    assert beat["iteration"] == 3
+    assert beat["total_spawns"] == 1
+    assert beat["planned_sleep_s"] == 42.0
+    assert beat["last_exit_rc"] == 0
+    assert not (tmp_path / (SUPERVISOR_HEARTBEAT_FILENAME + ".tmp")).exists()
+
+
+class _FakeProc:
+    pid = 4242
+
+    def __init__(self) -> None:
+        self._polls = 0
+
+    def poll(self):
+        self._polls += 1
+        return 0 if self._polls >= 2 else None
+
+    def terminate(self):  # pragma: no cover - stop-signal path
+        pass
+
+    def wait(self, timeout=None):  # pragma: no cover - stop-signal path
+        return 0
+
+
+def test_run_supervisor_writes_heartbeats(tmp_path):
+    run_supervisor(
+        tmp_path,
+        max_iterations=1,
+        spawn_fn=lambda universe: _FakeProc(),
+        sleep_fn=lambda s: None,
+        producer_poll_interval=0,
+    )
+    beat = json.loads(
+        (tmp_path / SUPERVISOR_HEARTBEAT_FILENAME).read_text(encoding="utf-8")
+    )
+    assert beat["phase"] == "stopped"
+    assert beat["total_spawns"] == 1
+    assert beat["last_exit_rc"] == 0
+
+
+# ---------------------------------------------------------------------------
+# healthcheck decision logic
+# ---------------------------------------------------------------------------
+
+
+def _write_beat(universe: Path, *, age_s: float, phase: str = "polling",
+                planned_sleep_s: float = 0.0) -> None:
+    beat = {
+        "ts": _iso(_utc(-age_s)),
+        "phase": phase,
+        "planned_sleep_s": planned_sleep_s,
+    }
+    (universe / SUPERVISOR_HEARTBEAT_FILENAME).write_text(
+        json.dumps(beat), encoding="utf-8",
+    )
+
+
+def test_healthcheck_fails_without_beat(tmp_path):
+    healthy, reason = healthcheck_check(tmp_path)
+    assert not healthy
+    assert "no supervisor heartbeat" in reason
+
+
+def test_healthcheck_passes_on_fresh_beat(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "workflow.cloud_worker._has_pickable_branch_task", lambda u: False,
+    )
+    _write_beat(tmp_path, age_s=10)
+    healthy, reason = healthcheck_check(tmp_path)
+    assert healthy, reason
+
+
+def test_healthcheck_fails_on_stale_beat(tmp_path):
+    _write_beat(tmp_path, age_s=600)
+    healthy, reason = healthcheck_check(tmp_path)
+    assert not healthy
+    assert "stale" in reason
+
+
+def test_healthcheck_honors_planned_backoff_sleep(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "workflow.cloud_worker._has_pickable_branch_task", lambda u: False,
+    )
+    _write_beat(tmp_path, age_s=600, phase="backoff", planned_sleep_s=900)
+    healthy, reason = healthcheck_check(tmp_path)
+    assert healthy, reason
+
+
+def test_healthcheck_fails_when_pickable_waits_through_backoff(
+    tmp_path, monkeypatch,
+):
+    # Work arrived while the supervisor sleeps a long idle backoff: the
+    # beat is within its planned-sleep allowance but pickable work is
+    # waiting — unhealthy, restart picks it up.
+    monkeypatch.setattr(
+        "workflow.cloud_worker._has_pickable_branch_task", lambda u: True,
+    )
+    _write_beat(tmp_path, age_s=600, phase="backoff", planned_sleep_s=900)
+    healthy, reason = healthcheck_check(tmp_path)
+    assert not healthy
+    assert "pickable" in reason
+
+
+# ---------------------------------------------------------------------------
+# universe inspect worker_liveness
+# ---------------------------------------------------------------------------
+
+
+def test_worker_liveness_absent(tmp_path):
+    from workflow.api.universe import _worker_liveness
+
+    assert _worker_liveness(tmp_path) == {"present": False}
+
+
+def test_worker_liveness_alive_and_dead(tmp_path):
+    from workflow.api.universe import _worker_liveness
+
+    _write_beat(tmp_path, age_s=10)
+    live = _worker_liveness(tmp_path)
+    assert live["present"] and live["alive"]
+
+    _write_beat(tmp_path, age_s=3600)
+    dead = _worker_liveness(tmp_path)
+    assert dead["present"] and not dead["alive"]
+    assert dead["beat_age_s"] > 3000
+
+
+# ---------------------------------------------------------------------------
+# canary worker_liveness preference
+# ---------------------------------------------------------------------------
+
+
+def _canary(daemon: dict) -> tuple[int, str]:
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+    import last_activity_canary as canary
+
+    def fake_post(url, sid, payload, timeout, step_code=0):
+        if payload and payload.get("method") == "tools/call":
+            return {
+                "result": {
+                    "structuredContent": {
+                        "universe_id": "u-test",
+                        "daemon": daemon,
+                    },
+                },
+            }, "session-1"
+        return {"result": {}}, "session-1"
+
+    return canary.run_canary(
+        "http://test/mcp", 5.0, 30, post_fn=fake_post,
+    )
+
+
+def test_canary_pages_on_dead_worker():
+    code, msg = _canary({
+        "staleness": "fresh",
+        "is_paused": False,
+        "has_work": True,
+        "last_activity_at": _iso(_utc(-60)),
+        "worker_liveness": {
+            "present": True, "alive": False, "beat_age_s": 9999.0,
+            "phase": "polling", "consec_crashes": 0,
+        },
+    })
+    assert code == 2
+    assert "worker_wedged" in msg
+
+
+def test_canary_quiet_on_alive_worker_with_no_work():
+    code, msg = _canary({
+        "staleness": "dormant",
+        "is_paused": False,
+        "has_work": False,
+        "last_activity_at": _iso(_utc(-90_000)),
+        "worker_liveness": {
+            "present": True, "alive": True, "beat_age_s": 12.0,
+            "phase": "backoff", "consec_crashes": 0,
+        },
+    })
+    assert code == 0
+    assert "worker alive" in msg
+
+
+def test_canary_falls_through_when_alive_with_work():
+    code, _msg = _canary({
+        "staleness": "dormant",
+        "is_paused": False,
+        "has_work": True,
+        "last_activity_at": _iso(_utc(-90_000)),
+        "worker_liveness": {
+            "present": True, "alive": True, "beat_age_s": 12.0,
+            "phase": "polling", "consec_crashes": 0,
+        },
+    })
+    assert code == 2  # stale activity with live worker + work = real problem
+
+
+# ---------------------------------------------------------------------------
+# router call meta
+# ---------------------------------------------------------------------------
+
+
+def test_call_meta_shape():
+    from workflow.providers.base import ProviderResponse
+    from workflow.providers.router import ProviderRouter
+
+    resp = ProviderResponse(
+        text="hi", provider="codex", model="gpt-5.1-codex",
+        family="openai", latency_ms=812,
+    )
+    meta = ProviderRouter._call_meta(resp, attempts=2)
+    assert meta == {
+        "model": "gpt-5.1-codex",
+        "family": "openai",
+        "latency_ms": 812,
+        "degraded": False,
+        "attempts": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_call_with_policy_returns_meta_triple():
+    from workflow.providers.base import ProviderResponse
+    from workflow.providers.router import ProviderRouter
+
+    class _Prov:
+        name = "fake"
+
+        async def complete(self, prompt, system, cfg):
+            return ProviderResponse(
+                text="out", provider="fake", model="fake-1",
+                family="test", latency_ms=5,
+            )
+
+    router = ProviderRouter()
+    router._providers = {"fake": _Prov()}
+    router._role_chains = {"writer": ["fake"]}
+
+    text, name, meta = await router.call_with_policy(
+        "writer", "p", "s", {"preferred": {"provider": "fake"}},
+    )
+    assert text == "out"
+    assert name == "fake"
+    assert meta["model"] == "fake-1"
+    assert meta["attempts"] == 1

--- a/tests/test_provider_allowlist.py
+++ b/tests/test_provider_allowlist.py
@@ -193,7 +193,7 @@ def test_call_with_policy_filters_policy_attempt_order_by_allowlist(
         ],
     }
 
-    text, provider = _run(router.call_with_policy("writer", "p", "s", policy))
+    text, provider, _meta = _run(router.call_with_policy("writer", "p", "s", policy))
 
     assert text == "content"
     assert provider == "ollama-local"

--- a/workflow/api/status.py
+++ b/workflow/api/status.py
@@ -543,8 +543,11 @@ def _compute_supervisor_liveness(
     if out["stale_running_tasks"]:
         out["warnings"].append(
             f"{len(out['stale_running_tasks'])} stale running task(s) "
-            "(heartbeat past threshold or lease expired). BUG-011 "
-            "Phase C reclaim would reclaim these once shipped."
+            "(heartbeat past threshold or lease expired). "
+            "branch_tasks.reclaim_expired_leases sweeps these at every "
+            "dispatcher pick (BUG-011 Phase C, shipped 2026-06-10); a "
+            "persistent entry here means no picks are happening — check "
+            "worker_liveness in universe inspect."
         )
 
     return out

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -939,10 +939,47 @@ def _daemon_liveness(udir: Path, status: dict[str, Any] | None) -> dict[str, Any
         "has_work": has_work,
         "last_activity_at": last_activity,
         "staleness": staleness,
+        "worker_liveness": _worker_liveness(udir),
         "word_count": word_count,
         "word_count_sample": word_count_sample,
         "accept_rate": accept_rate,
         "accept_rate_sample": accept_sample,
+    }
+
+
+def _worker_liveness(udir: Path) -> dict[str, Any]:
+    """Supervisor-heartbeat liveness, distinct from content activity.
+
+    ``last_activity_at`` answers "when did the daemon last DO something"
+    (activity.log / .runtime_status.json mtimes) — it goes stale both
+    when the worker is wedged AND when there is simply nothing to do.
+    This field answers "is the worker process alive right now" from the
+    ``.worker_supervisor.json`` beat the cloud_worker supervisor writes
+    (docs/specs/daemon-liveness-watchdog.md). Consumers (the activity
+    canary) use it to page on wedge and stay quiet on idle.
+    """
+    beat_path = udir / ".worker_supervisor.json"
+    if not beat_path.exists():
+        return {"present": False}
+    try:
+        beat = json.loads(beat_path.read_text(encoding="utf-8"))
+        ts = datetime.strptime(
+            str(beat.get("ts", "")), "%Y-%m-%dT%H:%M:%SZ",
+        ).replace(tzinfo=timezone.utc)
+    except (OSError, ValueError, TypeError):  # noqa: BLE001 — probe, not gate
+        return {"present": True, "parse_error": True}
+    age_s = max(0.0, (datetime.now(timezone.utc) - ts).total_seconds())
+    planned_sleep = float(beat.get("planned_sleep_s") or 0.0)
+    allowed = max(300.0, planned_sleep + 120.0)
+    return {
+        "present": True,
+        "alive": age_s <= allowed,
+        "beat_age_s": round(age_s, 1),
+        "phase": beat.get("phase", ""),
+        "subprocess_alive": bool(beat.get("subprocess_alive", False)),
+        "consec_crashes": beat.get("consec_crashes", 0),
+        "total_spawns": beat.get("total_spawns", 0),
+        "last_exit_rc": beat.get("last_exit_rc"),
     }
 
 

--- a/workflow/branch_tasks.py
+++ b/workflow/branch_tasks.py
@@ -526,6 +526,72 @@ def recover_claimed_tasks(universe_path: Path) -> int:
     return count
 
 
+def reclaim_expired_leases(
+    universe_path: Path,
+    *,
+    now: datetime | None = None,
+) -> int:
+    """Lease-aware reclaim: reset ``running`` rows whose lease expired.
+
+    BUG-011 Phase C / daemon-liveness-watchdog spec: ``claim_task``
+    stamps a lease window and the runner refreshes it via
+    ``refresh_task_heartbeat`` while alive — so a ``running`` row with
+    an expired lease means its worker wedged or died mid-task. Unlike
+    :func:`recover_claimed_tasks` (startup-only blanket reset), this is
+    safe to call while OTHER workers are healthy: live claims keep
+    their leases fresh and are never touched. Intended call site is the
+    dispatcher claim path, so every claim attempt sweeps first and a
+    wedged claim is reaped on the next pick instead of the next daemon
+    restart. Returns the count reclaimed.
+    """
+    current = now or datetime.now(timezone.utc)
+    qp = queue_path(universe_path)
+    if not qp.exists():
+        return 0
+    count = 0
+    with _file_lock(universe_path):
+        raw = _read_raw(qp)
+        for row in raw:
+            if not isinstance(row, dict) or row.get("status") != "running":
+                continue
+            lease_raw = str(row.get("lease_expires_at") or "")
+            if not lease_raw:
+                # Pre-lease-era claim: no lease to judge by; leave it
+                # for startup recovery rather than guessing.
+                continue
+            lease_at = _parse_iso_utc(lease_raw)
+            if lease_at is None or lease_at > current:
+                continue
+            logger.warning(
+                "branch_tasks reclaim: lease expired %s ago on %s "
+                "(claimed_by=%s heartbeat_at=%s) — resetting to pending",
+                current - lease_at,
+                row.get("branch_task_id"),
+                row.get("claimed_by"),
+                row.get("heartbeat_at"),
+            )
+            row["status"] = "pending"
+            row["claimed_by"] = ""
+            row["worker_owner_id"] = ""
+            row["lease_expires_at"] = ""
+            row["heartbeat_at"] = ""
+            count += 1
+        if count:
+            _write_raw(qp, raw)
+    return count
+
+
+def _parse_iso_utc(value: str) -> datetime | None:
+    """Parse an ISO timestamp; assume UTC when naive. None on failure."""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
 def garbage_collect(
     universe_path: Path,
     *,

--- a/workflow/cloud_worker.py
+++ b/workflow/cloud_worker.py
@@ -63,6 +63,7 @@ Stdlib only.
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import signal
@@ -70,6 +71,7 @@ import socket
 import subprocess
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -301,9 +303,13 @@ class SupervisorState:
         self.total_spawns = 0
         self.total_clean_exits = 0
         self.total_crashes = 0
+        self.started_at = _utcnow_iso()
+        self.last_spawn_at = ""
+        self.last_exit_rc: int | None = None
 
     def record_exit(self, returncode: int) -> None:
         self.total_spawns += 1
+        self.last_exit_rc = returncode
         if returncode == 0:
             self.crash_count = 0
             self.clean_exit_count += 1
@@ -320,6 +326,58 @@ class SupervisorState:
             f"crashes={self.total_crashes} "
             f"consec={self.crash_count}"
         )
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# Heartbeat file the supervisor writes into the universe dir. Liveness
+# consumers (workflow.api.universe worker_liveness, the activity canary,
+# workflow.cloud_worker_healthcheck) read it to distinguish "worker wedged"
+# from "idle, nothing queued" — the gap behind the 2026-06 dormancy
+# (docs/specs/daemon-liveness-watchdog.md). Deliberately NOT activity.log:
+# that file's mtime is the daemon last-activity source, and supervisor
+# ticks freshening it would mask a wedged subprocess.
+SUPERVISOR_HEARTBEAT_FILENAME = ".worker_supervisor.json"
+
+
+def write_supervisor_heartbeat(
+    universe: Path,
+    state: SupervisorState,
+    *,
+    iteration: int,
+    phase: str,
+    subprocess_pid: int | None = None,
+    subprocess_alive: bool = False,
+    planned_sleep_s: float = 0.0,
+) -> None:
+    """Atomically write the supervisor liveness beat. Best-effort.
+
+    A probe write must never take down the supervisor (the loop IS the
+    uptime surface), so failures log loudly and return.
+    """
+    beat = {
+        "ts": _utcnow_iso(),
+        "phase": phase,
+        "iteration": iteration,
+        "supervisor_started_at": state.started_at,
+        "last_spawn_at": state.last_spawn_at,
+        "last_exit_rc": state.last_exit_rc,
+        "total_spawns": state.total_spawns,
+        "total_crashes": state.total_crashes,
+        "consec_crashes": state.crash_count,
+        "subprocess_pid": subprocess_pid,
+        "subprocess_alive": subprocess_alive,
+        "planned_sleep_s": planned_sleep_s,
+    }
+    target = universe / SUPERVISOR_HEARTBEAT_FILENAME
+    tmp = universe / (SUPERVISOR_HEARTBEAT_FILENAME + ".tmp")
+    try:
+        tmp.write_text(json.dumps(beat), encoding="utf-8")
+        tmp.replace(target)
+    except OSError:
+        logger.exception("cloud_worker: heartbeat write failed at %s", target)
 
 
 def run_supervisor(
@@ -399,8 +457,17 @@ def run_supervisor(
             )
             logger.info("cloud_worker: backoff %.1fs after spawn failure (consec=%d)",
                         delay, state.crash_count)
+            write_supervisor_heartbeat(
+                universe, state, iteration=iteration, phase="spawn_failed",
+                planned_sleep_s=delay,
+            )
             sleep_fn(delay)
             continue
+        state.last_spawn_at = _utcnow_iso()
+        write_supervisor_heartbeat(
+            universe, state, iteration=iteration, phase="spawned",
+            subprocess_pid=getattr(proc, "pid", None), subprocess_alive=True,
+        )
 
         # Poll until subprocess exits, while respecting stop signal.
         returncode: int | None = None
@@ -411,7 +478,15 @@ def run_supervisor(
         # loop. Start the producer clock now and only restart if the task is
         # still pickable after one poll interval.
         last_producer_poll = time.monotonic()
+        last_beat = time.monotonic()
         while True:
+            if time.monotonic() - last_beat >= 15.0:
+                last_beat = time.monotonic()
+                write_supervisor_heartbeat(
+                    universe, state, iteration=iteration, phase="polling",
+                    subprocess_pid=getattr(proc, "pid", None),
+                    subprocess_alive=True,
+                )
             if stopping["flag"]:
                 logger.info("cloud_worker: terminating subprocess on stop signal")
                 try:
@@ -498,8 +573,15 @@ def run_supervisor(
                 base=crash_backoff, mult=backoff_mult, ceiling=max_backoff,
             )
         logger.info("cloud_worker: sleeping %.1fs before next spawn", delay)
+        write_supervisor_heartbeat(
+            universe, state, iteration=iteration, phase="backoff",
+            planned_sleep_s=delay,
+        )
         sleep_fn(delay)
 
+    write_supervisor_heartbeat(
+        universe, state, iteration=iteration, phase="stopped",
+    )
     return state
 
 

--- a/workflow/cloud_worker_healthcheck.py
+++ b/workflow/cloud_worker_healthcheck.py
@@ -1,0 +1,113 @@
+"""Container healthcheck asserting the daemon is ALIVE, not just running.
+
+docs/specs/daemon-liveness-watchdog.md §1: the stock ``docker inspect``
+healthcheck is a false positive — it reports "container alive" when the
+condition that matters is "container alive AND the supervisor is beating
+AND pickable work is actually being picked up". The 2026-06 dormancy
+(worker wedged June 3-10, container "healthy" throughout) is the failure
+class this closes: with ``restart: unless-stopped`` plus this check, a
+wedged worker self-heals via container restart instead of waiting for a
+human to notice.
+
+Exit codes:
+    0  healthy (supervisor beating; no stuck pickable work).
+    1  unhealthy — one-line reason on stderr.
+
+Wire-up (deploy/compose.yml ``worker`` service):
+
+    healthcheck:
+      test: ["CMD", "python", "-m", "workflow.cloud_worker_healthcheck"]
+      interval: 60s
+      timeout: 15s
+      retries: 3
+      start_period: 120s
+
+Stdlib only; read-only against the universe dir.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Beat older than this is always unhealthy, regardless of planned sleep
+# floor — matches the spec's "no supervisor heartbeat for >5min" rule.
+STALE_FLOOR_S = 300.0
+# Grace added on top of the supervisor's own declared backoff sleep.
+PLANNED_SLEEP_GRACE_S = 120.0
+# With pickable work present the supervisor must beat at least this often
+# (it polls at sub-second granularity while a subprocess runs, and a fresh
+# spawn beats immediately). Catches "work arrived mid-backoff and the
+# supervisor is sleeping through it" as well as a wedged supervisor.
+PICKABLE_STALE_S = 180.0
+
+
+def _parse_ts(value: str) -> datetime | None:
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc,
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def check(universe: Path, *, now: datetime | None = None) -> tuple[bool, str]:
+    """Return (healthy, reason). Pure logic — testable without a container."""
+    from workflow.cloud_worker import SUPERVISOR_HEARTBEAT_FILENAME
+
+    now = now or datetime.now(timezone.utc)
+    beat_path = universe / SUPERVISOR_HEARTBEAT_FILENAME
+    if not beat_path.exists():
+        return False, f"no supervisor heartbeat at {beat_path}"
+    try:
+        beat = json.loads(beat_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return False, f"unreadable supervisor heartbeat: {exc}"
+
+    ts = _parse_ts(str(beat.get("ts", "")))
+    if ts is None:
+        return False, f"heartbeat has no parseable ts: {beat.get('ts')!r}"
+    age_s = (now - ts).total_seconds()
+
+    planned_sleep = float(beat.get("planned_sleep_s") or 0.0)
+    allowed = max(STALE_FLOOR_S, planned_sleep + PLANNED_SLEEP_GRACE_S)
+    if age_s > allowed:
+        return False, (
+            f"supervisor beat stale: age={age_s:.0f}s allowed={allowed:.0f}s "
+            f"phase={beat.get('phase')}"
+        )
+
+    try:
+        from workflow.cloud_worker import _has_pickable_branch_task
+
+        pickable = _has_pickable_branch_task(universe)
+    except Exception as exc:  # noqa: BLE001 — probe must report, not crash
+        return False, f"queue probe failed: {exc}"
+    if pickable and age_s > PICKABLE_STALE_S:
+        return False, (
+            f"pickable work waiting but supervisor beat is {age_s:.0f}s old "
+            f"(phase={beat.get('phase')})"
+        )
+
+    return True, (
+        f"ok: beat age={age_s:.0f}s phase={beat.get('phase')} "
+        f"pickable={pickable}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    from workflow.cloud_worker import _resolve_universe_path
+
+    universe = _resolve_universe_path()
+    healthy, reason = check(universe)
+    if healthy:
+        print(reason)
+        return 0
+    print(reason, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workflow/graph_compiler.py
+++ b/workflow/graph_compiler.py
@@ -220,7 +220,7 @@ def _call_policy_router_with_retry(
     prompt: str,
     system: str,
     policy: dict[str, Any],
-) -> tuple[str, str]:
+) -> tuple[str, str, dict]:
     """Retry policy-aware provider dispatch on transient chain exhaustion."""
     attempts = len(_POLICY_PROVIDER_RETRY_BACKOFF_SECONDS) + 1
     for attempt_index in range(attempts):
@@ -1053,6 +1053,7 @@ def _build_prompt_template_node(
             concurrency_tracker.acquire()
         try:
             provider_served: str = "unknown"
+            provider_meta: dict[str, Any] = {}
             if provider_call is None:
                 response = f"[Mock response for {node.node_id}]"
                 provider_served = "mock"
@@ -1067,7 +1068,7 @@ def _build_prompt_template_node(
                         router_providers is None or bool(router_providers)
                     )
                     if _policy_router is not None and router_has_providers:
-                        def _policy_call() -> tuple[str, str]:
+                        def _policy_call() -> tuple[str, str, dict]:
                             return _call_policy_router_with_retry(
                                 _policy_router,
                                 role=role,
@@ -1080,7 +1081,7 @@ def _build_prompt_template_node(
                             timeout_s=timeout_s,
                             node_id=node.node_id,
                         )
-                        response, provider_served = text_and_name
+                        response, provider_served, provider_meta = text_and_name
                     else:
                         # Router unavailable or empty — fall through to the
                         # run_branch-injected provider bridge.
@@ -1136,11 +1137,20 @@ def _build_prompt_template_node(
 
         if event_sink is not None:
             try:
+                _meta_detail = {}
+                if provider_meta:
+                    _meta_detail = {
+                        "provider_model": provider_meta.get("model", ""),
+                        "provider_latency_ms": provider_meta.get("latency_ms"),
+                        "provider_attempts": provider_meta.get("attempts"),
+                        "provider_degraded": provider_meta.get("degraded", False),
+                    }
                 event_sink(
                     node_id=node.node_id,
                     phase="ran",
                     prompt=prompt, response=response, role=role,
                     provider_served=provider_served,
+                    **_meta_detail,
                 )
             except Exception as exc:
                 if _is_cancel_exception(exc):

--- a/workflow/providers/router.py
+++ b/workflow/providers/router.py
@@ -441,6 +441,23 @@ class ProviderRouter:
     # Policy-aware routing (per-node llm_policy override)
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _call_meta(resp, attempts: int) -> dict:
+        """Telemetry for one routed call: model identity, latency, attempts.
+
+        Persisted onto run receipts (runs.provider_used/model columns and the
+        per-run ``provider_calls`` event) so receipts can answer "which model
+        produced this, how long did it take, after how many tries" — spec
+        §11.3 model-stamp requirement.
+        """
+        return {
+            "model": getattr(resp, "model", "") or "",
+            "family": getattr(resp, "family", "") or "",
+            "latency_ms": getattr(resp, "latency_ms", None),
+            "degraded": bool(getattr(resp, "degraded", False)),
+            "attempts": attempts,
+        }
+
     async def call_with_policy(
         self,
         role: str,
@@ -449,10 +466,11 @@ class ProviderRouter:
         policy: dict | None,
         config: ModelConfig | None = None,
         difficulty: str = "",
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, dict]:
         """Route a call honouring an explicit llm_policy dict.
 
-        Returns ``(response_text, provider_name_used)``.
+        Returns ``(response_text, provider_name_used, call_meta)`` where
+        ``call_meta`` is :meth:`_call_meta` telemetry for the winning call.
 
         Policy resolution order:
         1. ``preferred`` provider — try first.
@@ -467,14 +485,14 @@ class ProviderRouter:
            through to the standard role-based ``call()`` method.
 
         When ``call()`` is reached it returns a ``ProviderResponse``; this
-        method extracts ``.text`` and returns (text, provider_name). For
+        method extracts ``.text`` and returns (text, provider_name, meta). For
         the policy path we track the name explicitly.
         """
         cfg = config or _default_config()
 
         if not policy:
             resp = await self.call(role, prompt, system, cfg)
-            return resp.text, resp.provider
+            return resp.text, resp.provider, self._call_meta(resp, attempts=1)
 
         # Build ordered attempt list from policy
         attempt_order: list[str] = []
@@ -532,6 +550,7 @@ class ProviderRouter:
         attempt_order = auth_filtered_order
 
         # Try policy-derived providers
+        tried = 0
         for provider_name in attempt_order:
             provider = self._providers.get(provider_name)
             if provider is None:
@@ -546,10 +565,11 @@ class ProviderRouter:
             logger.info(
                 "Trying policy provider %s for role=%s", provider_name, role,
             )
+            tried += 1
             try:
                 resp = await provider.complete(prompt, system, cfg)
                 self._quota.record_success(provider_name)
-                return resp.text, provider_name
+                return resp.text, provider_name, self._call_meta(resp, attempts=tried)
             except ProviderUnavailableError:
                 self._quota.cooldown(provider_name, COOLDOWN_UNAVAILABLE)
                 logger.warning(
@@ -578,7 +598,7 @@ class ProviderRouter:
             role,
         )
         resp = await self.call(role, prompt, system, cfg)
-        return resp.text, resp.provider
+        return resp.text, resp.provider, self._call_meta(resp, attempts=tried + 1)
 
     def call_with_policy_sync(
         self,
@@ -588,12 +608,12 @@ class ProviderRouter:
         policy: dict | None,
         config: ModelConfig | None = None,
         difficulty: str = "",
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, dict]:
         """Synchronous wrapper for :meth:`call_with_policy`."""
         cfg = config or _default_config()
         sync_timeout = cfg.timeout + 30
 
-        def _run() -> tuple[str, str]:
+        def _run() -> tuple[str, str, dict]:
             loop = asyncio.new_event_loop()
             try:
                 return loop.run_until_complete(

--- a/workflow/runs.py
+++ b/workflow/runs.py
@@ -2057,7 +2057,11 @@ def _invoke_graph(
     """
     thread_id = run_id
     execution_cursor = {"step": 0}
-    provider_tracker: dict[str, str | None] = {"last": None}
+    # Telemetry accumulator: "last" feeds runs.provider_used (legacy
+    # last-wins), "model" feeds the runs.model column, "calls" becomes a
+    # per-run ``provider_calls`` system event (one entry per provider-served
+    # node: provider, model, latency, attempts).
+    provider_tracker: dict[str, Any] = {"last": None, "model": None, "calls": []}
 
     def _emit_node_status(node_id: str, status: str) -> None:
         if on_node_status is None:
@@ -2128,6 +2132,18 @@ def _invoke_graph(
         served = detail.get("provider_served")
         if served:
             provider_tracker["last"] = str(served)
+            model = detail.get("provider_model")
+            if model:
+                provider_tracker["model"] = str(model)
+            provider_tracker["calls"].append({
+                "node_id": node_id,
+                "provider": str(served),
+                "model": str(model or ""),
+                "latency_ms": detail.get("provider_latency_ms"),
+                "attempts": detail.get("provider_attempts"),
+                "degraded": bool(detail.get("provider_degraded", False)),
+                "at": _now(),
+            })
         record_event(base_path, RunStepEvent(
             run_id=run_id,
             step_index=step + _PENDING_OFFSET,
@@ -2453,6 +2469,21 @@ def _invoke_graph(
             detail=stats,
         ))
 
+    # Model-stamp telemetry (spec §11.3 / PR-172): one system event with the
+    # full per-call list so receipts can answer "which model, how long, how
+    # many tries" per provider-served node.
+    if provider_tracker["calls"]:
+        step = execution_cursor["step"]
+        execution_cursor["step"] += 1
+        record_event(base_path, RunStepEvent(
+            run_id=run_id,
+            step_index=step + _PENDING_OFFSET,
+            node_id="__system__",
+            status="provider_calls",
+            started_at=_now(),
+            detail={"calls": provider_tracker["calls"]},
+        ))
+
     # PR-122 Phase 1 — external-write effectors.
     # After a successful run, walk node_defs that declared an ``effects``
     # list and route their outputs to the matching effector (today only
@@ -2481,6 +2512,7 @@ def _invoke_graph(
         output=output,
         finished_at=_now(),
         provider_used=provider_tracker["last"],
+        model=provider_tracker["model"],
     )
     return RunOutcome(
         run_id=run_id, status=RUN_STATUS_COMPLETED,
@@ -3213,7 +3245,7 @@ def _invoke_graph_resume(
 ) -> RunOutcome:
     """Compile branch + invoke with None inputs to resume from checkpoint."""
     execution_cursor = {"step": 1000}  # offset so resume events don't collide
-    provider_tracker: dict[str, str | None] = {"last": None}
+    provider_tracker: dict[str, Any] = {"last": None, "model": None, "calls": []}
 
     def _on_node(node_id: str, **detail: Any) -> None:
         phase = detail.pop("phase", "ran")
@@ -3223,6 +3255,18 @@ def _invoke_graph_resume(
             served = detail.get("provider_served")
             if served:
                 provider_tracker["last"] = served
+                model = detail.get("provider_model")
+                if model:
+                    provider_tracker["model"] = str(model)
+                provider_tracker["calls"].append({
+                    "node_id": node_id,
+                    "provider": str(served),
+                    "model": str(model or ""),
+                    "latency_ms": detail.get("provider_latency_ms"),
+                    "attempts": detail.get("provider_attempts"),
+                    "degraded": bool(detail.get("provider_degraded", False)),
+                    "at": _now(),
+                })
 
         if phase == "starting":
             record_event(base_path, RunStepEvent(
@@ -3347,6 +3391,7 @@ def _invoke_graph_resume(
         output=output,
         finished_at=_now(),
         provider_used=provider_tracker["last"],
+        model=provider_tracker["model"],
     )
     return RunOutcome(
         run_id=run_id, status=RUN_STATUS_COMPLETED,


### PR DESCRIPTION
## Loop telemetry slice — dormancy becomes detectable, reapable, and attributable

Implements the remaining pieces of `docs/specs/daemon-liveness-watchdog.md` plus the model-stamp requirement from the Tiny spec (§11.3 / §15 D1-2), driven by today's live evidence: the worker was wedged June 3→10 while its container reported "healthy" for 37 hours, and only a deploy restart revived it.

### Three commits

**1. Model/provider stamps on run receipts** (`1424580d`)
`ProviderResponse` always carried `model` + `latency_ms`; the router discarded them. `call_with_policy(_sync)` now returns `(text, provider, meta)`; the graph compiler emits `provider_model/latency_ms/attempts/degraded` into node events; `runs.py` lights up the **already-migrated-but-never-written `runs.model` column** and records a per-run `provider_calls` system event (one entry per provider-served node). Run receipts can now answer "which model produced this, how long, after how many tries" — the compliance-layer model-stamp primitive.

**2. Supervisor heartbeat + container healthcheck + autoheal** (`87a0eae4`)
- `cloud_worker` writes `<universe>/.worker_supervisor.json` atomically at spawn/poll(15s throttle)/backoff/stop — deliberately NOT `activity.log` (its mtime is the last-activity source; ticks there would mask a wedged subprocess).
- New `workflow/cloud_worker_healthcheck.py` (spec §1): fails on stale beat (planned-backoff-aware) or pickable-work-waiting-while-supervisor-sleeps. Wired as the worker service healthcheck in `deploy/compose.yml`.
- Compose does NOT restart unhealthy containers (restart policies act on exit) — new `deploy/workflow-autoheal.{service,timer}` host units restart unhealthy workflow containers every 2min, no docker.sock-in-container. Wedge-to-recovery goes from 7 days to ~6 minutes.

**3. Liveness consumers + lease reaper** (`a591e6d7`)
- `universe inspect` daemon block gains `worker_liveness` — wedged vs idle finally distinguishable.
- `last_activity_canary` prefers it: dead beat → pages `worker_wedged`; live beat + no work → FRESH (kills the false-page class where deliberate idleness looked like an outage); live beat + work → falls through to the real freshness gate.
- `branch_tasks.reclaim_expired_leases` (BUG-011 Phase C — the reclaim `status.py`'s warning literally said "would reclaim these once shipped"): lease-gated, file-locked, swept at every dispatcher pick. Live claims refresh leases and are never touched; pre-lease rows are left to startup recovery.

### Evidence
- 18 new tests (`tests/test_loop_telemetry.py`): reaper semantics, heartbeat shape + supervisor integration, healthcheck decision table, worker_liveness interpretation, canary wedge/idle/fall-through, router meta.
- Touched suites green: 50 (policy/allowlist/failed-event) + 65 (cloud_worker/branch_tasks/telemetry) + 564 (runs/graph_compiler/status sweep). `ruff` clean. Plugin mirror rebuilt (parity gate green).
- The 4 remaining sweep failures reproduce on **pristine origin/main** in a detached baseline worktree (provider-stub registration ×2, run-actions key set, worktree-status CRLF) — pre-existing, zero new failures.
- Pre-existing main breakage found while sweeping (not fixed here): `tests/test_wiki_alias_corner_cases.py` fails collection — `_resolve_bugs_canonical` no longer exists in `workflow/api/wiki.py`.

### Rollout note
Code ships via the normal merge→build-image→deploy-prod chain. The compose healthcheck + autoheal units do NOT auto-apply (droplet compose is locally dirty; systemd units need install): I'll do the targeted droplet rollout + live verification after merge, same pattern as the backup fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
