### PR TITLE
Fix prod Codex subscription auth persistence

### DIFF
--- a/.agents/worktrees.md
+++ b/.agents/worktrees.md
@@ -666,3 +666,15 @@ Notes:
   scopes context-engine build and vocabulary lock.
 - Ship condition: artifact under `docs/audits/`, STATUS row retired/updated,
   branch pushed, PR opened.
+
+## Prod Codex Auth Data Volume - 2026-06-17
+
+- 2026-06-17 create `../wf-prod-codex-auth-data-volume` on
+  `codex/prod-codex-auth-data-volume` by codex-gpt5-desktop.
+- Source: host-directed production outage fix; Codex OAuth auth was tied to
+  ephemeral container home and went stale after idle windows.
+- Purpose: persist subscription-backed Codex auth at shared `/data/.codex`,
+  make `get_status` honor `CODEX_HOME`, and add weekly SSH keepalive.
+- Ship condition: focused tests pass, PR merged to main, deploy-prod green,
+  live `get_status` sees Codex auth, trivial LLM node succeeds, keepalive
+  dispatch green.

--- a/.github/workflows/codex-auth-keepalive.yml
+++ b/.github/workflows/codex-auth-keepalive.yml
@@ -1,0 +1,49 @@
+name: codex-auth-keepalive
+
+# Keep the ChatGPT-subscription Codex session fresh on the Droplet.
+# A normal `codex exec` refreshes auth.json in place. The daemon can sit
+# idle long enough for the session to become stale, so run one trivial
+# call weekly against the persistent /data/.codex auth home.
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch: {}
+
+concurrency:
+  group: codex-auth-keepalive
+  cancel-in-progress: false
+
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      DO_DROPLET_HOST: ${{ secrets.DO_DROPLET_HOST || vars.DO_DROPLET_HOST }}
+      DO_SSH_USER: ${{ secrets.DO_SSH_USER || vars.DO_SSH_USER }}
+      DO_SSH_KEY: ${{ secrets.DO_SSH_KEY }}
+    steps:
+      - name: Verify SSH settings
+        run: |
+          missing=()
+          [ -z "${DO_DROPLET_HOST:-}" ] && missing+=("DO_DROPLET_HOST")
+          [ -z "${DO_SSH_USER:-}" ] && missing+=("DO_SSH_USER")
+          [ -z "${DO_SSH_KEY:-}" ] && missing+=("DO_SSH_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required secrets/vars: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Install SSH key
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s' "$DO_SSH_KEY" > ~/.ssh/do_deploy
+          chmod 600 ~/.ssh/do_deploy
+          ssh-keyscan -t ed25519,rsa "$DO_DROPLET_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Exercise Codex subscription auth
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
+            "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
+            'sudo docker exec -e CODEX_HOME=/data/.codex workflow-daemon codex exec --full-auto --skip-git-repo-check "Reply with the single word OK." >/dev/null'
+          echo "Codex keepalive OK; subscription session exercised."

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -265,21 +265,22 @@ jobs:
           SH
 
       # Codex CLI rotates single-use OAuth refresh tokens in-place inside
-      # the container. PR #965 binds /var/lib/workflow-codex -> /app/.codex
-      # so the rotated chain survives container restart. This step makes
-      # that volume self-provisioning on every deploy — idempotent, no
-      # host hands required, per the Forever Rule (24/7 uptime, zero
-      # hosts online).
+      # the container. compose.yml sets CODEX_HOME=/data/.codex for daemon
+      # + worker, backed by the shared workflow-data volume, so the rotated
+      # chain survives container restart. This step makes that directory
+      # self-provisioning on every deploy — idempotent, no host hands
+      # required, per the Forever Rule (24/7 uptime, zero hosts online).
       #
       # Three idempotent branches:
-      #   - dir already present  -> skip creation
-      #   - auth.json already in volume -> skip migration (entrypoint preserves it)
-      #   - no running container with /app/.codex/auth.json -> skip migration
+      #   - workflow-data/.codex already present -> skip creation
+      #   - /data/.codex/auth.json already in volume -> skip migration
+      #   - no running container with /data/.codex/auth.json or legacy
+      #     /app/.codex/auth.json -> skip migration
       #     (new container will seed from WORKFLOW_CODEX_AUTH_JSON_B64 on first boot)
       #
-      # The migration branch only fires once: the first deploy after
-      # PR #965 merges onto a live droplet where workflow-worker has a
-      # rotated auth.json that pre-dates the persistent volume.
+      # The migration branch only fires once: the first deploy after this
+      # CODEX_HOME move onto a live droplet where workflow-worker has a
+      # rotated auth.json at either the new or legacy location.
       - name: Prepare codex auth persistent volume
         run: |
           ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
@@ -287,43 +288,53 @@ jobs:
               'sudo bash -s' <<'SH'
           set -euo pipefail
 
-          VOLUME_DIR="/var/lib/workflow-codex"
+          VOLUME_NAME="workflow-data"
           WORKFLOW_UID=1001
           WORKFLOW_GID=1001
 
+          docker volume create "$VOLUME_NAME" >/dev/null
+          VOLUME_DIR="$(docker volume inspect "$VOLUME_NAME" --format '{{ .Mountpoint }}')"
+          CODEX_DIR="$VOLUME_DIR/.codex"
+
           # Create the directory if missing. mkdir -p is itself a no-op
           # when the path already exists.
-          if [ ! -d "$VOLUME_DIR" ]; then
-            echo "creating codex auth persistent volume at $VOLUME_DIR"
-            mkdir -p "$VOLUME_DIR"
+          if [ ! -d "$CODEX_DIR" ]; then
+            echo "creating codex auth persistent directory at $CODEX_DIR"
+            mkdir -p "$CODEX_DIR"
           fi
 
           # Ownership + mode are repaired UNCONDITIONALLY every deploy.
-          # If a prior attempt left the dir root-owned (e.g. docker bind
-          # auto-create races the create-with-chown branch), this heals
-          # the posture so uid 1001 can write. Both chown and chmod are
+          # If a prior attempt left the dir root-owned, this heals the
+          # posture so uid 1001 can write. Both chown and chmod are
           # themselves idempotent — no-op when state already matches.
-          chown "$WORKFLOW_UID:$WORKFLOW_GID" "$VOLUME_DIR"
-          chmod 700 "$VOLUME_DIR"
+          chown "$WORKFLOW_UID:$WORKFLOW_GID" "$CODEX_DIR"
+          chmod 700 "$CODEX_DIR"
 
           # Migration: if the volume is empty but a workflow-worker container is
-          # currently running with a /app/.codex/auth.json inside it (= we're rolling
-          # out PR #965 onto an existing live system), copy the live refresh chain
-          # into the volume so the new container preserves it instead of falling
-          # back to the stale env-var secret.
-          if [ ! -f "$VOLUME_DIR/auth.json" ]; then
+          # currently running with a Codex auth.json inside it, copy the live
+          # refresh chain into /data/.codex so the new container preserves it
+          # instead of falling back to the stale env-var secret.
+          if [ ! -f "$CODEX_DIR/auth.json" ]; then
+            tmp_dir="$(mktemp -d)"
+            trap 'rm -rf "$tmp_dir"' EXIT
             if docker inspect workflow-worker >/dev/null 2>&1; then
-              if docker exec workflow-worker test -f /app/.codex/auth.json 2>/dev/null; then
-                echo "migrating live codex auth.json from workflow-worker into persistent volume"
-                docker cp workflow-worker:/app/.codex/auth.json "$VOLUME_DIR/auth.json"
-                chown "$WORKFLOW_UID:$WORKFLOW_GID" "$VOLUME_DIR/auth.json"
-                chmod 600 "$VOLUME_DIR/auth.json"
+              if docker exec workflow-worker test -f /data/.codex/auth.json 2>/dev/null; then
+                echo "migrating live codex auth.json from workflow-worker:/data/.codex"
+                docker cp workflow-worker:/data/.codex/auth.json "$tmp_dir/auth.json"
+              elif docker exec workflow-worker test -f /app/.codex/auth.json 2>/dev/null; then
+                echo "migrating legacy codex auth.json from workflow-worker:/app/.codex"
+                docker cp workflow-worker:/app/.codex/auth.json "$tmp_dir/auth.json"
               fi
+            fi
+            if [ -s "$tmp_dir/auth.json" ]; then
+              cp "$tmp_dir/auth.json" "$CODEX_DIR/auth.json"
+              chown "$WORKFLOW_UID:$WORKFLOW_GID" "$CODEX_DIR/auth.json"
+              chmod 600 "$CODEX_DIR/auth.json"
             fi
           fi
 
           # Confirm final state for the log.
-          ls -la "$VOLUME_DIR" || true
+          ls -la "$CODEX_DIR" || true
           SH
 
       - name: Deploy new image

--- a/STATUS.md
+++ b/STATUS.md
@@ -50,7 +50,6 @@ universe_server.py: 14012 → 972 LOC live in main. PLAN.md restructured 30→11
 | **Loop telemetry slice** (PR-172 + spec §15 D1-2): model/provider stamps on run receipts, worker liveness heartbeat, periodic stuck-claim recovery — so loop dormancy is detected, not discovered | fantasy_daemon/__main__.py, workflow/branch_tasks.py, workflow/providers/router.py, workflow/api/status.py + plugin mirrors, tests/ | - | claimed:claude-fable ACTIVE 2026-06-10 |
 | Host-action: re-register `Workflow DEV` ChatGPT connector as workspace admin | OpenAI workspace admin | - | host-action |
 | Memory-scope Stage 2c flag | - | 30d clean | monitoring |
-| Prod Codex auth persistence outage — move subscription auth to shared `/data/.codex`, add keepalive, verify deploy | deploy/docker-entrypoint.sh, deploy/compose.yml, deploy/workflow-env.template, deploy/codex-flock-wrapper.sh, deploy/DEPLOY.md, workflow/api/status.py, packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py, .github/workflows/codex-auth-keepalive.yml, .github/workflows/deploy-prod.yml, tests/test_docker_entrypoint.py, tests/test_dockerfile_shape.py, tests/test_get_status_primitive.py, tests/test_runtime_status_bridge.py, tests/test_deploy_prod_workflow.py | host-directed uptime; overlaps Loop telemetry status/tests row | claimed:codex-gpt5-desktop ACTIVE 2026-06-17 |
 
 ## Live brain notes (informational; not work rows)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -50,7 +50,7 @@ universe_server.py: 14012 → 972 LOC live in main. PLAN.md restructured 30→11
 | **Loop telemetry slice** (PR-172 + spec §15 D1-2): model/provider stamps on run receipts, worker liveness heartbeat, periodic stuck-claim recovery — so loop dormancy is detected, not discovered | fantasy_daemon/__main__.py, workflow/branch_tasks.py, workflow/providers/router.py, workflow/api/status.py + plugin mirrors, tests/ | - | claimed:claude-fable ACTIVE 2026-06-10 |
 | Host-action: re-register `Workflow DEV` ChatGPT connector as workspace admin | OpenAI workspace admin | - | host-action |
 | Memory-scope Stage 2c flag | - | 30d clean | monitoring |
-| Remove provider+DO keys from persistent uptime surfaces | `deploy/*` | host Qs answered | host->e2e |
+| Prod Codex auth persistence outage — move subscription auth to shared `/data/.codex`, add keepalive, verify deploy | deploy/docker-entrypoint.sh, deploy/compose.yml, deploy/workflow-env.template, deploy/codex-flock-wrapper.sh, deploy/DEPLOY.md, workflow/api/status.py, packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py, .github/workflows/codex-auth-keepalive.yml, .github/workflows/deploy-prod.yml, tests/test_docker_entrypoint.py, tests/test_dockerfile_shape.py, tests/test_get_status_primitive.py, tests/test_runtime_status_bridge.py, tests/test_deploy_prod_workflow.py | host-directed uptime; overlaps Loop telemetry status/tests row | claimed:codex-gpt5-desktop ACTIVE 2026-06-17 |
 
 ## Live brain notes (informational; not work rows)
 

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -114,29 +114,30 @@ ls -la /etc/workflow/env
 If ownership/mode differs, re-run the bootstrap — it resets to
 `root:workflow 640`.
 
-## Step 3b — Codex auth persistent volume (no host action needed)
+## Step 3b — Codex auth persistent volume
 
 Codex CLI uses single-use OAuth refresh tokens that rotate in-place
 during normal operation. The compose stack persists Codex's auth state
-across container restarts via a bind mount at
-`/var/lib/workflow-codex` → `/app/.codex` (see `deploy/compose.yml`).
+across container restarts at `CODEX_HOME=/data/.codex` on the shared
+`workflow-data` Docker volume (see `deploy/compose.yml`).
 Without this, every restart throws away rotated tokens and the next
 refresh attempt fails with `refresh_token_reused`. Design source:
 <https://developers.openai.com/codex/auth/ci-cd-auth>.
 
-**The deploy workflow handles the volume + migration automatically.**
+**The deploy workflow prepares the auth directory + migration automatically.**
 `.github/workflows/deploy-prod.yml` has a `Prepare codex auth
 persistent volume` step that runs on every deploy. It is idempotent:
 
-- Creates `/var/lib/workflow-codex` when missing (`mkdir -p`); repairs
-  ownership (`uid 1001:1001`) and mode (`700`) unconditionally every
-  deploy so a root-owned dir left by a docker-bind auto-create or a
-  failed earlier attempt gets healed back to a state uid 1001 can
-  write.
+- Creates `workflow-data` when missing, resolves its local mountpoint,
+  and creates `.codex` inside it; repairs ownership (`uid 1001:1001`)
+  and mode (`700`) unconditionally every deploy so a failed earlier
+  attempt gets healed back to a state uid 1001 can write.
 - On the very first deploy onto a pre-existing live droplet, copies
   the rotated `auth.json` out of the running `workflow-worker`
-  container into the new volume so the post-restart container
-  preserves the live refresh chain.
+  container into `/data/.codex` so the post-restart container preserves
+  the live refresh chain. It checks the new `/data/.codex/auth.json`
+  path first and then the legacy `/app/.codex/auth.json` path for the
+  one-time migration.
 - After that, every subsequent deploy is a complete no-op for this
   section — the volume + `auth.json` are already in place and the
   entrypoint preserves the file on restart.
@@ -148,21 +149,22 @@ in-process executor handles `run_branch` MCP calls; the worker's
 refresh attempts are serialized by `/usr/local/bin/codex` (which is
 `deploy/codex-flock-wrapper.sh`, installed by the Dockerfile in place
 of the bare codex symlink) — it takes an exclusive `flock -x` on
-`/app/.codex/.lock` before every invocation. This mitigates the
+`$CODEX_HOME/.lock` before every invocation. This mitigates the
 `refresh_token_reused` race that Codex's official CI/CD auth guide
 warns about for shared-auth scenarios (Codex Issue #10332).
 
 **Host action is only needed in two rare cases:**
 
 1. **Brand-new droplet, no live container to migrate from.** The
-   workflow step creates the empty volume; the new container then
+   workflow step creates the empty `/data/.codex`; the new container then
    seeds `auth.json` from `WORKFLOW_CODEX_AUTH_JSON_B64` (GitHub
-   Actions secret) on first boot. Host action: keep
-   `WORKFLOW_CODEX_AUTH_JSON_B64` rotated in GitHub secrets so a
-   fresh-droplet bootstrap has a known-good seed available.
+   Actions secret or `/etc/workflow/env`) on first boot. Host action:
+   keep `WORKFLOW_CODEX_AUTH_JSON_B64` rotated so a fresh-droplet
+   bootstrap has a known-good seed available.
 2. **Persistent volume wiped (disaster recovery).** Same as case 1:
    the entrypoint reseeds from the env-var on the next boot. Host
-   action: same — keep the GitHub Actions secret fresh.
+   action: same — keep the GitHub Actions secret or `/etc/workflow/env`
+   value fresh.
 
 In normal steady-state operation (volume intact, container restarts
 for image bumps), Codex's in-place refresh chain survives indefinitely

--- a/deploy/codex-flock-wrapper.sh
+++ b/deploy/codex-flock-wrapper.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Codex CLI cross-container serialization wrapper.
 #
-# PR #965 binds /var/lib/workflow-codex -> /app/.codex into both the
+# deploy/compose.yml sets CODEX_HOME=/data/.codex in both the
 # workflow-daemon and workflow-worker containers so Codex's in-place
-# refresh chain survives container restarts. Codex's official CI/CD
+# refresh chain survives container restarts on the shared workflow-data
+# volume. Codex's official CI/CD
 # auth guide warns that one auth.json must NOT be shared across
 # concurrent runners — concurrent refresh attempts race the rotation
 # and trigger the exact `refresh_token_reused` class we are fixing
@@ -17,15 +18,15 @@
 # refresh + write happen inside one `codex exec` process, so the
 # serialization window matches the rotation window exactly.
 #
-# When /app/.codex is not present (local dev, Docker run without the
-# compose bind mount), the wrapper falls back to a per-process lock in
-# /tmp. Single-container correctness is not at risk because there's no
-# second container competing for the auth file.
+# When CODEX_HOME is not present (local dev, Docker run without the
+# compose env/volume), the wrapper falls back to HOME/.codex and then a
+# per-process lock in /tmp. Single-container correctness is not at risk
+# because there's no second container competing for the auth file.
 
 set -euo pipefail
 
 CODEX_BIN="/opt/codex-install/node_modules/.bin/codex"
-CODEX_LOCK_DIR="${HOME:-/app}/.codex"
+CODEX_LOCK_DIR="${CODEX_HOME:-${HOME:-/app}/.codex}"
 CODEX_LOCK_FALLBACK_DIR="/tmp"
 
 if [[ -d "${CODEX_LOCK_DIR}" ]]; then

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -43,11 +43,12 @@ services:
     ports:
       - "127.0.0.1:8001:8001"
     environment:
-      # Keep Codex CLI + get_status provider binding aligned with the
-      # persistent bind mount below. If HOME drifts, ~/.codex points away
-      # from /app/.codex and the mounted subscription auth becomes invisible.
       HOME: /app
       WORKFLOW_DATA_DIR: /data
+      # Persist Codex subscription auth on the shared workflow-data volume.
+      # daemon + worker intentionally share one auth.json lineage; do not
+      # split CODEX_HOME per service or duplicate the single-use refresh token.
+      CODEX_HOME: /data/.codex
       WORKFLOW_REPO_ROOT: /data/community-pool
       WORKFLOW_ALLOW_API_KEY_PROVIDERS: "0"
       WORKFLOW_CLOUD_DAEMON_SUBSCRIPTION_ONLY: "1"
@@ -58,20 +59,6 @@ services:
       - /etc/workflow/env
     volumes:
       - workflow-data:/data
-      # Persist codex OAuth state across container restarts. Codex CLI
-      # rotates single-use refresh tokens in-place; without persistence,
-      # every restart throws away the rotated token and the next refresh
-      # hits `refresh_token_reused`. Shared bind so `daemon` + `worker`
-      # see the same auth.json (the daemon's in-process executor pool
-      # calls `codex exec` synchronously for `run_branch` MCP calls; the
-      # worker's `fantasy_daemon` subprocess does the same for queued
-      # BranchTasks). Cross-container refresh races are serialized by
-      # /usr/local/bin/codex (-> deploy/codex-flock-wrapper.sh), which
-      # takes an exclusive flock on /app/.codex/.lock before every
-      # invocation. The persistent volume is auto-provisioned by the
-      # `Prepare codex auth persistent volume` step in
-      # .github/workflows/deploy-prod.yml — no host action required.
-      - /var/lib/workflow-codex:/app/.codex
     healthcheck:
       # Use the same canary shape as Layer-1 / tier-3 / docker-build
       # CI. Python already in the image.
@@ -164,9 +151,10 @@ services:
       - apparmor=unconfined
     command: ["python", "-m", "workflow.cloud_worker"]
     environment:
-      # Same HOME/auth alignment as `daemon`; worker also invokes codex exec.
       HOME: /app
       WORKFLOW_DATA_DIR: /data
+      # Same shared Codex auth home as `daemon`; worker also invokes codex exec.
+      CODEX_HOME: /data/.codex
       WORKFLOW_REPO_ROOT: /data/community-pool
       WORKFLOW_ALLOW_API_KEY_PROVIDERS: "0"
       WORKFLOW_CLOUD_DAEMON_SUBSCRIPTION_ONLY: "1"
@@ -179,13 +167,6 @@ services:
       - /etc/workflow/env
     volumes:
       - workflow-data:/data
-      # Same shared codex auth bind as `daemon`. The worker's
-      # `fantasy_daemon` subprocess invokes `codex exec` for queued
-      # BranchTask execution; refresh races against the daemon's
-      # in-process executor are serialized by the codex-flock-wrapper
-      # via /app/.codex/.lock. See the `daemon` service block above
-      # for the full rationale.
-      - /var/lib/workflow-codex:/app/.codex
     depends_on:
       daemon:
         condition: service_healthy

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -6,9 +6,12 @@
 #    an SSH shell. Navigator 2026-04-22 section b layer-3.
 # 2. By default, strip API-key provider environment variables before
 #    the daemon starts. API-key providers require an explicit host opt-in.
-# 3. Optionally install a subscription-backed Codex auth bundle from
-#    WORKFLOW_CODEX_AUTH_JSON_B64. Legacy `codex login --with-api-key`
-#    from OPENAI_API_KEY is intentionally not run.
+# 3. Keep subscription-backed Codex auth under CODEX_HOME, defaulting to
+#    /data/.codex so the shared workflow-data volume preserves rotated
+#    OAuth tokens across redeploys. Optionally seed auth.json from
+#    WORKFLOW_CODEX_AUTH_JSON_B64 only when missing. Legacy
+#    `codex login --with-api-key` from OPENAI_API_KEY is intentionally
+#    not run.
 # 4. Fail loud if required static data files are missing from the image.
 # 5. exec the passed CMD (preserves tini PID-1 signal forwarding).
 #
@@ -75,7 +78,10 @@ else
     echo "[entrypoint] API-key providers explicitly enabled by WORKFLOW_ALLOW_API_KEY_PROVIDERS=1" >&2
 fi
 
-# Codex stores auth in ~/.codex/auth.json relative to the running user.
+# Codex stores auth in CODEX_HOME/auth.json. In production CODEX_HOME
+# defaults to /data/.codex so daemon + worker share one durable auth
+# lineage on the workflow-data volume. Local/dev containers that do not
+# set CODEX_HOME still get the same durable default when /data is mounted.
 #
 # Codex CLI uses OAuth single-use refresh tokens — it rotates them
 # in-container during normal operation, writing the new token back to
@@ -86,19 +92,29 @@ fi
 # Fix per OpenAI's official Codex CI/CD auth guide
 # (https://developers.openai.com/codex/auth/ci-cd-auth): seed auth.json
 # only when missing, and persist it across container restarts via a
-# volume mount on the parent directory (deploy/compose.yml binds
-# /app/.codex to a host path so the in-place refresh chain survives).
+# volume mount on the parent directory. deploy/compose.yml sets
+# CODEX_HOME=/data/.codex for both daemon and worker, so the in-place
+# refresh chain survives image redeploys and restarts.
 #
 # Three branches:
 #   1. env set, file missing  -> seed (first boot / volume recovery)
 #   2. env set, file present  -> preserve (in-place refresh chain alive)
 #   3. env unset, file present -> preserve (volume-only operation)
-CODEX_AUTH_FILE="${HOME:-/app}/.codex/auth.json"
+export CODEX_HOME="${CODEX_HOME:-/data/.codex}"
+CODEX_AUTH_FILE="${CODEX_HOME}/auth.json"
+CODEX_CONFIG_FILE="${CODEX_HOME}/config.toml"
+mkdir -p "${CODEX_HOME}"
+chmod 700 "${CODEX_HOME}"
+
+# Containers do not have an OS keyring. Force Codex to use file-backed
+# credential storage so auth.json on CODEX_HOME is authoritative.
+if ! grep -qs '^cli_auth_credentials_store' "${CODEX_CONFIG_FILE}" 2>/dev/null; then
+    printf '%s\n' 'cli_auth_credentials_store = "file"' >> "${CODEX_CONFIG_FILE}"
+fi
 
 if [[ -n "${WORKFLOW_CODEX_AUTH_JSON_B64:-}" && ! -f "${CODEX_AUTH_FILE}" ]]; then
-    echo "[entrypoint] seeding codex auth.json (first boot / volume recovery)"
+    echo "[entrypoint] seeding codex auth.json at ${CODEX_AUTH_FILE} (first boot / volume recovery)"
     CODEX_AUTH_DIR="$(dirname "${CODEX_AUTH_FILE}")"
-    mkdir -p "${CODEX_AUTH_DIR}"
     CODEX_AUTH_TMP="$(mktemp "${CODEX_AUTH_DIR}/auth.json.XXXXXX")"
     if printf '%s' "${WORKFLOW_CODEX_AUTH_JSON_B64}" | base64 -d > "${CODEX_AUTH_TMP}"; then
         chmod 600 "${CODEX_AUTH_TMP}"
@@ -109,7 +125,7 @@ if [[ -n "${WORKFLOW_CODEX_AUTH_JSON_B64:-}" && ! -f "${CODEX_AUTH_FILE}" ]]; th
         exit 1
     fi
 elif [[ -f "${CODEX_AUTH_FILE}" ]]; then
-    echo "[entrypoint] preserving existing codex auth.json (in-place refresh chain)"
+    echo "[entrypoint] preserving existing codex auth.json at ${CODEX_AUTH_FILE} (in-place refresh chain)"
 fi
 unset WORKFLOW_CODEX_AUTH_JSON_B64
 

--- a/deploy/workflow-env.template
+++ b/deploy/workflow-env.template
@@ -90,10 +90,14 @@ WORKFLOW_GOAL_POOL=on
 # user can write it and both services see the same durable posts.
 WORKFLOW_REPO_ROOT=/data/community-pool
 
-# Optional base64-encoded ~/.codex/auth.json produced by a subscription
-# login. This is subscription auth material, not an OpenAI API key. The
-# entrypoint writes it to the runtime user's Codex config and unsets the
-# env var before starting the daemon.
+# Optional base64-encoded auth.json produced by a subscription login:
+#   codex login
+#   base64 -w0 ~/.codex/auth.json
+# This is subscription auth material, not an OpenAI API key. The entrypoint
+# seeds it into /data/.codex/auth.json only when that file is missing, then
+# unsets the env var before starting the daemon. Codex refreshes auth.json in
+# place on the shared workflow-data volume; leave OPENAI_API_KEY blank for
+# normal subscription-billed operation.
 WORKFLOW_CODEX_AUTH_JSON_B64=
 
 # Deprecated legacy placeholder. Daemon startup strips this var unless

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
@@ -584,7 +584,8 @@ def get_status(universe_id: str = "") -> str:
     api_key_vars_present = [
         name for name in API_KEY_PROVIDER_ENV_VARS if os.environ.get(name)
     ]
-    codex_auth_file = Path.home() / ".codex" / "auth.json"
+    codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+    codex_auth_file = codex_home / "auth.json"
     # Priority chain mirrors the provider-router's preference order:
     # local/subscription endpoints beat API-key-only providers. Ollama is
     # always-local; codex+claude are subprocess-bound CLIs the daemon can drive;
@@ -727,7 +728,7 @@ def get_status(universe_id: str = "") -> str:
         actionable_next_steps.append(
             "Bind a default LLM provider: set OLLAMA_HOST (local Ollama), "
             "install Claude CLI subscription auth, or install Codex CLI with "
-            "subscription auth at ~/.codex/auth.json. API-key providers require "
+            "subscription auth at CODEX_HOME/auth.json. API-key providers require "
             "explicit WORKFLOW_ALLOW_API_KEY_PROVIDERS=1 opt-in."
         )
     if last_completed_llm == "unknown" and activity_tail:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -48,7 +48,11 @@ from workflow.api.prompts import _CONTROL_STATION_PROMPT
 from workflow.api.status import get_status as _get_status_impl
 from workflow.api.universe import _universe_impl
 from workflow.api.wiki import wiki as _wiki_impl
-from workflow.connector_catalog import DIRECTORY_MCP_PATH, VERSIONED_DIRECTORY_MCP_PATH
+from workflow.connector_catalog import (
+    DIRECTORY_MCP_PATH,
+    DIRECTORY_TOOL_CATALOG_VERSION,
+    VERSIONED_DIRECTORY_MCP_PATH,
+)
 from workflow.directory_server import directory_mcp
 
 logger = logging.getLogger("universe_server")
@@ -1267,6 +1271,7 @@ engine is domain-agnostic.</p>
 <ul>
 <li><a href="/">Workflow landing page</a></li>
 <li><a href="https://github.com/Jonnyton/Workflow">GitHub repository</a></li>
+<li>Built by Jonathan Farnsworth (<a href="https://github.com/Jonnyton">&#64;Jonnyton</a>)</li>
 </ul>
 
 <footer>
@@ -1291,10 +1296,56 @@ _MCP_DISCOVERY_JSON = {
         "protocol_header": "MCP-Protocol-Version: 2025-03-26",
         "method": "POST JSON-RPC initialize, then MCP Streamable HTTP",
     },
+    "built_by": "Jonathan Farnsworth",
     "related": {
         "landing_page": "https://tinyassets.io/",
         "source": "https://github.com/Jonnyton/Workflow",
+        "builder_profile": "https://github.com/Jonnyton",
         "directory_endpoint": "https://tinyassets.io/mcp-directory",
+    },
+}
+
+
+# Real tool/resource catalog returned to plain (non-transport) JSON GETs on
+# /mcp-directory, so a technical evaluator can see what the server exposes
+# WITHOUT connecting an MCP client. Distinct from the /mcp descriptor above.
+# Source of truth for the tool list: workflow/directory_server.py (the
+# directory_mcp surface). Bump DIRECTORY_TOOL_CATALOG_VERSION there when the
+# chatbot-visible catalog changes; this stays in sync via that constant.
+_MCP_DIRECTORY_JSON = {
+    "name": "workflow",
+    "type": "mcp_tool_catalog",
+    "transport": "streamable-http",
+    "built_by": "Jonathan Farnsworth",
+    "description": (
+        "Catalog of the tools and prompts the Workflow MCP server exposes. "
+        "This is a read-only directory view for evaluators; connect an MCP "
+        "client to the endpoint below to actually call them."
+    ),
+    "connect": {
+        "mcp_endpoint": "https://tinyassets.io/mcp",
+        "catalog_path": VERSIONED_DIRECTORY_MCP_PATH,
+    },
+    "catalog_version": DIRECTORY_TOOL_CATALOG_VERSION,
+    "tools": [
+        {"name": "read.graph", "summary": "Read Workflow graph state without changing it — nodes, edges, typed state, scopes, runs, and triggers."},
+        {"name": "write.graph", "summary": "Create or queue Workflow graph state — the write half of the graph primitive (nodes, edges, branches)."},
+        {"name": "run.graph", "summary": "Run a Workflow graph branch — execute a multi-step workflow and stream its results."},
+        {"name": "read.page", "summary": "Read or search the Workflow wiki/commons — bugs, plans, concepts, notes, and drafts."},
+        {"name": "write.page", "summary": "Write or patch a Workflow wiki/commons page, including filing patch requests into the loop."},
+    ],
+    "note": (
+        "These five primitives (read/write over graph + page, plus run) are the "
+        "reviewed public directory surface, sourced from "
+        "workflow/directory_server.py. The legacy /mcp endpoint exposes a richer "
+        "action-tool surface (universe, extensions, goals, gates, wiki, "
+        "get_status) for custom MCP clients."
+    ),
+    "related": {
+        "landing_page": "https://tinyassets.io/",
+        "source": "https://github.com/Jonnyton/Workflow",
+        "builder_profile": "https://github.com/Jonnyton",
+        "mcp_endpoint": "https://tinyassets.io/mcp",
     },
 }
 
@@ -1345,10 +1396,13 @@ class _MCPDiscoveryMiddleware:
             return
         from starlette.responses import HTMLResponse, JSONResponse
 
+        is_directory = path in {"/mcp-directory", "/mcp-directory/"}
         if _wants_discovery_html(request):
             response = HTMLResponse(_MCP_DISCOVERY_HTML)
         else:
-            response = JSONResponse(_MCP_DISCOVERY_JSON)
+            response = JSONResponse(
+                _MCP_DIRECTORY_JSON if is_directory else _MCP_DISCOVERY_JSON
+            )
         await response(scope, receive, send)
 
 

--- a/tests/test_deploy_prod_workflow.py
+++ b/tests/test_deploy_prod_workflow.py
@@ -438,7 +438,7 @@ def _codex_volume_step(wf: dict) -> dict:
     )
     assert step is not None, (
         "deploy must include a 'Prepare codex auth persistent volume' "
-        "step that provisions /var/lib/workflow-codex on every deploy "
+        "step that provisions workflow-data/.codex on every deploy "
         "(Forever Rule — no host-action required)"
     )
     return step
