### PR TITLE
feat(status): loop-stall detector + lease-window/orphan-recovery fixes (Codex review)

### DIFF
--- a/fantasy_daemon/__main__.py
+++ b/fantasy_daemon/__main__.py
@@ -191,7 +191,11 @@ def _dispatcher_startup(universe_path: Path) -> None:
             reclaim_expired_leases,
         )
 
-        reclaim_expired_leases(universe_path)
+        # reclaim_leaseless=True: startup is the one safe place to also reset
+        # running rows that carry no lease (pre-lease-era / corrupt orphans),
+        # which the lease-only sweep skips and would otherwise strand forever
+        # (Codex cross-family review, 2026-06-25).
+        reclaim_expired_leases(universe_path, reclaim_leaseless=True)
         garbage_collect(universe_path)
     except Exception:  # noqa: BLE001
         logger.exception(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
@@ -49,6 +49,12 @@ _HEARTBEAT_STALE_THRESHOLD_S = _HEARTBEAT_REFRESH_INTERVAL_S * 2
 # BUG-009 class).
 _STUCK_PENDING_THRESHOLD_S = 120
 
+# Loop-stall window: if a backlog (pending tasks older than this) has produced
+# ZERO terminal transitions within the same window, the loop is stalled even
+# though workers may look busy — the 2026-06-25 wedge ran ~3 weeks because no
+# signal distinguished "claiming but never completing" from healthy operation.
+_LOOP_STALL_WINDOW_S = int(os.environ.get("WORKFLOW_LOOP_STALL_WINDOW_S", "1800"))
+
 # Auto-ship observation window surfaced in get_status.auto_ship_health.
 _AUTO_SHIP_OBSERVATION_WINDOW_S = 24 * 60 * 60
 _AUTO_SHIP_RECENT_ATTEMPT_LIMIT = 10
@@ -381,6 +387,7 @@ def _compute_supervisor_liveness(
             "stuck_pending_max_age_s": 0,
             "policy_parked_pending_max_age_s": 0,
             "stuck_running_max_age_s": 0,
+            "recent_succeeded_count": 0,
         },
         "running_tasks_lease": [],
         "stale_running_tasks": [],
@@ -410,11 +417,30 @@ def _compute_supervisor_liveness(
     pending_ages: list[float] = []
     policy_parked_pending_ages: list[float] = []
     running_ages: list[float] = []
+    recent_succeeded_count = 0
+    any_terminal_at_seen = False
 
     for task in queue:
         status = getattr(task, "status", "") or ""
         if status in out["queue_state"]:
             out["queue_state"][status] = out["queue_state"].get(status, 0) + 1
+
+        # Completion-health signal. We count recent SUCCESSES (not all
+        # terminals): a loop that only produces failures is still wedged.
+        # ``any_terminal_at_seen`` gates the stall warning so a freshly
+        # deployed queue (terminal_at not yet stamped on any row) cannot
+        # false-fire — during a real wedge the fail-fast tasks stamp
+        # terminal_at, so the gate opens while successes stay at zero.
+        terminal_at = getattr(task, "terminal_at", "") or ""
+        if terminal_at:
+            any_terminal_at_seen = True
+            terminal_ts = _parse_iso_to_epoch(terminal_at)
+            if (
+                status == "succeeded"
+                and terminal_ts is not None
+                and (now_ts - terminal_ts) <= _LOOP_STALL_WINDOW_S
+            ):
+                recent_succeeded_count += 1
 
         # Pending-task age (queued_at -> now). Detects dispatcher pickup
         # gaps even before a task gets claimed (today's BUG-009 pattern).
@@ -520,6 +546,8 @@ def _compute_supervisor_liveness(
     # warning. Today's BUG-009 RCA: a pending task that sits >2min
     # without claim means the supervisor restart logic isn't reaching
     # the queue (the exact pattern PR #205 fixed).
+    out["queue_state"]["recent_succeeded_count"] = recent_succeeded_count
+
     if (
         out["queue_state"]["stuck_pending_max_age_s"]
         > _STUCK_PENDING_THRESHOLD_S
@@ -530,6 +558,30 @@ def _compute_supervisor_liveness(
             f"(threshold {_STUCK_PENDING_THRESHOLD_S}s). Likely "
             "supervisor restart loop, dispatcher disabled, or daemon "
             "subprocess wedged. See PR #206 spec for incident pattern."
+        )
+
+    # Loop-stall: a backlog older than the window with ZERO successful
+    # completions in that window means the loop is claiming but never
+    # succeeding — the durable 2026-06-25 wedge signature (which ran ~3 weeks
+    # undetected). Distinct from stuck_pending (pickup latency): this is the
+    # completion-rate dimension, and counts successes only so a fail-only loop
+    # still trips it. ``any_terminal_at_seen`` suppresses the false-positive on
+    # a freshly deployed queue whose rows predate the terminal_at field.
+    if (
+        recent_succeeded_count == 0
+        and any_terminal_at_seen
+        and out["queue_state"]["pending"] > 0
+        and out["queue_state"]["stuck_pending_max_age_s"] > _LOOP_STALL_WINDOW_S
+    ):
+        out["warnings"].append(
+            f"loop_stalled: 0 successful completions in the last "
+            f"{_LOOP_STALL_WINDOW_S}s despite "
+            f"{out['queue_state']['pending']} pending "
+            f"(oldest {out['queue_state']['stuck_pending_max_age_s']}s) and "
+            f"{out['queue_state']['failed']} failed total. The loop is claiming "
+            "but not succeeding — provider auth, double-claim, or finalize crash "
+            "(2026-06-25 loop-wedge signature). Check worker logs for provider "
+            "'exhausted' / 'Invalid transition'."
         )
 
     if out["queue_state"]["running"] > 0 and not any_lease_field_seen:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
@@ -35,7 +35,13 @@ logger = logging.getLogger(__name__)
 QUEUE_FILENAME = "branch_tasks.json"
 ARCHIVE_FILENAME = "branch_tasks_archive.json"
 LOCK_FILENAME = "branch_tasks.json.lock"
-DEFAULT_LEASE_SECONDS = 300
+# Lease window. INVARIANT: must comfortably exceed the worst-case time between
+# heartbeat refreshes, which happen per graph node (not on an independent
+# timer). A single writer node can run the whole provider fallback chain, each
+# attempt up to ModelConfig.timeout (300s) — so ~900s worst case. 1800s gives a
+# 2x margin so a long-but-healthy node is never wrongly reclaimed mid-flight
+# (Codex cross-family review, 2026-06-25: lease==provider-timeout was a race).
+DEFAULT_LEASE_SECONDS = 1800
 
 # Exposed for test override (invariant 10).
 ARCHIVE_AFTER_DAYS = 30
@@ -553,6 +559,7 @@ def reclaim_expired_leases(
     universe_path: Path,
     *,
     now: datetime | None = None,
+    reclaim_leaseless: bool = False,
 ) -> int:
     """Lease-aware reclaim: reset ``running`` rows whose lease expired.
 
@@ -566,6 +573,14 @@ def reclaim_expired_leases(
     dispatcher claim path, so every claim attempt sweeps first and a
     wedged claim is reaped on the next pick instead of the next daemon
     restart. Returns the count reclaimed.
+
+    ``reclaim_leaseless`` (startup-only): also reset ``running`` rows that
+    carry NO lease / an unparsable one. Since ``claim_task`` always stamps a
+    lease, a lease-less running row can only be a pre-lease-era or corrupt
+    orphan — never a live peer — so it is safe to reclaim. Without this a
+    lease-less row would stay ``running`` forever once startup stopped using
+    the blanket :func:`recover_claimed_tasks` (Codex cross-family review,
+    2026-06-25).
     """
     current = now or datetime.now(timezone.utc)
     qp = queue_path(universe_path)
@@ -578,17 +593,19 @@ def reclaim_expired_leases(
             if not isinstance(row, dict) or row.get("status") != "running":
                 continue
             lease_raw = str(row.get("lease_expires_at") or "")
-            if not lease_raw:
-                # Pre-lease-era claim: no lease to judge by; leave it
-                # for startup recovery rather than guessing.
+            lease_at = _parse_iso_utc(lease_raw) if lease_raw else None
+            if lease_at is not None and lease_at > current:
+                continue  # live lease — never touch a healthy peer
+            if lease_at is None and not reclaim_leaseless:
+                # No / unparsable lease. A current-code worker always stamps a
+                # valid one, so this is a pre-lease-era or corrupt orphan, but
+                # only the startup sweep reclaims it (no risk of racing a peer).
                 continue
-            lease_at = _parse_iso_utc(lease_raw)
-            if lease_at is None or lease_at > current:
-                continue
+            expired_for = (current - lease_at) if lease_at is not None else "no-lease"
             logger.warning(
-                "branch_tasks reclaim: lease expired %s ago on %s "
+                "branch_tasks reclaim: lease expired %s on %s "
                 "(claimed_by=%s heartbeat_at=%s) — resetting to pending",
-                current - lease_at,
+                expired_for,
                 row.get("branch_task_id"),
                 row.get("claimed_by"),
                 row.get("heartbeat_at"),

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
@@ -97,6 +97,11 @@ class BranchTask:
     lease_expires_at: str = ""
     heartbeat_at: str = ""
     last_progress_at: str = ""
+    # When the task reached a terminal status (succeeded/failed/cancelled).
+    # Powers the loop-stall signal in get_status: a backlog with zero terminal
+    # transitions over a window is the 2026-06-25 wedge signature. Empty for
+    # pre-field rows; stamped by mark_status on terminal transition.
+    terminal_at: str = ""
     rung_claim_recommendations: list[dict] = field(default_factory=list)
     # Spawn depth. 0 for user/forward-triggered tasks. A task enqueued from
     # inside a running branch (via the in-node enqueue verb) carries
@@ -451,6 +456,8 @@ def mark_status(
                     f"for task {task_id}"
                 )
             row["status"] = status
+            if status in TERMINAL_STATUSES:
+                row["terminal_at"] = _now_iso()
             if error:
                 row["error"] = error
             _write_raw(qp, raw)

--- a/tests/test_branch_tasks.py
+++ b/tests/test_branch_tasks.py
@@ -15,6 +15,7 @@ from workflow.branch_tasks import (
     new_task_id,
     queue_path,
     read_queue,
+    reclaim_expired_leases,
     recover_claimed_tasks,
     refresh_task_heartbeat,
 )
@@ -145,6 +146,43 @@ def test_recover_claimed_tasks_clears_active_lease_metadata(tmp_path: Path) -> N
     assert recovered.lease_expires_at == ""
     assert recovered.heartbeat_at == ""
     assert recovered.last_progress_at == "2026-05-02T12:00:00+00:00"
+
+
+def test_reclaim_leaseless_running_row_only_in_startup_mode(tmp_path: Path) -> None:
+    """A lease-less running orphan is reclaimed only in the startup sweep.
+
+    Codex cross-family review (2026-06-25): switching startup from the blanket
+    recover to lease-aware reclaim stranded pre-lease/corrupt rows forever.
+    """
+    task = _task()
+    append_task(tmp_path, task)
+    claim_task(tmp_path, task.branch_task_id, "daemon-a")  # stamps a lease
+    qp = queue_path(tmp_path)
+    data = json.loads(qp.read_text())
+    data[0]["lease_expires_at"] = ""  # simulate pre-lease-era / corrupt row
+    qp.write_text(json.dumps(data))
+
+    # Claim-path mode must NOT touch a lease-less row (could race a peer).
+    assert reclaim_expired_leases(tmp_path) == 0
+    assert read_queue(tmp_path)[0].status == "running"
+
+    # Startup mode reclaims the orphan back to pending.
+    assert reclaim_expired_leases(tmp_path, reclaim_leaseless=True) == 1
+    recovered = read_queue(tmp_path)[0]
+    assert recovered.status == "pending"
+    assert recovered.claimed_by == ""
+
+
+def test_lease_window_exceeds_worst_case_provider_node(tmp_path: Path) -> None:
+    """Regression guard: the lease must outlast a long-but-healthy node so it
+    is never reclaimed mid-flight (Codex review — lease==provider-timeout race).
+    """
+    from workflow.branch_tasks import DEFAULT_LEASE_SECONDS
+    from workflow.providers.base import ModelConfig
+
+    # Worst case single node = full fallback chain (~3 providers) x per-call
+    # timeout. The lease must clear that with margin.
+    assert DEFAULT_LEASE_SECONDS > ModelConfig().timeout * 3
 
 
 def test_mark_status_stamps_terminal_at_on_terminal_transition(tmp_path: Path) -> None:

--- a/tests/test_branch_tasks.py
+++ b/tests/test_branch_tasks.py
@@ -147,6 +147,19 @@ def test_recover_claimed_tasks_clears_active_lease_metadata(tmp_path: Path) -> N
     assert recovered.last_progress_at == "2026-05-02T12:00:00+00:00"
 
 
+def test_mark_status_stamps_terminal_at_on_terminal_transition(tmp_path: Path) -> None:
+    task = _task()
+    append_task(tmp_path, task)
+    claim_task(tmp_path, task.branch_task_id, "daemon-a")  # -> running
+    assert read_queue(tmp_path)[0].terminal_at == ""
+
+    mark_status(tmp_path, task.branch_task_id, status="succeeded")
+
+    row = read_queue(tmp_path)[0]
+    assert row.status == "succeeded"
+    assert row.terminal_at, "terminal_at must be stamped on terminal transition"
+
+
 def test_mark_status_terminal_finalize_is_idempotent(tmp_path: Path) -> None:
     """A duplicate finalize on an already-terminal task is a no-op.
 

--- a/tests/test_supervisor_liveness.py
+++ b/tests/test_supervisor_liveness.py
@@ -169,6 +169,90 @@ def test_recent_pending_no_warning(tmp_path):
     assert not any("stuck_pending" in w for w in out["warnings"])
 
 
+# ── loop-stall signal (2026-06-25 wedge detector) ──────────────────────────
+
+
+def test_loop_stalled_warns_on_fail_only_backlog(tmp_path):
+    """The real wedge: failures stamp terminal_at but zero successes."""
+    from workflow.api.status import _LOOP_STALL_WINDOW_S
+
+    now = datetime.now(timezone.utc)
+    old = (now - timedelta(seconds=_LOOP_STALL_WINDOW_S + 600)).isoformat()
+    append_task(tmp_path, BranchTask(
+        branch_task_id="bt-stalled",
+        branch_def_id="branch-1",
+        universe_id="u",
+        status="pending",
+        queued_at=old,
+    ))
+    # A recently FAILED task: opens the any_terminal_at gate but is not a success.
+    append_task(tmp_path, BranchTask(
+        branch_task_id="bt-failed",
+        branch_def_id="branch-1",
+        universe_id="u",
+        status="failed",
+        queued_at=old,
+        terminal_at=now.isoformat(),
+    ))
+    out = _compute_supervisor_liveness(tmp_path)
+    assert out["queue_state"]["recent_succeeded_count"] == 0
+    assert out["queue_state"]["stuck_pending_max_age_s"] > _LOOP_STALL_WINDOW_S
+    assert any("loop_stalled" in w for w in out["warnings"])
+
+
+def test_no_loop_stalled_when_a_recent_success_exists(tmp_path):
+    from workflow.api.status import _LOOP_STALL_WINDOW_S
+
+    now = datetime.now(timezone.utc)
+    old = (now - timedelta(seconds=_LOOP_STALL_WINDOW_S + 600)).isoformat()
+    append_task(tmp_path, BranchTask(
+        branch_task_id="bt-pending",
+        branch_def_id="branch-1",
+        universe_id="u",
+        status="pending",
+        queued_at=old,
+    ))
+    append_task(tmp_path, BranchTask(
+        branch_task_id="bt-done",
+        branch_def_id="branch-1",
+        universe_id="u",
+        status="succeeded",
+        queued_at=old,
+        terminal_at=now.isoformat(),
+    ))
+    out = _compute_supervisor_liveness(tmp_path)
+    assert out["queue_state"]["recent_succeeded_count"] == 1
+    assert not any("loop_stalled" in w for w in out["warnings"])
+
+
+def test_no_loop_stalled_on_fresh_queue_without_terminal_at(tmp_path):
+    """Old rows predating terminal_at must not false-fire the stall warning."""
+    from workflow.api.status import _LOOP_STALL_WINDOW_S
+
+    old = (
+        datetime.now(timezone.utc)
+        - timedelta(seconds=_LOOP_STALL_WINDOW_S + 600)
+    ).isoformat()
+    # Backlog + a succeeded row that predates the field (no terminal_at).
+    append_task(tmp_path, BranchTask(
+        branch_task_id="bt-pending",
+        branch_def_id="branch-1",
+        universe_id="u",
+        status="pending",
+        queued_at=old,
+    ))
+    append_task(tmp_path, BranchTask(
+        branch_task_id="bt-legacy-done",
+        branch_def_id="branch-1",
+        universe_id="u",
+        status="succeeded",
+        queued_at=old,
+        terminal_at="",  # pre-field row
+    ))
+    out = _compute_supervisor_liveness(tmp_path)
+    assert not any("loop_stalled" in w for w in out["warnings"])
+
+
 # ── lease metadata path (post-#212) ────────────────────────────────────────
 
 

--- a/workflow/api/status.py
+++ b/workflow/api/status.py
@@ -49,6 +49,12 @@ _HEARTBEAT_STALE_THRESHOLD_S = _HEARTBEAT_REFRESH_INTERVAL_S * 2
 # BUG-009 class).
 _STUCK_PENDING_THRESHOLD_S = 120
 
+# Loop-stall window: if a backlog (pending tasks older than this) has produced
+# ZERO terminal transitions within the same window, the loop is stalled even
+# though workers may look busy — the 2026-06-25 wedge ran ~3 weeks because no
+# signal distinguished "claiming but never completing" from healthy operation.
+_LOOP_STALL_WINDOW_S = int(os.environ.get("WORKFLOW_LOOP_STALL_WINDOW_S", "1800"))
+
 # Auto-ship observation window surfaced in get_status.auto_ship_health.
 _AUTO_SHIP_OBSERVATION_WINDOW_S = 24 * 60 * 60
 _AUTO_SHIP_RECENT_ATTEMPT_LIMIT = 10
@@ -381,6 +387,7 @@ def _compute_supervisor_liveness(
             "stuck_pending_max_age_s": 0,
             "policy_parked_pending_max_age_s": 0,
             "stuck_running_max_age_s": 0,
+            "recent_succeeded_count": 0,
         },
         "running_tasks_lease": [],
         "stale_running_tasks": [],
@@ -410,11 +417,30 @@ def _compute_supervisor_liveness(
     pending_ages: list[float] = []
     policy_parked_pending_ages: list[float] = []
     running_ages: list[float] = []
+    recent_succeeded_count = 0
+    any_terminal_at_seen = False
 
     for task in queue:
         status = getattr(task, "status", "") or ""
         if status in out["queue_state"]:
             out["queue_state"][status] = out["queue_state"].get(status, 0) + 1
+
+        # Completion-health signal. We count recent SUCCESSES (not all
+        # terminals): a loop that only produces failures is still wedged.
+        # ``any_terminal_at_seen`` gates the stall warning so a freshly
+        # deployed queue (terminal_at not yet stamped on any row) cannot
+        # false-fire — during a real wedge the fail-fast tasks stamp
+        # terminal_at, so the gate opens while successes stay at zero.
+        terminal_at = getattr(task, "terminal_at", "") or ""
+        if terminal_at:
+            any_terminal_at_seen = True
+            terminal_ts = _parse_iso_to_epoch(terminal_at)
+            if (
+                status == "succeeded"
+                and terminal_ts is not None
+                and (now_ts - terminal_ts) <= _LOOP_STALL_WINDOW_S
+            ):
+                recent_succeeded_count += 1
 
         # Pending-task age (queued_at -> now). Detects dispatcher pickup
         # gaps even before a task gets claimed (today's BUG-009 pattern).
@@ -520,6 +546,8 @@ def _compute_supervisor_liveness(
     # warning. Today's BUG-009 RCA: a pending task that sits >2min
     # without claim means the supervisor restart logic isn't reaching
     # the queue (the exact pattern PR #205 fixed).
+    out["queue_state"]["recent_succeeded_count"] = recent_succeeded_count
+
     if (
         out["queue_state"]["stuck_pending_max_age_s"]
         > _STUCK_PENDING_THRESHOLD_S
@@ -530,6 +558,30 @@ def _compute_supervisor_liveness(
             f"(threshold {_STUCK_PENDING_THRESHOLD_S}s). Likely "
             "supervisor restart loop, dispatcher disabled, or daemon "
             "subprocess wedged. See PR #206 spec for incident pattern."
+        )
+
+    # Loop-stall: a backlog older than the window with ZERO successful
+    # completions in that window means the loop is claiming but never
+    # succeeding — the durable 2026-06-25 wedge signature (which ran ~3 weeks
+    # undetected). Distinct from stuck_pending (pickup latency): this is the
+    # completion-rate dimension, and counts successes only so a fail-only loop
+    # still trips it. ``any_terminal_at_seen`` suppresses the false-positive on
+    # a freshly deployed queue whose rows predate the terminal_at field.
+    if (
+        recent_succeeded_count == 0
+        and any_terminal_at_seen
+        and out["queue_state"]["pending"] > 0
+        and out["queue_state"]["stuck_pending_max_age_s"] > _LOOP_STALL_WINDOW_S
+    ):
+        out["warnings"].append(
+            f"loop_stalled: 0 successful completions in the last "
+            f"{_LOOP_STALL_WINDOW_S}s despite "
+            f"{out['queue_state']['pending']} pending "
+            f"(oldest {out['queue_state']['stuck_pending_max_age_s']}s) and "
+            f"{out['queue_state']['failed']} failed total. The loop is claiming "
+            "but not succeeding — provider auth, double-claim, or finalize crash "
+            "(2026-06-25 loop-wedge signature). Check worker logs for provider "
+            "'exhausted' / 'Invalid transition'."
         )
 
     if out["queue_state"]["running"] > 0 and not any_lease_field_seen:

--- a/workflow/branch_tasks.py
+++ b/workflow/branch_tasks.py
@@ -35,7 +35,13 @@ logger = logging.getLogger(__name__)
 QUEUE_FILENAME = "branch_tasks.json"
 ARCHIVE_FILENAME = "branch_tasks_archive.json"
 LOCK_FILENAME = "branch_tasks.json.lock"
-DEFAULT_LEASE_SECONDS = 300
+# Lease window. INVARIANT: must comfortably exceed the worst-case time between
+# heartbeat refreshes, which happen per graph node (not on an independent
+# timer). A single writer node can run the whole provider fallback chain, each
+# attempt up to ModelConfig.timeout (300s) — so ~900s worst case. 1800s gives a
+# 2x margin so a long-but-healthy node is never wrongly reclaimed mid-flight
+# (Codex cross-family review, 2026-06-25: lease==provider-timeout was a race).
+DEFAULT_LEASE_SECONDS = 1800
 
 # Exposed for test override (invariant 10).
 ARCHIVE_AFTER_DAYS = 30
@@ -553,6 +559,7 @@ def reclaim_expired_leases(
     universe_path: Path,
     *,
     now: datetime | None = None,
+    reclaim_leaseless: bool = False,
 ) -> int:
     """Lease-aware reclaim: reset ``running`` rows whose lease expired.
 
@@ -566,6 +573,14 @@ def reclaim_expired_leases(
     dispatcher claim path, so every claim attempt sweeps first and a
     wedged claim is reaped on the next pick instead of the next daemon
     restart. Returns the count reclaimed.
+
+    ``reclaim_leaseless`` (startup-only): also reset ``running`` rows that
+    carry NO lease / an unparsable one. Since ``claim_task`` always stamps a
+    lease, a lease-less running row can only be a pre-lease-era or corrupt
+    orphan — never a live peer — so it is safe to reclaim. Without this a
+    lease-less row would stay ``running`` forever once startup stopped using
+    the blanket :func:`recover_claimed_tasks` (Codex cross-family review,
+    2026-06-25).
     """
     current = now or datetime.now(timezone.utc)
     qp = queue_path(universe_path)
@@ -578,17 +593,19 @@ def reclaim_expired_leases(
             if not isinstance(row, dict) or row.get("status") != "running":
                 continue
             lease_raw = str(row.get("lease_expires_at") or "")
-            if not lease_raw:
-                # Pre-lease-era claim: no lease to judge by; leave it
-                # for startup recovery rather than guessing.
+            lease_at = _parse_iso_utc(lease_raw) if lease_raw else None
+            if lease_at is not None and lease_at > current:
+                continue  # live lease — never touch a healthy peer
+            if lease_at is None and not reclaim_leaseless:
+                # No / unparsable lease. A current-code worker always stamps a
+                # valid one, so this is a pre-lease-era or corrupt orphan, but
+                # only the startup sweep reclaims it (no risk of racing a peer).
                 continue
-            lease_at = _parse_iso_utc(lease_raw)
-            if lease_at is None or lease_at > current:
-                continue
+            expired_for = (current - lease_at) if lease_at is not None else "no-lease"
             logger.warning(
-                "branch_tasks reclaim: lease expired %s ago on %s "
+                "branch_tasks reclaim: lease expired %s on %s "
                 "(claimed_by=%s heartbeat_at=%s) — resetting to pending",
-                current - lease_at,
+                expired_for,
                 row.get("branch_task_id"),
                 row.get("claimed_by"),
                 row.get("heartbeat_at"),

--- a/workflow/branch_tasks.py
+++ b/workflow/branch_tasks.py
@@ -97,6 +97,11 @@ class BranchTask:
     lease_expires_at: str = ""
     heartbeat_at: str = ""
     last_progress_at: str = ""
+    # When the task reached a terminal status (succeeded/failed/cancelled).
+    # Powers the loop-stall signal in get_status: a backlog with zero terminal
+    # transitions over a window is the 2026-06-25 wedge signature. Empty for
+    # pre-field rows; stamped by mark_status on terminal transition.
+    terminal_at: str = ""
     rung_claim_recommendations: list[dict] = field(default_factory=list)
     # Spawn depth. 0 for user/forward-triggered tasks. A task enqueued from
     # inside a running branch (via the in-node enqueue verb) carries
@@ -451,6 +456,8 @@ def mark_status(
                     f"for task {task_id}"
                 )
             row["status"] = status
+            if status in TERMINAL_STATUSES:
+                row["terminal_at"] = _now_iso()
             if error:
                 row["error"] = error
             _write_raw(qp, raw)


### PR DESCRIPTION
Two parts, both from the 2026-06-25 loop-wedge incident + its cross-family (Codex) review.

## Part A — loop-stall detector (make the wedge visible)
The wedge ran ~3 weeks because `get_status` had no signal distinguishing "claiming but never succeeding" from healthy operation.
- **`BranchTask.terminal_at`** stamped by `mark_status` on any terminal transition (migration-safe; empty for old rows).
- **`queue_state.recent_succeeded_count`** + **`loop_stalled` warning** when: 0 recent successes AND the field is populated (`any_terminal_at_seen`, suppresses fresh-deploy false-positives) AND `pending>0` AND oldest pending exceeds `WORKFLOW_LOOP_STALL_WINDOW_S` (1800s). Counts **successes**, so a fail-only loop (the real wedge shape) still trips it. Visible-signal, not auto-restart (a code/auth stall won't be fixed by a restart).

## Part B — lease fixes from Codex cross-family review (resolves NEEDS-FIX on #1339)
1. **Lease window was == provider timeout (both 300s)**, and the lease only refreshes between graph nodes. A long-but-healthy node (writer fallback chain ≈ 3×300s) could expire its lease mid-flight → reclaim → re-run (wasteful duplicate; #1339's idempotent-finalize prevents the crash but not the waste). **Raise `DEFAULT_LEASE_SECONDS` to 1800** (>2× worst-case single node) + documented invariant + regression-guard test.
2. **Lease-less running orphans were stranded forever** after #1339 switched startup from blanket recover → lease-aware reclaim (which skips lease-less rows). **Add `reclaim_leaseless` (startup-only)**: a lease-less running row can only be a pre-lease/corrupt orphan (claim_task always stamps a lease), so the startup sweep reclaims it; the claim-path sweep still leaves it untouched to avoid racing a live peer.

## Tests / verification
`terminal_at` stamped; `loop_stalled` warns on fail-only backlog, quiet on recent success / fresh queue; lease-less orphan reclaimed only in startup mode; lease > 3× provider timeout. 50+ status/branch_tasks tests pass; plugin mirror byte-parity; `get_status` schema_version stays 1 (additive).

Cross-family review by Codex (OpenAI family) — verdict was NEEDS-FIX on the #1339 lease logic; this PR applies the fixes. Closes incident-log Q2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)