### PR TITLE
PR-179 Slice 1: per-worker/runtime identity visible end-to-end (additive)

### DIFF
--- a/fantasy_daemon/__main__.py
+++ b/fantasy_daemon/__main__.py
@@ -414,7 +414,17 @@ def _try_dispatcher_pick(
         picked = select_next_task(universe_path, config=cfg)
         if picked is None:
             return None, {}
-        claimed = claim_task(universe_path, picked.branch_task_id, daemon_id)
+        executor_worker_id = os.environ.get("WORKFLOW_WORKER_ID", "").strip()
+        executor_runtime_id = os.environ.get(
+            "WORKFLOW_RUNTIME_INSTANCE_ID", "",
+        ).strip()
+        claimed = claim_task(
+            universe_path,
+            picked.branch_task_id,
+            daemon_id,
+            executor_worker_id=executor_worker_id,
+            executor_runtime_id=executor_runtime_id,
+        )
         if claimed is None:
             logger.info(
                 "dispatcher_pick: claim_lost_to_cancel %s",
@@ -890,12 +900,21 @@ def _try_execute_claimed_branch_task(
             provider_call = None
 
         actor = os.environ.get("UNIVERSE_SERVER_USER", "anonymous") or "anonymous"
+        executor_worker_id = str(
+            getattr(claimed_task, "executor_worker_id", "") or "",
+        )
+        executor_runtime_id = str(
+            getattr(claimed_task, "executor_runtime_id", "") or "",
+        )
         outcome = execute_branch(
             base_path,
             branch=branch,
             inputs=_branch_task_inputs_for_execution(claimed_task),
             run_name=run_name,
             actor=actor,
+            daemon_id=daemon_id,
+            runtime_instance_id=executor_runtime_id,
+            worker_id=executor_worker_id,
             provider_call=provider_call,
             on_node_status=on_node_status,
             # Carry spawn depth across the queue boundary so an in-node enqueue

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
@@ -464,6 +464,10 @@ def _compute_supervisor_liveness(
         # Lease metadata (PR #212). Defensive getattr so pre-#212 tasks
         # surface as empty strings rather than AttributeError.
         worker_owner_id = getattr(task, "worker_owner_id", "") or ""
+        claimed_by = getattr(task, "claimed_by", "") or ""
+        daemon_id = worker_owner_id or claimed_by
+        executor_worker_id = getattr(task, "executor_worker_id", "") or ""
+        executor_runtime_id = getattr(task, "executor_runtime_id", "") or ""
         lease_expires_at = getattr(task, "lease_expires_at", "") or ""
         heartbeat_at = getattr(task, "heartbeat_at", "") or ""
         last_progress_at = getattr(task, "last_progress_at", "") or ""
@@ -496,7 +500,10 @@ def _compute_supervisor_liveness(
 
         record = {
             "branch_task_id": getattr(task, "branch_task_id", ""),
+            "daemon_id": daemon_id,
             "worker_owner_id": worker_owner_id,
+            "executor_worker_id": executor_worker_id,
+            "executor_runtime_id": executor_runtime_id,
             "lease_expires_at": lease_expires_at,
             "lease_remaining_s": lease_remaining_s,
             "heartbeat_at": heartbeat_at,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -993,27 +993,48 @@ def _daemon_liveness(udir: Path, status: dict[str, Any] | None) -> dict[str, Any
     }
 
 
-def _worker_liveness(udir: Path) -> dict[str, Any]:
-    """Supervisor-heartbeat liveness, distinct from content activity.
+_WORKER_SUPERVISOR_FILENAME = ".worker_supervisor.json"
+_WORKER_SUPERVISOR_PREFIX = ".worker_supervisor."
+_WORKER_SUPERVISOR_SUFFIX = ".json"
 
-    ``last_activity_at`` answers "when did the daemon last DO something"
-    (activity.log / .runtime_status.json mtimes) — it goes stale both
-    when the worker is wedged AND when there is simply nothing to do.
-    This field answers "is the worker process alive right now" from the
-    ``.worker_supervisor.json`` beat the cloud_worker supervisor writes
-    (docs/specs/daemon-liveness-watchdog.md). Consumers (the activity
-    canary) use it to page on wedge and stay quiet on idle.
-    """
-    beat_path = udir / ".worker_supervisor.json"
-    if not beat_path.exists():
-        return {"present": False}
+
+def _worker_id_from_heartbeat_path(path: Path) -> str:
+    name = path.name
+    if (
+        name.startswith(_WORKER_SUPERVISOR_PREFIX)
+        and name.endswith(_WORKER_SUPERVISOR_SUFFIX)
+    ):
+        return name[
+            len(_WORKER_SUPERVISOR_PREFIX):-len(_WORKER_SUPERVISOR_SUFFIX)
+        ]
+    return ""
+
+
+def _read_worker_liveness_entry(beat_path: Path) -> dict[str, Any]:
+    worker_id = _worker_id_from_heartbeat_path(beat_path)
     try:
         beat = json.loads(beat_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):  # noqa: BLE001 — probe, not gate
+        return {
+            "present": True,
+            "parse_error": True,
+            "worker_id": worker_id,
+            "runtime_instance_id": "",
+        }
+
+    worker_id = str(beat.get("worker_id") or worker_id)
+    runtime_instance_id = str(beat.get("runtime_instance_id") or "")
+    try:
         ts = datetime.strptime(
             str(beat.get("ts", "")), "%Y-%m-%dT%H:%M:%SZ",
         ).replace(tzinfo=timezone.utc)
-    except (OSError, ValueError, TypeError):  # noqa: BLE001 — probe, not gate
-        return {"present": True, "parse_error": True}
+    except (ValueError, TypeError):  # noqa: BLE001 — probe, not gate
+        return {
+            "present": True,
+            "parse_error": True,
+            "worker_id": worker_id,
+            "runtime_instance_id": runtime_instance_id,
+        }
     age_s = max(0.0, (datetime.now(timezone.utc) - ts).total_seconds())
     planned_sleep = float(beat.get("planned_sleep_s") or 0.0)
     allowed = max(300.0, planned_sleep + 120.0)
@@ -1026,7 +1047,51 @@ def _worker_liveness(udir: Path) -> dict[str, Any]:
         "consec_crashes": beat.get("consec_crashes", 0),
         "total_spawns": beat.get("total_spawns", 0),
         "last_exit_rc": beat.get("last_exit_rc"),
+        "worker_id": worker_id,
+        "runtime_instance_id": runtime_instance_id,
     }
+
+
+def _worker_liveness(udir: Path) -> dict[str, Any]:
+    """Supervisor-heartbeat liveness, distinct from content activity.
+
+    ``last_activity_at`` answers "when did the daemon last DO something"
+    (activity.log / .runtime_status.json mtimes) — it goes stale both
+    when the worker is wedged AND when there is simply nothing to do.
+    This field answers "is the worker process alive right now" from the
+    ``.worker_supervisor.json`` beat the cloud_worker supervisor writes
+    (docs/specs/daemon-liveness-watchdog.md). Consumers (the activity
+    canary) use it to page on wedge and stay quiet on idle.
+    """
+    legacy_path = udir / _WORKER_SUPERVISOR_FILENAME
+    worker_paths = sorted(
+        path for path in udir.glob(
+            f"{_WORKER_SUPERVISOR_PREFIX}*{_WORKER_SUPERVISOR_SUFFIX}"
+        )
+        if path.name != _WORKER_SUPERVISOR_FILENAME
+    )
+    if not worker_paths and legacy_path.exists():
+        worker_paths = [legacy_path]
+    if not worker_paths:
+        return {"present": False}
+
+    workers = [_read_worker_liveness_entry(path) for path in worker_paths]
+    if legacy_path.exists():
+        summary = _read_worker_liveness_entry(legacy_path)
+    else:
+        summary = min(
+            workers,
+            key=lambda entry: float(entry.get("beat_age_s", float("inf"))),
+        )
+    out = dict(summary)
+    out["workers"] = workers
+    out["worker_count"] = len(workers)
+    out["runtime_instance_count"] = len({
+        str(worker.get("runtime_instance_id") or "")
+        for worker in workers
+        if worker.get("runtime_instance_id")
+    })
+    return out
 
 
 _TOP_LEVEL_OPERATIONAL_DATA_DIRS = frozenset({

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/branch_tasks.py
@@ -100,6 +100,8 @@ class BranchTask:
     request_type: str = "branch_run"
     deadline: str = ""
     worker_owner_id: str = ""
+    executor_worker_id: str = ""
+    executor_runtime_id: str = ""
     lease_expires_at: str = ""
     heartbeat_at: str = ""
     last_progress_at: str = ""
@@ -324,7 +326,12 @@ def append_task_capped(
 
 
 def claim_task(
-    universe_path: Path, task_id: str, claimer: str,
+    universe_path: Path,
+    task_id: str,
+    claimer: str,
+    *,
+    executor_worker_id: str | None = None,
+    executor_runtime_id: str | None = None,
 ) -> BranchTask | None:
     """File-locked claim. Returns claimed task, or None if already
     claimed / missing / not pending.
@@ -343,6 +350,8 @@ def claim_task(
             row["status"] = "running"
             row["claimed_by"] = claimer
             row["worker_owner_id"] = claimer
+            row["executor_worker_id"] = executor_worker_id or ""
+            row["executor_runtime_id"] = executor_runtime_id or ""
             row["heartbeat_at"] = heartbeat_at
             row["lease_expires_at"] = lease_expires_at
             _write_raw(qp, raw)

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker.py
@@ -200,7 +200,10 @@ def _worker_model_for_provider(provider_name: str) -> str:
     if provider_name == "codex":
         return os.environ.get("WORKFLOW_CODEX_MODEL", "").strip() or DEFAULT_WORKER_MODELS["codex"]
     if provider_name == "claude-code":
-        return os.environ.get("WORKFLOW_CLAUDE_MODEL", "").strip() or DEFAULT_WORKER_MODELS["claude-code"]
+        return (
+            os.environ.get("WORKFLOW_CLAUDE_MODEL", "").strip()
+            or DEFAULT_WORKER_MODELS["claude-code"]
+        )
     return provider_name
 
 
@@ -219,17 +222,17 @@ def _subscription_auth_available(provider_name: str) -> bool:
     return True
 
 
-def _register_worker_runtime(universe: Path, provider_name: str) -> None:
+def _register_worker_runtime(universe: Path, provider_name: str) -> str | None:
     """Best-effort runtime registry visibility for a supervised worker."""
     if not provider_name:
-        return
+        return None
     if not _subscription_auth_available(provider_name):
         logger.warning(
             "cloud_worker: %s subscription auth not available; "
             "runtime registration will retry on next spawn",
             provider_name,
         )
-        return
+        return None
     try:
         from workflow.daemon_registry import (
             ensure_daemon_runtime,
@@ -262,11 +265,13 @@ def _register_worker_runtime(universe: Path, provider_name: str) -> None:
             "cloud_worker: runtime registered worker_id=%s provider=%s runtime=%s",
             _worker_id(), provider_name, runtime["runtime_instance_id"],
         )
+        return str(runtime["runtime_instance_id"])
     except Exception:  # noqa: BLE001
         logger.exception(
             "cloud_worker: runtime registration failed for provider=%s",
             provider_name,
         )
+    return None
 
 
 def _truthy_env(name: str) -> bool:
@@ -374,8 +379,20 @@ def _spawn_fantasy_daemon(
     ]
     if extra_args:
         args.extend(extra_args)
-    _register_worker_runtime(universe, _provider_from_daemon_args(extra_args))
+    runtime_instance_id = _register_worker_runtime(
+        universe,
+        _provider_from_daemon_args(extra_args),
+    )
+    if runtime_instance_id:
+        os.environ["WORKFLOW_RUNTIME_INSTANCE_ID"] = runtime_instance_id
+    else:
+        os.environ.pop("WORKFLOW_RUNTIME_INSTANCE_ID", None)
     env = _build_subprocess_env(universe)
+    env["WORKFLOW_WORKER_ID"] = _worker_id()
+    if runtime_instance_id:
+        env["WORKFLOW_RUNTIME_INSTANCE_ID"] = runtime_instance_id
+    else:
+        env.pop("WORKFLOW_RUNTIME_INSTANCE_ID", None)
     logger.info(
         "spawning fantasy_daemon: universe=%s host_user=%s",
         universe, env.get("UNIVERSE_SERVER_HOST_USER"),
@@ -482,6 +499,9 @@ def write_supervisor_heartbeat(
         "subprocess_alive": subprocess_alive,
         "planned_sleep_s": planned_sleep_s,
         "worker_id": _worker_id(),
+        "runtime_instance_id": os.environ.get(
+            "WORKFLOW_RUNTIME_INSTANCE_ID", "",
+        ).strip(),
     }
     filenames = [supervisor_heartbeat_filename(_worker_id())]
     if filenames[0] != SUPERVISOR_HEARTBEAT_FILENAME:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_brain.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/daemon_brain.py
@@ -1843,6 +1843,7 @@ def open_brain_status_surface(
             "schema_version": SCHEMA_VERSION,
             "read_only": True,
             "daemon_count": 0,
+            "runtime_instance_count": 0,
             "daemons": [],
             "warnings": ["daemon_registry_db_missing"],
         }
@@ -1853,6 +1854,7 @@ def open_brain_status_surface(
         uri=True,
     )
     conn.row_factory = sqlite3.Row
+    runtime_instance_count = 0
     try:
         rows = conn.execute(
             """
@@ -1861,6 +1863,14 @@ def open_brain_status_surface(
             ORDER BY created_at, author_id
             """
         ).fetchall()
+        try:
+            runtime_row = conn.execute(
+                "SELECT COUNT(*) AS count FROM author_runtime_instances"
+            ).fetchone()
+            if runtime_row is not None:
+                runtime_instance_count = int(runtime_row["count"] or 0)
+        except sqlite3.Error:
+            runtime_instance_count = 0
     finally:
         conn.close()
     daemons: list[dict[str, Any]] = []
@@ -1900,6 +1910,7 @@ def open_brain_status_surface(
         "schema_version": SCHEMA_VERSION,
         "read_only": True,
         "daemon_count": len(daemons),
+        "runtime_instance_count": runtime_instance_count,
         "returned_daemon_count": len(out_daemons),
         "daemons": out_daemons,
         "warnings": [],

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/runs.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/runs.py
@@ -241,7 +241,10 @@ def initialize_runs_db(base_path: str | Path) -> Path:
         finished_at    REAL,
         provider_used  TEXT,
         model          TEXT,
-        token_count    INTEGER
+        token_count    INTEGER,
+        daemon_id      TEXT,
+        runtime_instance_id TEXT,
+        worker_id      TEXT
     );
 
     CREATE INDEX IF NOT EXISTS idx_runs_branch ON runs(branch_def_id);
@@ -394,7 +397,8 @@ def initialize_runs_db(base_path: str | Path) -> Path:
                 conn.execute(
                     f"ALTER TABLE node_edit_audit ADD COLUMN {col} {ddl}"
                 )
-        # Migration: add provider telemetry columns to runs (added 2026-04-25).
+        # Migration: add run instrumentation columns. Provider telemetry
+        # landed first; executor identity fields are nullable observability.
         existing_runs = {
             row["name"]
             for row in conn.execute("PRAGMA table_info(runs)")
@@ -403,6 +407,9 @@ def initialize_runs_db(base_path: str | Path) -> Path:
             ("provider_used", "TEXT"),
             ("model",         "TEXT"),
             ("token_count",   "INTEGER"),
+            ("daemon_id",     "TEXT"),
+            ("runtime_instance_id", "TEXT"),
+            ("worker_id",     "TEXT"),
         ):
             if col not in existing_runs:
                 conn.execute(f"ALTER TABLE runs ADD COLUMN {col} {ddl}")
@@ -466,6 +473,13 @@ def _row_to_run(row: sqlite3.Row) -> dict[str, Any]:
         "provider_used": row["provider_used"] if "provider_used" in col_names else None,
         "model": row["model"] if "model" in col_names else None,
         "token_count": row["token_count"] if "token_count" in col_names else None,
+        "daemon_id": row["daemon_id"] if "daemon_id" in col_names else None,
+        "runtime_instance_id": (
+            row["runtime_instance_id"]
+            if "runtime_instance_id" in col_names
+            else None
+        ),
+        "worker_id": row["worker_id"] if "worker_id" in col_names else None,
     }
 
 
@@ -708,6 +722,9 @@ def create_run(
     run_name: str = "",
     actor: str = "anonymous",
     branch_version_id: str | None = None,
+    daemon_id: str | None = None,
+    runtime_instance_id: str | None = None,
+    worker_id: str | None = None,
 ) -> str:
     initialize_runs_db(base_path)
     run_id = uuid.uuid4().hex[:16]
@@ -717,14 +734,18 @@ def create_run(
             INSERT INTO runs (
                 run_id, branch_def_id, run_name, thread_id,
                 status, actor, inputs_json, started_at,
-                branch_version_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                branch_version_id, daemon_id, runtime_instance_id,
+                worker_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 run_id, branch_def_id, run_name, thread_id,
                 RUN_STATUS_QUEUED, actor,
                 json.dumps(inputs, default=str), _now(),
                 branch_version_id,
+                daemon_id,
+                runtime_instance_id,
+                worker_id,
             ),
         )
     return run_id
@@ -1954,6 +1975,9 @@ def _prepare_run(
     run_name: str,
     actor: str,
     branch_version_id: str | None = None,
+    daemon_id: str | None = None,
+    runtime_instance_id: str | None = None,
+    worker_id: str | None = None,
 ) -> str:
     """Write the run row + pending-node events + lineage synchronously.
 
@@ -1972,6 +1996,9 @@ def _prepare_run(
         run_name=run_name,
         actor=actor,
         branch_version_id=branch_version_id,
+        daemon_id=daemon_id,
+        runtime_instance_id=runtime_instance_id,
+        worker_id=worker_id,
     )
     thread_id = run_id
     with _connect(base_path) as conn:
@@ -2694,6 +2721,9 @@ def execute_branch(
     recursion_limit_override: int | None = None,
     concurrency_budget_override: int | None = None,
     on_node_status: Callable[[str, str], None] | None = None,
+    daemon_id: str | None = None,
+    runtime_instance_id: str | None = None,
+    worker_id: str | None = None,
     _invocation_depth: int = 0,
     _enqueue_universe_id: str = "",
     _parent_branch_task_id: str = "",
@@ -2718,6 +2748,9 @@ def execute_branch(
         base_path,
         branch=branch, inputs=inputs,
         run_name=run_name, actor=actor,
+        daemon_id=daemon_id,
+        runtime_instance_id=runtime_instance_id,
+        worker_id=worker_id,
     )
     enqueue_context = NodeEnqueueContext(
         universe_id=_enqueue_universe_id,
@@ -2875,6 +2908,9 @@ def _execute_branch_core(
     concurrency_budget_override: int | None = None,
     on_node_status: Callable[[str, str], None] | None = None,
     branch_version_id: str | None = None,
+    daemon_id: str | None = None,
+    runtime_instance_id: str | None = None,
+    worker_id: str | None = None,
     _invocation_depth: int = 0,
 ) -> RunOutcome:
     """Shared async-execution core for def-based and version-based runs.
@@ -2899,6 +2935,9 @@ def _execute_branch_core(
         branch=branch, inputs=inputs,
         run_name=run_name, actor=actor,
         branch_version_id=branch_version_id,
+        daemon_id=daemon_id,
+        runtime_instance_id=runtime_instance_id,
+        worker_id=worker_id,
     )
 
     executor = _get_executor(invocation_depth=_invocation_depth)

--- a/tests/test_branch_runner.py
+++ b/tests/test_branch_runner.py
@@ -566,6 +566,41 @@ def test_execute_branch_end_to_end(tmp_path):
     assert any(e["status"] == "ran" for e in events)
 
 
+def test_execute_branch_records_executor_identity_without_changing_actor(tmp_path):
+    from workflow.runs import execute_branch, get_run
+
+    b = BranchDefinition(name="test", entry_point="n1")
+    b.node_defs = [NodeDefinition(
+        node_id="n1", display_name="N1", approved=True,
+        source_code="def run(state): return {'out': state.get('x', 0) + 1}",
+    )]
+    b.graph_nodes = [GraphNodeRef(id="n1", node_def_id="n1")]
+    b.edges = [
+        EdgeDefinition(from_node="START", to_node="n1"),
+        EdgeDefinition(from_node="n1", to_node="END"),
+    ]
+    b.state_schema = [
+        {"name": "x", "type": "int"}, {"name": "out", "type": "int"},
+    ]
+
+    outcome = execute_branch(
+        tmp_path,
+        branch=b,
+        inputs={"x": 1},
+        actor="requester-user",
+        daemon_id="daemon::owner",
+        runtime_instance_id="runtime-123",
+        worker_id="codex-1",
+    )
+
+    record = get_run(tmp_path, outcome.run_id)
+    assert record is not None
+    assert record["actor"] == "requester-user"
+    assert record["daemon_id"] == "daemon::owner"
+    assert record["runtime_instance_id"] == "runtime-123"
+    assert record["worker_id"] == "codex-1"
+
+
 def test_execute_branch_reports_node_status_callback(tmp_path):
     from workflow.runs import (
         NODE_STATUS_RAN,

--- a/tests/test_loop_telemetry.py
+++ b/tests/test_loop_telemetry.py
@@ -283,6 +283,37 @@ def test_worker_liveness_alive_and_dead(tmp_path):
     assert dead["beat_age_s"] > 3000
 
 
+def test_worker_liveness_enumerates_worker_specific_beats(tmp_path):
+    from workflow.api.universe import _worker_liveness
+
+    for worker_id, runtime_id in (
+        ("codex-1", "runtime-codex"),
+        ("claude-1", "runtime-claude"),
+    ):
+        beat = {
+            "ts": _iso(_utc(-10)),
+            "phase": "polling",
+            "planned_sleep_s": 0.0,
+            "worker_id": worker_id,
+            "runtime_instance_id": runtime_id,
+        }
+        (tmp_path / supervisor_heartbeat_filename(worker_id)).write_text(
+            json.dumps(beat), encoding="utf-8",
+        )
+
+    liveness = _worker_liveness(tmp_path)
+
+    assert liveness["present"] is True
+    assert liveness["worker_count"] == 2
+    assert liveness["runtime_instance_count"] == 2
+    workers = {
+        worker["worker_id"]: worker
+        for worker in liveness["workers"]
+    }
+    assert workers["codex-1"]["runtime_instance_id"] == "runtime-codex"
+    assert workers["claude-1"]["runtime_instance_id"] == "runtime-claude"
+
+
 # ---------------------------------------------------------------------------
 # canary worker_liveness preference
 # ---------------------------------------------------------------------------

--- a/tests/test_supervisor_liveness.py
+++ b/tests/test_supervisor_liveness.py
@@ -17,7 +17,7 @@ from workflow.api.status import (
     _compute_supervisor_liveness,
     _parse_iso_to_epoch,
 )
-from workflow.branch_tasks import BranchTask, append_task
+from workflow.branch_tasks import BranchTask, append_task, claim_task
 
 # ── _parse_iso_to_epoch unit ───────────────────────────────────────────────
 
@@ -315,6 +315,36 @@ def test_running_task_with_fresh_lease_not_stale(tmp_path):
     assert record["lease_remaining_s"] > 0
     assert out["stale_running_tasks"] == []
     assert out["lease_data_available"] is True
+
+
+def test_running_task_lease_surfaces_executor_identity(tmp_path):
+    task = BranchTask(
+        branch_task_id="bt-executor-id",
+        branch_def_id="branch-1",
+        universe_id="u",
+        status="pending",
+    )
+    append_task(tmp_path, task)
+
+    claimed = claim_task(
+        tmp_path,
+        task.branch_task_id,
+        "daemon::owner",
+        executor_worker_id="codex-1",
+        executor_runtime_id="runtime-123",
+    )
+
+    assert claimed is not None
+    assert claimed.claimed_by == "daemon::owner"
+    assert claimed.worker_owner_id == "daemon::owner"
+    assert claimed.executor_worker_id == "codex-1"
+    assert claimed.executor_runtime_id == "runtime-123"
+
+    out = _compute_supervisor_liveness(tmp_path)
+    record = out["running_tasks_lease"][0]
+    assert record["daemon_id"] == "daemon::owner"
+    assert record["executor_worker_id"] == "codex-1"
+    assert record["executor_runtime_id"] == "runtime-123"
 
 
 def test_stale_heartbeat_flagged_as_stale(tmp_path):

--- a/workflow/api/status.py
+++ b/workflow/api/status.py
@@ -464,6 +464,10 @@ def _compute_supervisor_liveness(
         # Lease metadata (PR #212). Defensive getattr so pre-#212 tasks
         # surface as empty strings rather than AttributeError.
         worker_owner_id = getattr(task, "worker_owner_id", "") or ""
+        claimed_by = getattr(task, "claimed_by", "") or ""
+        daemon_id = worker_owner_id or claimed_by
+        executor_worker_id = getattr(task, "executor_worker_id", "") or ""
+        executor_runtime_id = getattr(task, "executor_runtime_id", "") or ""
         lease_expires_at = getattr(task, "lease_expires_at", "") or ""
         heartbeat_at = getattr(task, "heartbeat_at", "") or ""
         last_progress_at = getattr(task, "last_progress_at", "") or ""
@@ -496,7 +500,10 @@ def _compute_supervisor_liveness(
 
         record = {
             "branch_task_id": getattr(task, "branch_task_id", ""),
+            "daemon_id": daemon_id,
             "worker_owner_id": worker_owner_id,
+            "executor_worker_id": executor_worker_id,
+            "executor_runtime_id": executor_runtime_id,
             "lease_expires_at": lease_expires_at,
             "lease_remaining_s": lease_remaining_s,
             "heartbeat_at": heartbeat_at,

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -993,27 +993,48 @@ def _daemon_liveness(udir: Path, status: dict[str, Any] | None) -> dict[str, Any
     }
 
 
-def _worker_liveness(udir: Path) -> dict[str, Any]:
-    """Supervisor-heartbeat liveness, distinct from content activity.
+_WORKER_SUPERVISOR_FILENAME = ".worker_supervisor.json"
+_WORKER_SUPERVISOR_PREFIX = ".worker_supervisor."
+_WORKER_SUPERVISOR_SUFFIX = ".json"
 
-    ``last_activity_at`` answers "when did the daemon last DO something"
-    (activity.log / .runtime_status.json mtimes) — it goes stale both
-    when the worker is wedged AND when there is simply nothing to do.
-    This field answers "is the worker process alive right now" from the
-    ``.worker_supervisor.json`` beat the cloud_worker supervisor writes
-    (docs/specs/daemon-liveness-watchdog.md). Consumers (the activity
-    canary) use it to page on wedge and stay quiet on idle.
-    """
-    beat_path = udir / ".worker_supervisor.json"
-    if not beat_path.exists():
-        return {"present": False}
+
+def _worker_id_from_heartbeat_path(path: Path) -> str:
+    name = path.name
+    if (
+        name.startswith(_WORKER_SUPERVISOR_PREFIX)
+        and name.endswith(_WORKER_SUPERVISOR_SUFFIX)
+    ):
+        return name[
+            len(_WORKER_SUPERVISOR_PREFIX):-len(_WORKER_SUPERVISOR_SUFFIX)
+        ]
+    return ""
+
+
+def _read_worker_liveness_entry(beat_path: Path) -> dict[str, Any]:
+    worker_id = _worker_id_from_heartbeat_path(beat_path)
     try:
         beat = json.loads(beat_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):  # noqa: BLE001 — probe, not gate
+        return {
+            "present": True,
+            "parse_error": True,
+            "worker_id": worker_id,
+            "runtime_instance_id": "",
+        }
+
+    worker_id = str(beat.get("worker_id") or worker_id)
+    runtime_instance_id = str(beat.get("runtime_instance_id") or "")
+    try:
         ts = datetime.strptime(
             str(beat.get("ts", "")), "%Y-%m-%dT%H:%M:%SZ",
         ).replace(tzinfo=timezone.utc)
-    except (OSError, ValueError, TypeError):  # noqa: BLE001 — probe, not gate
-        return {"present": True, "parse_error": True}
+    except (ValueError, TypeError):  # noqa: BLE001 — probe, not gate
+        return {
+            "present": True,
+            "parse_error": True,
+            "worker_id": worker_id,
+            "runtime_instance_id": runtime_instance_id,
+        }
     age_s = max(0.0, (datetime.now(timezone.utc) - ts).total_seconds())
     planned_sleep = float(beat.get("planned_sleep_s") or 0.0)
     allowed = max(300.0, planned_sleep + 120.0)
@@ -1026,7 +1047,51 @@ def _worker_liveness(udir: Path) -> dict[str, Any]:
         "consec_crashes": beat.get("consec_crashes", 0),
         "total_spawns": beat.get("total_spawns", 0),
         "last_exit_rc": beat.get("last_exit_rc"),
+        "worker_id": worker_id,
+        "runtime_instance_id": runtime_instance_id,
     }
+
+
+def _worker_liveness(udir: Path) -> dict[str, Any]:
+    """Supervisor-heartbeat liveness, distinct from content activity.
+
+    ``last_activity_at`` answers "when did the daemon last DO something"
+    (activity.log / .runtime_status.json mtimes) — it goes stale both
+    when the worker is wedged AND when there is simply nothing to do.
+    This field answers "is the worker process alive right now" from the
+    ``.worker_supervisor.json`` beat the cloud_worker supervisor writes
+    (docs/specs/daemon-liveness-watchdog.md). Consumers (the activity
+    canary) use it to page on wedge and stay quiet on idle.
+    """
+    legacy_path = udir / _WORKER_SUPERVISOR_FILENAME
+    worker_paths = sorted(
+        path for path in udir.glob(
+            f"{_WORKER_SUPERVISOR_PREFIX}*{_WORKER_SUPERVISOR_SUFFIX}"
+        )
+        if path.name != _WORKER_SUPERVISOR_FILENAME
+    )
+    if not worker_paths and legacy_path.exists():
+        worker_paths = [legacy_path]
+    if not worker_paths:
+        return {"present": False}
+
+    workers = [_read_worker_liveness_entry(path) for path in worker_paths]
+    if legacy_path.exists():
+        summary = _read_worker_liveness_entry(legacy_path)
+    else:
+        summary = min(
+            workers,
+            key=lambda entry: float(entry.get("beat_age_s", float("inf"))),
+        )
+    out = dict(summary)
+    out["workers"] = workers
+    out["worker_count"] = len(workers)
+    out["runtime_instance_count"] = len({
+        str(worker.get("runtime_instance_id") or "")
+        for worker in workers
+        if worker.get("runtime_instance_id")
+    })
+    return out
 
 
 _TOP_LEVEL_OPERATIONAL_DATA_DIRS = frozenset({

--- a/workflow/branch_tasks.py
+++ b/workflow/branch_tasks.py
@@ -100,6 +100,8 @@ class BranchTask:
     request_type: str = "branch_run"
     deadline: str = ""
     worker_owner_id: str = ""
+    executor_worker_id: str = ""
+    executor_runtime_id: str = ""
     lease_expires_at: str = ""
     heartbeat_at: str = ""
     last_progress_at: str = ""
@@ -324,7 +326,12 @@ def append_task_capped(
 
 
 def claim_task(
-    universe_path: Path, task_id: str, claimer: str,
+    universe_path: Path,
+    task_id: str,
+    claimer: str,
+    *,
+    executor_worker_id: str | None = None,
+    executor_runtime_id: str | None = None,
 ) -> BranchTask | None:
     """File-locked claim. Returns claimed task, or None if already
     claimed / missing / not pending.
@@ -343,6 +350,8 @@ def claim_task(
             row["status"] = "running"
             row["claimed_by"] = claimer
             row["worker_owner_id"] = claimer
+            row["executor_worker_id"] = executor_worker_id or ""
+            row["executor_runtime_id"] = executor_runtime_id or ""
             row["heartbeat_at"] = heartbeat_at
             row["lease_expires_at"] = lease_expires_at
             _write_raw(qp, raw)

--- a/workflow/cloud_worker.py
+++ b/workflow/cloud_worker.py
@@ -200,7 +200,10 @@ def _worker_model_for_provider(provider_name: str) -> str:
     if provider_name == "codex":
         return os.environ.get("WORKFLOW_CODEX_MODEL", "").strip() or DEFAULT_WORKER_MODELS["codex"]
     if provider_name == "claude-code":
-        return os.environ.get("WORKFLOW_CLAUDE_MODEL", "").strip() or DEFAULT_WORKER_MODELS["claude-code"]
+        return (
+            os.environ.get("WORKFLOW_CLAUDE_MODEL", "").strip()
+            or DEFAULT_WORKER_MODELS["claude-code"]
+        )
     return provider_name
 
 
@@ -219,17 +222,17 @@ def _subscription_auth_available(provider_name: str) -> bool:
     return True
 
 
-def _register_worker_runtime(universe: Path, provider_name: str) -> None:
+def _register_worker_runtime(universe: Path, provider_name: str) -> str | None:
     """Best-effort runtime registry visibility for a supervised worker."""
     if not provider_name:
-        return
+        return None
     if not _subscription_auth_available(provider_name):
         logger.warning(
             "cloud_worker: %s subscription auth not available; "
             "runtime registration will retry on next spawn",
             provider_name,
         )
-        return
+        return None
     try:
         from workflow.daemon_registry import (
             ensure_daemon_runtime,
@@ -262,11 +265,13 @@ def _register_worker_runtime(universe: Path, provider_name: str) -> None:
             "cloud_worker: runtime registered worker_id=%s provider=%s runtime=%s",
             _worker_id(), provider_name, runtime["runtime_instance_id"],
         )
+        return str(runtime["runtime_instance_id"])
     except Exception:  # noqa: BLE001
         logger.exception(
             "cloud_worker: runtime registration failed for provider=%s",
             provider_name,
         )
+    return None
 
 
 def _truthy_env(name: str) -> bool:
@@ -374,8 +379,20 @@ def _spawn_fantasy_daemon(
     ]
     if extra_args:
         args.extend(extra_args)
-    _register_worker_runtime(universe, _provider_from_daemon_args(extra_args))
+    runtime_instance_id = _register_worker_runtime(
+        universe,
+        _provider_from_daemon_args(extra_args),
+    )
+    if runtime_instance_id:
+        os.environ["WORKFLOW_RUNTIME_INSTANCE_ID"] = runtime_instance_id
+    else:
+        os.environ.pop("WORKFLOW_RUNTIME_INSTANCE_ID", None)
     env = _build_subprocess_env(universe)
+    env["WORKFLOW_WORKER_ID"] = _worker_id()
+    if runtime_instance_id:
+        env["WORKFLOW_RUNTIME_INSTANCE_ID"] = runtime_instance_id
+    else:
+        env.pop("WORKFLOW_RUNTIME_INSTANCE_ID", None)
     logger.info(
         "spawning fantasy_daemon: universe=%s host_user=%s",
         universe, env.get("UNIVERSE_SERVER_HOST_USER"),
@@ -482,6 +499,9 @@ def write_supervisor_heartbeat(
         "subprocess_alive": subprocess_alive,
         "planned_sleep_s": planned_sleep_s,
         "worker_id": _worker_id(),
+        "runtime_instance_id": os.environ.get(
+            "WORKFLOW_RUNTIME_INSTANCE_ID", "",
+        ).strip(),
     }
     filenames = [supervisor_heartbeat_filename(_worker_id())]
     if filenames[0] != SUPERVISOR_HEARTBEAT_FILENAME:

--- a/workflow/daemon_brain.py
+++ b/workflow/daemon_brain.py
@@ -1843,6 +1843,7 @@ def open_brain_status_surface(
             "schema_version": SCHEMA_VERSION,
             "read_only": True,
             "daemon_count": 0,
+            "runtime_instance_count": 0,
             "daemons": [],
             "warnings": ["daemon_registry_db_missing"],
         }
@@ -1853,6 +1854,7 @@ def open_brain_status_surface(
         uri=True,
     )
     conn.row_factory = sqlite3.Row
+    runtime_instance_count = 0
     try:
         rows = conn.execute(
             """
@@ -1861,6 +1863,14 @@ def open_brain_status_surface(
             ORDER BY created_at, author_id
             """
         ).fetchall()
+        try:
+            runtime_row = conn.execute(
+                "SELECT COUNT(*) AS count FROM author_runtime_instances"
+            ).fetchone()
+            if runtime_row is not None:
+                runtime_instance_count = int(runtime_row["count"] or 0)
+        except sqlite3.Error:
+            runtime_instance_count = 0
     finally:
         conn.close()
     daemons: list[dict[str, Any]] = []
@@ -1900,6 +1910,7 @@ def open_brain_status_surface(
         "schema_version": SCHEMA_VERSION,
         "read_only": True,
         "daemon_count": len(daemons),
+        "runtime_instance_count": runtime_instance_count,
         "returned_daemon_count": len(out_daemons),
         "daemons": out_daemons,
         "warnings": [],

--- a/workflow/runs.py
+++ b/workflow/runs.py
@@ -241,7 +241,10 @@ def initialize_runs_db(base_path: str | Path) -> Path:
         finished_at    REAL,
         provider_used  TEXT,
         model          TEXT,
-        token_count    INTEGER
+        token_count    INTEGER,
+        daemon_id      TEXT,
+        runtime_instance_id TEXT,
+        worker_id      TEXT
     );
 
     CREATE INDEX IF NOT EXISTS idx_runs_branch ON runs(branch_def_id);
@@ -394,7 +397,8 @@ def initialize_runs_db(base_path: str | Path) -> Path:
                 conn.execute(
                     f"ALTER TABLE node_edit_audit ADD COLUMN {col} {ddl}"
                 )
-        # Migration: add provider telemetry columns to runs (added 2026-04-25).
+        # Migration: add run instrumentation columns. Provider telemetry
+        # landed first; executor identity fields are nullable observability.
         existing_runs = {
             row["name"]
             for row in conn.execute("PRAGMA table_info(runs)")
@@ -403,6 +407,9 @@ def initialize_runs_db(base_path: str | Path) -> Path:
             ("provider_used", "TEXT"),
             ("model",         "TEXT"),
             ("token_count",   "INTEGER"),
+            ("daemon_id",     "TEXT"),
+            ("runtime_instance_id", "TEXT"),
+            ("worker_id",     "TEXT"),
         ):
             if col not in existing_runs:
                 conn.execute(f"ALTER TABLE runs ADD COLUMN {col} {ddl}")
@@ -466,6 +473,13 @@ def _row_to_run(row: sqlite3.Row) -> dict[str, Any]:
         "provider_used": row["provider_used"] if "provider_used" in col_names else None,
         "model": row["model"] if "model" in col_names else None,
         "token_count": row["token_count"] if "token_count" in col_names else None,
+        "daemon_id": row["daemon_id"] if "daemon_id" in col_names else None,
+        "runtime_instance_id": (
+            row["runtime_instance_id"]
+            if "runtime_instance_id" in col_names
+            else None
+        ),
+        "worker_id": row["worker_id"] if "worker_id" in col_names else None,
     }
 
 
@@ -708,6 +722,9 @@ def create_run(
     run_name: str = "",
     actor: str = "anonymous",
     branch_version_id: str | None = None,
+    daemon_id: str | None = None,
+    runtime_instance_id: str | None = None,
+    worker_id: str | None = None,
 ) -> str:
     initialize_runs_db(base_path)
     run_id = uuid.uuid4().hex[:16]
@@ -717,14 +734,18 @@ def create_run(
             INSERT INTO runs (
                 run_id, branch_def_id, run_name, thread_id,
                 status, actor, inputs_json, started_at,
-                branch_version_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                branch_version_id, daemon_id, runtime_instance_id,
+                worker_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 run_id, branch_def_id, run_name, thread_id,
                 RUN_STATUS_QUEUED, actor,
                 json.dumps(inputs, default=str), _now(),
                 branch_version_id,
+                daemon_id,
+                runtime_instance_id,
+                worker_id,
             ),
         )
     return run_id
@@ -1954,6 +1975,9 @@ def _prepare_run(
     run_name: str,
     actor: str,
     branch_version_id: str | None = None,
+    daemon_id: str | None = None,
+    runtime_instance_id: str | None = None,
+    worker_id: str | None = None,
 ) -> str:
     """Write the run row + pending-node events + lineage synchronously.
 
@@ -1972,6 +1996,9 @@ def _prepare_run(
         run_name=run_name,
         actor=actor,
         branch_version_id=branch_version_id,
+        daemon_id=daemon_id,
+        runtime_instance_id=runtime_instance_id,
+        worker_id=worker_id,
     )
     thread_id = run_id
     with _connect(base_path) as conn:
@@ -2694,6 +2721,9 @@ def execute_branch(
     recursion_limit_override: int | None = None,
     concurrency_budget_override: int | None = None,
     on_node_status: Callable[[str, str], None] | None = None,
+    daemon_id: str | None = None,
+    runtime_instance_id: str | None = None,
+    worker_id: str | None = None,
     _invocation_depth: int = 0,
     _enqueue_universe_id: str = "",
     _parent_branch_task_id: str = "",
@@ -2718,6 +2748,9 @@ def execute_branch(
         base_path,
         branch=branch, inputs=inputs,
         run_name=run_name, actor=actor,
+        daemon_id=daemon_id,
+        runtime_instance_id=runtime_instance_id,
+        worker_id=worker_id,
     )
     enqueue_context = NodeEnqueueContext(
         universe_id=_enqueue_universe_id,
@@ -2875,6 +2908,9 @@ def _execute_branch_core(
     concurrency_budget_override: int | None = None,
     on_node_status: Callable[[str, str], None] | None = None,
     branch_version_id: str | None = None,
+    daemon_id: str | None = None,
+    runtime_instance_id: str | None = None,
+    worker_id: str | None = None,
     _invocation_depth: int = 0,
 ) -> RunOutcome:
     """Shared async-execution core for def-based and version-based runs.
@@ -2899,6 +2935,9 @@ def _execute_branch_core(
         branch=branch, inputs=inputs,
         run_name=run_name, actor=actor,
         branch_version_id=branch_version_id,
+        daemon_id=daemon_id,
+        runtime_instance_id=runtime_instance_id,
+        worker_id=worker_id,
     )
 
     executor = _get_executor(invocation_depth=_invocation_depth)


### PR DESCRIPTION
## PR-179 Slice 1 — per-worker/runtime identity visible end-to-end (additive)

Implements the **observability-only** slice of PR-179 (daemon/worker identity collapse). Makes the real per-worker identity (`WORKFLOW_WORKER_ID` / `runtime_instance_id`) flow through leases, runs, and status **without changing any existing semantics**. Today all fleet workers collapse to one souled `daemon_id` at the lease and runs are `anonymous`; per-worker heartbeats are written but not surfaced.

### Why
As the platform scales to many users contributing daemons (to goals/universes, for money, or by personality), daemon/worker identity must be specific and visible — to attribute work, pay contributors, build reputation, and show "this daemon did this." This slice lays the visible identity foundation. (Aligns with `PLAN.md:246` "separate identity from runtime".)

### Changes — additive, backward-compatible, observability-only
- **cloud_worker → fantasy_daemon:** passes `WORKFLOW_WORKER_ID` + `WORKFLOW_RUNTIME_INSTANCE_ID` into the spawned daemon; heartbeat carries `runtime_instance_id`.
- **claim path:** `claim_task` gains optional keyword-only `executor_worker_id` / `executor_runtime_id`, recorded as NEW fields on the task row. `claimed_by` / `worker_owner_id` **UNCHANGED** (still the daemon_id) — the just-fixed BUG-127 lease/dispatch/reclaim/finalize semantics are untouched.
- **runs:** `execute_branch` run records persist optional `daemon_id` / `runtime_instance_id` / `worker_id`. `actor` stays the requester identity (unchanged).
- **visibility:** `get_status.supervisor_liveness.running_tasks_lease[]` now includes `executor_worker_id` / `executor_runtime_id` / `daemon_id`; `universe inspect` `worker_liveness` enumerates per-worker `.worker_supervisor.<id>.json` heartbeats → `workers[]`, `worker_count`, `runtime_instance_count` (legacy single-file shape preserved for backward compat); `open_brain` adds additive `runtime_instance_count` alongside `daemon_count`.

### Explicitly NOT in scope (PR-179 slice 2 — host/economy-gated)
Wiring executor identity into `attribution_credit` / royalties / paid bids / daemon selection. That needs host product decisions on payment/personality policy and a separate review. No economy/payment path is touched here.

### Provenance & verification
- Authored by **Codex** (`mcp__codex__codex`); **cross-family reviewed + independently tested by Claude**.
- Plugin mirrors updated; `build_plugin.py` import probe ok. `ruff check` clean.
- 102 affected tests pass; new tests (`test_running_task_lease_surfaces_executor_identity`, `test_worker_liveness_enumerates_worker_specific_beats`, `test_execute_branch_records_executor_identity_without_changing_actor`) independently re-verified green, alongside the BUG-127 lease/recover tests (no regression).

### Merge gate
Touches the dispatcher/lease/runs surface → **host merge key required**.

Links: live-brain PR-179 (identity-collapse finding + recommended direction; dispatcher request `f6b0616d-04f1-432c-a595-f7001fe92285`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
