### PR TITLE
harden(watchdog): persist EnvironmentFile + auto-discover real heartbeats

### DIFF
--- a/deploy/daemon-watchdog.service
+++ b/deploy/daemon-watchdog.service
@@ -9,6 +9,11 @@ Type=oneshot
 User=root
 Group=root
 WorkingDirectory=/opt/workflow
+# Load WORKFLOW_IMAGE (and the rest of the deploy env) so the script's
+# `docker compose ps` can interpolate services.daemon.image. Without this the
+# unit failed `required variable WORKFLOW_IMAGE is missing a value` and the
+# whole auto-recovery layer was dark (2026-06-25 loop-wedge incident).
+EnvironmentFile=/etc/workflow/env
 ExecStart=/opt/workflow/deploy/daemon-watchdog.sh
 TimeoutStartSec=90s
 StandardOutput=journal

--- a/deploy/daemon-watchdog.sh
+++ b/deploy/daemon-watchdog.sh
@@ -7,7 +7,10 @@ set -euo pipefail
 COMPOSE_FILE="${WORKFLOW_COMPOSE_FILE:-/opt/workflow/compose.yml}"
 SERVICE_UNIT="${WORKFLOW_DAEMON_UNIT:-workflow-daemon.service}"
 DATA_VOLUME="${WORKFLOW_DATA_VOLUME:-workflow-data}"
-HEARTBEAT_RELATIVE="${WORKFLOW_HEARTBEAT_RELATIVE:-earthos/heartbeat}"
+# Empty default -> auto-discover the freshest worker-supervisor heartbeat
+# (see heartbeat_path). Set WORKFLOW_HEARTBEAT_RELATIVE to a
+# "<universe>/<file>" path under the data volume to pin a specific one.
+HEARTBEAT_RELATIVE="${WORKFLOW_HEARTBEAT_RELATIVE:-}"
 HEARTBEAT_MAX_AGE_SECONDS="${WORKFLOW_HEARTBEAT_MAX_AGE_SECONDS:-900}"
 LOCK_FILE="${WORKFLOW_DAEMON_WATCHDOG_LOCK:-/run/workflow-daemon-watchdog.lock}"
 LOG_TAG="daemon-watchdog"
@@ -36,7 +39,23 @@ heartbeat_path() {
     if [[ -z "$mountpoint" ]]; then
         return 1
     fi
-    printf '%s/%s\n' "$mountpoint" "$HEARTBEAT_RELATIVE"
+    # Operator-pinned path wins.
+    if [[ -n "$HEARTBEAT_RELATIVE" ]]; then
+        printf '%s/%s\n' "$mountpoint" "$HEARTBEAT_RELATIVE"
+        return 0
+    fi
+    # Auto-discover: the active universe rewrites
+    # <universe>/.worker_supervisor*.json every ~15s. Check the FRESHEST one so
+    # a restart fires only when the ENTIRE fleet has gone silent — not a single
+    # dormant universe. The legacy default (earthos/heartbeat) pointed at a path
+    # that never existed, so heartbeat detection was effectively dead.
+    local freshest
+    freshest="$(find "$mountpoint" -name '.worker_supervisor*.json' -printf '%T@ %p\n' 2>/dev/null \
+        | sort -rn | head -1 | cut -d' ' -f2-)"
+    if [[ -z "$freshest" ]]; then
+        return 1
+    fi
+    printf '%s\n' "$freshest"
 }
 
 heartbeat_stale() {


### PR DESCRIPTION
Two fixes to the daemon auto-recovery layer (`daemon-watchdog`), both surfaced by the 2026-06-25 loop wedge:

### 1. `EnvironmentFile` — the watchdog was failing to even run
`daemon-watchdog.service` had no `EnvironmentFile`, so `WORKFLOW_IMAGE` was unset and the script's `docker compose ps` failed `required variable WORKFLOW_IMAGE is missing a value`. The unit was in `failed` state — **the entire auto-recovery layer was dark** during the wedge. Add `EnvironmentFile=/etc/workflow/env` (matching `workflow-daemon.service`). The manual `/etc/systemd` fix applied during incident recovery would otherwise be **reverted** by the next `install-host-services.yml` run (which installs this template), so it must live in the repo.

### 2. Heartbeat detection pointed at a path that never existed
The staleness check targeted `earthos/heartbeat` — `earthos` is a dormant universe and that file never existed, so heartbeat-based detection was effectively dead. The active universe writes `<universe>/.worker_supervisor*.json` every ~15s. Replace the hardcoded default with **auto-discovery of the freshest** `.worker_supervisor*.json` under the data volume, so a restart fires only when the **entire fleet** has gone silent (>900s) — adapting to whichever universe is active. `WORKFLOW_HEARTBEAT_RELATIVE` still pins an explicit path when set.

### Verification
`bash -n` clean; functional test confirms auto-discovery selects the fresh supervisor heartbeat and ignores the legacy `earthos` path; FRESH (age 0s) → no restart. Propagates to the droplet via `install-host-services.yml`.

Note: this catches a *fully dead* fleet (all supervisors silent). It would NOT have caught the actual wedge (supervisors kept beating while tasks stalled) — that "tasks not completing" class needs the loop-progress signal tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)