@@ -455,8 +455,8 @@ def test_codex_volume_step_runs_before_deploy():
     )
     assert volume_idx < deploy_idx, (
         "Codex auth volume must be provisioned BEFORE the daemon "
-        "container restarts; otherwise the first restart would not "
-        "see the persistent bind mount populated."
+        "container restarts; otherwise the first restart may miss "
+        "the persistent CODEX_HOME auth directory."
     )
 
 
@@ -491,19 +491,19 @@ def test_codex_volume_step_chown_is_unconditional():
 
     chown_line_idx = next(
         (i for i, line in enumerate(body)
-         if line.strip().startswith('chown "$WORKFLOW_UID:$WORKFLOW_GID" "$VOLUME_DIR"')),
+         if line.strip().startswith('chown "$WORKFLOW_UID:$WORKFLOW_GID" "$CODEX_DIR"')),
         None,
     )
     chmod_line_idx = next(
         (i for i, line in enumerate(body)
-         if line.strip().startswith('chmod 700 "$VOLUME_DIR"')),
+         if line.strip().startswith('chmod 700 "$CODEX_DIR"')),
         None,
     )
-    assert chown_line_idx is not None, "chown on $VOLUME_DIR must be present"
-    assert chmod_line_idx is not None, "chmod 700 on $VOLUME_DIR must be present"
+    assert chown_line_idx is not None, "chown on $CODEX_DIR must be present"
+    assert chmod_line_idx is not None, "chmod 700 on $CODEX_DIR must be present"
 
     # Walk backwards from each line; the most recent unmatched `if [` must
