### PR TITLE
Tighten branch janitor to 14-day deletion

### DIFF
--- a/.github/workflows/branch-janitor.yml
+++ b/.github/workflows/branch-janitor.yml
@@ -5,7 +5,7 @@ name: branch-janitor
 #
 # The daily scheduled run sweeps in `apply-all` mode: it deletes MERGED
 # branches (already on main) and STALE_DELETE branches (unmerged, no open PR,
-# no commit in 45d), and updates the rolling tracking issue. Hard guardrails
+# no commit in 14d), and updates the rolling tracking issue. Hard guardrails
 # always protect main/release, open-PR branches, and commits < 7d.
 # For an on-demand dry-run, trigger it manually with mode `report`.
 

--- a/docs/design-notes/2026-06-24-branch-lifecycle-automation.md
+++ b/docs/design-notes/2026-06-24-branch-lifecycle-automation.md
@@ -60,15 +60,16 @@ drift **detected, not discovered** (loop-telemetry philosophy).
 Daily GitHub Action, **host-independent**. Classifies every remote branch:
 - `MERGED` (ancestor of `origin/main`) -> safe to delete immediately; the
   commits are already on main.
-- `STALE_FLAG` (unmerged, no commits in `STALE_DAYS=30`, no open PR) -> flag in
+- `STALE_FLAG` (unmerged, no commits in `STALE_DAYS=7`, no open PR) -> flag in
   a single rolling tracking issue.
-- `STALE_DELETE` (flagged + still untouched past `GRACE_DAYS=45` total) ->
+- `STALE_DELETE` (flagged + still untouched past `GRACE_DAYS=14` total) ->
   delete in `--apply` mode.
 - `PROTECTED` / `ACTIVE` -> never touched.
 
 **Guardrails (hard):** never delete `main`/`master`/`production`/`release/*`;
 never delete a branch with an open PR; never delete a branch with a commit
-younger than `RECENT_DAYS=7`, regardless of total age.
+younger than `RECENT_DAYS=7`, regardless of total age. (Thresholds tightened
+from 30/45 to 7/14 per host directive 2026-06-25 — minimal lingering.)
 
 **Rollout (host directive 2026-06-24):** the report-first wait was waived. The
 scheduled run defaults to `apply-all`, so once the workflow lands on `main` its

--- a/scripts/branch_janitor.py
+++ b/scripts/branch_janitor.py
@@ -42,8 +42,8 @@ from dataclasses import asdict, dataclass
 PROTECTED_EXACT = {"main", "master", "production", "develop", "HEAD"}
 PROTECTED_PREFIXES = ("release/", "hotfix/")
 RECENT_DAYS = 7
-STALE_DAYS = 30
-GRACE_DAYS = 45
+STALE_DAYS = 7
+GRACE_DAYS = 14
 ISSUE_MARKER = "<!-- branch-janitor -->"
 ISSUE_TITLE = "🧹 Branch janitor report"
 

--- a/tests/test_branch_janitor.py
+++ b/tests/test_branch_janitor.py
@@ -64,7 +64,8 @@ def test_recent_commit_never_deleted(patched):
 
 
 def test_stale_unmerged_flagged_not_deleted(patched):
-    patched([("feature/stale", _age_ts(35))], merged=set())
+    # Between STALE_DAYS (flag) and GRACE_DAYS (delete): flagged, not deleted.
+    patched([("feature/stale", _age_ts(10))], merged=set())
     out = bj.classify("origin", "origin/main", NOW, open_prs=set())
     assert _verdict_for(out, "feature/stale").category == "STALE_FLAG"
 


### PR DESCRIPTION
Host directive 2026-06-25: minimal lingering of stale branches.

- `STALE_DAYS` 30 → 7 (flag in report)
- `GRACE_DAYS` 45 → 14 (delete unmerged, no-PR, idle branches)

Guardrails unchanged: never deletes main/release, open-PR branches, or commits < 7d. Follows #1338 (the lifecycle automation system).

After merge, the daily janitor (`apply-all`) sweeps everything ≥14d idle; the backlog sweep (143 branches) is fired manually right after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)