### PR TITLE
fix(loop): lease-aware startup recovery + idempotent finalize — unwedge dispatcher

### DIFF
--- a/.agents/skills/loop-uptime-maintenance/incidents/2026-06-25-dispatcher-double-claim-wedge.md
+++ b/.agents/skills/loop-uptime-maintenance/incidents/2026-06-25-dispatcher-double-claim-wedge.md
@@ -1,0 +1,127 @@
+---
+incident_date: 2026-06-25
+short_name: dispatcher-double-claim-wedge
+severity: p1
+time_to_recovery_minutes: 30
+applied_by: claude-code-opus-4.8 (session c160dea2)
+---
+
+# Incident: dispatcher wedged — blanket startup recovery double-claims tasks; dead provider auth
+
+The community patch loop had produced **zero terminal successes since ~Jun 3**
+(~3 weeks). Discovered during a post-deploy connector sweep, not by an alarm.
+
+## Symptoms
+
+`read_graph target=status` against live `https://tinyassets.io/mcp`:
+
+- `supervisor_liveness.queue_state`: `depth=5623, pending=19, running=0,
+  succeeded=2476, failed=3128, stuck_pending_max_age_s=851`
+- warning: `stuck_pending: oldest pending task is 851s old (threshold 120s)`
+- 4 worker containers all `Up (healthy)` — so NOT idle workers
+- worker logs: the **same** task (`bt_…d7502b5a`) claimed + executed by
+  `workflow-worker`, `worker-claude-1`, `worker-claude-2`, AND `worker-codex-2`
+  in sequence; repeated `Invalid transition failed -> succeeded` /
+  `failed -> failed` exceptions in `_finalize_claimed_task`; `crashes=5 consec=3`.
+
+## Evidence snapshot
+
+```
+00:09:13 worker        dispatcher_pick: claimed bt_…d7502b5a
+00:11:38 worker-claude-2 dispatcher_pick: claimed bt_…d7502b5a   ← same task
+00:11:43 worker-claude-1 dispatcher_pick: claimed bt_…d7502b5a   ← same task
+CompilerError: Pinned writer provider 'claude-code' exhausted. WORKFLOW_PIN_WRITER disables fallback
+00:11:48 worker-claude-2 executed … status=failed
+ValueError: Invalid transition failed -> succeeded for task bt_…d7502b5a   ← codex success LOST
+…
+daemon-watchdog.service: failed — "required variable WORKFLOW_IMAGE is missing a value"
+/data/.codex/auth.json → codex login status: "Logged in using ChatGPT"   (codex OK)
+/data/.claude → claude -p: "Not logged in · Please run /login"            (claude DEAD)
+```
+
+## Immediate fix applied
+
+Collapsed the fleet to a **single authenticated codex worker** (reversible,
+no file edits, the failed watchdog won't auto-restart them):
+
+```
+docker stop workflow-worker-claude-1 workflow-worker-claude-2 workflow-worker
+# leaves only workflow-worker-codex-2 (codex authed)
+```
+
+This removes the cross-worker claim race and the dead-claude poison.
+
+## Verification
+
+Watched the single codex worker drive a task clean through to terminal
+success **after** the break (the required canary advance):
+
+```
+00:18:06 dispatcher_pick: claimed bt_1782345536900_f7094917
+00:24:32 executed branch task … run=c751d637f075415a status=completed
+00:24:33 dispatcher_pick: finalized bt_1782345536900_f7094917 -> succeeded
+00:24:40 cloud_worker: subprocess exited rc=0 (clean)
+```
+
+Canary record: **request `bt_1782345536900_f7094917` → succeeded** (run
+`c751d637f075415a`), 2026-06-25 00:24:33 UTC, no Invalid-transition crash.
+
+## Question 1 — How did the loop break this time?
+
+`_dispatcher_startup` (runs at *every* fantasy_daemon subprocess start) called
+the blanket `recover_claimed_tasks`, which resets **every** `running` row to
+`pending` — lease-blind. With 4 workers sharing `/data`, each worker restart
+re-queued tasks a live peer was mid-execution on. The task got re-claimed by a
+second worker; when both finalized, the second `mark_status` hit
+`Invalid transition` and threw, **losing genuine successes**. Amplifiers: (a)
+the restart-on-pending producer poll SIGTERMs in-flight tasks, multiplying
+restarts; (b) **claude provider auth on the droplet is dead** ("Not logged
+in"), so the 2 claude workers failed every claim instantly and marked tasks
+`failed` before the codex worker's success could land. Net: 0 successes,
+failed (3128) > succeeded (2476).
+
+## Question 2 — How can the loop notice this break next time, automatically?
+
+The `stuck_pending` warning fired but did not escalate. Add to
+`supervisor_liveness` / `get_status`: (a) a **succeeded-rate-over-window**
+signal — `0 terminal successes in N min while pending>0 and workers healthy`
+is the precise shape; (b) a **duplicate-finalize counter** (count
+Invalid-transition events — non-zero means double-claim); (c) **provider-auth
+health** — surface `claude-code: not logged in` as a provider-down warning so
+"all writers dead" is visible in status, not buried in worker logs.
+
+## Question 3 — How can the loop fix this break next time, automatically?
+
+`daemon-watchdog.service` is the intended auto-recovery layer but is itself
+**failed** (`WORKFLOW_IMAGE` missing) — fixing separately so it can act. A
+periodic stuck-claim reaper (`reclaim_expired_leases` already exists; ensure it
+runs on a timer, not only on claim attempts). Auto-quarantine a provider whose
+auth check fails so dead-auth workers stop poisoning the queue and work routes
+to healthy providers.
+
+## Question 4 — How can the loop avoid this break in the first place next time?
+
+Shipped (PR #1339): startup recovery is now lease-aware (`reclaim_expired_leases`,
+never steals a live peer's fresh-lease task) and `mark_status` is terminal-
+idempotent (first-writer-wins, never crashes on a duplicate finalize). This
+makes the multi-worker fleet structurally immune to the double-claim corruption.
+Deeper, still open: (1) **provider-auth must be monitored + auto-healed** — the
+true root was dead claude auth with no working-provider guarantee; (2) the
+**restart-on-pending producer poll** is a churn amplifier and should be replaced
+by the daemon claiming in a loop (not only at startup), removing the need to
+restart a live subprocess at all.
+
+## Substrate improvement filed
+
+- **PR #1339** — lease-aware startup recovery + idempotent finalize (the cure).
+- Follow-ups (not yet filed as PRs): daemon-watchdog `WORKFLOW_IMAGE` fix
+  (host-side, in progress); claude-auth re-seed on the droplet (host decision —
+  needs their subscription creds, or run a codex-only fleet); restart-on-pending
+  hardening; provider-auth health surfaced in `get_status`.
+
+## PLAN.md update
+
+None required for this incident — the fix restores documented invariant §4.3 #7
+(claimed→pending recovery) with the safer lease-aware mechanism already specified
+under BUG-011 Phase C. The provider-auth-monitoring + restart-on-pending items
+above are candidates for the next loop-uptime design pass if they recur.

--- a/.claude/skills/loop-uptime-maintenance/incidents/2026-06-25-dispatcher-double-claim-wedge.md
+++ b/.claude/skills/loop-uptime-maintenance/incidents/2026-06-25-dispatcher-double-claim-wedge.md
@@ -1,0 +1,127 @@
+---
+incident_date: 2026-06-25
+short_name: dispatcher-double-claim-wedge
+severity: p1
+time_to_recovery_minutes: 30
+applied_by: claude-code-opus-4.8 (session c160dea2)
+---
+
+# Incident: dispatcher wedged — blanket startup recovery double-claims tasks; dead provider auth
+
+The community patch loop had produced **zero terminal successes since ~Jun 3**
+(~3 weeks). Discovered during a post-deploy connector sweep, not by an alarm.
+
+## Symptoms
+
+`read_graph target=status` against live `https://tinyassets.io/mcp`:
+
+- `supervisor_liveness.queue_state`: `depth=5623, pending=19, running=0,
+  succeeded=2476, failed=3128, stuck_pending_max_age_s=851`
+- warning: `stuck_pending: oldest pending task is 851s old (threshold 120s)`
+- 4 worker containers all `Up (healthy)` — so NOT idle workers
+- worker logs: the **same** task (`bt_…d7502b5a`) claimed + executed by
+  `workflow-worker`, `worker-claude-1`, `worker-claude-2`, AND `worker-codex-2`
+  in sequence; repeated `Invalid transition failed -> succeeded` /
+  `failed -> failed` exceptions in `_finalize_claimed_task`; `crashes=5 consec=3`.
+
+## Evidence snapshot
+
+```
+00:09:13 worker        dispatcher_pick: claimed bt_…d7502b5a
+00:11:38 worker-claude-2 dispatcher_pick: claimed bt_…d7502b5a   ← same task
+00:11:43 worker-claude-1 dispatcher_pick: claimed bt_…d7502b5a   ← same task
+CompilerError: Pinned writer provider 'claude-code' exhausted. WORKFLOW_PIN_WRITER disables fallback
+00:11:48 worker-claude-2 executed … status=failed
+ValueError: Invalid transition failed -> succeeded for task bt_…d7502b5a   ← codex success LOST
+…
+daemon-watchdog.service: failed — "required variable WORKFLOW_IMAGE is missing a value"
+/data/.codex/auth.json → codex login status: "Logged in using ChatGPT"   (codex OK)
+/data/.claude → claude -p: "Not logged in · Please run /login"            (claude DEAD)
+```
+
+## Immediate fix applied
+
+Collapsed the fleet to a **single authenticated codex worker** (reversible,
+no file edits, the failed watchdog won't auto-restart them):
+
+```
+docker stop workflow-worker-claude-1 workflow-worker-claude-2 workflow-worker
+# leaves only workflow-worker-codex-2 (codex authed)
+```
+
+This removes the cross-worker claim race and the dead-claude poison.
+
+## Verification
+
+Watched the single codex worker drive a task clean through to terminal
+success **after** the break (the required canary advance):
+
+```
+00:18:06 dispatcher_pick: claimed bt_1782345536900_f7094917
+00:24:32 executed branch task … run=c751d637f075415a status=completed
+00:24:33 dispatcher_pick: finalized bt_1782345536900_f7094917 -> succeeded
+00:24:40 cloud_worker: subprocess exited rc=0 (clean)
+```
+
+Canary record: **request `bt_1782345536900_f7094917` → succeeded** (run
+`c751d637f075415a`), 2026-06-25 00:24:33 UTC, no Invalid-transition crash.
+
+## Question 1 — How did the loop break this time?
+
+`_dispatcher_startup` (runs at *every* fantasy_daemon subprocess start) called
+the blanket `recover_claimed_tasks`, which resets **every** `running` row to
+`pending` — lease-blind. With 4 workers sharing `/data`, each worker restart
+re-queued tasks a live peer was mid-execution on. The task got re-claimed by a
+second worker; when both finalized, the second `mark_status` hit
+`Invalid transition` and threw, **losing genuine successes**. Amplifiers: (a)
+the restart-on-pending producer poll SIGTERMs in-flight tasks, multiplying
+restarts; (b) **claude provider auth on the droplet is dead** ("Not logged
+in"), so the 2 claude workers failed every claim instantly and marked tasks
+`failed` before the codex worker's success could land. Net: 0 successes,
+failed (3128) > succeeded (2476).
+
+## Question 2 — How can the loop notice this break next time, automatically?
+
+The `stuck_pending` warning fired but did not escalate. Add to
+`supervisor_liveness` / `get_status`: (a) a **succeeded-rate-over-window**
+signal — `0 terminal successes in N min while pending>0 and workers healthy`
+is the precise shape; (b) a **duplicate-finalize counter** (count
+Invalid-transition events — non-zero means double-claim); (c) **provider-auth
+health** — surface `claude-code: not logged in` as a provider-down warning so
+"all writers dead" is visible in status, not buried in worker logs.
+
+## Question 3 — How can the loop fix this break next time, automatically?
+
+`daemon-watchdog.service` is the intended auto-recovery layer but is itself
+**failed** (`WORKFLOW_IMAGE` missing) — fixing separately so it can act. A
+periodic stuck-claim reaper (`reclaim_expired_leases` already exists; ensure it
+runs on a timer, not only on claim attempts). Auto-quarantine a provider whose
+auth check fails so dead-auth workers stop poisoning the queue and work routes
+to healthy providers.
+
+## Question 4 — How can the loop avoid this break in the first place next time?
+
+Shipped (PR #1339): startup recovery is now lease-aware (`reclaim_expired_leases`,
+never steals a live peer's fresh-lease task) and `mark_status` is terminal-
+idempotent (first-writer-wins, never crashes on a duplicate finalize). This
+makes the multi-worker fleet structurally immune to the double-claim corruption.
+Deeper, still open: (1) **provider-auth must be monitored + auto-healed** — the
+true root was dead claude auth with no working-provider guarantee; (2) the
+**restart-on-pending producer poll** is a churn amplifier and should be replaced
+by the daemon claiming in a loop (not only at startup), removing the need to
+restart a live subprocess at all.
+
+## Substrate improvement filed
+
+- **PR #1339** — lease-aware startup recovery + idempotent finalize (the cure).
+- Follow-ups (not yet filed as PRs): daemon-watchdog `WORKFLOW_IMAGE` fix
+  (host-side, in progress); claude-auth re-seed on the droplet (host decision —
+  needs their subscription creds, or run a codex-only fleet); restart-on-pending
+  hardening; provider-auth health surfaced in `get_status`.
+
+## PLAN.md update
+
+None required for this incident — the fix restores documented invariant §4.3 #7
+(claimed→pending recovery) with the safer lease-aware mechanism already specified
+under BUG-011 Phase C. The provider-auth-monitoring + restart-on-pending items
+above are candidates for the next loop-uptime design pass if they recur.

--- a/fantasy_daemon/__main__.py
+++ b/fantasy_daemon/__main__.py
@@ -168,20 +168,30 @@ def _soul_loop_dispatch_enabled() -> bool:
 
 
 def _dispatcher_startup(universe_path: Path) -> None:
-    """Phase E startup hook: recover claimed tasks + run GC.
+    """Phase E startup hook: reclaim expired-lease tasks + run GC.
 
     Invariant §4.3 #7 (claimed→pending recovery) and §4.3 #10
     (terminal-task archive). One-shot at ``_run_graph`` entry. Safe
     regardless of dispatcher flag: recovery and GC keep the queue
     file healthy even when the dispatcher is off.
+
+    Uses lease-aware :func:`reclaim_expired_leases`, NOT the blanket
+    :func:`recover_claimed_tasks`. The blanket reset is unsafe in the
+    multi-worker fleet (each worker shares ``/data``): a starting
+    worker would reset *every* ``running`` row — including tasks a live
+    peer worker is mid-execution on — back to ``pending``, so the task
+    gets re-claimed and double-finalized (the ``Invalid transition``
+    crash + lost results that wedged the loop, 2026-06-25 incident).
+    The lease-aware sweep only reclaims rows whose lease actually
+    expired (a wedged/dead worker), leaving healthy peers untouched.
     """
     try:
         from workflow.branch_tasks import (
             garbage_collect,
-            recover_claimed_tasks,
+            reclaim_expired_leases,
         )
 
-        recover_claimed_tasks(universe_path)
+        reclaim_expired_leases(universe_path)
         garbage_collect(universe_path)
     except Exception:  # noqa: BLE001
         logger.exception(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
@@ -64,6 +64,11 @@ _VALID_TRANSITIONS = {
     "cancelled": set(),
 }
 
+# Absorbing states: once a task reaches one of these, a further
+# ``mark_status`` is treated as an idempotent no-op rather than an
+# error (multi-worker duplicate-finalize safety).
+_TERMINAL_STATUSES = frozenset({"succeeded", "failed", "cancelled"})
+
 
 @dataclass
 class BranchTask:
@@ -429,6 +434,22 @@ def mark_status(
             if row.get("branch_task_id") != task_id:
                 continue
             current = row.get("status", "pending")
+            if current in _TERMINAL_STATUSES:
+                # Idempotent finalize: a peer worker or a lease reclaim
+                # already resolved this task. A duplicate finalize must
+                # never crash the daemon or flip a terminal result
+                # (first-writer-wins); it is a no-op. This is the
+                # defence-in-depth half of the 2026-06-25 loop-wedge fix
+                # (the cure is lease-aware startup recovery, which stops
+                # the double-claim that produces these duplicates).
+                if status != current:
+                    logger.warning(
+                        "mark_status: ignoring duplicate finalize "
+                        "%s -> %s for task %s (already terminal; "
+                        "keeping first result)",
+                        current, status, task_id,
+                    )
+                return
             if status not in _VALID_TRANSITIONS.get(current, set()):
                 raise ValueError(
                     f"Invalid transition {current} -> {status} "

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
@@ -64,11 +64,6 @@ _VALID_TRANSITIONS = {
     "cancelled": set(),
 }
 
-# Absorbing states: once a task reaches one of these, a further
-# ``mark_status`` is treated as an idempotent no-op rather than an
-# error (multi-worker duplicate-finalize safety).
-_TERMINAL_STATUSES = frozenset({"succeeded", "failed", "cancelled"})
-
 
 @dataclass
 class BranchTask:
@@ -434,7 +429,7 @@ def mark_status(
             if row.get("branch_task_id") != task_id:
                 continue
             current = row.get("status", "pending")
-            if current in _TERMINAL_STATUSES:
+            if current in TERMINAL_STATUSES:
                 # Idempotent finalize: a peer worker or a lease reclaim
                 # already resolved this task. A duplicate finalize must
                 # never crash the daemon or flip a terminal result

--- a/tests/test_branch_tasks.py
+++ b/tests/test_branch_tasks.py
@@ -4,10 +4,13 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
 from workflow.branch_tasks import (
     BranchTask,
     append_task,
     claim_task,
+    mark_status,
     mark_task_progress,
     new_task_id,
     queue_path,
@@ -142,3 +145,71 @@ def test_recover_claimed_tasks_clears_active_lease_metadata(tmp_path: Path) -> N
     assert recovered.lease_expires_at == ""
     assert recovered.heartbeat_at == ""
     assert recovered.last_progress_at == "2026-05-02T12:00:00+00:00"
+
+
+def test_mark_status_terminal_finalize_is_idempotent(tmp_path: Path) -> None:
+    """A duplicate finalize on an already-terminal task is a no-op.
+
+    Multi-worker duplicate-claim races (and lease reclaims) can finalize
+    the same task twice. The second call must not raise (which would
+    crash the daemon mid-finalize) and must not flip the first result.
+    """
+    task = _task()
+    append_task(tmp_path, task)
+    claim_task(tmp_path, task.branch_task_id, "daemon-a")  # -> running
+
+    mark_status(tmp_path, task.branch_task_id, status="succeeded")
+    # A conflicting late finalize from a duplicate worker: no raise, no flip.
+    mark_status(tmp_path, task.branch_task_id, status="failed", error="late dup")
+    assert read_queue(tmp_path)[0].status == "succeeded"
+    # Same-status duplicate is also a clean no-op.
+    mark_status(tmp_path, task.branch_task_id, status="succeeded")
+    assert read_queue(tmp_path)[0].status == "succeeded"
+
+
+def test_mark_status_still_raises_on_nonterminal_invalid(tmp_path: Path) -> None:
+    """Genuinely invalid non-terminal transitions still raise loudly."""
+    task = _task()
+    append_task(tmp_path, task)  # pending
+    with pytest.raises(ValueError):
+        # pending -> succeeded skips running; a real anomaly, keep surfacing it.
+        mark_status(tmp_path, task.branch_task_id, status="succeeded")
+
+
+def test_dispatcher_startup_preserves_live_peer_running_task(tmp_path: Path) -> None:
+    """Startup recovery must NOT reset a peer's fresh-lease running task.
+
+    The blanket reset (recover_claimed_tasks) stole live peers' tasks on
+    every worker restart, causing double-claim + Invalid-transition wedge
+    (2026-06-25). Startup now uses lease-aware reclaim.
+    """
+    from fantasy_daemon.__main__ import _dispatcher_startup
+
+    task = _task()
+    append_task(tmp_path, task)
+    claim_task(tmp_path, task.branch_task_id, "live-peer")  # stamps a fresh 300s lease
+
+    _dispatcher_startup(tmp_path)
+
+    row = read_queue(tmp_path)[0]
+    assert row.status == "running"  # untouched; blanket reset would make it pending
+    assert row.claimed_by == "live-peer"
+
+
+def test_dispatcher_startup_reclaims_expired_lease(tmp_path: Path) -> None:
+    """A wedged/dead worker's expired-lease task is still reclaimed."""
+    from fantasy_daemon.__main__ import _dispatcher_startup
+
+    task = _task()
+    append_task(tmp_path, task)
+    claim_task(tmp_path, task.branch_task_id, "dead-worker")
+    qp = queue_path(tmp_path)
+    data = json.loads(qp.read_text())
+    data[0]["lease_expires_at"] = "2000-01-01T00:00:00+00:00"  # long expired
+    qp.write_text(json.dumps(data))
+
+    _dispatcher_startup(tmp_path)
+
+    row = read_queue(tmp_path)[0]
+    assert row.status == "pending"
+    assert row.claimed_by == ""

--- a/workflow/branch_tasks.py
+++ b/workflow/branch_tasks.py
@@ -64,6 +64,11 @@ _VALID_TRANSITIONS = {
     "cancelled": set(),
 }
 
+# Absorbing states: once a task reaches one of these, a further
+# ``mark_status`` is treated as an idempotent no-op rather than an
+# error (multi-worker duplicate-finalize safety).
+_TERMINAL_STATUSES = frozenset({"succeeded", "failed", "cancelled"})
+
 
 @dataclass
 class BranchTask:
@@ -429,6 +434,22 @@ def mark_status(
             if row.get("branch_task_id") != task_id:
                 continue
             current = row.get("status", "pending")
+            if current in _TERMINAL_STATUSES:
+                # Idempotent finalize: a peer worker or a lease reclaim
+                # already resolved this task. A duplicate finalize must
+                # never crash the daemon or flip a terminal result
+                # (first-writer-wins); it is a no-op. This is the
+                # defence-in-depth half of the 2026-06-25 loop-wedge fix
+                # (the cure is lease-aware startup recovery, which stops
+                # the double-claim that produces these duplicates).
+                if status != current:
+                    logger.warning(
+                        "mark_status: ignoring duplicate finalize "
+                        "%s -> %s for task %s (already terminal; "
+                        "keeping first result)",
+                        current, status, task_id,
+                    )
+                return
             if status not in _VALID_TRANSITIONS.get(current, set()):
                 raise ValueError(
                     f"Invalid transition {current} -> {status} "

--- a/workflow/branch_tasks.py
+++ b/workflow/branch_tasks.py
@@ -64,11 +64,6 @@ _VALID_TRANSITIONS = {
     "cancelled": set(),
 }
 
-# Absorbing states: once a task reaches one of these, a further
-# ``mark_status`` is treated as an idempotent no-op rather than an
-# error (multi-worker duplicate-finalize safety).
-_TERMINAL_STATUSES = frozenset({"succeeded", "failed", "cancelled"})
-
 
 @dataclass
 class BranchTask:
@@ -434,7 +429,7 @@ def mark_status(
             if row.get("branch_task_id") != task_id:
                 continue
             current = row.get("status", "pending")
-            if current in _TERMINAL_STATUSES:
+            if current in TERMINAL_STATUSES:
                 # Idempotent finalize: a peer worker or a lease reclaim
                 # already resolved this task. A duplicate finalize must
                 # never crash the daemon or flip a terminal result


### PR DESCRIPTION
## Incident: community patch loop wedged since ~Jun 3 (0 successes)

Diagnosed live on the prod droplet (2026-06-25) via `loop-uptime-maintenance`. `get_status` showed `running=0, pending=19, failed=3128, stuck_pending=851s` despite 4 healthy worker containers. The dispatcher claim is atomic and correct — the wedge came from **two multi-worker substrate bugs plus dead provider auth**.

### Root causes (this PR fixes the two code bugs)

1. **Blanket startup recovery steals live peers' tasks.** `_dispatcher_startup` called `recover_claimed_tasks`, which resets *every* `running` row to `pending`, lease-blind. With 4 workers sharing `/data`, each worker restart re-queued tasks a live peer was mid-execution on → the same task claimed+executed by multiple workers sequentially. **Fix:** use the lease-aware `reclaim_expired_leases` (already present, BUG-011 Phase C) — only rows whose lease genuinely expired (dead/wedged worker) are reclaimed; healthy peers keep fresh leases. The runner refreshes its lease per node (<300s window), so long codex calls aren't reaped.

2. **Duplicate finalize crashed the daemon and lost results.** A raced second `mark_status` hit `Invalid transition failed -> succeeded` and threw, discarding a genuine success. **Fix:** already-terminal tasks finalize as an idempotent no-op (first-writer-wins). Genuinely invalid non-terminal transitions still raise.

### Live verification

Immediate mitigation on the droplet — collapse to a single authenticated codex worker (kills the cross-worker race) — produced a clean terminal success straight away:
```
00:18:06 claimed bt_…f7094917
00:24:32 executed … status=completed
00:24:33 finalized bt_…f7094917 -> succeeded   ← terminal success, post-break
```
That's the loop-uptime-maintenance canary advance. This PR makes the **multi-worker** fleet correct so throughput can be restored without the race.

### Tests
- live-peer fresh-lease running task preserved by startup recovery (blanket reset would have stolen it)
- expired-lease task still reclaimed
- terminal finalize idempotent (no flip, no raise)
- non-terminal invalid transition still raises loudly

Plugin mirror (`workflow/branch_tasks.py`) kept byte-parity; `fantasy_daemon` is not mirrored.

### Out of scope (flagged separately, NOT in this PR)
- **Claude provider auth on the droplet is dead** (`/data/.claude` → "Not logged in"); claude workers fail every claim. Needs host re-seed or a codex-only fleet.
- **`daemon-watchdog.service` is failed** (`WORKFLOW_IMAGE` missing) — the auto-recovery layer that should have caught this; fixing separately.
- The restart-on-pending producer poll is a churn amplifier; lease-aware recovery + idempotent finalize neutralize its corruption, but it's a candidate for follow-up hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)