### PR TITLE
fix(mcp): version-independent handle param labels (PR-178 follow-up)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import json
 from functools import wraps
-from inspect import signature
 from typing import Annotated, Any
 
 from fastmcp import FastMCP
@@ -24,6 +23,7 @@ from workflow.api.market import goals as _goals_impl
 from workflow.api.status import get_status as _get_status_impl
 from workflow.api.universe import _universe_impl
 from workflow.api.wiki import wiki as _wiki_impl
+from workflow.mcp_schema_utils import describe_signature
 
 directory_mcp = FastMCP(
     "workflow-directory",
@@ -159,7 +159,10 @@ def _register_structured_tool(
         return _structured_return(fn(*args, **kwargs))
 
     _tool.__name__ = f"_mcp_{fn.__name__}"
-    _tool.__signature__ = signature(fn).replace(return_annotation=dict)
+    # Inject docstring-derived parameter descriptions so the advertised
+    # tool contract is labelled identically on every FastMCP version.
+    # See workflow.mcp_schema_utils.
+    _tool.__signature__, _tool.__annotations__ = describe_signature(fn)
     kwargs = {"name": name or fn.__name__, "output_schema": None}
     if title is not None:
         kwargs["title"] = title

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/directory_server.py
@@ -13,10 +13,11 @@ from __future__ import annotations
 import json
 from functools import wraps
 from inspect import signature
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
+from pydantic import Field
 
 from workflow.api.extensions import _extensions_impl
 from workflow.api.market import goals as _goals_impl
@@ -344,7 +345,16 @@ def read_page(
     page: str = "",
     query: str = "",
     category: str = "",
-    changed_since: str = "",
+    changed_since: Annotated[
+        str,
+        Field(
+            description=(
+                "Optional ISO timestamp for feed freshness filtering. With an "
+                "empty page/query/category, returns pages changed after this "
+                "timestamp."
+            ),
+        ),
+    ] = "",
     max_results: int = 10,
     universe_id: str = "",
 ) -> str:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/mcp_schema_utils.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/mcp_schema_utils.py
@@ -1,0 +1,147 @@
+"""Version-independent MCP tool parameter descriptions.
+
+FastMCP's docstring->schema extraction is version-dependent: ``fastmcp``
+3.2.0 ships none, 3.4.x parses Google-style ``Args:`` blocks. The live
+``/mcp`` surface must advertise the *same* labelled tool contract on
+every FastMCP/Python combination, so we parse the ``Args:`` block
+ourselves at registration time and inject the descriptions into the
+adapter's signature + annotations. FastMCP reads parameter descriptions
+from ``__annotations__`` on all versions, so this lands the labels
+deterministically without per-parameter ``Field`` boilerplate.
+
+Design: the function docstring is the *default* source of truth; an
+explicit ``Annotated[T, Field(description=...)]`` at the parameter site
+*overrides* it (we never clobber an existing ``Field``). That layering
+keeps one description per parameter while still allowing a hand-tuned
+override where a docstring line would be awkward.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from inspect import Parameter, Signature, signature
+from typing import Annotated, get_type_hints
+
+from pydantic import Field
+from pydantic.fields import FieldInfo
+
+logger = logging.getLogger("mcp_schema_utils")
+
+# Section headers that terminate a Google-style ``Args:`` block.
+_DOC_SECTIONS = frozenset(
+    {
+        "Returns",
+        "Return",
+        "Raises",
+        "Yields",
+        "Examples",
+        "Example",
+        "Note",
+        "Notes",
+        "Attributes",
+        "See Also",
+    }
+)
+
+_ARG_LINE = re.compile(r"^(\w+)\s*(?:\([^)]*\))?:\s*(.*)$")
+
+
+def parse_docstring_args(doc: str | None) -> dict[str, str]:
+    """Extract ``{param: description}`` from a Google-style ``Args:`` block.
+
+    Continuation lines (indented under a parameter) are folded into that
+    parameter's description. Returns an empty dict when there is no
+    ``Args:`` block.
+    """
+    if not doc:
+        return {}
+    out: dict[str, str] = {}
+    in_args = False
+    cur: str | None = None
+    buf: list[str] = []
+
+    def _flush() -> None:
+        if cur is not None:
+            out[cur] = " ".join(buf).strip()
+
+    for line in doc.splitlines():
+        stripped = line.strip()
+        if stripped == "Args:":
+            in_args = True
+            continue
+        if not in_args:
+            continue
+        if stripped.endswith(":") and stripped[:-1] in _DOC_SECTIONS:
+            _flush()
+            cur = None
+            buf = []
+            break
+        match = _ARG_LINE.match(stripped)
+        if match:
+            _flush()
+            cur = match.group(1)
+            buf = [match.group(2)] if match.group(2) else []
+        elif stripped and cur is not None:
+            buf.append(stripped)
+    _flush()
+    return out
+
+
+def _has_explicit_field(annotation: object) -> bool:
+    """True when ``annotation`` already declares a pydantic ``Field``.
+
+    ``get_origin(Annotated[T, ...])`` returns ``T`` (not ``Annotated``), so
+    detection goes through ``__metadata__``, which only ``Annotated`` types
+    carry.
+    """
+    metadata = getattr(annotation, "__metadata__", ())
+    return any(isinstance(meta, FieldInfo) for meta in metadata)
+
+
+def describe_signature(fn) -> tuple[Signature, dict[str, object]]:
+    """Build a labelled ``(signature, annotations)`` pair for an MCP adapter.
+
+    The returned signature has return annotation ``dict`` (FastMCP adapters
+    return a structured dict) and each documented parameter without an
+    explicit ``Field`` gains ``Annotated[ann, Field(description=...)]``.
+    The annotations dict mirrors the signature because FastMCP reads
+    parameter descriptions from ``__annotations__``. Assign both onto the
+    wrapper::
+
+        _tool.__signature__, _tool.__annotations__ = describe_signature(fn)
+    """
+    sig = signature(fn)
+    # Both MCP server modules use ``from __future__ import annotations``
+    # (PEP 563), so ``sig.parameters[...].annotation`` is a *string*.
+    # Resolve to real types (preserving ``Annotated`` metadata) so explicit
+    # ``Field`` overrides are detected and the injected schema is correct.
+    try:
+        hints = get_type_hints(fn, include_extras=True)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("could not resolve type hints for %s: %s", getattr(fn, "__name__", fn), exc)
+        hints = {}
+    descriptions = parse_docstring_args(fn.__doc__)
+    params = []
+    for name, param in sig.parameters.items():
+        annotation = hints.get(name, param.annotation)
+        if (
+            name in descriptions
+            and descriptions[name]
+            and annotation is not Parameter.empty
+            and not _has_explicit_field(annotation)
+        ):
+            annotation = Annotated[annotation, Field(description=descriptions[name])]
+        # Always carry the resolved (real-type) annotation so FastMCP and
+        # the override check see types, not PEP 563 strings.
+        if annotation is not Parameter.empty:
+            param = param.replace(annotation=annotation)
+        params.append(param)
+    new_sig = sig.replace(parameters=params, return_annotation=dict)
+    annotations: dict[str, object] = {
+        name: param.annotation
+        for name, param in new_sig.parameters.items()
+        if param.annotation is not Parameter.empty
+    }
+    annotations["return"] = dict
+    return new_sig, annotations

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import logging
 from contextlib import AsyncExitStack, asynccontextmanager
 from functools import wraps
-from inspect import signature
 from typing import Annotated
 
 import uvicorn
@@ -55,6 +54,7 @@ from workflow.connector_catalog import (
     VERSIONED_DIRECTORY_MCP_PATH,
 )
 from workflow.directory_server import directory_mcp
+from workflow.mcp_schema_utils import describe_signature
 
 logger = logging.getLogger("universe_server")
 
@@ -151,7 +151,11 @@ def _register_structured_tool(fn, *, title, tags, annotations, name=None):
         return _structured_return(fn(*args, **kwargs))
 
     _tool.__name__ = f"_mcp_{fn.__name__}"
-    _tool.__signature__ = signature(fn).replace(return_annotation=dict)
+    # Inject docstring-derived parameter descriptions so the advertised
+    # tool contract is labelled identically on every FastMCP version
+    # (3.2.0 ships no docstring extraction; 3.4.x does). See
+    # workflow.mcp_schema_utils.
+    _tool.__signature__, _tool.__annotations__ = describe_signature(fn)
     return mcp.tool(
         name=name or fn.__name__,
         title=title,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -549,7 +549,16 @@ def read_page(
     page: str = "",
     query: str = "",
     category: str = "",
-    changed_since: str = "",
+    changed_since: Annotated[
+        str,
+        Field(
+            description=(
+                "Optional ISO timestamp for feed freshness filtering. With an "
+                "empty page/query/category, returns pages changed after this "
+                "timestamp."
+            ),
+        ),
+    ] = "",
     max_results: int = 10,
     universe_id: str = "",
 ) -> str:
@@ -1728,11 +1737,31 @@ _MCP_DIRECTORY_JSON = {
     },
     "catalog_version": DIRECTORY_TOOL_CATALOG_VERSION,
     "tools": [
-        {"name": "read.graph", "summary": "Read Workflow graph state without changing it — nodes, edges, typed state, scopes, runs, and triggers."},
-        {"name": "write.graph", "summary": "Create or queue Workflow graph state — the write half of the graph primitive (nodes, edges, branches)."},
-        {"name": "run.graph", "summary": "Run a Workflow graph branch — execute a multi-step workflow and stream its results."},
-        {"name": "read.page", "summary": "Read or search the Workflow wiki/commons — bugs, plans, concepts, notes, and drafts."},
-        {"name": "write.page", "summary": "Write or patch a Workflow wiki/commons page, including filing patch requests into the loop."},
+        {
+            "name": "read.graph",
+            "summary": "Read Workflow graph state without changing it — nodes, "
+            "edges, typed state, scopes, runs, and triggers.",
+        },
+        {
+            "name": "write.graph",
+            "summary": "Create or queue Workflow graph state — the write half "
+            "of the graph primitive (nodes, edges, branches).",
+        },
+        {
+            "name": "run.graph",
+            "summary": "Run a Workflow graph branch — execute a multi-step "
+            "workflow and stream its results.",
+        },
+        {
+            "name": "read.page",
+            "summary": "Read or search the Workflow wiki/commons — bugs, plans, "
+            "concepts, notes, and drafts.",
+        },
+        {
+            "name": "write.page",
+            "summary": "Write or patch a Workflow wiki/commons page, including "
+            "filing patch requests into the loop.",
+        },
     ],
     "note": (
         "These five primitives (read/write over graph + page, plus run) are the "

--- a/tests/test_mcp_handle_param_descriptions.py
+++ b/tests/test_mcp_handle_param_descriptions.py
@@ -1,0 +1,107 @@
+"""Contract lock: every advertised MCP handle parameter must be labelled.
+
+This is the version-independent guard behind PR-178's labelled tool
+surface. FastMCP's own docstring->schema extraction is version-dependent
+(absent in fastmcp 3.2.0, present in 3.4.x), so without
+``workflow.mcp_schema_utils`` the live ``/mcp`` surface would advertise
+unlabelled parameters on some installs and labelled ones on others.
+
+The test asserts the *outcome* (every advertised parameter carries a
+non-empty description) rather than the mechanism, so it stays green
+regardless of which FastMCP version resolves at test time and fails
+loudly if a future parameter or refactor ships an unlabelled param.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Annotated
+
+import pytest
+from pydantic import Field
+
+from workflow import directory_server, universe_server
+from workflow.mcp_schema_utils import describe_signature, parse_docstring_args
+
+
+def _advertised(mcp) -> list:
+    return asyncio.run(mcp.list_tools())
+
+
+def _unlabelled_params(tools) -> list[str]:
+    missing: list[str] = []
+    for tool in tools:
+        props = (tool.parameters or {}).get("properties", {})
+        for pname, pschema in props.items():
+            if not str(pschema.get("description", "")).strip():
+                missing.append(f"{tool.name}.{pname}")
+    return missing
+
+
+@pytest.mark.parametrize(
+    "mcp",
+    [universe_server.mcp, directory_server.directory_mcp],
+    ids=["universe_server", "directory_server"],
+)
+def test_every_advertised_param_is_labelled(mcp):
+    tools = _advertised(mcp)
+    assert tools, "expected the server to advertise at least one tool"
+    missing = _unlabelled_params(tools)
+    assert not missing, (
+        "advertised MCP parameters missing descriptions "
+        f"(FastMCP-version-independent contract violated): {missing}"
+    )
+
+
+def test_five_canonical_handles_fully_labelled():
+    tools = {t.name: t for t in _advertised(universe_server.mcp)}
+    for handle in ("read.graph", "write.graph", "run.graph", "read.page", "write.page"):
+        assert handle in tools, f"canonical handle {handle} not advertised"
+        props = (tools[handle].parameters or {}).get("properties", {})
+        assert props, f"{handle} advertises no parameters"
+        for pname, pschema in props.items():
+            assert str(pschema.get("description", "")).strip(), (
+                f"{handle}.{pname} advertised without a description"
+            )
+
+
+def _parser_sample(a: str = "", b: int = 0) -> str:
+    """Summary.
+
+    Args:
+        a: First parameter description.
+        b: Second parameter
+            spanning two lines.
+
+    Returns:
+        Nothing useful.
+    """
+
+
+def _override_sample(
+    a: Annotated[str, Field(description="explicit override")] = "",
+    b: str = "",
+) -> str:
+    """Summary.
+
+    Args:
+        a: docstring default that must lose to the explicit Field.
+        b: docstring description that should win.
+    """
+
+
+def test_parser_extracts_google_args_block():
+    parsed = parse_docstring_args(_parser_sample.__doc__)
+    assert parsed["a"] == "First parameter description."
+    assert parsed["b"] == "Second parameter spanning two lines."
+    assert "Returns" not in parsed
+
+
+def test_explicit_field_is_not_overridden():
+    # Defined at module scope so get_type_hints resolves Annotated/Field
+    # against module globals (mirrors how the real server modules import them).
+    _, annotations = describe_signature(_override_sample)
+    a_meta = annotations["a"].__metadata__[0]
+    b_meta = annotations["b"].__metadata__[0]
+    assert a_meta.description == "explicit override"
+    assert b_meta.description == "docstring description that should win."

--- a/workflow/directory_server.py
+++ b/workflow/directory_server.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import json
 from functools import wraps
-from inspect import signature
 from typing import Annotated, Any
 
 from fastmcp import FastMCP
@@ -24,6 +23,7 @@ from workflow.api.market import goals as _goals_impl
 from workflow.api.status import get_status as _get_status_impl
 from workflow.api.universe import _universe_impl
 from workflow.api.wiki import wiki as _wiki_impl
+from workflow.mcp_schema_utils import describe_signature
 
 directory_mcp = FastMCP(
     "workflow-directory",
@@ -159,7 +159,10 @@ def _register_structured_tool(
         return _structured_return(fn(*args, **kwargs))
 
     _tool.__name__ = f"_mcp_{fn.__name__}"
-    _tool.__signature__ = signature(fn).replace(return_annotation=dict)
+    # Inject docstring-derived parameter descriptions so the advertised
+    # tool contract is labelled identically on every FastMCP version.
+    # See workflow.mcp_schema_utils.
+    _tool.__signature__, _tool.__annotations__ = describe_signature(fn)
     kwargs = {"name": name or fn.__name__, "output_schema": None}
     if title is not None:
         kwargs["title"] = title

--- a/workflow/directory_server.py
+++ b/workflow/directory_server.py
@@ -13,10 +13,11 @@ from __future__ import annotations
 import json
 from functools import wraps
 from inspect import signature
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
+from pydantic import Field
 
 from workflow.api.extensions import _extensions_impl
 from workflow.api.market import goals as _goals_impl
@@ -344,7 +345,16 @@ def read_page(
     page: str = "",
     query: str = "",
     category: str = "",
-    changed_since: str = "",
+    changed_since: Annotated[
+        str,
+        Field(
+            description=(
+                "Optional ISO timestamp for feed freshness filtering. With an "
+                "empty page/query/category, returns pages changed after this "
+                "timestamp."
+            ),
+        ),
+    ] = "",
     max_results: int = 10,
     universe_id: str = "",
 ) -> str:

--- a/workflow/mcp_schema_utils.py
+++ b/workflow/mcp_schema_utils.py
@@ -1,0 +1,147 @@
+"""Version-independent MCP tool parameter descriptions.
+
+FastMCP's docstring->schema extraction is version-dependent: ``fastmcp``
+3.2.0 ships none, 3.4.x parses Google-style ``Args:`` blocks. The live
+``/mcp`` surface must advertise the *same* labelled tool contract on
+every FastMCP/Python combination, so we parse the ``Args:`` block
+ourselves at registration time and inject the descriptions into the
+adapter's signature + annotations. FastMCP reads parameter descriptions
+from ``__annotations__`` on all versions, so this lands the labels
+deterministically without per-parameter ``Field`` boilerplate.
+
+Design: the function docstring is the *default* source of truth; an
+explicit ``Annotated[T, Field(description=...)]`` at the parameter site
+*overrides* it (we never clobber an existing ``Field``). That layering
+keeps one description per parameter while still allowing a hand-tuned
+override where a docstring line would be awkward.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from inspect import Parameter, Signature, signature
+from typing import Annotated, get_type_hints
+
+from pydantic import Field
+from pydantic.fields import FieldInfo
+
+logger = logging.getLogger("mcp_schema_utils")
+
+# Section headers that terminate a Google-style ``Args:`` block.
+_DOC_SECTIONS = frozenset(
+    {
+        "Returns",
+        "Return",
+        "Raises",
+        "Yields",
+        "Examples",
+        "Example",
+        "Note",
+        "Notes",
+        "Attributes",
+        "See Also",
+    }
+)
+
+_ARG_LINE = re.compile(r"^(\w+)\s*(?:\([^)]*\))?:\s*(.*)$")
+
+
+def parse_docstring_args(doc: str | None) -> dict[str, str]:
+    """Extract ``{param: description}`` from a Google-style ``Args:`` block.
+
+    Continuation lines (indented under a parameter) are folded into that
+    parameter's description. Returns an empty dict when there is no
+    ``Args:`` block.
+    """
+    if not doc:
+        return {}
+    out: dict[str, str] = {}
+    in_args = False
+    cur: str | None = None
+    buf: list[str] = []
+
+    def _flush() -> None:
+        if cur is not None:
+            out[cur] = " ".join(buf).strip()
+
+    for line in doc.splitlines():
+        stripped = line.strip()
+        if stripped == "Args:":
+            in_args = True
+            continue
+        if not in_args:
+            continue
+        if stripped.endswith(":") and stripped[:-1] in _DOC_SECTIONS:
+            _flush()
+            cur = None
+            buf = []
+            break
+        match = _ARG_LINE.match(stripped)
+        if match:
+            _flush()
+            cur = match.group(1)
+            buf = [match.group(2)] if match.group(2) else []
+        elif stripped and cur is not None:
+            buf.append(stripped)
+    _flush()
+    return out
+
+
+def _has_explicit_field(annotation: object) -> bool:
+    """True when ``annotation`` already declares a pydantic ``Field``.
+
+    ``get_origin(Annotated[T, ...])`` returns ``T`` (not ``Annotated``), so
+    detection goes through ``__metadata__``, which only ``Annotated`` types
+    carry.
+    """
+    metadata = getattr(annotation, "__metadata__", ())
+    return any(isinstance(meta, FieldInfo) for meta in metadata)
+
+
+def describe_signature(fn) -> tuple[Signature, dict[str, object]]:
+    """Build a labelled ``(signature, annotations)`` pair for an MCP adapter.
+
+    The returned signature has return annotation ``dict`` (FastMCP adapters
+    return a structured dict) and each documented parameter without an
+    explicit ``Field`` gains ``Annotated[ann, Field(description=...)]``.
+    The annotations dict mirrors the signature because FastMCP reads
+    parameter descriptions from ``__annotations__``. Assign both onto the
+    wrapper::
+
+        _tool.__signature__, _tool.__annotations__ = describe_signature(fn)
+    """
+    sig = signature(fn)
+    # Both MCP server modules use ``from __future__ import annotations``
+    # (PEP 563), so ``sig.parameters[...].annotation`` is a *string*.
+    # Resolve to real types (preserving ``Annotated`` metadata) so explicit
+    # ``Field`` overrides are detected and the injected schema is correct.
+    try:
+        hints = get_type_hints(fn, include_extras=True)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("could not resolve type hints for %s: %s", getattr(fn, "__name__", fn), exc)
+        hints = {}
+    descriptions = parse_docstring_args(fn.__doc__)
+    params = []
+    for name, param in sig.parameters.items():
+        annotation = hints.get(name, param.annotation)
+        if (
+            name in descriptions
+            and descriptions[name]
+            and annotation is not Parameter.empty
+            and not _has_explicit_field(annotation)
+        ):
+            annotation = Annotated[annotation, Field(description=descriptions[name])]
+        # Always carry the resolved (real-type) annotation so FastMCP and
+        # the override check see types, not PEP 563 strings.
+        if annotation is not Parameter.empty:
+            param = param.replace(annotation=annotation)
+        params.append(param)
+    new_sig = sig.replace(parameters=params, return_annotation=dict)
+    annotations: dict[str, object] = {
+        name: param.annotation
+        for name, param in new_sig.parameters.items()
+        if param.annotation is not Parameter.empty
+    }
+    annotations["return"] = dict
+    return new_sig, annotations

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import logging
 from contextlib import AsyncExitStack, asynccontextmanager
 from functools import wraps
-from inspect import signature
 from typing import Annotated
 
 import uvicorn
@@ -55,6 +54,7 @@ from workflow.connector_catalog import (
     VERSIONED_DIRECTORY_MCP_PATH,
 )
 from workflow.directory_server import directory_mcp
+from workflow.mcp_schema_utils import describe_signature
 
 logger = logging.getLogger("universe_server")
 
@@ -151,7 +151,11 @@ def _register_structured_tool(fn, *, title, tags, annotations, name=None):
         return _structured_return(fn(*args, **kwargs))
 
     _tool.__name__ = f"_mcp_{fn.__name__}"
-    _tool.__signature__ = signature(fn).replace(return_annotation=dict)
+    # Inject docstring-derived parameter descriptions so the advertised
+    # tool contract is labelled identically on every FastMCP version
+    # (3.2.0 ships no docstring extraction; 3.4.x does). See
+    # workflow.mcp_schema_utils.
+    _tool.__signature__, _tool.__annotations__ = describe_signature(fn)
     return mcp.tool(
         name=name or fn.__name__,
         title=title,

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -549,7 +549,16 @@ def read_page(
     page: str = "",
     query: str = "",
     category: str = "",
-    changed_since: str = "",
+    changed_since: Annotated[
+        str,
+        Field(
+            description=(
+                "Optional ISO timestamp for feed freshness filtering. With an "
+                "empty page/query/category, returns pages changed after this "
+                "timestamp."
+            ),
+        ),
+    ] = "",
     max_results: int = 10,
     universe_id: str = "",
 ) -> str:
@@ -1728,11 +1737,31 @@ _MCP_DIRECTORY_JSON = {
     },
     "catalog_version": DIRECTORY_TOOL_CATALOG_VERSION,
     "tools": [
-        {"name": "read.graph", "summary": "Read Workflow graph state without changing it — nodes, edges, typed state, scopes, runs, and triggers."},
-        {"name": "write.graph", "summary": "Create or queue Workflow graph state — the write half of the graph primitive (nodes, edges, branches)."},
-        {"name": "run.graph", "summary": "Run a Workflow graph branch — execute a multi-step workflow and stream its results."},
-        {"name": "read.page", "summary": "Read or search the Workflow wiki/commons — bugs, plans, concepts, notes, and drafts."},
-        {"name": "write.page", "summary": "Write or patch a Workflow wiki/commons page, including filing patch requests into the loop."},
+        {
+            "name": "read.graph",
+            "summary": "Read Workflow graph state without changing it — nodes, "
+            "edges, typed state, scopes, runs, and triggers.",
+        },
+        {
+            "name": "write.graph",
+            "summary": "Create or queue Workflow graph state — the write half "
+            "of the graph primitive (nodes, edges, branches).",
+        },
+        {
+            "name": "run.graph",
+            "summary": "Run a Workflow graph branch — execute a multi-step "
+            "workflow and stream its results.",
+        },
+        {
+            "name": "read.page",
+            "summary": "Read or search the Workflow wiki/commons — bugs, plans, "
+            "concepts, notes, and drafts.",
+        },
+        {
+            "name": "write.page",
+            "summary": "Write or patch a Workflow wiki/commons page, including "
+            "filing patch requests into the loop.",
+        },
     ],
     "note": (
         "These five primitives (read/write over graph + page, plus run) are the "


### PR DESCRIPTION
## What

Make the live `/mcp` tool surface advertise the **same labelled parameters on every FastMCP version**, and lock that contract with a test so it can never silently regress.

## Why (the real finding)

PR-178 collapsed the user surface to the 5 canonical handles. Confirming it through the live connector surfaced a subtler issue: **parameter labels depend on FastMCP's docstring→schema extraction, which is version-dependent** — `fastmcp` 3.2.0 ships none, 3.4.x parses Google-style `Args:`. Prod (Python 3.11 + fastmcp 3.4.2) labels everything, so there is **no production bug today**. But the labelled contract was incidental to whichever fastmcp resolved, not guaranteed. If a future fastmcp drops docstring parsing, public params would silently go unlabelled.

## Best-long-term architecture (per host direction)

Rather than the proportionate one-param fix, or duplicating ~49 `Field` descriptions:

- **`workflow/mcp_schema_utils.py`** parses each tool's `Args:` block once at registration and injects the descriptions into the adapter signature + `__annotations__` (which FastMCP reads on **all** versions).
- The **docstring stays the single source of truth**; an explicit `Annotated[T, Field(...)]` at the param site **overrides** it (clean layering, no duplication).
- Resolves PEP 563 string annotations via `get_type_hints` so the override check sees real types.
- Both `universe_server` (live `/mcp`) and `directory_server` route through the shared helper — covers every tool, including legacy.

## Contract lock

`tests/test_mcp_handle_param_descriptions.py` asserts **every advertised handle param carries a non-empty description**, plus parser + override-precedence unit tests. This guards the labelled surface regardless of fastmcp/Python version. Writing it caught two real bugs in the helper (a `get_origin(Annotated)` misdetection and the PEP 563 string-annotation gap) before they shipped.

## Evidence

- Verified on the hardest combo (**fastmcp 3.2.0 + Python 3.14**): all 6 advertised tools, every param labelled — `read.graph` 8/8, `read.page` 6/6, `run.graph` 5/5, `write.graph` 9/9, `write.page` 21/21, `get_status` 1/1.
- 100 passed across MCP server + canary + directory tests; new file 5/5.
- ruff clean on touched files; plugin mirror rebuilt to byte parity.
- deploy-prod post-deploy `--assert-handles` canary will re-prove the live 5-handle surface.

## Open question for host (not changed)

Wire names are dotted (`read.graph`); Claude's connector renders them `read_graph` (dots aren't valid in the client tool-name charset). Ratified vocabulary kept as-is. If you'd prefer wire == display everywhere, switching to underscore is a one-line-per-handle change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)