### PR TITLE
Add search cross-reference to github_read module docstring

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_read.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_read.py
@@ -6,6 +6,7 @@ user-buildable loop EDIT existing files: a node named ``read_repo_files`` (in th
 GitHub repository and writes them into run state, so a downstream
 ``propose_changes`` node can base a correct diff on the real file contents
 instead of guessing.
+See also ``search_repo_files`` in ``workflow/effectors/github_search.py`` for the localization/search counterpart.
 
 Design note: docs/design-notes/2026-05-29-read-repo-files-primitive.md
 (Option A — opaque domain callable; Cowork + Codex review, amendments folded).

--- a/workflow/effectors/github_read.py
+++ b/workflow/effectors/github_read.py
@@ -6,6 +6,7 @@ user-buildable loop EDIT existing files: a node named ``read_repo_files`` (in th
 GitHub repository and writes them into run state, so a downstream
 ``propose_changes`` node can base a correct diff on the real file contents
 instead of guessing.
+See also ``search_repo_files`` in ``workflow/effectors/github_search.py`` for the localization/search counterpart.
 
 Design note: docs/design-notes/2026-05-29-read-repo-files-primitive.md
 (Option A — opaque domain callable; Cowork + Codex review, amendments folded).


### PR DESCRIPTION
This change updates the module docstring in `workflow/effectors/github_read.py` to make `search_repo_files` discoverable alongside `read_repo_files`.

Request: extend the existing read/write wording without changing it, by adding a one-line cross-reference to the localization/search counterpart implemented in `workflow/effectors/github_search.py`.

Bug ID: `manager-health-check-2026-06-20-github-read-docstring-xref`