### PR TITLE
Fix broken escrow test on main (_connect contextmanager)

### DIFF
--- a/tests/test_payments_escrow_mcp.py
+++ b/tests/test_payments_escrow_mcp.py
@@ -384,11 +384,18 @@ class TestEscrowRoundTrip:
 
 class TestPaymentsActionsUnit:
     def _conn(self, tmp_path):
+        # storage._connect is a context manager (closes on exit); these unit
+        # tests need a connection that stays open across multiple action calls,
+        # so open a raw connection to the same DB path with matching pragmas.
+        import sqlite3
+
         from workflow.daemon_server import initialize_author_server
         from workflow.payments.escrow import migrate_escrow_schema
-        from workflow.storage import _connect
+        from workflow.storage import db_path
         initialize_author_server(tmp_path)
-        conn = _connect(tmp_path)
+        conn = sqlite3.connect(str(db_path(tmp_path)), timeout=30.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
         migrate_escrow_schema(conn)
         return conn
 


### PR DESCRIPTION
## Breakage

On current `main`, `tests/test_payments_escrow_mcp.py` is broken. `#1218` turned `workflow.storage._connect` into a `@contextlib.contextmanager`, but `TestPaymentsActionsUnit._conn` still called it bare:

```python
from workflow.storage import _connect
conn = _connect(tmp_path)            # returns a _GeneratorContextManager
migrate_escrow_schema(conn)          # AttributeError: no attribute 'executescript'
```

`conn` is a `_GeneratorContextManager`, not a `sqlite3.Connection`, so the first `.executescript()` / `.execute()` raises `AttributeError`. 5 unit tests in `TestPaymentsActionsUnit` fail. Production callers already use `with _connect(...)`, so the bug is test-only.

## Fix

Open a raw `sqlite3.connect(str(db_path(tmp_path)), timeout=30.0)` with matching pragmas (`row_factory = Row`, `PRAGMA foreign_keys = ON`) so the helper returns a real connection that stays open across the unit test's multiple action calls (the context manager would close it on exit).

This re-lands the escrow-only portion of origin SHA `2f086075`'s branch `claude/fix-1218-connect-testcaller` — specifically commit `c4975897` ("Fix bare `_connect()` test caller broken by #1218"). The `tests/test_api_market.py` change on that branch is intentionally **NOT** taken; it is stale/divergent against current `main`.

## Scope

- Test-only: 1 file, `tests/test_payments_escrow_mcp.py`, +9/-2.
- No production code touched.

## Verification

- Before fix (current main): `FAILED ... AttributeError: '_GeneratorContextManager' object has no attribute 'executescript'` (1 failed under `-x`, 5 in `TestPaymentsActionsUnit` overall).
- After fix: `35 passed` via `WORKFLOW_DATA_DIR=<isolated-tmp> python -m pytest tests/test_payments_escrow_mcp.py -p no:cacheprovider -x`.
- `ruff check tests/test_payments_escrow_mcp.py --line-length 100`: All checks passed.

Recovery issue: #1346. Original SHA: `c4975897` (escrow fix), branch tip `2f086075`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)