### PR TITLE
Add daemon restart watchdog and secure merge bot setup

### DIFF
--- a/.github/workflows/install-host-services.yml
+++ b/.github/workflows/install-host-services.yml
@@ -1,0 +1,77 @@
+name: Install host services
+
+on:
+  workflow_run:
+    workflows: ["Deploy prod"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: install-host-services
+  cancel-in-progress: false
+
+env:
+  DO_DROPLET_HOST: ${{ secrets.DO_DROPLET_HOST }}
+  DO_SSH_USER: ${{ secrets.DO_SSH_USER }}
+
+jobs:
+  install:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify secrets present
+        run: |
+          missing=()
+          [ -z "$DO_DROPLET_HOST" ] && missing+=("DO_DROPLET_HOST")
+          [ -z "$DO_SSH_USER" ] && missing+=("DO_SSH_USER")
+          [ -z "${{ secrets.DO_SSH_KEY }}" ] && missing+=("DO_SSH_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Install SSH key
+        env:
+          SSH_KEY: ${{ secrets.DO_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/do_deploy
+          chmod 600 ~/.ssh/do_deploy
+          ssh-keyscan -t ed25519,rsa "$DO_DROPLET_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Upload host service files
+        run: |
+          scp -i ~/.ssh/do_deploy -o BatchMode=yes \
+              deploy/daemon-watchdog.sh \
+              deploy/daemon-watchdog.service \
+              deploy/daemon-watchdog.timer \
+              deploy/github-app-token-refresher.service \
+              deploy/github-app-token-refresher.timer \
+              scripts/github-app-token-refresher.py \
+              "${DO_SSH_USER}@${DO_DROPLET_HOST}:/tmp/"
+
+      - name: Install and enable host services
+        run: |
+          ssh -i ~/.ssh/do_deploy -o BatchMode=yes "${DO_SSH_USER}@${DO_DROPLET_HOST}" <<'SH'
+          set -euo pipefail
+          sudo mkdir -p /opt/workflow/deploy /opt/workflow/scripts
+          sudo install -m 0755 -o root -g root /tmp/daemon-watchdog.sh /opt/workflow/deploy/daemon-watchdog.sh
+          sudo install -m 0644 -o root -g root /tmp/daemon-watchdog.service /etc/systemd/system/daemon-watchdog.service
+          sudo install -m 0644 -o root -g root /tmp/daemon-watchdog.timer /etc/systemd/system/daemon-watchdog.timer
+          sudo install -m 0755 -o root -g root /tmp/github-app-token-refresher.py /opt/workflow/scripts/github-app-token-refresher.py
+          sudo install -m 0644 -o root -g root /tmp/github-app-token-refresher.service /etc/systemd/system/github-app-token-refresher.service
+          sudo install -m 0644 -o root -g root /tmp/github-app-token-refresher.timer /etc/systemd/system/github-app-token-refresher.timer
+          sudo systemctl daemon-reload
+          sudo systemctl enable --now daemon-watchdog.timer
+          sudo systemctl enable --now github-app-token-refresher.timer
+          sudo systemctl list-timers --no-pager daemon-watchdog.timer github-app-token-refresher.timer || true
+          SH

--- a/.github/workflows/restart-daemon.yml
+++ b/.github/workflows/restart-daemon.yml
@@ -1,0 +1,92 @@
+name: Restart daemon
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for the manual restart'
+        required: false
+        type: string
+      install_watchdog:
+        description: 'Install or refresh daemon-watchdog before restart'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: restart-daemon
+  cancel-in-progress: false
+
+env:
+  DO_DROPLET_HOST: ${{ secrets.DO_DROPLET_HOST }}
+  DO_SSH_USER: ${{ secrets.DO_SSH_USER }}
+  CANARY_URL: https://tinyassets.io/mcp
+
+jobs:
+  restart:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Verify secrets present
+        run: |
+          missing=()
+          [ -z "$DO_DROPLET_HOST" ] && missing+=("DO_DROPLET_HOST")
+          [ -z "$DO_SSH_USER" ] && missing+=("DO_SSH_USER")
+          [ -z "${{ secrets.DO_SSH_KEY }}" ] && missing+=("DO_SSH_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Install SSH key
+        env:
+          SSH_KEY: ${{ secrets.DO_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/do_deploy
+          chmod 600 ~/.ssh/do_deploy
+          ssh-keyscan -t ed25519,rsa "$DO_DROPLET_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Install daemon watchdog
+        if: inputs.install_watchdog == true
+        run: |
+          scp -i ~/.ssh/do_deploy -o BatchMode=yes deploy/daemon-watchdog.sh \
+              "${DO_SSH_USER}@${DO_DROPLET_HOST}:/tmp/daemon-watchdog.sh"
+          scp -i ~/.ssh/do_deploy -o BatchMode=yes deploy/daemon-watchdog.service \
+              "${DO_SSH_USER}@${DO_DROPLET_HOST}:/tmp/daemon-watchdog.service"
+          scp -i ~/.ssh/do_deploy -o BatchMode=yes deploy/daemon-watchdog.timer \
+              "${DO_SSH_USER}@${DO_DROPLET_HOST}:/tmp/daemon-watchdog.timer"
+          ssh -i ~/.ssh/do_deploy -o BatchMode=yes "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
+              "set -e; \
+               sudo mkdir -p /opt/workflow/deploy; \
+               sudo install -m 0755 -o root -g root /tmp/daemon-watchdog.sh /opt/workflow/deploy/daemon-watchdog.sh; \
+               sudo install -m 0644 -o root -g root /tmp/daemon-watchdog.service /etc/systemd/system/daemon-watchdog.service; \
+               sudo install -m 0644 -o root -g root /tmp/daemon-watchdog.timer /etc/systemd/system/daemon-watchdog.timer; \
+               sudo systemctl daemon-reload; \
+               sudo systemctl enable --now daemon-watchdog.timer"
+
+      - name: Restart workflow daemon
+        run: |
+          echo "Restart reason: ${{ inputs.reason }}"
+          ssh -i ~/.ssh/do_deploy -o BatchMode=yes "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
+              "set -e; sudo systemctl reset-failed workflow-daemon.service || true; sudo systemctl restart workflow-daemon.service"
+
+      - name: Wait for public canary
+        run: |
+          for i in $(seq 1 24); do
+            if python scripts/mcp_public_canary.py --url "$CANARY_URL" --timeout 10 >/dev/null 2>&1; then
+              echo "canary green after ${i} poll(s)"
+              exit 0
+            fi
+            sleep 5
+          done
+          python scripts/mcp_public_canary.py --url "$CANARY_URL" --timeout 10 --verbose

--- a/deploy/daemon-watchdog.service
+++ b/deploy/daemon-watchdog.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Workflow daemon container and heartbeat watchdog
+Documentation=https://github.com/Jonnyton/Workflow/blob/main/pages/plans/daemon-uptime-auto-recovery-2026-06-19.md
+Requires=docker.service
+After=docker.service workflow-daemon.service
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+WorkingDirectory=/opt/workflow
+ExecStart=/opt/workflow/deploy/daemon-watchdog.sh
+TimeoutStartSec=90s
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=daemon-watchdog

--- a/deploy/daemon-watchdog.sh
+++ b/deploy/daemon-watchdog.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Recover the Workflow daemon when the systemd unit, compose containers, or
+# daemon heartbeat stop advancing. Intended for systemd timer execution.
+
+set -euo pipefail
+
+COMPOSE_FILE="${WORKFLOW_COMPOSE_FILE:-/opt/workflow/compose.yml}"
+SERVICE_UNIT="${WORKFLOW_DAEMON_UNIT:-workflow-daemon.service}"
+DATA_VOLUME="${WORKFLOW_DATA_VOLUME:-workflow-data}"
+HEARTBEAT_RELATIVE="${WORKFLOW_HEARTBEAT_RELATIVE:-earthos/heartbeat}"
+HEARTBEAT_MAX_AGE_SECONDS="${WORKFLOW_HEARTBEAT_MAX_AGE_SECONDS:-900}"
+LOCK_FILE="${WORKFLOW_DAEMON_WATCHDOG_LOCK:-/run/workflow-daemon-watchdog.lock}"
+LOG_TAG="daemon-watchdog"
+
+log() {
+    printf '%s [%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$LOG_TAG" "$*"
+}
+
+restart_daemon() {
+    local reason="$1"
+    log "restarting ${SERVICE_UNIT}: ${reason}"
+    systemctl reset-failed "${SERVICE_UNIT}" >/dev/null 2>&1 || true
+    systemctl restart "${SERVICE_UNIT}"
+}
+
+container_running() {
+    local name="$1"
+    local state
+    state="$(docker inspect -f '{{.State.Running}}' "$name" 2>/dev/null || true)"
+    [[ "$state" == "true" ]]
+}
+
+heartbeat_path() {
+    local mountpoint
+    mountpoint="$(docker volume inspect "$DATA_VOLUME" --format '{{ .Mountpoint }}' 2>/dev/null || true)"
+    if [[ -z "$mountpoint" ]]; then
+        return 1
+    fi
+    printf '%s/%s\n' "$mountpoint" "$HEARTBEAT_RELATIVE"
+}
+
+heartbeat_stale() {
+    local path="$1"
+    [[ -f "$path" ]] || return 1
+
+    local now mtime age
+    now="$(date +%s)"
+    mtime="$(stat -c %Y "$path")"
+    age=$(( now - mtime ))
+    if (( age > HEARTBEAT_MAX_AGE_SECONDS )); then
+        log "heartbeat stale: ${path} age=${age}s max=${HEARTBEAT_MAX_AGE_SECONDS}s"
+        return 0
+    fi
+    return 1
+}
+
+main() {
+    exec 9>"$LOCK_FILE"
+    if ! flock -n 9; then
+        log "another watchdog run is active; exiting"
+        exit 0
+    fi
+
+    if ! command -v docker >/dev/null 2>&1; then
+        log "docker is unavailable"
+        exit 1
+    fi
+
+    if ! systemctl is-active --quiet "$SERVICE_UNIT"; then
+        restart_daemon "systemd unit is not active"
+        exit 0
+    fi
+
+    if ! container_running workflow-daemon; then
+        restart_daemon "workflow-daemon container is not running"
+        exit 0
+    fi
+
+    if [[ -f "$COMPOSE_FILE" ]]; then
+        docker compose -f "$COMPOSE_FILE" ps >/dev/null
+    fi
+
+    local hb_path=""
+    if hb_path="$(heartbeat_path)"; then
+        if heartbeat_stale "$hb_path"; then
+            restart_daemon "heartbeat stale"
+            exit 0
+        fi
+    else
+        log "heartbeat volume ${DATA_VOLUME} is not available yet; relying on unit/container checks"
+    fi
+
+    log "healthy: unit active, workflow-daemon running"
+}
+
+main "$@"

--- a/deploy/daemon-watchdog.timer
+++ b/deploy/daemon-watchdog.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run Workflow daemon watchdog every two minutes
+Requires=daemon-watchdog.service
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=2min
+AccuracySec=15s
+Persistent=false
+Unit=daemon-watchdog.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/github-app-token-refresher.service
+++ b/deploy/github-app-token-refresher.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Refresh Workflow GitHub App installation token
+Documentation=https://github.com/Jonnyton/Workflow/blob/main/docs/ops/bot-identity-setup.md
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=/etc/workflow/github-app-token-refresher.env
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+WorkingDirectory=/opt/workflow
+EnvironmentFile=/etc/workflow/github-app-token-refresher.env
+ExecStart=/usr/bin/python3 /opt/workflow/scripts/github-app-token-refresher.py
+TimeoutStartSec=60s
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=github-app-token-refresher

--- a/deploy/github-app-token-refresher.timer
+++ b/deploy/github-app-token-refresher.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Refresh Workflow GitHub App installation token before expiry
+Requires=github-app-token-refresher.service
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=45min
+AccuracySec=1min
+RandomizedDelaySec=2min
+Persistent=false
+Unit=github-app-token-refresher.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/ops/bot-identity-setup.md
+++ b/docs/ops/bot-identity-setup.md
@@ -1,0 +1,57 @@
+# Bot identity setup
+
+The community patch loop must use a GitHub identity that is separate from `@Jonnyton`. The bot may create branches, open PRs, and enable auto-merge, but it must not be able to satisfy the founder code-owner review gate or administer the repository.
+
+## GitHub App setup
+
+Create a GitHub App owned by the account or organization that controls `Jonnyton/Workflow`.
+
+Settings:
+
+- Webhook: disabled.
+- Repository access: only `Jonnyton/Workflow`.
+- Repository permissions:
+  - Contents: Read and write.
+  - Pull requests: Read and write.
+  - Metadata: Read-only, implicit.
+- Do not grant Administration, Actions write, Secrets, Members, or Checks write.
+
+After creating the App:
+
+1. Install it on `Jonnyton/Workflow` only.
+2. Record the App ID and installation ID.
+3. Generate a private key and place it on the droplet at `/etc/workflow/github-app-private-key.pem` with `root:root` ownership and `0600` mode.
+4. Create `/etc/workflow/github-app-token-refresher.env` with:
+
+```bash
+GITHUB_APP_ID=<app-id>
+GITHUB_APP_INSTALLATION_ID=<installation-id>
+GITHUB_APP_PRIVATE_KEY_FILE=/etc/workflow/github-app-private-key.pem
+WORKFLOW_GITHUB_PR_CAPABILITIES_REPO=Jonnyton/Workflow
+```
+
+Then run:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now github-app-token-refresher.timer
+sudo systemctl start github-app-token-refresher.service
+sudo systemctl restart workflow-daemon.service
+```
+
+The refresher writes this value into `/etc/workflow/env` through `deploy/install-workflow-env.sh`:
+
+```json
+{"Jonnyton/Workflow":"<installation-token>"}
+```
+
+## Branch protection pairing
+
+Run `scripts/setup-secure-merge-gate.sh` with a GitHub identity that has repository administration permission. The bot identity must not be an admin and must not be listed in `.github/CODEOWNERS`.
+
+Expected merge behavior:
+
+1. The bot opens a PR and may enable auto-merge.
+2. Required checks must pass.
+3. `@Jonnyton` must approve the exact current head because `.github/CODEOWNERS` owns every path.
+4. A new push dismisses the approval and requires re-review.

--- a/scripts/github-app-token-refresher.py
+++ b/scripts/github-app-token-refresher.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Mint a GitHub App installation token and install it for PR effectors.
+
+The script intentionally uses stdlib plus the system openssl binary instead of
+adding Python package dependencies to the host. It writes the minted token into
+/etc/workflow/env through deploy/install-workflow-env.sh as:
+
+    WORKFLOW_GITHUB_PR_CAPABILITIES={"Jonnyton/Workflow":"<token>"}
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+API_ROOT = os.environ.get("GITHUB_API_ROOT", "https://api.github.com")
+APP_ID = os.environ.get("GITHUB_APP_ID", "").strip()
+INSTALLATION_ID = os.environ.get("GITHUB_APP_INSTALLATION_ID", "").strip()
+REPO = os.environ.get("WORKFLOW_GITHUB_PR_CAPABILITIES_REPO", "Jonnyton/Workflow")
+ENV_HELPER = Path(os.environ.get("WORKFLOW_ENV_HELPER", "/opt/workflow/deploy/install-workflow-env.sh"))
+PRIVATE_KEY_FILE = os.environ.get("GITHUB_APP_PRIVATE_KEY_FILE", "").strip()
+PRIVATE_KEY_B64 = os.environ.get("GITHUB_APP_PRIVATE_KEY_B64", "").strip()
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _private_key_path() -> tuple[Path, tempfile.TemporaryDirectory[str] | None]:
+    if PRIVATE_KEY_FILE:
+        path = Path(PRIVATE_KEY_FILE)
+        if not path.is_file():
+            raise SystemExit(f"private key file does not exist: {path}")
+        return path, None
+    if not PRIVATE_KEY_B64:
+        raise SystemExit("set GITHUB_APP_PRIVATE_KEY_FILE or GITHUB_APP_PRIVATE_KEY_B64")
+    tmp = tempfile.TemporaryDirectory(prefix="workflow-github-app-")
+    path = Path(tmp.name) / "app-private-key.pem"
+    path.write_bytes(base64.b64decode(PRIVATE_KEY_B64))
+    path.chmod(0o600)
+    return path, tmp
+
+
+def _sign_rs256(payload: bytes, private_key: Path) -> bytes:
+    result = subprocess.run(
+        ["openssl", "dgst", "-sha256", "-sign", str(private_key), "-binary"],
+        input=payload,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        err = result.stderr.decode("utf-8", errors="replace")[:300]
+        raise SystemExit(f"openssl signing failed: {err}")
+    return result.stdout
+
+
+def _jwt(private_key: Path) -> str:
+    now = int(time.time())
+    header = {"alg": "RS256", "typ": "JWT"}
+    claims = {"iat": now - 60, "exp": now + 540, "iss": APP_ID}
+    signing_input = f"{_b64url(json.dumps(header, separators=(',', ':')).encode())}.{_b64url(json.dumps(claims, separators=(',', ':')).encode())}"
+    signature = _sign_rs256(signing_input.encode("ascii"), private_key)
+    return f"{signing_input}.{_b64url(signature)}"
+
+
+def _request_json(url: str, *, token: str, payload: dict | None = None) -> dict:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method="GET" if payload is None else "POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")[:500]
+        raise SystemExit(f"GitHub API HTTP {exc.code}: {body}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"GitHub API error: {exc}") from exc
+
+
+def _installation_token(app_jwt: str) -> str:
+    url = f"{API_ROOT}/app/installations/{INSTALLATION_ID}/access_tokens"
+    payload = {"permissions": {"contents": "write", "pull_requests": "write"}}
+    result = _request_json(url, token=app_jwt, payload=payload)
+    token = result.get("token", "")
+    if not token:
+        raise SystemExit("GitHub did not return an installation token")
+    return token
+
+
+def _install_capability(token: str) -> None:
+    if not ENV_HELPER.is_file():
+        raise SystemExit(f"env helper does not exist: {ENV_HELPER}")
+    capability = json.dumps({REPO: token}, separators=(",", ":"))
+    result = subprocess.run(
+        ["bash", str(ENV_HELPER), "set", "WORKFLOW_GITHUB_PR_CAPABILITIES"],
+        input=capability,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        err = (result.stderr or result.stdout or "").strip()[:500]
+        raise SystemExit(f"failed to install WORKFLOW_GITHUB_PR_CAPABILITIES: {err}")
+
+
+def main() -> int:
+    if not APP_ID:
+        raise SystemExit("set GITHUB_APP_ID")
+    if not INSTALLATION_ID:
+        raise SystemExit("set GITHUB_APP_INSTALLATION_ID")
+    key_path, tmp = _private_key_path()
+    try:
+        token = _installation_token(_jwt(key_path))
+        _install_capability(token)
+    finally:
+        if tmp is not None:
+            tmp.cleanup()
+    print(f"installed WORKFLOW_GITHUB_PR_CAPABILITIES for {REPO}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/setup-secure-merge-gate.sh
+++ b/scripts/setup-secure-merge-gate.sh
@@ -13,11 +13,9 @@ if ! command -v gh >/dev/null 2>&1; then
     exit 1
 fi
 
-owner="${REPO%%/*}"
-repo="${REPO#*/}"
-
 IFS=',' read -r -a contexts <<< "$REQUIRED_STATUS_CONTEXTS"
 contexts_json="$(printf '%s\n' "${contexts[@]}" | python3 -c 'import json,sys; print(json.dumps([line.strip() for line in sys.stdin if line.strip()]))')"
+protection_url="repos/${REPO}/branches/${BRANCH}/protection"
 
 printf 'Enabling auto-merge for %s...\n' "$REPO"
 gh api --method PATCH "repos/${REPO}" \
@@ -25,7 +23,7 @@ gh api --method PATCH "repos/${REPO}" \
     -f allow_auto_merge=true >/dev/null
 
 printf 'Applying branch protection to %s/%s...\n' "$REPO" "$BRANCH"
-python3 - "$contexts_json" <<'PY' | gh api --method PUT "repos/'"$REPO"'/branches/'"$BRANCH"'/protection" \
+python3 - "$contexts_json" <<'PY' | gh api --method PUT "$protection_url" \
     -H 'Accept: application/vnd.github+json' \
     --input - >/dev/null
 import json

--- a/scripts/setup-secure-merge-gate.sh
+++ b/scripts/setup-secure-merge-gate.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Configure GitHub branch protection so main merges require a founder
+# code-owner review on the current head plus green CI.
+
+set -euo pipefail
+
+REPO="${REPO:-Jonnyton/Workflow}"
+BRANCH="${BRANCH:-main}"
+REQUIRED_STATUS_CONTEXTS="${REQUIRED_STATUS_CONTEXTS:-actionlint,Docker build smoke,Daemon request policy}"
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "gh CLI is required" >&2
+    exit 1
+fi
+
+owner="${REPO%%/*}"
+repo="${REPO#*/}"
+
+IFS=',' read -r -a contexts <<< "$REQUIRED_STATUS_CONTEXTS"
+contexts_json="$(printf '%s\n' "${contexts[@]}" | python3 -c 'import json,sys; print(json.dumps([line.strip() for line in sys.stdin if line.strip()]))')"
+
+printf 'Enabling auto-merge for %s...\n' "$REPO"
+gh api --method PATCH "repos/${REPO}" \
+    -H 'Accept: application/vnd.github+json' \
+    -f allow_auto_merge=true >/dev/null
+
+printf 'Applying branch protection to %s/%s...\n' "$REPO" "$BRANCH"
+python3 - "$contexts_json" <<'PY' | gh api --method PUT "repos/'"$REPO"'/branches/'"$BRANCH"'/protection" \
+    -H 'Accept: application/vnd.github+json' \
+    --input - >/dev/null
+import json
+import sys
+
+contexts = json.loads(sys.argv[1])
+print(json.dumps({
+    "required_status_checks": {
+        "strict": True,
+        "contexts": contexts,
+    },
+    "enforce_admins": True,
+    "required_pull_request_reviews": {
+        "dismiss_stale_reviews": True,
+        "require_code_owner_reviews": True,
+        "required_approving_review_count": 1,
+        "require_last_push_approval": True,
+    },
+    "restrictions": None,
+    "required_linear_history": False,
+    "allow_force_pushes": False,
+    "allow_deletions": False,
+    "block_creations": False,
+    "required_conversation_resolution": True,
+    "lock_branch": False,
+    "allow_fork_syncing": True,
+}))
+PY
+
+printf 'Secure merge gate applied. Verify CODEOWNERS includes @Jonnyton and that the bot is not an admin.\n'


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/restart-daemon.yml` so a manual Actions dispatch can restart `workflow-daemon.service`, wait for the public MCP canary, and optionally install/refresh `daemon-watchdog` first.
- Adds `.github/workflows/install-host-services.yml` so every successful `Deploy prod` run refreshes host-side uptime services: `daemon-watchdog` and the GitHub App token refresher timer.
- Adds `deploy/daemon-watchdog.sh` plus systemd service/timer for unit/container liveness and stale heartbeat recovery.
- Adds `scripts/setup-secure-merge-gate.sh` and `docs/ops/bot-identity-setup.md` for the GitHub-enforced founder review gate.
- Adds `scripts/github-app-token-refresher.py` plus systemd service/timer to mint short-lived GitHub App installation tokens into `WORKFLOW_GITHUB_PR_CAPABILITIES` through the existing atomic env helper.

## Notes

- Based on post-#1188 `main` (`6b5e1703`) so this does not revert the digest-pinning deploy changes.
- `.github/CODEOWNERS` already landed directly on `main` in `e76641f9` because branch protection needs it on the protected branch.
- The separate host-services workflow avoids a stale full-file replacement of the large `deploy-prod.yml` while still making every successful production deploy install/refresh the watchdog and token-refresher units.

## Verification

- Compared branch against `main`: host-service artifacts added without touching digest-pinned deploy semantics.
- Existing head before the host-services workflow addition passed: actionlint, Docker build smoke, Daemon request policy.
- Live brain source pages read: `daemon-uptime-auto-recovery-2026-06-19`, `secure-merge-gate-github-branch-protection-interim-2026-06-19`.
