### PR TITLE
Fix BUG-127: lease-aware startup recovery + duplicate-run guard

### DIFF
--- a/fantasy_daemon/__main__.py
+++ b/fantasy_daemon/__main__.py
@@ -820,6 +820,9 @@ def _try_execute_claimed_branch_task(
         from workflow.daemon_server import get_branch_definition
         from workflow.runs import (
             RUN_STATUS_COMPLETED,
+            RUN_STATUS_QUEUED,
+            RUN_STATUS_RESUMED,
+            RUN_STATUS_RUNNING,
             execute_branch,
             latest_run_by_name,
         )
@@ -874,6 +877,28 @@ def _try_execute_claimed_branch_task(
                 claimed_task.branch_task_id,
                 branch_def_id,
                 existing_run["run_id"],
+            )
+            return True, "", metadata
+        active_run_statuses = {
+            RUN_STATUS_QUEUED,
+            RUN_STATUS_RUNNING,
+            RUN_STATUS_RESUMED,
+        }
+        if existing_run and existing_run.get("status") in active_run_statuses:
+            metadata = {
+                "branch_def_id": branch_def_id,
+                "run_id": existing_run["run_id"],
+                "run_status": existing_run["status"],
+                "actor": existing_run.get("actor") or "",
+                "existing_run_in_flight": True,
+            }
+            logger.info(
+                "dispatcher_pick: branch task run already in flight %s "
+                "branch=%s run=%s status=%s",
+                claimed_task.branch_task_id,
+                branch_def_id,
+                existing_run["run_id"],
+                existing_run["status"],
             )
             return True, "", metadata
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
@@ -512,12 +512,13 @@ def is_task_cancel_requested(universe_path: Path, task_id: str) -> bool:
 
 
 def recover_claimed_tasks(universe_path: Path) -> int:
-    """Restart recovery: reset any ``running`` rows to ``pending``.
+    """Restart recovery: reset stale ``running`` rows to ``pending``.
 
-    Claimed-but-unfinished tasks at daemon startup can't know whether
-    the previous daemon finished them; safest is to re-queue. Returns
-    the count reset.
+    A fresh lease means a peer worker may still own the task, so startup
+    recovery only re-queues pre-lease rows or rows whose lease expired.
+    Returns the count reset.
     """
+    current = datetime.now(timezone.utc)
     qp = queue_path(universe_path)
     if not qp.exists():
         return 0
@@ -525,13 +526,19 @@ def recover_claimed_tasks(universe_path: Path) -> int:
     with _file_lock(universe_path):
         raw = _read_raw(qp)
         for row in raw:
-            if isinstance(row, dict) and row.get("status") == "running":
-                row["status"] = "pending"
-                row["claimed_by"] = ""
-                row["worker_owner_id"] = ""
-                row["lease_expires_at"] = ""
-                row["heartbeat_at"] = ""
-                count += 1
+            if not isinstance(row, dict) or row.get("status") != "running":
+                continue
+            lease_raw = str(row.get("lease_expires_at") or "")
+            if lease_raw:
+                lease_at = _parse_iso_utc(lease_raw)
+                if lease_at is None or lease_at > current:
+                    continue
+            row["status"] = "pending"
+            row["claimed_by"] = ""
+            row["worker_owner_id"] = ""
+            row["lease_expires_at"] = ""
+            row["heartbeat_at"] = ""
+            count += 1
         if count:
             _write_raw(qp, raw)
     if count:
@@ -558,7 +565,8 @@ def reclaim_expired_leases(
     their leases fresh and are never touched. Intended call site is the
     dispatcher claim path, so every claim attempt sweeps first and a
     wedged claim is reaped on the next pick instead of the next daemon
-    restart. Returns the count reclaimed.
+    restart. Missing pre-lease rows are left for startup recovery.
+    Returns the count reclaimed.
     """
     current = now or datetime.now(timezone.utc)
     qp = queue_path(universe_path)

--- a/tests/test_branch_tasks.py
+++ b/tests/test_branch_tasks.py
@@ -129,22 +129,46 @@ def test_mark_task_progress_stamps_running_task(tmp_path: Path) -> None:
     assert progressed.last_progress_at
 
 
-def test_recover_claimed_tasks_clears_active_lease_metadata(tmp_path: Path) -> None:
-    task = _task()
-    append_task(tmp_path, task)
-    claim_task(tmp_path, task.branch_task_id, "daemon-a")
-    mark_task_progress(tmp_path, task.branch_task_id, progress_at="2026-05-02T12:00:00+00:00")
+def test_recover_claimed_tasks_preserves_fresh_lease_and_requeues_expired(
+    tmp_path: Path,
+) -> None:
+    fresh = _task("bt_fresh")
+    expired = _task("bt_expired")
+    append_task(tmp_path, fresh)
+    append_task(tmp_path, expired)
+    fresh_claim = claim_task(tmp_path, fresh.branch_task_id, "daemon-a")
+    expired_claim = claim_task(tmp_path, expired.branch_task_id, "daemon-b")
+    assert fresh_claim is not None
+    assert expired_claim is not None
+    mark_task_progress(
+        tmp_path,
+        expired.branch_task_id,
+        progress_at="2026-05-02T12:00:00+00:00",
+    )
+    qp = queue_path(tmp_path)
+    data = json.loads(qp.read_text(encoding="utf-8"))
+    for row in data:
+        if row["branch_task_id"] == expired.branch_task_id:
+            row["lease_expires_at"] = "2000-01-01T00:00:00+00:00"
+    qp.write_text(json.dumps(data), encoding="utf-8")
 
     count = recover_claimed_tasks(tmp_path)
 
     assert count == 1
-    recovered = read_queue(tmp_path)[0]
-    assert recovered.status == "pending"
-    assert recovered.claimed_by == ""
-    assert recovered.worker_owner_id == ""
-    assert recovered.lease_expires_at == ""
-    assert recovered.heartbeat_at == ""
-    assert recovered.last_progress_at == "2026-05-02T12:00:00+00:00"
+    by_id = {task.branch_task_id: task for task in read_queue(tmp_path)}
+    fresh_recovered = by_id[fresh.branch_task_id]
+    expired_recovered = by_id[expired.branch_task_id]
+    assert fresh_recovered.status == "running"
+    assert fresh_recovered.claimed_by == "daemon-a"
+    assert fresh_recovered.worker_owner_id == "daemon-a"
+    assert fresh_recovered.lease_expires_at == fresh_claim.lease_expires_at
+    assert fresh_recovered.heartbeat_at == fresh_claim.heartbeat_at
+    assert expired_recovered.status == "pending"
+    assert expired_recovered.claimed_by == ""
+    assert expired_recovered.worker_owner_id == ""
+    assert expired_recovered.lease_expires_at == ""
+    assert expired_recovered.heartbeat_at == ""
+    assert expired_recovered.last_progress_at == "2026-05-02T12:00:00+00:00"
 
 
 def test_mark_status_terminal_finalize_is_idempotent(tmp_path: Path) -> None:

--- a/tests/test_bug_investigation_dispatcher.py
+++ b/tests/test_bug_investigation_dispatcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -418,6 +419,81 @@ class TestBugInvestigationDirectRunRouting:
         assert metadata["run_id"] == run_id
         assert metadata["run_status"] == RUN_STATUS_COMPLETED
         assert metadata["reused_existing_run"] is True
+
+    @pytest.mark.parametrize("active_status", ["queued", "running", "resumed"])
+    def test_direct_run_skips_duplicate_execute_for_active_branch_task_run(
+        self, tmp_path, monkeypatch, active_status
+    ):
+        from fantasy_daemon.__main__ import _try_execute_claimed_branch_task
+        from workflow.runs import (
+            RUN_STATUS_COMPLETED,
+            RUN_STATUS_QUEUED,
+            create_run,
+            update_run_status,
+        )
+
+        monkeypatch.setattr("workflow.storage.data_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "workflow.api.branches._resolve_branch_id",
+            lambda requested, base_path: "branch-1",
+        )
+        monkeypatch.setattr(
+            "workflow.daemon_server.get_branch_definition",
+            lambda base_path, branch_def_id: {"branch_def_id": branch_def_id},
+        )
+
+        class _Branch:
+            def validate(self):
+                return []
+
+        from workflow.branches import BranchDefinition
+        monkeypatch.setattr(
+            BranchDefinition,
+            "from_dict",
+            classmethod(lambda cls, data: _Branch()),
+        )
+
+        execute_calls = []
+
+        def _record_execute(*args, **kwargs):
+            execute_calls.append(kwargs["run_name"])
+            return SimpleNamespace(
+                run_id="new-run",
+                status=RUN_STATUS_COMPLETED,
+                error="",
+                output={},
+            )
+
+        monkeypatch.setattr("workflow.runs.execute_branch", _record_execute)
+
+        run_id = create_run(
+            tmp_path,
+            branch_def_id="branch-1",
+            thread_id="",
+            inputs={"bug_id": "BUG-127"},
+            run_name="branch-task-bt-active",
+            actor="daemon-a",
+        )
+        if active_status != RUN_STATUS_QUEUED:
+            update_run_status(tmp_path, run_id, status=active_status)
+        task = BranchTask(
+            branch_task_id="bt-active",
+            branch_def_id="branch-1",
+            universe_id="u",
+            inputs={"bug_id": "BUG-127"},
+            request_type=REQUEST_TYPE_BUG_INVESTIGATION,
+        )
+
+        success, error, metadata = _try_execute_claimed_branch_task(
+            tmp_path, task, "daemon-a",
+        )
+
+        assert success is True
+        assert error == ""
+        assert execute_calls == []
+        assert metadata["run_id"] == run_id
+        assert metadata["run_status"] == active_status
+        assert metadata["existing_run_in_flight"] is True
 
 
 class TestBugInvestigationPatchPacketWriteBack:

--- a/workflow/branch_tasks.py
+++ b/workflow/branch_tasks.py
@@ -512,12 +512,13 @@ def is_task_cancel_requested(universe_path: Path, task_id: str) -> bool:
 
 
 def recover_claimed_tasks(universe_path: Path) -> int:
-    """Restart recovery: reset any ``running`` rows to ``pending``.
+    """Restart recovery: reset stale ``running`` rows to ``pending``.
 
-    Claimed-but-unfinished tasks at daemon startup can't know whether
-    the previous daemon finished them; safest is to re-queue. Returns
-    the count reset.
+    A fresh lease means a peer worker may still own the task, so startup
+    recovery only re-queues pre-lease rows or rows whose lease expired.
+    Returns the count reset.
     """
+    current = datetime.now(timezone.utc)
     qp = queue_path(universe_path)
     if not qp.exists():
         return 0
@@ -525,13 +526,19 @@ def recover_claimed_tasks(universe_path: Path) -> int:
     with _file_lock(universe_path):
         raw = _read_raw(qp)
         for row in raw:
-            if isinstance(row, dict) and row.get("status") == "running":
-                row["status"] = "pending"
-                row["claimed_by"] = ""
-                row["worker_owner_id"] = ""
-                row["lease_expires_at"] = ""
-                row["heartbeat_at"] = ""
-                count += 1
+            if not isinstance(row, dict) or row.get("status") != "running":
+                continue
+            lease_raw = str(row.get("lease_expires_at") or "")
+            if lease_raw:
+                lease_at = _parse_iso_utc(lease_raw)
+                if lease_at is None or lease_at > current:
+                    continue
+            row["status"] = "pending"
+            row["claimed_by"] = ""
+            row["worker_owner_id"] = ""
+            row["lease_expires_at"] = ""
+            row["heartbeat_at"] = ""
+            count += 1
         if count:
             _write_raw(qp, raw)
     if count:
@@ -558,7 +565,8 @@ def reclaim_expired_leases(
     their leases fresh and are never touched. Intended call site is the
     dispatcher claim path, so every claim attempt sweeps first and a
     wedged claim is reaped on the next pick instead of the next daemon
-    restart. Returns the count reclaimed.
+    restart. Missing pre-lease rows are left for startup recovery.
+    Returns the count reclaimed.
     """
     current = now or datetime.now(timezone.utc)
     qp = queue_path(universe_path)


### PR DESCRIPTION
## BUG-127: duplicate concurrent dispatch of the same `branch_task_id`

Fixes the duplicate-dispatch race observed live on `patch-loop-live`: a single `branch_task_id` having 2+ runs alive at once, wasting worker slots and inflating the failed counter (3100+ failed vs ~2500 succeeded, largely retry/abandon churn even when the task ultimately completes).

### Provenance
- **Authored by Codex** (`mcp__codex__codex`), implementing the fix map from Codex's own opposite-family carrier review of BUG-127.
- **Cross-family reviewed + independently tested by Claude** (Opus 4.8).
- This is a fix to the **loop's own dispatcher engine** — i.e. "improve the loop", not hand-drafting the loop's content output.

### Root cause (confirmed in code)
- Steady-state claim is already guarded (`claim_task` only claims `pending` rows under the queue file lock). The race is **not** in normal dispatch.
- **Primary vector:** `recover_claimed_tasks` (`workflow/branch_tasks.py`) blanket-reset *every* `running` task to `pending` on daemon startup, clearing the lease **without checking expiry** — so an alive worker's task became re-claimable. Re-triggered on every daemon restart/redeploy.
- A duplicate claim becomes a duplicate **run** because run reuse only fired for `completed` runs; otherwise a second `execute_branch` ran with the same `run_name` (no uniqueness constraint).
- Mass-interrupt-on-restart (`recover_in_flight_runs` marking all in-flight runs `interrupted` at one timestamp) is the related worker-restart symptom.

### Changes
1. **Lease-aware startup recovery** — `recover_claimed_tasks` preserves `running` tasks with an unexpired `lease_expires_at`; only pre-lease or expired-lease rows re-queue. Mirrors `reclaim_expired_leases` expiry semantics.
2. **In-flight guard** — `_try_execute_claimed_branch_task` treats an existing `queued`/`running`/`resumed` `branch-task-<id>` run as already in flight and does not start a second `execute_branch`.
3. Plugin mirror updated (`packaging/claude-plugin/.../runtime/workflow/branch_tasks.py`); import probe ok; pre-commit mirror-parity verified.
4. Tests added: recover preserves fresh lease / requeues expired; active run blocks duplicate execute (queued/running/resumed).

### Deliberate trade-off
The in-flight guard returns success, so the duplicate-claim path finalizes the task as *success* while the in-flight run completes it. Returning failure would be worse — it re-inflates the failed counter BUG-127 is about. The **primary fix prevents the duplicate claim from occurring at all**; the guard is defense-in-depth.

### Test evidence (2026-06-25, Windows, project .venv)
- `pytest -p no:cacheprovider tests/test_branch_tasks.py tests/test_bug_investigation_dispatcher.py` → new BUG-127 tests green (recover/lease/in-flight x3).
- `ruff check` on all touched files → clean.
- 4 failures in `tests/test_dispatcher_queue.py` are **pre-existing** host-identity/priority/cancel env assertions, unrelated to this change (different code paths; that file is unmodified here).

### Merge gate
Substrate dispatcher change → **host merge key required**. Nothing deploys to the live fleet until merged.

Links: live-brain BUG-127 (Codex carrier review recorded on the bug page; dispatcher request `9a5319b0-31d6-4676-a85e-aea24d2d0643`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