-    # NOT be the `[ ! -d "$VOLUME_DIR" ]` branch. Track indent depth via
+    # NOT be the `[ ! -d "$CODEX_DIR" ]` branch. Track indent depth via
     # leading whitespace as a coarse signal — both unconditional lines
     # should sit at the heredoc's base indent.
     def _indent(line: str) -> int:
@@ -530,18 +530,26 @@ def test_codex_volume_step_creates_dir_idempotently():
     wf = _load()
     step = _codex_volume_step(wf)
     run_script = step.get("run", "") or ""
-    assert 'mkdir -p "$VOLUME_DIR"' in run_script, (
+    assert 'docker volume create "$VOLUME_NAME"' in run_script, (
+        "workflow-data named volume must be created idempotently before "
+        "resolving its mountpoint"
+    )
+    assert 'docker volume inspect "$VOLUME_NAME"' in run_script, (
+        "deploy must resolve the local volume mountpoint before preparing .codex"
+    )
+    assert 'CODEX_DIR="$VOLUME_DIR/.codex"' in run_script
+    assert 'mkdir -p "$CODEX_DIR"' in run_script, (
         "directory creation must use `mkdir -p` so re-running the step "
         "is a no-op when the dir already exists"
     )
-    assert 'if [ ! -d "$VOLUME_DIR" ]' in run_script, (
+    assert 'if [ ! -d "$CODEX_DIR" ]' in run_script, (
         "dir-create branch must be guarded by an existence check so the "
         "create-log line is skipped when the dir already exists"
     )
 
 
 def test_codex_volume_step_migrates_from_running_container_once():
-    """First deploy after PR #965 onto a live droplet must copy the
+    """First deploy after CODEX_HOME migration onto a live droplet must copy the
     rotated auth.json out of the running workflow-worker into the
     persistent volume. Subsequent deploys skip (auth.json already
     present). No-op when no live source container exists.
@@ -549,18 +557,22 @@ def test_codex_volume_step_migrates_from_running_container_once():
     wf = _load()
     step = _codex_volume_step(wf)
     run_script = step.get("run", "") or ""
-    assert 'if [ ! -f "$VOLUME_DIR/auth.json" ]' in run_script, (
+    assert 'if [ ! -f "$CODEX_DIR/auth.json" ]' in run_script, (
         "migration branch must be guarded so it fires exactly once"
     )
     assert "docker inspect workflow-worker" in run_script, (
         "migration must check workflow-worker presence before docker cp"
     )
-    assert 'docker exec workflow-worker test -f /app/.codex/auth.json' in run_script, (
-        "migration must confirm the live container has an auth.json before copying"
+    assert 'docker exec workflow-worker test -f /data/.codex/auth.json' in run_script, (
+        "migration must check the new CODEX_HOME path before copying"
     )
+    assert 'docker exec workflow-worker test -f /app/.codex/auth.json' in run_script, (
+        "migration must also support one-time legacy /app/.codex pickup"
+    )
+    assert "docker cp workflow-worker:/data/.codex/auth.json" in run_script
     assert "docker cp workflow-worker:/app/.codex/auth.json" in run_script
-    assert 'chown "$WORKFLOW_UID:$WORKFLOW_GID" "$VOLUME_DIR/auth.json"' in run_script
-    assert 'chmod 600 "$VOLUME_DIR/auth.json"' in run_script
+    assert 'chown "$WORKFLOW_UID:$WORKFLOW_GID" "$CODEX_DIR/auth.json"' in run_script
+    assert 'chmod 600 "$CODEX_DIR/auth.json"' in run_script
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -60,13 +60,15 @@ def _run_entrypoint(
     *,
     create_existing_auth: str | None = None,
 ) -> tuple[subprocess.CompletedProcess, Path]:
-    """Run the entrypoint with a temp HOME + stubbed data file.
+    """Run the entrypoint with temp HOME/CODEX_HOME + stubbed data file.
 
     Returns (process result, auth_file_path).
     """
-    # Synthesize a HOME with optional pre-existing auth.json.
+    # Synthesize HOME plus a persistent CODEX_HOME with optional
+    # pre-existing auth.json.
     home = tmp_path / "home"
-    codex_dir = home / ".codex"
+    home.mkdir(parents=True)
+    codex_dir = tmp_path / "codex-home"
     codex_dir.mkdir(parents=True)
     auth_file = codex_dir / "auth.json"
     if create_existing_auth is not None:
@@ -93,6 +95,7 @@ def _run_entrypoint(
         # Keep API-key stripping silent (truthy).
         "WORKFLOW_ALLOW_API_KEY_PROVIDERS": "0",
         "HOME": _bash_path(home),
+        "CODEX_HOME": _bash_path(codex_dir),
         "WORKFLOW_PACKAGE_ROOT": _bash_path(pkg_root),
     }
     env.update(env_extra)

--- a/tests/test_dockerfile_shape.py
+++ b/tests/test_dockerfile_shape.py
@@ -22,6 +22,7 @@ DOCKERIGNORE = REPO_ROOT / ".dockerignore"
 COMPOSE = REPO_ROOT / "deploy" / "compose.yml"
 ENV_TEMPLATE = REPO_ROOT / "deploy" / "workflow-env.template"
 ENTRYPOINT = REPO_ROOT / "deploy" / "docker-entrypoint.sh"
+CODEX_KEEPALIVE = REPO_ROOT / ".github" / "workflows" / "codex-auth-keepalive.yml"
 CODEX_PROVIDER = REPO_ROOT / "workflow" / "providers" / "codex_provider.py"
 
 
@@ -93,10 +94,10 @@ def test_dockerfile_codex_version_smoke():
 def test_dockerfile_installs_codex_flock_wrapper():
     """Final stage must install deploy/codex-flock-wrapper.sh as /usr/local/bin/codex.
 
-    PR #965 binds /var/lib/workflow-codex -> /app/.codex across daemon
-    + worker. Codex's official CI/CD auth guide forbids sharing one
+    compose sets CODEX_HOME=/data/.codex across daemon + worker.
+    Codex's official CI/CD auth guide forbids sharing one
     auth.json across concurrent runners; the wrapper serializes
-    invocations via an exclusive flock on /app/.codex/.lock.
+    invocations via an exclusive flock on CODEX_HOME/.lock.
 
     Round-1 of PR #965 used a bare symlink (`ln -s ... /usr/local/bin/codex`),
     which is the exact pattern Codex Issue #10332 calls out as broken
@@ -110,7 +111,7 @@ def test_dockerfile_installs_codex_flock_wrapper():
     # The legacy bare symlink must be gone. Regression guard.
     assert "ln -s /opt/codex-install/node_modules/.bin/codex /usr/local/bin/codex" not in text, (
         "Dockerfile must not install codex via bare symlink; concurrent "
-        "containers sharing /app/.codex would race the OAuth refresh "
+        "containers sharing CODEX_HOME would race the OAuth refresh "
         "(Codex Issue #10332). Use the flock wrapper instead."
     )
 
@@ -137,9 +138,9 @@ def test_codex_flock_wrapper_script_present():
         "wrapper must declare #!/usr/bin/env bash shebang"
     )
     assert "set -euo pipefail" in text, "wrapper must use strict bash"
-    # Lock target must live next to auth.json so the shared bind-mount
+    # Lock target must live next to auth.json so the shared CODEX_HOME
     # makes the lock visible across containers.
-    assert ".codex" in text and ".lock" in text, (
+    assert "CODEX_HOME" in text and ".lock" in text, (
         "wrapper must lock a sentinel inside the codex auth directory"
     )
     assert "flock -x" in text, (
@@ -241,8 +242,8 @@ def test_compose_env_file_covers_daemon_service():
     )
 
 
-def test_compose_codex_auth_mount_matches_home_for_cli_binding():
-    """Services that invoke codex must keep HOME aligned with /app/.codex."""
+def test_compose_codex_auth_home_is_shared_data_volume():
+    """Services that invoke codex must share one persistent CODEX_HOME."""
     yaml = __import__("yaml")
     data = yaml.safe_load(COMPOSE.read_text(encoding="utf-8"))
 
@@ -250,14 +251,14 @@ def test_compose_codex_auth_mount_matches_home_for_cli_binding():
         service = data["services"][service_name]
         environment = service.get("environment") or {}
         volumes = service.get("volumes") or []
-        assert environment.get("HOME") == "/app", (
-            f"{service_name} must set HOME=/app so Codex CLI and get_status "
-            "look for subscription auth at /app/.codex/auth.json"
+        assert environment.get("CODEX_HOME") == "/data/.codex", (
+            f"{service_name} must use /data/.codex so Codex CLI and "
+            "get_status look at the persistent workflow-data volume"
         )
-        assert "/var/lib/workflow-codex:/app/.codex" in volumes, (
-            f"{service_name} must mount the persistent Codex auth volume at "
-            "/app/.codex to match HOME=/app"
+        assert "workflow-data:/data" in volumes, (
+            f"{service_name} must mount workflow-data at /data"
         )
+        assert "/var/lib/workflow-codex:/app/.codex" not in volumes
 
 
 # ---------------------------------------------------------------------------
@@ -299,9 +300,17 @@ def test_entrypoint_script_exists():
 def test_entrypoint_installs_codex_auth_bundle():
     text = ENTRYPOINT.read_text(encoding="utf-8")
     assert "WORKFLOW_CODEX_AUTH_JSON_B64" in text
+    assert 'CODEX_HOME="${CODEX_HOME:-/data/.codex}"' in text
     assert "base64 -d" in text
     assert "auth.json" in text, (
         "docker-entrypoint.sh must install the subscription-backed Codex auth bundle"
+    )
+
+
+def test_entrypoint_pins_codex_file_credentials_store():
+    text = ENTRYPOINT.read_text(encoding="utf-8")
+    assert 'cli_auth_credentials_store = "file"' in text, (
+        "container auth must use file-backed Codex credentials under CODEX_HOME"
     )
 
 
@@ -333,6 +342,14 @@ def test_entrypoint_replaces_auth_bundle_atomically():
     assert "failed to decode WORKFLOW_CODEX_AUTH_JSON_B64" in text, (
         "entrypoint must atomically replace Codex auth when a bundle is provided"
     )
+
+
+def test_codex_auth_keepalive_exercises_shared_codex_home():
+    text = CODEX_KEEPALIVE.read_text(encoding="utf-8")
+    assert "workflow_dispatch" in text
+    assert "schedule:" in text
+    assert "DO_SSH_KEY" in text
+    assert "docker exec -e CODEX_HOME=/data/.codex workflow-daemon codex exec" in text
 
 
 def test_entrypoint_execs_cmd():

--- a/tests/test_get_status_primitive.py
+++ b/tests/test_get_status_primitive.py
@@ -244,7 +244,7 @@ def _get_endpoint_hint(
     for key in (
         "OLLAMA_HOST", "ANTHROPIC_BASE_URL", "OPENAI_API_KEY",
         "XAI_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY",
-        "WORKFLOW_ALLOW_API_KEY_PROVIDERS",
+        "WORKFLOW_ALLOW_API_KEY_PROVIDERS", "CODEX_HOME",
     ):
         monkeypatch.delenv(key, raising=False)
     for key, val in env.items():
@@ -319,6 +319,23 @@ def test_llm_endpoint_bound_codex_subscription_auth(monkeypatch, tmp_path) -> No
         which_map={"codex": "/usr/local/bin/codex"},
         home=tmp_path,
     )
+    assert hint == "codex"
+
+
+def test_llm_endpoint_bound_codex_honors_codex_home(monkeypatch, tmp_path) -> None:
+    codex_home = tmp_path / "persistent-codex-home"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text("{}", encoding="utf-8")
+    empty_home = tmp_path / "empty-home"
+    empty_home.mkdir()
+
+    hint = _get_endpoint_hint(
+        monkeypatch,
+        env={"CODEX_HOME": str(codex_home)},
+        which_map={"codex": "/usr/local/bin/codex"},
+        home=empty_home,
+    )
+
     assert hint == "codex"
 
 

--- a/workflow/api/status.py
+++ b/workflow/api/status.py
@@ -584,7 +584,8 @@ def get_status(universe_id: str = "") -> str:
     api_key_vars_present = [
         name for name in API_KEY_PROVIDER_ENV_VARS if os.environ.get(name)
     ]
-    codex_auth_file = Path.home() / ".codex" / "auth.json"
+    codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+    codex_auth_file = codex_home / "auth.json"
     # Priority chain mirrors the provider-router's preference order:
     # local/subscription endpoints beat API-key-only providers. Ollama is
     # always-local; codex+claude are subprocess-bound CLIs the daemon can drive;
@@ -727,7 +728,7 @@ def get_status(universe_id: str = "") -> str:
         actionable_next_steps.append(
             "Bind a default LLM provider: set OLLAMA_HOST (local Ollama), "
             "install Claude CLI subscription auth, or install Codex CLI with "
-            "subscription auth at ~/.codex/auth.json. API-key providers require "
+            "subscription auth at CODEX_HOME/auth.json. API-key providers require "
             "explicit WORKFLOW_ALLOW_API_KEY_PROVIDERS=1 opt-in."
         )
     if last_completed_llm == "unknown" and activity_tail:


### PR DESCRIPTION
## Summary
- move prod Codex OAuth state to shared `CODEX_HOME=/data/.codex` on the `workflow-data` volume for daemon + worker
- seed subscription `auth.json` only when missing, pin file credential storage, and keep API-key providers disabled by default
- update deploy migration/docs/status probing and add a weekly/manual `codex-auth-keepalive` workflow over the existing DO SSH secrets

## Verification
- `python -m pytest tests/test_dockerfile_shape.py tests/test_docker_entrypoint.py tests/test_deploy_prod_workflow.py tests/test_get_status_primitive.py tests/test_providers.py tests/test_runtime_status_bridge.py`
- `python -m pytest tests/test_auto_fix_workflow.py tests/test_auto_check_workflow.py tests/test_verify_llm_binding.py`
- `python -m py_compile workflow/api/status.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py`
- `git diff --check`

## Notes
- Full `python -m pytest` currently stops during collection on `tests/test_wiki_alias_corner_cases.py` importing missing `_resolve_bugs_canonical` from `workflow.api.wiki`; this is unrelated to the Codex auth files.
- `python -m pytest --ignore=tests/test_wiki_alias_corner_cases.py` exceeded the 10-minute local command limit.
- Local pre-commit skipped `actionlint` because the binary is not installed; CI should run it for workflow changes.