### PR TITLE
Add head-SHA-bound GitHub merge effector

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/__init__.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/__init__.py
@@ -19,8 +19,12 @@ from __future__ import annotations
 
 from workflow.effectors.github_pr import (
     EXTERNAL_WRITE_SINK_GITHUB_PR,
-    run_effects_for_branch,
+    run_effects_for_branch as _run_github_pr_effects_for_branch,
     run_github_pr_effector,
+)
+from workflow.effectors.github_merge import (
+    EXTERNAL_WRITE_SINK_GITHUB_MERGE,
+    run_github_merge_effector,
 )
 from workflow.effectors.github_read import (
     read_repo_files,
@@ -44,7 +48,70 @@ from workflow.effectors.windows_desktop import (
 register_read_repo_files()
 register_search_repo_files()
 
+
+def _branch_without_github_merge(branch):
+    """Return a branch-like view with github_merge removed from effects."""
+    from types import SimpleNamespace
+
+    filtered_nodes = []
+    for node in getattr(branch, "node_defs", None) or []:
+        effects = list(getattr(node, "effects", None) or [])
+        kept = [sink for sink in effects if sink != EXTERNAL_WRITE_SINK_GITHUB_MERGE]
+        if not kept:
+            continue
+        filtered_nodes.append(
+            SimpleNamespace(
+                node_id=getattr(node, "node_id", ""),
+                output_keys=list(getattr(node, "output_keys", None) or []),
+                effects=kept,
+            )
+        )
+    return SimpleNamespace(node_defs=filtered_nodes)
+
+
+def run_effects_for_branch(
+    *,
+    branch,
+    run_state,
+    base_path=None,
+    run_id="",
+    dry_run=None,
+):
+    """Dispatch all branch effects, including the PR-175 merge effector."""
+    evidence_map = _run_github_pr_effects_for_branch(
+        branch=_branch_without_github_merge(branch),
+        run_state=run_state,
+        base_path=base_path,
+        run_id=run_id,
+        dry_run=dry_run,
+    )
+    for node in getattr(branch, "node_defs", None) or []:
+        effects = list(getattr(node, "effects", None) or [])
+        if EXTERNAL_WRITE_SINK_GITHUB_MERGE not in effects:
+            continue
+        node_id = getattr(node, "node_id", "")
+        output_keys = list(getattr(node, "output_keys", None) or [])
+        per_node = evidence_map.setdefault(node_id, {})
+        try:
+            result = run_github_merge_effector(
+                node_id=node_id,
+                output_keys=output_keys,
+                run_state=run_state,
+                base_path=base_path,
+                run_id=run_id,
+                dry_run=bool(dry_run),
+            )
+        except Exception as exc:  # defensive: never raise from completion path
+            result = {
+                "error": f"effector crashed: {exc}",
+                "error_kind": "effector_crashed",
+            }
+        per_node[EXTERNAL_WRITE_SINK_GITHUB_MERGE] = result
+    return evidence_map
+
+
 __all__ = [
+    "EXTERNAL_WRITE_SINK_GITHUB_MERGE",
     "EXTERNAL_WRITE_SINK_GITHUB_PR",
     "EXTERNAL_WRITE_SINK_WINDOWS_DESKTOP_CLASSIC_GAME",
     "EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK",
@@ -52,6 +119,7 @@ __all__ = [
     "register_read_repo_files",
     "search_repo_files",
     "register_search_repo_files",
+    "run_github_merge_effector",
     "run_github_pr_effector",
     "run_windows_desktop_effector",
     "run_wiki_write_back_effector",

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_merge.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_merge.py
@@ -1,0 +1,363 @@
+"""GitHub merge effector for owner-controlled PR merge authorization.
+
+This is the first PR-175 adapter: GitHub branch protection is the
+authorization surface, and the effector binds the merge request to the exact
+current PR head SHA. Wiki position records may describe review context, but
+they are not accepted as merge authorization.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.error
+import urllib.request
+from typing import Any
+
+from workflow.effectors.github_pr import (
+    _DRY_RUN_ENV,
+    _GH_PR_TIMEOUT_S,
+    _GITHUB_API,
+    _env_truthy,
+    _read_capability,
+)
+
+EXTERNAL_WRITE_SINK_GITHUB_MERGE = "github_merge"
+AUTHORIZATION_MODE_GITHUB_BRANCH_PROTECTION = "github_branch_protection"
+
+_REPO_RE = re.compile(r"[\w.-]+/[\w.-]+")
+_SHA_RE = re.compile(r"[0-9a-fA-F]{40}")
+_MERGE_METHODS = frozenset({"merge", "squash", "rebase"})
+
+
+def _parse_packet(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        packet = value
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped or not stripped.startswith("{"):
+            return None
+        try:
+            packet = json.loads(stripped)
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(packet, dict):
+            return None
+    else:
+        return None
+    if packet.get("sink") != EXTERNAL_WRITE_SINK_GITHUB_MERGE:
+        return None
+    return packet
+
+
+def _error(kind: str, message: str, **extra: Any) -> dict[str, Any]:
+    result: dict[str, Any] = {"error": message, "error_kind": kind, **extra}
+    return result
+
+
+def _github_api(
+    *,
+    method: str,
+    path: str,
+    capability_token: str,
+    body: dict[str, Any] | None = None,
+) -> tuple[Any, dict[str, Any] | None]:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(
+        f"{_GITHUB_API}{path}",
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {capability_token}",
+            "Content-Type": "application/json",
+            "User-Agent": "workflow-github-merge-effector/1.0",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_GH_PR_TIMEOUT_S) as resp:
+            raw = resp.read().decode("utf-8")
+            return (json.loads(raw) if raw.strip() else {}), None
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:500]
+        return None, {"http_status": exc.code, "detail": detail}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return None, {"http_status": None, "detail": str(exc)}
+    except (TypeError, ValueError) as exc:
+        return None, {"http_status": None, "detail": f"parse error: {exc}"}
+
+
+def _merge_error_kind(error: dict[str, Any]) -> str:
+    status = error.get("http_status")
+    if status == 404:
+        return "github_pr_not_found"
+    if status in (401, 403):
+        return "github_merge_denied"
+    if status in (405, 409, 422):
+        return "github_merge_blocked"
+    return "github_api_error"
+
+
+def _payload_authorization_mode(packet: dict[str, Any], payload: dict[str, Any]) -> str:
+    raw = payload.get("authorization_mode") or packet.get("authorization_mode")
+    if isinstance(raw, str):
+        return raw.strip()
+    authorization = payload.get("authorization")
+    if authorization is None:
+        authorization = packet.get("authorization")
+    if isinstance(authorization, dict):
+        mode = authorization.get("mode")
+        if isinstance(mode, str):
+            return mode.strip()
+    return ""
+
+
+def _payload_pr_number(payload: dict[str, Any]) -> int | None:
+    raw = payload.get("pr_number")
+    if isinstance(raw, int) and raw > 0:
+        return raw
+    if isinstance(raw, str) and raw.strip().isdigit():
+        value = int(raw.strip())
+        return value if value > 0 else None
+    return None
+
+
+def _payload_expected_head_sha(payload: dict[str, Any]) -> str:
+    raw = payload.get("expected_head_sha") or payload.get("head_sha") or ""
+    if not isinstance(raw, str):
+        return ""
+    value = raw.strip()
+    return value if _SHA_RE.fullmatch(value) else ""
+
+
+def run_github_merge_effector(
+    *,
+    node_id: str,
+    output_keys: list[str],
+    run_state: dict[str, Any],
+    base_path: str | None = None,
+    run_id: str = "",
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    """Merge a GitHub PR only through head-SHA-bound server authorization.
+
+    The initial authorization adapter is GitHub branch protection. The packet
+    must explicitly opt into that mode, the effector verifies the current head
+    SHA before attempting the merge, and GitHub enforces founder review/status
+    checks on the merge endpoint. Missing or stale authorization fails closed.
+    """
+    del base_path, run_id, dry_run
+
+    matched_key: str | None = None
+    packet: dict[str, Any] | None = None
+    for key in output_keys or []:
+        if not isinstance(key, str) or key not in run_state:
+            continue
+        candidate = _parse_packet(run_state.get(key))
+        if candidate is None:
+            continue
+        matched_key = key
+        packet = candidate
+        break
+    if packet is None:
+        return _error(
+            "no_matching_packet",
+            (
+                f"node '{node_id}' declared effects=[github_merge] but no output_key "
+                "held a parseable external_write_packet with sink='github_merge'"
+            ),
+        )
+
+    if _env_truthy(_DRY_RUN_ENV):
+        return {
+            "dry_run": True,
+            "phase": "phase_2",
+            "reason": "operator_kill_switch_active",
+            "kill_switch_env": _DRY_RUN_ENV,
+            "intent": packet,
+            "matched_output_key": matched_key,
+        }
+
+    destination_raw = packet.get("destination", "")
+    destination = destination_raw.strip().strip("/") if isinstance(destination_raw, str) else ""
+    if not destination or not _REPO_RE.fullmatch(destination):
+        return _error(
+            "invalid_destination",
+            f"packet.destination must be an owner/repo GitHub repository, got {destination_raw!r}",
+            matched_output_key=matched_key,
+        )
+
+    payload = packet.get("payload")
+    if not isinstance(payload, dict):
+        return _error(
+            "invalid_payload",
+            "packet.payload must be a JSON object",
+            destination=destination,
+            matched_output_key=matched_key,
+        )
+
+    authorization_mode = _payload_authorization_mode(packet, payload)
+    if authorization_mode != AUTHORIZATION_MODE_GITHUB_BRANCH_PROTECTION:
+        return _error(
+            "missing_merge_authorization",
+            (
+                "github_merge requires authorization.mode="
+                f"{AUTHORIZATION_MODE_GITHUB_BRANCH_PROTECTION!r}; wiki position records "
+                "are audit context only and cannot authorize a merge"
+            ),
+            destination=destination,
+            authorization_mode=authorization_mode,
+            matched_output_key=matched_key,
+        )
+
+    pr_number = _payload_pr_number(payload)
+    if pr_number is None:
+        return _error(
+            "invalid_pr_number",
+            "packet.payload.pr_number must be a positive integer",
+            destination=destination,
+            matched_output_key=matched_key,
+        )
+
+    expected_head_sha = _payload_expected_head_sha(payload)
+    if not expected_head_sha:
+        return _error(
+            "missing_expected_head_sha",
+            "packet.payload.expected_head_sha must be a 40-character commit SHA",
+            destination=destination,
+            pr_number=pr_number,
+            matched_output_key=matched_key,
+        )
+
+    merge_method = payload.get("merge_method") or "squash"
+    if not isinstance(merge_method, str) or merge_method not in _MERGE_METHODS:
+        return _error(
+            "invalid_merge_method",
+            "packet.payload.merge_method must be one of merge, squash, or rebase",
+            destination=destination,
+            pr_number=pr_number,
+            matched_output_key=matched_key,
+        )
+
+    capability = _read_capability(destination)
+    if not capability:
+        return {
+            "dry_run": True,
+            "phase": "phase_2",
+            "reason": "missing_capability",
+            "destination": destination,
+            "matched_output_key": matched_key,
+            "hint": (
+                "Add the bot installation token to WORKFLOW_GITHUB_PR_CAPABILITIES "
+                f'under the exact key "{destination}".'
+            ),
+            "intent": packet,
+        }
+
+    pr_obj, err = _github_api(
+        method="GET",
+        path=f"/repos/{destination}/pulls/{pr_number}",
+        capability_token=capability,
+    )
+    if err is not None:
+        return _error(
+            _merge_error_kind(err),
+            f"GitHub PR lookup failed: {err.get('detail')}",
+            destination=destination,
+            pr_number=pr_number,
+            http_status=err.get("http_status"),
+            matched_output_key=matched_key,
+        )
+    if not isinstance(pr_obj, dict):
+        return _error(
+            "github_api_error",
+            "GitHub PR lookup returned a non-object response",
+            destination=destination,
+            pr_number=pr_number,
+            matched_output_key=matched_key,
+        )
+
+    if pr_obj.get("state") != "open":
+        return _error(
+            "pr_not_open",
+            f"PR #{pr_number} is not open",
+            destination=destination,
+            pr_number=pr_number,
+            matched_output_key=matched_key,
+        )
+    if bool(pr_obj.get("draft")):
+        return _error(
+            "pr_is_draft",
+            f"PR #{pr_number} is still draft",
+            destination=destination,
+            pr_number=pr_number,
+            matched_output_key=matched_key,
+        )
+
+    actual_head_sha = ((pr_obj.get("head") or {}).get("sha") or "").strip()
+    if actual_head_sha != expected_head_sha:
+        return _error(
+            "head_sha_mismatch",
+            (
+                f"PR #{pr_number} head SHA is {actual_head_sha or '(missing)'}, "
+                f"not expected {expected_head_sha}; refusing stale authorization"
+            ),
+            destination=destination,
+            pr_number=pr_number,
+            expected_head_sha=expected_head_sha,
+            actual_head_sha=actual_head_sha,
+            matched_output_key=matched_key,
+        )
+
+    merge_body: dict[str, Any] = {
+        "sha": expected_head_sha,
+        "merge_method": merge_method,
+    }
+    for source_key, api_key in (
+        ("commit_title", "commit_title"),
+        ("commit_message", "commit_message"),
+    ):
+        value = payload.get(source_key)
+        if isinstance(value, str) and value.strip():
+            merge_body[api_key] = value
+
+    merge_obj, err = _github_api(
+        method="PUT",
+        path=f"/repos/{destination}/pulls/{pr_number}/merge",
+        capability_token=capability,
+        body=merge_body,
+    )
+    if err is not None:
+        return _error(
+            _merge_error_kind(err),
+            f"GitHub merge refused: {err.get('detail')}",
+            destination=destination,
+            pr_number=pr_number,
+            expected_head_sha=expected_head_sha,
+            http_status=err.get("http_status"),
+            matched_output_key=matched_key,
+        )
+    if not isinstance(merge_obj, dict) or merge_obj.get("merged") is not True:
+        return _error(
+            "github_merge_blocked",
+            f"GitHub merge response did not confirm merged=true: {merge_obj!r}",
+            destination=destination,
+            pr_number=pr_number,
+            expected_head_sha=expected_head_sha,
+            matched_output_key=matched_key,
+        )
+
+    merge_commit_sha = merge_obj.get("sha") if isinstance(merge_obj.get("sha"), str) else ""
+    return {
+        "phase": "phase_2",
+        "destination": destination,
+        "matched_output_key": matched_key,
+        "authorization_mode": AUTHORIZATION_MODE_GITHUB_BRANCH_PROTECTION,
+        "pr_number": pr_number,
+        "head_sha": expected_head_sha,
+        "merge_method": merge_method,
+        "merged": True,
+        "merge_commit_sha": merge_commit_sha,
+        "message": merge_obj.get("message") if isinstance(merge_obj.get("message"), str) else "",
+    }

--- a/tests/test_github_merge_effector.py
+++ b/tests/test_github_merge_effector.py
@@ -1,0 +1,165 @@
+"""PR-175: github_merge effector is head-SHA-bound and fail-closed."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from workflow import effectors
+from workflow.effectors import github_merge
+
+_DEST = "Jonnyton/Workflow"
+_HEAD = "a" * 40
+_OTHER_HEAD = "b" * 40
+
+
+def _packet(**payload):
+    data = {
+        "sink": github_merge.EXTERNAL_WRITE_SINK_GITHUB_MERGE,
+        "destination": _DEST,
+        "payload": {
+            "pr_number": 1325,
+            "expected_head_sha": _HEAD,
+            "authorization": {
+                "mode": github_merge.AUTHORIZATION_MODE_GITHUB_BRANCH_PROTECTION,
+            },
+            **payload,
+        },
+    }
+    return {"merge_packet": data}
+
+
+def _run(run_state=None):
+    return github_merge.run_github_merge_effector(
+        node_id="merge",
+        output_keys=["merge_packet"],
+        run_state=_packet() if run_state is None else run_state,
+    )
+
+
+def _with_capability(monkeypatch):
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_PR_CAPABILITIES",
+        json.dumps({_DEST: "capability-token"}),
+    )
+
+
+def _scripted_api(responses):
+    def fake(*, method, path, capability_token, body=None):
+        fake.calls.append((method, path, capability_token, body))
+        for matcher, result in responses:
+            if matcher(method, path):
+                return result
+        raise AssertionError(f"no scripted response for {method} {path}")
+
+    fake.calls = []
+    return fake
+
+
+def _open_pr(head_sha=_HEAD):
+    return {
+        "state": "open",
+        "draft": False,
+        "head": {"sha": head_sha},
+    }
+
+
+def test_missing_authorization_fails_before_github(monkeypatch):
+    _with_capability(monkeypatch)
+    fake = _scripted_api([])
+    monkeypatch.setattr(github_merge, "_github_api", fake)
+    state = _packet(authorization={})
+    result = _run(state)
+    assert result["error_kind"] == "missing_merge_authorization"
+    assert fake.calls == []
+
+
+def test_head_sha_mismatch_refuses_stale_authorization(monkeypatch):
+    _with_capability(monkeypatch)
+    fake = _scripted_api([
+        (lambda m, p: m == "GET" and p.endswith("/pulls/1325"), (_open_pr(_OTHER_HEAD), None)),
+    ])
+    monkeypatch.setattr(github_merge, "_github_api", fake)
+    result = _run()
+    assert result["error_kind"] == "head_sha_mismatch"
+    assert result["expected_head_sha"] == _HEAD
+    assert result["actual_head_sha"] == _OTHER_HEAD
+    assert [call[0] for call in fake.calls] == ["GET"]
+
+
+def test_github_branch_protection_block_is_fail_closed(monkeypatch):
+    _with_capability(monkeypatch)
+    fake = _scripted_api([
+        (lambda m, p: m == "GET" and p.endswith("/pulls/1325"), (_open_pr(), None)),
+        (
+            lambda m, p: m == "PUT" and p.endswith("/pulls/1325/merge"),
+            (None, {"http_status": 405, "detail": "Required reviews are missing"}),
+        ),
+    ])
+    monkeypatch.setattr(github_merge, "_github_api", fake)
+    result = _run()
+    assert result["error_kind"] == "github_merge_blocked"
+    assert result["http_status"] == 405
+    assert fake.calls[1][3]["sha"] == _HEAD
+
+
+def test_successful_merge_is_bound_to_expected_head_sha(monkeypatch):
+    _with_capability(monkeypatch)
+    fake = _scripted_api([
+        (lambda m, p: m == "GET" and p.endswith("/pulls/1325"), (_open_pr(), None)),
+        (
+            lambda m, p: m == "PUT" and p.endswith("/pulls/1325/merge"),
+            ({"merged": True, "sha": "mergecommit", "message": "merged"}, None),
+        ),
+    ])
+    monkeypatch.setattr(github_merge, "_github_api", fake)
+    result = _run()
+    assert result["merged"] is True
+    assert result["head_sha"] == _HEAD
+    assert result["merge_commit_sha"] == "mergecommit"
+    assert fake.calls[1][3] == {"sha": _HEAD, "merge_method": "squash"}
+
+
+def test_missing_capability_returns_dry_run(monkeypatch):
+    monkeypatch.delenv("WORKFLOW_GITHUB_PR_CAPABILITIES", raising=False)
+    fake = _scripted_api([])
+    monkeypatch.setattr(github_merge, "_github_api", fake)
+    result = _run()
+    assert result["dry_run"] is True
+    assert result["reason"] == "missing_capability"
+    assert fake.calls == []
+
+
+def test_operator_kill_switch_returns_dry_run(monkeypatch):
+    monkeypatch.setenv("WORKFLOW_EXTERNAL_WRITE_DRY_RUN", "1")
+    fake = _scripted_api([])
+    monkeypatch.setattr(github_merge, "_github_api", fake)
+    result = _run()
+    assert result["dry_run"] is True
+    assert result["reason"] == "operator_kill_switch_active"
+    assert fake.calls == []
+
+
+def test_package_run_effects_dispatches_github_merge(monkeypatch):
+    def fake_merge(**kwargs):
+        return {"merged": True, "node_id": kwargs["node_id"]}
+
+    monkeypatch.setattr(effectors, "run_github_merge_effector", fake_merge)
+    branch = SimpleNamespace(
+        node_defs=[
+            SimpleNamespace(
+                node_id="merge-node",
+                output_keys=["merge_packet"],
+                effects=[github_merge.EXTERNAL_WRITE_SINK_GITHUB_MERGE],
+            )
+        ]
+    )
+    result = effectors.run_effects_for_branch(branch=branch, run_state=_packet())
+    assert result == {
+        "merge-node": {
+            github_merge.EXTERNAL_WRITE_SINK_GITHUB_MERGE: {
+                "merged": True,
+                "node_id": "merge-node",
+            }
+        }
+    }

--- a/workflow/effectors/__init__.py
+++ b/workflow/effectors/__init__.py
@@ -19,8 +19,12 @@ from __future__ import annotations
 
 from workflow.effectors.github_pr import (
     EXTERNAL_WRITE_SINK_GITHUB_PR,
-    run_effects_for_branch,
+    run_effects_for_branch as _run_github_pr_effects_for_branch,
     run_github_pr_effector,
+)
+from workflow.effectors.github_merge import (
+    EXTERNAL_WRITE_SINK_GITHUB_MERGE,
+    run_github_merge_effector,
 )
 from workflow.effectors.github_read import (
     read_repo_files,
@@ -44,7 +48,70 @@ from workflow.effectors.windows_desktop import (
 register_read_repo_files()
 register_search_repo_files()
 
+
+def _branch_without_github_merge(branch):
+    """Return a branch-like view with github_merge removed from effects."""
+    from types import SimpleNamespace
+
+    filtered_nodes = []
+    for node in getattr(branch, "node_defs", None) or []:
+        effects = list(getattr(node, "effects", None) or [])
+        kept = [sink for sink in effects if sink != EXTERNAL_WRITE_SINK_GITHUB_MERGE]
+        if not kept:
+            continue
+        filtered_nodes.append(
+            SimpleNamespace(
+                node_id=getattr(node, "node_id", ""),
+                output_keys=list(getattr(node, "output_keys", None) or []),
+                effects=kept,
+            )
+        )
+    return SimpleNamespace(node_defs=filtered_nodes)
+
+
+def run_effects_for_branch(
+    *,
+    branch,
+    run_state,
+    base_path=None,
+    run_id="",
+    dry_run=None,
+):
+    """Dispatch all branch effects, including the PR-175 merge effector."""
+    evidence_map = _run_github_pr_effects_for_branch(
+        branch=_branch_without_github_merge(branch),
+        run_state=run_state,
+        base_path=base_path,
+        run_id=run_id,
+        dry_run=dry_run,
+    )
+    for node in getattr(branch, "node_defs", None) or []:
+        effects = list(getattr(node, "effects", None) or [])
+        if EXTERNAL_WRITE_SINK_GITHUB_MERGE not in effects:
+            continue
+        node_id = getattr(node, "node_id", "")
+        output_keys = list(getattr(node, "output_keys", None) or [])
+        per_node = evidence_map.setdefault(node_id, {})
+        try:
+            result = run_github_merge_effector(
+                node_id=node_id,
+                output_keys=output_keys,
+                run_state=run_state,
+                base_path=base_path,
+                run_id=run_id,
+                dry_run=bool(dry_run),
+            )
+        except Exception as exc:  # defensive: never raise from completion path
+            result = {
+                "error": f"effector crashed: {exc}",
+                "error_kind": "effector_crashed",
+            }
+        per_node[EXTERNAL_WRITE_SINK_GITHUB_MERGE] = result
+    return evidence_map
+
+
 __all__ = [
+    "EXTERNAL_WRITE_SINK_GITHUB_MERGE",
     "EXTERNAL_WRITE_SINK_GITHUB_PR",
     "EXTERNAL_WRITE_SINK_WINDOWS_DESKTOP_CLASSIC_GAME",
     "EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK",
@@ -52,6 +119,7 @@ __all__ = [
     "register_read_repo_files",
     "search_repo_files",
     "register_search_repo_files",
+    "run_github_merge_effector",
     "run_github_pr_effector",
     "run_windows_desktop_effector",
     "run_wiki_write_back_effector",

--- a/workflow/effectors/github_merge.py
+++ b/workflow/effectors/github_merge.py
@@ -1,0 +1,363 @@
+"""GitHub merge effector for owner-controlled PR merge authorization.
+
+This is the first PR-175 adapter: GitHub branch protection is the
+authorization surface, and the effector binds the merge request to the exact
+current PR head SHA. Wiki position records may describe review context, but
+they are not accepted as merge authorization.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.error
+import urllib.request
+from typing import Any
+
+from workflow.effectors.github_pr import (
+    _DRY_RUN_ENV,
+    _GH_PR_TIMEOUT_S,
+    _GITHUB_API,
+    _env_truthy,
+    _read_capability,
+)
+
+EXTERNAL_WRITE_SINK_GITHUB_MERGE = "github_merge"
+AUTHORIZATION_MODE_GITHUB_BRANCH_PROTECTION = "github_branch_protection"
+
+_REPO_RE = re.compile(r"[\w.-]+/[\w.-]+")
+_SHA_RE = re.compile(r"[0-9a-fA-F]{40}")
+_MERGE_METHODS = frozenset({"merge", "squash", "rebase"})
+
+
+def _parse_packet(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        packet = value
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped or not stripped.startswith("{"):
+            return None
+        try:
+            packet = json.loads(stripped)
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(packet, dict):
+            return None
+    else:
+        return None
+    if packet.get("sink") != EXTERNAL_WRITE_SINK_GITHUB_MERGE:
+        return None
+    return packet
+
+
+def _error(kind: str, message: str, **extra: Any) -> dict[str, Any]:
+    result: dict[str, Any] = {"error": message, "error_kind": kind, **extra}
+    return result
+
+
+def _github_api(
+    *,
+    method: str,
+    path: str,
+    capability_token: str,
+    body: dict[str, Any] | None = None,
+) -> tuple[Any, dict[str, Any] | None]:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(
+        f"{_GITHUB_API}{path}",
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {capability_token}",
+            "Content-Type": "application/json",
+            "User-Agent": "workflow-github-merge-effector/1.0",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_GH_PR_TIMEOUT_S) as resp:
+            raw = resp.read().decode("utf-8")
+            return (json.loads(raw) if raw.strip() else {}), None
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:500]
+        return None, {"http_status": exc.code, "detail": detail}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return None, {"http_status": None, "detail": str(exc)}
+    except (TypeError, ValueError) as exc:
+        return None, {"http_status": None, "detail": f"parse error: {exc}"}
+
+
+def _merge_error_kind(error: dict[str, Any]) -> str:
+    status = error.get("http_status")
+    if status == 404:
+        return "github_pr_not_found"
+    if status in (401, 403):
+        return "github_merge_denied"
+    if status in (405, 409, 422):
+        return "github_merge_blocked"
+    return "github_api_error"
+
+
+def _payload_authorization_mode(packet: dict[str, Any], payload: dict[str, Any]) -> str:
+    raw = payload.get("authorization_mode") or packet.get("authorization_mode")
+    if isinstance(raw, str):
+        return raw.strip()
+    authorization = payload.get("authorization")
+    if authorization is None:
+        authorization = packet.get("authorization")
+    if isinstance(authorization, dict):
+        mode = authorization.get("mode")
+        if isinstance(mode, str):
+            return mode.strip()
+    return ""
+
+
+def _payload_pr_number(payload: dict[str, Any]) -> int | None:
+    raw = payload.get("pr_number")
+    if isinstance(raw, int) and raw > 0:
+        return raw
+    if isinstance(raw, str) and raw.strip().isdigit():
+        value = int(raw.strip())
+        return value if value > 0 else None
+    return None
+
+
+def _payload_expected_head_sha(payload: dict[str, Any]) -> str:
+    raw = payload.get("expected_head_sha") or payload.get("head_sha") or ""
+    if not isinstance(raw, str):
+        return ""
+    value = raw.strip()
+    return value if _SHA_RE.fullmatch(value) else ""
+
+
+def run_github_merge_effector(
+    *,
+    node_id: str,
+    output_keys: list[str],
+    run_state: dict[str, Any],
+    base_path: str | None = None,
+    run_id: str = "",
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    """Merge a GitHub PR only through head-SHA-bound server authorization.
+
+    The initial authorization adapter is GitHub branch protection. The packet
+    must explicitly opt into that mode, the effector verifies the current head
+    SHA before attempting the merge, and GitHub enforces founder review/status
+    checks on the merge endpoint. Missing or stale authorization fails closed.
+    """
+    del base_path, run_id, dry_run
+
+    matched_key: str | None = None
+    packet: dict[str, Any] | None = None
+    for key in output_keys or []:
+        if not isinstance(key, str) or key not in run_state:
+            continue
+        candidate = _parse_packet(run_state.get(key))
+        if candidate is None:
+            continue
+        matched_key = key
+        packet = candidate
+        break
+    if packet is None:
+        return _error(
+            "no_matching_packet",
+            (
+                f"node '{node_id}' declared effects=[github_merge] but no output_key "
+                "held a parseable external_write_packet with sink='github_merge'"
+            ),
+        )
+
+    if _env_truthy(_DRY_RUN_ENV):
+        return {
+            "dry_run": True,
+            "phase": "phase_2",
+            "reason": "operator_kill_switch_active",
+            "kill_switch_env": _DRY_RUN_ENV,
+            "intent": packet,
+            "matched_output_key": matched_key,
+        }
+
+    destination_raw = packet.get("destination", "")
+    destination = destination_raw.strip().strip("/") if isinstance(destination_raw, str) else ""
+    if not destination or not _REPO_RE.fullmatch(destination):
+        return _error(
+            "invalid_destination",
+            f"packet.destination must be an owner/repo GitHub repository, got {destination_raw!r}",
+            matched_output_key=matched_key,
+        )
+
+    payload = packet.get("payload")
+    if not isinstance(payload, dict):
+        return _error(
+            "invalid_payload",
+            "packet.payload must be a JSON object",
+            destination=destination,
+            matched_output_key=matched_key,
+        )
+
+    authorization_mode = _payload_authorization_mode(packet, payload)
+    if authorization_mode != AUTHORIZATION_MODE_GITHUB_BRANCH_PROTECTION:
+        return _error(
+            "missing_merge_authorization",
+            (
+                "github_merge requires authorization.mode="
+                f"{AUTHORIZATION_MODE_GITHUB_BRANCH_PROTECTION!r}; wiki position records "
+                "are audit context only and cannot authorize a merge"
+            ),
+            destination=destination,
+            authorization_mode=authorization_mode,
+            matched_output_key=matched_key,
+        )
+
+    pr_number = _payload_pr_number(payload)
+    if pr_number is None:
+        return _error(
+            "invalid_pr_number",
+            "packet.payload.pr_number must be a positive integer",
+            destination=destination,
+            matched_output_key=matched_key,
+        )
+
+    expected_head_sha = _payload_expected_head_sha(payload)
+    if not expected_head_sha:
+        return _error(
+            "missing_expected_head_sha",
+            "packet.payload.expected_head_sha must be a 40-character commit SHA",
+            destination=destination,
+            pr_number=pr_number,
+            matched_output_key=matched_key,
+        )
+
+    merge_method = payload.get("merge_method") or "squash"
+    if not isinstance(merge_method, str) or merge_method not in _MERGE_METHODS:
+        return _error(
+            "invalid_merge_method",
+            "packet.payload.merge_method must be one of merge, squash, or rebase",
+            destination=destination,
+            pr_number=pr_number,
+            matched_output_key=matched_key,
+        )
+
+    capability = _read_capability(destination)
+    if not capability:
+        return {
+            "dry_run": True,
+            "phase": "phase_2",
+            "reason": "missing_capability",
+            "destination": destination,
+            "matched_output_key": matched_key,
+            "hint": (
+                "Add the bot installation token to WORKFLOW_GITHUB_PR_CAPABILITIES "
+                f'under the exact key "{destination}".'
+            ),
+            "intent": packet,
+        }
+
+    pr_obj, err = _github_api(
+        method="GET",
+        path=f"/repos/{destination}/pulls/{pr_number}",
+        capability_token=capability,
+    )
+    if err is not None:
+        return _error(
+            _merge_error_kind(err),
+            f"GitHub PR lookup failed: {err.get('detail')}",
+            destination=destination,
+            pr_number=pr_number,
+            http_status=err.get("http_status"),
+            matched_output_key=matched_key,
+        )
+    if not isinstance(pr_obj, dict):
+        return _error(
+            "github_api_error",
+            "GitHub PR lookup returned a non-object response",
+            destination=destination,
+            pr_number=pr_number,
+            matched_output_key=matched_key,
+        )
+
+    if pr_obj.get("state") != "open":
+        return _error(
+            "pr_not_open",
+            f"PR #{pr_number} is not open",
+            destination=destination,
+            pr_number=pr_number,
+            matched_output_key=matched_key,
+        )
+    if bool(pr_obj.get("draft")):
+        return _error(
+            "pr_is_draft",
+            f"PR #{pr_number} is still draft",
+            destination=destination,
+            pr_number=pr_number,
+            matched_output_key=matched_key,
+        )
+
+    actual_head_sha = ((pr_obj.get("head") or {}).get("sha") or "").strip()
+    if actual_head_sha != expected_head_sha:
+        return _error(
+            "head_sha_mismatch",
+            (
+                f"PR #{pr_number} head SHA is {actual_head_sha or '(missing)'}, "
+                f"not expected {expected_head_sha}; refusing stale authorization"
+            ),
+            destination=destination,
+            pr_number=pr_number,
+            expected_head_sha=expected_head_sha,
+            actual_head_sha=actual_head_sha,
+            matched_output_key=matched_key,
+        )
+
+    merge_body: dict[str, Any] = {
+        "sha": expected_head_sha,
+        "merge_method": merge_method,
+    }
+    for source_key, api_key in (
+        ("commit_title", "commit_title"),
+        ("commit_message", "commit_message"),
+    ):
+        value = payload.get(source_key)
+        if isinstance(value, str) and value.strip():
+            merge_body[api_key] = value
+
+    merge_obj, err = _github_api(
+        method="PUT",
+        path=f"/repos/{destination}/pulls/{pr_number}/merge",
+        capability_token=capability,
+        body=merge_body,
+    )
+    if err is not None:
+        return _error(
+            _merge_error_kind(err),
+            f"GitHub merge refused: {err.get('detail')}",
+            destination=destination,
+            pr_number=pr_number,
+            expected_head_sha=expected_head_sha,
+            http_status=err.get("http_status"),
+            matched_output_key=matched_key,
+        )
+    if not isinstance(merge_obj, dict) or merge_obj.get("merged") is not True:
+        return _error(
+            "github_merge_blocked",
+            f"GitHub merge response did not confirm merged=true: {merge_obj!r}",
+            destination=destination,
+            pr_number=pr_number,
+            expected_head_sha=expected_head_sha,
+            matched_output_key=matched_key,
+        )
+
+    merge_commit_sha = merge_obj.get("sha") if isinstance(merge_obj.get("sha"), str) else ""
+    return {
+        "phase": "phase_2",
+        "destination": destination,
+        "matched_output_key": matched_key,
+        "authorization_mode": AUTHORIZATION_MODE_GITHUB_BRANCH_PROTECTION,
+        "pr_number": pr_number,
+        "head_sha": expected_head_sha,
+        "merge_method": merge_method,
+        "merged": True,
+        "merge_commit_sha": merge_commit_sha,
+        "message": merge_obj.get("message") if isinstance(merge_obj.get("message"), str) else "",
+    }


### PR DESCRIPTION
Fixes #1325

## Summary

- Adds a `github_merge` external-write effector that only accepts `authorization.mode=github_branch_protection`.
- Verifies the PR is open, non-draft, and still at `payload.expected_head_sha` before attempting a merge.
- Calls GitHub's merge endpoint with `sha=expected_head_sha` so branch protection and founder CODEOWNERS review remain the server-side enforcement gate.
- Wires package-level `run_effects_for_branch` dispatch for `effects=[github_merge]` without editing the large existing `github_pr.py` effector.
- Mirrors the implementation and dispatch in the packaged Claude plugin runtime.

## Verification

- `python -m py_compile workflow/effectors/github_merge.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_merge.py workflow/effectors/__init__.py packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/__init__.py tests/test_github_merge_effector.py`
- `C:\Users\Jonathan\Projects\Workflow\.venv\Scripts\python.exe -m pytest tests/test_github_merge_effector.py -q` (`7 passed`)
- `C:\Users\Jonathan\Projects\Workflow\.venv\Scripts\python.exe -m pytest tests/test_external_write_effector.py::test_run_effects_for_branch_skips_nodes_without_effects tests/test_external_write_effector.py::test_run_effects_for_branch_no_op_when_no_effects_declared tests/test_external_write_effector.py::test_run_effects_for_branch_records_unknown_sink -q` (`3 passed`)

## Known Adjacent State

A broader adjacent external-write suite still has current-main expectation drift in the existing `github_pr` materialization path (`missing_changes` versus older `gh` invocation expectations). That mismatch is not introduced by this PR-175 merge effector slice.