### PR TITLE
PR-179 Slice 2: executor identity on economic primitives (additive, record-only)

### DIFF
--- a/fantasy_daemon/__main__.py
+++ b/fantasy_daemon/__main__.py
@@ -640,11 +640,32 @@ def _try_execute_claimed_node_bid(
         except RuntimeError as exc:
             return False, f"repo_root_not_resolvable: {exc}"
 
+        runtime_instance_id = os.environ.get(
+            "WORKFLOW_RUNTIME_INSTANCE_ID", "",
+        ).strip()
+        worker_id = os.environ.get("WORKFLOW_WORKER_ID", "").strip()
+        owner_user_id = ""
+        try:
+            from workflow.daemon_registry import get_daemon
+            from workflow.storage import data_dir
+
+            daemon = get_daemon(data_dir(), daemon_id=daemon_id)
+            owner_user_id = str(daemon.get("owner_user_id") or "")
+        except Exception:  # noqa: BLE001
+            owner_user_id = ""
+
         # Preflight §4.1 #1: atomic claim via git-rename + push BEFORE
         # execution. claim_node_bid returns None on race loss; we
         # fall through to "claim_race_lost" so the BranchTask is
         # marked failed and the next cycle proceeds.
-        claimed_bid = claim_node_bid(repo_root, node_bid_id, daemon_id)
+        claimed_bid = claim_node_bid(
+            repo_root,
+            node_bid_id,
+            daemon_id,
+            owner_user_id=owner_user_id,
+            runtime_instance_id=runtime_instance_id,
+            worker_id=worker_id,
+        )
         if claimed_bid is None:
             # Bid YAML may have been deleted between producer emit
             # and claim attempt (or race was lost, or status != open).
@@ -681,7 +702,13 @@ def _try_execute_claimed_node_bid(
         completed_at = datetime.now(timezone.utc).isoformat()
         try:
             record_settlement_event(
-                repo_root, bid, result, daemon_id,
+                repo_root,
+                bid,
+                result,
+                daemon_id,
+                owner_user_id=owner_user_id,
+                runtime_instance_id=runtime_instance_id,
+                worker_id=worker_id,
             )
         except SettlementExistsError:
             # Already recorded — idempotent finalize path (e.g.

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/market.py
@@ -715,6 +715,10 @@ def _action_record_remix(kwargs: dict[str, Any]) -> str:
     credit_share = max(0.0, min(1.0, credit_share))
 
     actor_id = (kwargs.get("actor_id") or "anonymous").strip() or "anonymous"
+    owner_user_id = (kwargs.get("owner_user_id") or "").strip()
+    daemon_id = (kwargs.get("daemon_id") or "").strip()
+    runtime_instance_id = (kwargs.get("runtime_instance_id") or "").strip()
+    worker_id = (kwargs.get("worker_id") or "").strip()
     base = _base_path()
 
     with _attribution_connect(base) as conn:
@@ -773,12 +777,16 @@ def _action_record_remix(kwargs: dict[str, Any]) -> str:
                 """
                 INSERT OR IGNORE INTO attribution_credit
                     (credit_id, artifact_id, artifact_kind, actor_id,
+                     owner_user_id, daemon_id, runtime_instance_id, worker_id,
                      credit_share, royalty_share, generation_depth,
                      contribution_kind, recorded_at)
-                VALUES (?, ?, 'branch', ?, ?, 0.0, ?, ?, ?)
+                VALUES (?, ?, 'branch', ?, ?, ?, ?, ?, ?, 0.0, ?, ?, ?)
                 """,
-                (credit_id, child_id, actor_id, credit_share,
-                 generation_depth, contribution_kind, created_at),
+                (
+                    credit_id, child_id, actor_id, owner_user_id, daemon_id,
+                    runtime_instance_id, worker_id, credit_share,
+                    generation_depth, contribution_kind, created_at,
+                ),
             )
 
     return json.dumps({

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/attribution/schema.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/attribution/schema.py
@@ -59,6 +59,10 @@ CREATE TABLE IF NOT EXISTS attribution_credit (
     artifact_kind   TEXT NOT NULL DEFAULT 'branch'
                         CHECK (artifact_kind IN ('branch', 'node')),
     actor_id        TEXT NOT NULL,
+    owner_user_id   TEXT NOT NULL DEFAULT '',
+    daemon_id       TEXT NOT NULL DEFAULT '',
+    runtime_instance_id TEXT NOT NULL DEFAULT '',
+    worker_id       TEXT NOT NULL DEFAULT '',
     credit_share    REAL NOT NULL CHECK (credit_share >= 0.0 AND credit_share <= 1.0),
     royalty_share   REAL NOT NULL DEFAULT 0.0
                         CHECK (royalty_share >= 0.0 AND royalty_share <= 1.0),
@@ -135,6 +139,10 @@ class AttributionCredit:
     generation_depth: int
     contribution_kind: ContributionKind
     recorded_at: str
+    owner_user_id: str = ""
+    daemon_id: str = ""
+    runtime_instance_id: str = ""
+    worker_id: str = ""
 
     def __post_init__(self) -> None:
         if not 0.0 <= self.credit_share <= 1.0:
@@ -170,6 +178,10 @@ class AttributionCredit:
             generation_depth=int(row.get("generation_depth") or 0),
             contribution_kind=row.get("contribution_kind") or "original",
             recorded_at=row["recorded_at"],
+            owner_user_id=row.get("owner_user_id") or "",
+            daemon_id=row.get("daemon_id") or "",
+            runtime_instance_id=row.get("runtime_instance_id") or "",
+            worker_id=row.get("worker_id") or "",
         )
 
 
@@ -212,3 +224,15 @@ class RemixProvenance:
 def migrate_attribution_schema(conn) -> None:  # type: ignore[no-untyped-def]
     """Create attribution tables if absent. Idempotent."""
     conn.executescript(ATTRIBUTION_SCHEMA)
+    existing_credit_cols = {
+        row["name"] if hasattr(row, "keys") else row[1]
+        for row in conn.execute("PRAGMA table_info(attribution_credit)")
+    }
+    for col, ddl in (
+        ("owner_user_id", "TEXT NOT NULL DEFAULT ''"),
+        ("daemon_id", "TEXT NOT NULL DEFAULT ''"),
+        ("runtime_instance_id", "TEXT NOT NULL DEFAULT ''"),
+        ("worker_id", "TEXT NOT NULL DEFAULT ''"),
+    ):
+        if col not in existing_credit_cols:
+            conn.execute(f"ALTER TABLE attribution_credit ADD COLUMN {col} {ddl}")

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/bid/node_bid.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/bid/node_bid.py
@@ -45,6 +45,10 @@ class NodeBid:
     inputs: dict = field(default_factory=dict)
     bid: float = 0.0
     submitted_by: str = ""
+    owner_user_id: str = ""
+    daemon_id: str = ""
+    runtime_instance_id: str = ""
+    worker_id: str = ""
     status: str = "open"
     evidence_url: str = ""
     submitted_at: str = ""
@@ -250,7 +254,13 @@ def _revert_claim(
 
 
 def claim_node_bid(
-    repo_root: Path, node_bid_id: str, daemon_id: str,
+    repo_root: Path,
+    node_bid_id: str,
+    daemon_id: str,
+    *,
+    owner_user_id: str = "",
+    runtime_instance_id: str = "",
+    worker_id: str = "",
 ) -> "NodeBid | None":
     """Atomic claim via git-rename + push (preflight §4.1 #1).
 
@@ -298,6 +308,10 @@ def claim_node_bid(
             return None
         data["node_bid_id"] = p.stem
         data["status"] = f"claimed:{daemon_id}"
+        data["owner_user_id"] = owner_user_id or ""
+        data["daemon_id"] = daemon_id or ""
+        data["runtime_instance_id"] = runtime_instance_id or ""
+        data["worker_id"] = worker_id or ""
         try:
             claimed_path.write_text(
                 yaml.safe_dump(data, sort_keys=False, default_flow_style=False),

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/bid/settlements.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/bid/settlements.py
@@ -16,7 +16,10 @@ Schema v1 fields:
 
     schema_version: "1"
     bid_id: <str>
+    owner_user_id: <str>
     daemon_id: <str>
+    runtime_instance_id: <str>
+    worker_id: <str>
     requester_id: <str>       # from bid.submitted_by
     bid_amount: <float>
     evidence_url: <str>       # "" on failure
@@ -70,6 +73,10 @@ def record_settlement_event(
     bid: "NodeBid",
     result: "NodeBidResult",
     daemon_id: str,
+    *,
+    owner_user_id: str = "",
+    runtime_instance_id: str = "",
+    worker_id: str = "",
 ) -> Path:
     """Write an immutable settlement record for a completed bid.
 
@@ -101,7 +108,14 @@ def record_settlement_event(
     payload = {
         "schema_version": SCHEMA_VERSION,
         "bid_id": bid.node_bid_id,
+        "owner_user_id": owner_user_id or getattr(bid, "owner_user_id", "") or "",
         "daemon_id": daemon_id,
+        "runtime_instance_id": (
+            runtime_instance_id
+            or getattr(bid, "runtime_instance_id", "")
+            or ""
+        ),
+        "worker_id": worker_id or getattr(bid, "worker_id", "") or "",
         "requester_id": getattr(bid, "submitted_by", "") or "",
         "bid_amount": float(getattr(bid, "bid", 0.0) or 0.0),
         "evidence_url": getattr(result, "evidence_url", "") or "",

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/contribution_events.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/contribution_events.py
@@ -42,6 +42,10 @@ CONTRIBUTION_EVENTS_SCHEMA = """
         event_type            TEXT NOT NULL,
         actor_id              TEXT NOT NULL,
         actor_handle          TEXT NOT NULL DEFAULT '',
+        owner_user_id         TEXT NOT NULL DEFAULT '',
+        daemon_id             TEXT NOT NULL DEFAULT '',
+        runtime_instance_id   TEXT NOT NULL DEFAULT '',
+        worker_id             TEXT NOT NULL DEFAULT '',
         source_run_id         TEXT,
         source_artifact_id    TEXT,
         source_artifact_kind  TEXT NOT NULL DEFAULT '',
@@ -60,6 +64,24 @@ CONTRIBUTION_EVENTS_SCHEMA = """
     CREATE INDEX IF NOT EXISTS idx_contribution_events_run
         ON contribution_events(source_run_id);
 """
+
+CONTRIBUTION_EVENT_IDENTITY_COLUMNS = (
+    ("owner_user_id", "TEXT NOT NULL DEFAULT ''"),
+    ("daemon_id", "TEXT NOT NULL DEFAULT ''"),
+    ("runtime_instance_id", "TEXT NOT NULL DEFAULT ''"),
+    ("worker_id", "TEXT NOT NULL DEFAULT ''"),
+)
+
+
+def migrate_contribution_events_schema(conn: sqlite3.Connection) -> None:
+    """Additive migrations for existing contribution_events tables."""
+    existing = {
+        row["name"] if hasattr(row, "keys") else row[1]
+        for row in conn.execute("PRAGMA table_info(contribution_events)")
+    }
+    for col, ddl in CONTRIBUTION_EVENT_IDENTITY_COLUMNS:
+        if col not in existing:
+            conn.execute(f"ALTER TABLE contribution_events ADD COLUMN {col} {ddl}")
 
 
 def _connect(base_path: str | Path) -> sqlite3.Connection:
@@ -85,6 +107,7 @@ def initialize_contribution_events_db(base_path: str | Path) -> None:
     runs_db_path(base_path)  # ensure parent runs DB path exists
     with _connect(base_path) as conn:
         conn.executescript(CONTRIBUTION_EVENTS_SCHEMA)
+        migrate_contribution_events_schema(conn)
 
 
 def record_contribution_event(
@@ -94,6 +117,10 @@ def record_contribution_event(
     event_type: str,
     actor_id: str,
     actor_handle: str = "",
+    owner_user_id: str = "",
+    daemon_id: str = "",
+    runtime_instance_id: str = "",
+    worker_id: str = "",
     source_run_id: str | None = None,
     source_artifact_id: str | None = None,
     source_artifact_kind: str = "",
@@ -122,15 +149,17 @@ def record_contribution_event(
 
     sql = (
         "INSERT OR IGNORE INTO contribution_events "
-        "(event_id, event_type, actor_id, actor_handle, source_run_id, "
+        "(event_id, event_type, actor_id, actor_handle, owner_user_id, "
+        " daemon_id, runtime_instance_id, worker_id, source_run_id, "
         " source_artifact_id, source_artifact_kind, weight, occurred_at, "
         " metadata_json) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     )
     params = (
-        event_id, event_type, actor_id, actor_handle, source_run_id,
-        source_artifact_id, source_artifact_kind, weight, occurred_at,
-        metadata_json,
+        event_id, event_type, actor_id, actor_handle, owner_user_id or "",
+        daemon_id or "", runtime_instance_id or "", worker_id or "",
+        source_run_id, source_artifact_id, source_artifact_kind, weight,
+        occurred_at, metadata_json,
     )
 
     if conn is not None:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/runs.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/runs.py
@@ -93,6 +93,22 @@ def _now() -> float:
     return time.time()
 
 
+def _resolve_owner_user_id(
+    base_path: str | Path,
+    daemon_id: str | None,
+) -> str:
+    clean_daemon_id = str(daemon_id or "").strip()
+    if not clean_daemon_id:
+        return ""
+    try:
+        from workflow.daemon_registry import get_daemon
+
+        daemon = get_daemon(base_path, daemon_id=clean_daemon_id)
+    except Exception:
+        return ""
+    return str(daemon.get("owner_user_id") or "")
+
+
 def _orphaned_run_grace_seconds() -> float | None:
     """Return the read-time orphan recovery grace window.
 
@@ -233,6 +249,7 @@ def initialize_runs_db(base_path: str | Path) -> Path:
         thread_id      TEXT NOT NULL,
         status         TEXT NOT NULL DEFAULT 'queued',
         actor          TEXT NOT NULL DEFAULT 'anonymous',
+        owner_user_id  TEXT NOT NULL DEFAULT '',
         inputs_json    TEXT NOT NULL DEFAULT '{}',
         output_json    TEXT NOT NULL DEFAULT '{}',
         error          TEXT NOT NULL DEFAULT '',
@@ -369,7 +386,10 @@ def initialize_runs_db(base_path: str | Path) -> Path:
         ON run_receipts(subject_id);
     """
     from workflow.branch_versions import BRANCH_VERSIONS_SCHEMA
-    from workflow.contribution_events import CONTRIBUTION_EVENTS_SCHEMA
+    from workflow.contribution_events import (
+        CONTRIBUTION_EVENTS_SCHEMA,
+        migrate_contribution_events_schema,
+    )
     from workflow.gate_events.schema import GATE_EVENT_SCHEMA
     from workflow.scheduler import SCHEDULER_SCHEMA
     schema = (
@@ -407,12 +427,14 @@ def initialize_runs_db(base_path: str | Path) -> Path:
             ("provider_used", "TEXT"),
             ("model",         "TEXT"),
             ("token_count",   "INTEGER"),
+            ("owner_user_id", "TEXT NOT NULL DEFAULT ''"),
             ("daemon_id",     "TEXT"),
             ("runtime_instance_id", "TEXT"),
             ("worker_id",     "TEXT"),
         ):
             if col not in existing_runs:
                 conn.execute(f"ALTER TABLE runs ADD COLUMN {col} {ddl}")
+        migrate_contribution_events_schema(conn)
         # Phase A item 6 (Task #65a) — branch_version_id on runs. NULL for
         # def-based runs (the existing path); populated only by
         # execute_branch_version_async for version-based runs. Required by
@@ -464,6 +486,9 @@ def _row_to_run(row: sqlite3.Row) -> dict[str, Any]:
         "thread_id": row["thread_id"],
         "status": row["status"],
         "actor": row["actor"],
+        "owner_user_id": (
+            row["owner_user_id"] if "owner_user_id" in col_names else ""
+        ),
         "inputs": json.loads(row["inputs_json"] or "{}"),
         "output": json.loads(row["output_json"] or "{}"),
         "error": row["error"],
@@ -722,25 +747,31 @@ def create_run(
     run_name: str = "",
     actor: str = "anonymous",
     branch_version_id: str | None = None,
+    owner_user_id: str | None = None,
     daemon_id: str | None = None,
     runtime_instance_id: str | None = None,
     worker_id: str | None = None,
 ) -> str:
     initialize_runs_db(base_path)
     run_id = uuid.uuid4().hex[:16]
+    resolved_owner_user_id = (
+        str(owner_user_id or "")
+        if owner_user_id is not None
+        else _resolve_owner_user_id(base_path, daemon_id)
+    )
     with _connect(base_path) as conn:
         conn.execute(
             """
             INSERT INTO runs (
                 run_id, branch_def_id, run_name, thread_id,
-                status, actor, inputs_json, started_at,
+                status, actor, owner_user_id, inputs_json, started_at,
                 branch_version_id, daemon_id, runtime_instance_id,
                 worker_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 run_id, branch_def_id, run_name, thread_id,
-                RUN_STATUS_QUEUED, actor,
+                RUN_STATUS_QUEUED, actor, resolved_owner_user_id,
                 json.dumps(inputs, default=str), _now(),
                 branch_version_id,
                 daemon_id,
@@ -807,7 +838,9 @@ def update_run_status(
         if status in _TERMINAL_STATUSES:
             try:
                 row = conn.execute(
-                    "SELECT actor, branch_def_id, branch_version_id "
+                    "SELECT actor, owner_user_id, daemon_id, "
+                    "runtime_instance_id, worker_id, branch_def_id, "
+                    "branch_version_id "
                     "FROM runs WHERE run_id = ?", (run_id,),
                 ).fetchone()
                 if row is not None:
@@ -827,6 +860,10 @@ def update_run_status(
                             event_id=f"execute_step:{run_id}:{status}",
                             event_type="execute_step",
                             actor_id=row["actor"] or "anonymous",
+                            owner_user_id=row["owner_user_id"] or "",
+                            daemon_id=row["daemon_id"] or "",
+                            runtime_instance_id=row["runtime_instance_id"] or "",
+                            worker_id=row["worker_id"] or "",
                             source_run_id=run_id,
                             source_artifact_id=artifact_id,
                             source_artifact_kind=artifact_kind,
@@ -2089,6 +2126,27 @@ def _invoke_graph(
     # per-run ``provider_calls`` system event (one entry per provider-served
     # node: provider, model, latency, attempts).
     provider_tracker: dict[str, Any] = {"last": None, "model": None, "calls": []}
+    run_identity = {
+        "owner_user_id": "",
+        "daemon_id": "",
+        "runtime_instance_id": "",
+        "worker_id": "",
+    }
+    with _connect(base_path) as conn:
+        identity_row = conn.execute(
+            """
+            SELECT owner_user_id, daemon_id, runtime_instance_id, worker_id
+            FROM runs WHERE run_id = ?
+            """,
+            (run_id,),
+        ).fetchone()
+    if identity_row is not None:
+        run_identity = {
+            "owner_user_id": identity_row["owner_user_id"] or "",
+            "daemon_id": identity_row["daemon_id"] or "",
+            "runtime_instance_id": identity_row["runtime_instance_id"] or "",
+            "worker_id": identity_row["worker_id"] or "",
+        }
 
     def _emit_node_status(node_id: str, status: str) -> None:
         if on_node_status is None:
@@ -2204,6 +2262,10 @@ def _invoke_graph(
                 event_id=f"design_used:{run_id}:{step}:{node_def_id}",
                 event_type="design_used",
                 actor_id=author,
+                owner_user_id=run_identity["owner_user_id"],
+                daemon_id=run_identity["daemon_id"],
+                runtime_instance_id=run_identity["runtime_instance_id"],
+                worker_id=run_identity["worker_id"],
                 source_run_id=run_id,
                 source_artifact_id=node_def_id,
                 source_artifact_kind="node_def",

--- a/tests/test_attribution_calc.py
+++ b/tests/test_attribution_calc.py
@@ -37,6 +37,24 @@ def _credit(actor: str, artifact: str, gen_depth: int = 0) -> AttributionCredit:
     )
 
 
+def _credit_with_identity(actor: str, artifact: str) -> AttributionCredit:
+    return AttributionCredit(
+        credit_id=f"{actor}-{artifact}",
+        artifact_id=artifact,
+        artifact_kind="branch",
+        actor_id=actor,
+        owner_user_id=f"owner-{actor}",
+        daemon_id=f"daemon::{actor}",
+        runtime_instance_id=f"runtime-{actor}",
+        worker_id=f"worker-{actor}",
+        credit_share=1.0,
+        royalty_share=0.0,
+        generation_depth=0,
+        contribution_kind="original",
+        recorded_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
 # ── helper assertions ────────────────────────────────────────────────────────
 
 
@@ -62,6 +80,17 @@ class TestComputeCreditSharesFromCredits:
         credits = [
             _credit("alice", "art-1", gen_depth=0),
             _credit("bob", "art-1", gen_depth=0),
+        ]
+        shares = compute_credit_shares(edges=[], credits=credits)
+        assert shares["alice"] == pytest.approx(0.5)
+        assert shares["bob"] == pytest.approx(0.5)
+        _assert_sums_to_one(shares)
+
+    def test_identity_fields_do_not_change_credit_split(self):
+        from workflow.attribution.calc import compute_credit_shares
+        credits = [
+            _credit_with_identity("alice", "art-1"),
+            _credit_with_identity("bob", "art-1"),
         ]
         shares = compute_credit_shares(edges=[], credits=credits)
         assert shares["alice"] == pytest.approx(0.5)

--- a/tests/test_attribution_mcp.py
+++ b/tests/test_attribution_mcp.py
@@ -11,6 +11,8 @@ import pytest
 
 from workflow.runs import initialize_runs_db
 from workflow.universe_server import extensions
+
+
 @pytest.fixture(autouse=True)
 def _set_data_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
@@ -98,6 +100,40 @@ class TestRecordRemix:
         ))
         assert result["status"] == "recorded"
         assert abs(result["credit_share"] - 0.3) < 1e-9
+
+    def test_record_credit_persists_identity_tuple(self, tmp_path):
+        from workflow.api.market import _action_record_remix
+
+        result = json.loads(_action_record_remix({
+            "parent_branch_def_id": "branch-A",
+            "child_branch_def_id": "branch-B",
+            "actor_id": "actor-daemon",
+            "owner_user_id": "owner-user",
+            "daemon_id": "daemon::actor",
+            "runtime_instance_id": "runtime-1",
+            "worker_id": "worker-1",
+            "credit_share": 0.3,
+        }))
+        assert result["status"] == "recorded"
+
+        from workflow.runs import _connect
+
+        with _connect(tmp_path) as conn:
+            row = conn.execute(
+                """
+                SELECT actor_id, owner_user_id, daemon_id,
+                       runtime_instance_id, worker_id, credit_share
+                FROM attribution_credit
+                WHERE artifact_id = ? AND artifact_kind = 'branch'
+                """,
+                ("branch-B",),
+            ).fetchone()
+        assert row["actor_id"] == "actor-daemon"
+        assert row["owner_user_id"] == "owner-user"
+        assert row["daemon_id"] == "daemon::actor"
+        assert row["runtime_instance_id"] == "runtime-1"
+        assert row["worker_id"] == "worker-1"
+        assert row["credit_share"] == pytest.approx(0.3)
 
     def test_cycle_rejected_direct(self):
         extensions(

--- a/tests/test_attribution_schema.py
+++ b/tests/test_attribution_schema.py
@@ -36,6 +36,10 @@ def _credit_row(**overrides) -> dict:
         "artifact_id": "branch-B",
         "artifact_kind": "branch",
         "actor_id": "alice",
+        "owner_user_id": "owner-alice",
+        "daemon_id": "daemon::alice-worker",
+        "runtime_instance_id": "runtime-1",
+        "worker_id": "worker-1",
         "credit_share": 0.7,
         "royalty_share": 0.05,
         "generation_depth": 0,
@@ -113,9 +117,25 @@ class TestAttributionCredit:
         c = AttributionCredit.from_row(_credit_row())
         assert c.credit_id == "cred-1"
         assert c.actor_id == "alice"
+        assert c.owner_user_id == "owner-alice"
+        assert c.daemon_id == "daemon::alice-worker"
+        assert c.runtime_instance_id == "runtime-1"
+        assert c.worker_id == "worker-1"
         assert c.credit_share == pytest.approx(0.7)
         assert c.royalty_share == pytest.approx(0.05)
         assert c.generation_depth == 0
+
+    def test_schema_has_optional_identity_tuple_columns(self, db):
+        columns = {
+            row["name"]
+            for row in db.execute("PRAGMA table_info(attribution_credit)")
+        }
+        assert {
+            "owner_user_id",
+            "daemon_id",
+            "runtime_instance_id",
+            "worker_id",
+        } <= columns
 
     def test_is_original_author_true(self):
         c = AttributionCredit.from_row(_credit_row(generation_depth=0))
@@ -166,6 +186,10 @@ class TestAttributionCredit:
         assert c.royalty_share == pytest.approx(0.0)
         assert c.generation_depth == 0
         assert c.contribution_kind == "original"
+        assert c.owner_user_id == ""
+        assert c.daemon_id == ""
+        assert c.runtime_instance_id == ""
+        assert c.worker_id == ""
 
 
 # ── RemixProvenance ────────────────────────────────────────────────────────────

--- a/tests/test_contribution_events_emit.py
+++ b/tests/test_contribution_events_emit.py
@@ -32,8 +32,16 @@ from workflow.runs import (
 )
 
 
-def _fresh_run(tmp_path, *, branch_def_id: str = "b1", actor: str = "alice",
-               branch_version_id: str | None = None) -> str:
+def _fresh_run(
+    tmp_path,
+    *,
+    branch_def_id: str = "b1",
+    actor: str = "alice",
+    branch_version_id: str | None = None,
+    daemon_id: str | None = None,
+    runtime_instance_id: str | None = None,
+    worker_id: str | None = None,
+) -> str:
     """Create a fresh queued run, return its run_id."""
     initialize_runs_db(tmp_path)
     return create_run(
@@ -44,6 +52,9 @@ def _fresh_run(tmp_path, *, branch_def_id: str = "b1", actor: str = "alice",
         run_name="emit-test",
         actor=actor,
         branch_version_id=branch_version_id,
+        daemon_id=daemon_id,
+        runtime_instance_id=runtime_instance_id,
+        worker_id=worker_id,
     )
 
 
@@ -127,6 +138,46 @@ class TestTerminalStatusEmits:
         ev = events[0]
         assert ev["source_artifact_id"] == "b1@abc12345"
         assert ev["source_artifact_kind"] == "branch_version"
+
+    def test_completed_run_emits_full_identity_tuple(self, tmp_path):
+        from workflow.daemon_registry import create_daemon
+
+        daemon = create_daemon(
+            tmp_path,
+            display_name="Economic Worker",
+            created_by="owner-user",
+            soul_mode="soulless",
+        )
+        run_id = _fresh_run(
+            tmp_path,
+            daemon_id=daemon["daemon_id"],
+            runtime_instance_id="runtime-1",
+            worker_id="worker-1",
+        )
+        update_run_status(tmp_path, run_id, status=RUN_STATUS_COMPLETED)
+        events = _events(tmp_path, run_id)
+        assert len(events) == 1
+        ev = events[0]
+        assert ev["actor_id"] == "alice"
+        assert ev["owner_user_id"] == "owner-user"
+        assert ev["daemon_id"] == daemon["daemon_id"]
+        assert ev["runtime_instance_id"] == "runtime-1"
+        assert ev["worker_id"] == "worker-1"
+        assert ev["weight"] == 1.0
+
+    def test_unresolvable_daemon_owner_defaults_empty_on_emit(self, tmp_path):
+        run_id = _fresh_run(
+            tmp_path,
+            daemon_id="daemon::missing",
+            runtime_instance_id="runtime-missing",
+            worker_id="worker-missing",
+        )
+        update_run_status(tmp_path, run_id, status=RUN_STATUS_COMPLETED)
+        ev = _events(tmp_path, run_id)[0]
+        assert ev["owner_user_id"] == ""
+        assert ev["daemon_id"] == "daemon::missing"
+        assert ev["runtime_instance_id"] == "runtime-missing"
+        assert ev["worker_id"] == "worker-missing"
 
 
 # ── Non-terminal status does NOT emit ────────────────────────────────────────

--- a/tests/test_node_bid.py
+++ b/tests/test_node_bid.py
@@ -237,6 +237,39 @@ def test_claim_node_bid_first_wins(repo_root):
     assert second is None
 
 
+def test_claim_node_bid_records_identity_tuple(repo_root, monkeypatch):
+    import workflow.bid.node_bid as nb_mod
+    from workflow.bid.node_bid import bids_dir
+
+    monkeypatch.setattr(nb_mod, "_git_has_remote", lambda _root: False)
+
+    _write_bid_yaml(repo_root, "nb_identity")
+    claimed = claim_node_bid(
+        repo_root,
+        "nb_identity",
+        "daemon-A",
+        owner_user_id="owner-A",
+        runtime_instance_id="runtime-A",
+        worker_id="worker-A",
+    )
+    assert claimed is not None
+    assert claimed.status == "claimed:daemon-A"
+    assert claimed.owner_user_id == "owner-A"
+    assert claimed.daemon_id == "daemon-A"
+    assert claimed.runtime_instance_id == "runtime-A"
+    assert claimed.worker_id == "worker-A"
+
+    [claimed_path] = [
+        p for p in bids_dir(repo_root).iterdir()
+        if p.name.startswith("nb_identity.yaml.claimed_by_")
+    ]
+    data = yaml.safe_load(claimed_path.read_text(encoding="utf-8"))
+    assert data["owner_user_id"] == "owner-A"
+    assert data["daemon_id"] == "daemon-A"
+    assert data["runtime_instance_id"] == "runtime-A"
+    assert data["worker_id"] == "worker-A"
+
+
 def test_claim_missing_bid_returns_none(repo_root):
     assert claim_node_bid(repo_root, "nb_missing", "daemon-A") is None
 
@@ -801,6 +834,37 @@ def test_settlement_emitted_on_succeeded_bid(repo_root):
     assert "success" not in data
 
 
+def test_settlement_records_identity_tuple_without_changing_amount(repo_root):
+    from workflow.bid.settlements import record_settlement_event
+    from workflow.executors.node_bid import NodeBidResult
+
+    bid = NodeBid(
+        node_bid_id="nb_identity", node_def_id="n/x",
+        submitted_by="alice", bid=7.25,
+    )
+    result = NodeBidResult(
+        node_bid_id="nb_identity", status="succeeded",
+        evidence_url="file:///tmp/e",
+    )
+    path = record_settlement_event(
+        repo_root,
+        bid,
+        result,
+        "daemon-1",
+        owner_user_id="owner-1",
+        runtime_instance_id="runtime-1",
+        worker_id="worker-1",
+    )
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert data["owner_user_id"] == "owner-1"
+    assert data["daemon_id"] == "daemon-1"
+    assert data["runtime_instance_id"] == "runtime-1"
+    assert data["worker_id"] == "worker-1"
+    assert data["bid_amount"] == 7.25
+    assert data["outcome_status"] == "succeeded"
+    assert data["settled"] is False
+
+
 def test_settlement_emitted_on_failed_bid(repo_root):
     from workflow.bid.settlements import record_settlement_event
     from workflow.executors.node_bid import NodeBidResult
@@ -1092,7 +1156,7 @@ def test_race_bypass_rejected_when_remote_configured(
     # up the patched callable.
     import workflow.bid.node_bid as nb_mod
 
-    def _patched_claim(repo, bid_id, daemon_id):
+    def _patched_claim(repo, bid_id, daemon_id, **_kwargs):
         return None  # always "race lost"
     monkeypatch.setattr(nb_mod, "claim_node_bid", _patched_claim)
 
@@ -1179,7 +1243,7 @@ def test_fallback_rejected_when_remote_and_yaml_missing(
 
     import workflow.bid.node_bid as nb_mod
     monkeypatch.setattr(
-        nb_mod, "claim_node_bid", lambda r, b, d: None,
+        nb_mod, "claim_node_bid", lambda r, b, d, **_kwargs: None,
     )
 
     from fantasy_daemon.__main__ import _try_execute_claimed_node_bid

--- a/tests/test_runs_schema_migration.py
+++ b/tests/test_runs_schema_migration.py
@@ -126,6 +126,41 @@ class TestNewColumnsExist:
             ).fetchone()
         assert row["branch_version_id"] == "b1@abc12345"
 
+    def test_create_run_resolves_owner_user_id_from_daemon_registry(
+        self, tmp_path: Path,
+    ) -> None:
+        from workflow.daemon_registry import create_daemon
+
+        daemon = create_daemon(
+            tmp_path,
+            display_name="Owner Resolved Runner",
+            created_by="owner-user",
+            soul_mode="soulless",
+        )
+        run_id = create_run(
+            tmp_path,
+            branch_def_id="b1",
+            thread_id="t1",
+            inputs={},
+            run_name="identity",
+            actor="actor-user",
+            daemon_id=daemon["daemon_id"],
+            runtime_instance_id="runtime-1",
+            worker_id="worker-1",
+        )
+        with _connect(tmp_path) as conn:
+            row = conn.execute(
+                """
+                SELECT owner_user_id, daemon_id, runtime_instance_id, worker_id
+                FROM runs WHERE run_id = ?
+                """,
+                (run_id,),
+            ).fetchone()
+        assert row["owner_user_id"] == "owner-user"
+        assert row["daemon_id"] == daemon["daemon_id"]
+        assert row["runtime_instance_id"] == "runtime-1"
+        assert row["worker_id"] == "worker-1"
+
 
 class TestMigrationExistingDb:
     def _old_schema_db(self, base: Path) -> None:

--- a/workflow/api/market.py
+++ b/workflow/api/market.py
@@ -715,6 +715,10 @@ def _action_record_remix(kwargs: dict[str, Any]) -> str:
     credit_share = max(0.0, min(1.0, credit_share))
 
     actor_id = (kwargs.get("actor_id") or "anonymous").strip() or "anonymous"
+    owner_user_id = (kwargs.get("owner_user_id") or "").strip()
+    daemon_id = (kwargs.get("daemon_id") or "").strip()
+    runtime_instance_id = (kwargs.get("runtime_instance_id") or "").strip()
+    worker_id = (kwargs.get("worker_id") or "").strip()
     base = _base_path()
 
     with _attribution_connect(base) as conn:
@@ -773,12 +777,16 @@ def _action_record_remix(kwargs: dict[str, Any]) -> str:
                 """
                 INSERT OR IGNORE INTO attribution_credit
                     (credit_id, artifact_id, artifact_kind, actor_id,
+                     owner_user_id, daemon_id, runtime_instance_id, worker_id,
                      credit_share, royalty_share, generation_depth,
                      contribution_kind, recorded_at)
-                VALUES (?, ?, 'branch', ?, ?, 0.0, ?, ?, ?)
+                VALUES (?, ?, 'branch', ?, ?, ?, ?, ?, ?, 0.0, ?, ?, ?)
                 """,
-                (credit_id, child_id, actor_id, credit_share,
-                 generation_depth, contribution_kind, created_at),
+                (
+                    credit_id, child_id, actor_id, owner_user_id, daemon_id,
+                    runtime_instance_id, worker_id, credit_share,
+                    generation_depth, contribution_kind, created_at,
+                ),
             )
 
     return json.dumps({

--- a/workflow/attribution/schema.py
+++ b/workflow/attribution/schema.py
@@ -59,6 +59,10 @@ CREATE TABLE IF NOT EXISTS attribution_credit (
     artifact_kind   TEXT NOT NULL DEFAULT 'branch'
                         CHECK (artifact_kind IN ('branch', 'node')),
     actor_id        TEXT NOT NULL,
+    owner_user_id   TEXT NOT NULL DEFAULT '',
+    daemon_id       TEXT NOT NULL DEFAULT '',
+    runtime_instance_id TEXT NOT NULL DEFAULT '',
+    worker_id       TEXT NOT NULL DEFAULT '',
     credit_share    REAL NOT NULL CHECK (credit_share >= 0.0 AND credit_share <= 1.0),
     royalty_share   REAL NOT NULL DEFAULT 0.0
                         CHECK (royalty_share >= 0.0 AND royalty_share <= 1.0),
@@ -135,6 +139,10 @@ class AttributionCredit:
     generation_depth: int
     contribution_kind: ContributionKind
     recorded_at: str
+    owner_user_id: str = ""
+    daemon_id: str = ""
+    runtime_instance_id: str = ""
+    worker_id: str = ""
 
     def __post_init__(self) -> None:
         if not 0.0 <= self.credit_share <= 1.0:
@@ -170,6 +178,10 @@ class AttributionCredit:
             generation_depth=int(row.get("generation_depth") or 0),
             contribution_kind=row.get("contribution_kind") or "original",
             recorded_at=row["recorded_at"],
+            owner_user_id=row.get("owner_user_id") or "",
+            daemon_id=row.get("daemon_id") or "",
+            runtime_instance_id=row.get("runtime_instance_id") or "",
+            worker_id=row.get("worker_id") or "",
         )
 
 
@@ -212,3 +224,15 @@ class RemixProvenance:
 def migrate_attribution_schema(conn) -> None:  # type: ignore[no-untyped-def]
     """Create attribution tables if absent. Idempotent."""
     conn.executescript(ATTRIBUTION_SCHEMA)
+    existing_credit_cols = {
+        row["name"] if hasattr(row, "keys") else row[1]
+        for row in conn.execute("PRAGMA table_info(attribution_credit)")
+    }
+    for col, ddl in (
+        ("owner_user_id", "TEXT NOT NULL DEFAULT ''"),
+        ("daemon_id", "TEXT NOT NULL DEFAULT ''"),
+        ("runtime_instance_id", "TEXT NOT NULL DEFAULT ''"),
+        ("worker_id", "TEXT NOT NULL DEFAULT ''"),
+    ):
+        if col not in existing_credit_cols:
+            conn.execute(f"ALTER TABLE attribution_credit ADD COLUMN {col} {ddl}")

--- a/workflow/bid/node_bid.py
+++ b/workflow/bid/node_bid.py
@@ -45,6 +45,10 @@ class NodeBid:
     inputs: dict = field(default_factory=dict)
     bid: float = 0.0
     submitted_by: str = ""
+    owner_user_id: str = ""
+    daemon_id: str = ""
+    runtime_instance_id: str = ""
+    worker_id: str = ""
     status: str = "open"
     evidence_url: str = ""
     submitted_at: str = ""
@@ -250,7 +254,13 @@ def _revert_claim(
 
 
 def claim_node_bid(
-    repo_root: Path, node_bid_id: str, daemon_id: str,
+    repo_root: Path,
+    node_bid_id: str,
+    daemon_id: str,
+    *,
+    owner_user_id: str = "",
+    runtime_instance_id: str = "",
+    worker_id: str = "",
 ) -> "NodeBid | None":
     """Atomic claim via git-rename + push (preflight §4.1 #1).
 
@@ -298,6 +308,10 @@ def claim_node_bid(
             return None
         data["node_bid_id"] = p.stem
         data["status"] = f"claimed:{daemon_id}"
+        data["owner_user_id"] = owner_user_id or ""
+        data["daemon_id"] = daemon_id or ""
+        data["runtime_instance_id"] = runtime_instance_id or ""
+        data["worker_id"] = worker_id or ""
         try:
             claimed_path.write_text(
                 yaml.safe_dump(data, sort_keys=False, default_flow_style=False),

--- a/workflow/bid/settlements.py
+++ b/workflow/bid/settlements.py
@@ -16,7 +16,10 @@ Schema v1 fields:
 
     schema_version: "1"
     bid_id: <str>
+    owner_user_id: <str>
     daemon_id: <str>
+    runtime_instance_id: <str>
+    worker_id: <str>
     requester_id: <str>       # from bid.submitted_by
     bid_amount: <float>
     evidence_url: <str>       # "" on failure
@@ -70,6 +73,10 @@ def record_settlement_event(
     bid: "NodeBid",
     result: "NodeBidResult",
     daemon_id: str,
+    *,
+    owner_user_id: str = "",
+    runtime_instance_id: str = "",
+    worker_id: str = "",
 ) -> Path:
     """Write an immutable settlement record for a completed bid.
 
@@ -101,7 +108,14 @@ def record_settlement_event(
     payload = {
         "schema_version": SCHEMA_VERSION,
         "bid_id": bid.node_bid_id,
+        "owner_user_id": owner_user_id or getattr(bid, "owner_user_id", "") or "",
         "daemon_id": daemon_id,
+        "runtime_instance_id": (
+            runtime_instance_id
+            or getattr(bid, "runtime_instance_id", "")
+            or ""
+        ),
+        "worker_id": worker_id or getattr(bid, "worker_id", "") or "",
         "requester_id": getattr(bid, "submitted_by", "") or "",
         "bid_amount": float(getattr(bid, "bid", 0.0) or 0.0),
         "evidence_url": getattr(result, "evidence_url", "") or "",

--- a/workflow/contribution_events.py
+++ b/workflow/contribution_events.py
@@ -42,6 +42,10 @@ CONTRIBUTION_EVENTS_SCHEMA = """
         event_type            TEXT NOT NULL,
         actor_id              TEXT NOT NULL,
         actor_handle          TEXT NOT NULL DEFAULT '',
+        owner_user_id         TEXT NOT NULL DEFAULT '',
+        daemon_id             TEXT NOT NULL DEFAULT '',
+        runtime_instance_id   TEXT NOT NULL DEFAULT '',
+        worker_id             TEXT NOT NULL DEFAULT '',
         source_run_id         TEXT,
         source_artifact_id    TEXT,
         source_artifact_kind  TEXT NOT NULL DEFAULT '',
@@ -60,6 +64,24 @@ CONTRIBUTION_EVENTS_SCHEMA = """
     CREATE INDEX IF NOT EXISTS idx_contribution_events_run
         ON contribution_events(source_run_id);
 """
+
+CONTRIBUTION_EVENT_IDENTITY_COLUMNS = (
+    ("owner_user_id", "TEXT NOT NULL DEFAULT ''"),
+    ("daemon_id", "TEXT NOT NULL DEFAULT ''"),
+    ("runtime_instance_id", "TEXT NOT NULL DEFAULT ''"),
+    ("worker_id", "TEXT NOT NULL DEFAULT ''"),
+)
+
+
+def migrate_contribution_events_schema(conn: sqlite3.Connection) -> None:
+    """Additive migrations for existing contribution_events tables."""
+    existing = {
+        row["name"] if hasattr(row, "keys") else row[1]
+        for row in conn.execute("PRAGMA table_info(contribution_events)")
+    }
+    for col, ddl in CONTRIBUTION_EVENT_IDENTITY_COLUMNS:
+        if col not in existing:
+            conn.execute(f"ALTER TABLE contribution_events ADD COLUMN {col} {ddl}")
 
 
 def _connect(base_path: str | Path) -> sqlite3.Connection:
@@ -85,6 +107,7 @@ def initialize_contribution_events_db(base_path: str | Path) -> None:
     runs_db_path(base_path)  # ensure parent runs DB path exists
     with _connect(base_path) as conn:
         conn.executescript(CONTRIBUTION_EVENTS_SCHEMA)
+        migrate_contribution_events_schema(conn)
 
 
 def record_contribution_event(
@@ -94,6 +117,10 @@ def record_contribution_event(
     event_type: str,
     actor_id: str,
     actor_handle: str = "",
+    owner_user_id: str = "",
+    daemon_id: str = "",
+    runtime_instance_id: str = "",
+    worker_id: str = "",
     source_run_id: str | None = None,
     source_artifact_id: str | None = None,
     source_artifact_kind: str = "",
@@ -122,15 +149,17 @@ def record_contribution_event(
 
     sql = (
         "INSERT OR IGNORE INTO contribution_events "
-        "(event_id, event_type, actor_id, actor_handle, source_run_id, "
+        "(event_id, event_type, actor_id, actor_handle, owner_user_id, "
+        " daemon_id, runtime_instance_id, worker_id, source_run_id, "
         " source_artifact_id, source_artifact_kind, weight, occurred_at, "
         " metadata_json) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     )
     params = (
-        event_id, event_type, actor_id, actor_handle, source_run_id,
-        source_artifact_id, source_artifact_kind, weight, occurred_at,
-        metadata_json,
+        event_id, event_type, actor_id, actor_handle, owner_user_id or "",
+        daemon_id or "", runtime_instance_id or "", worker_id or "",
+        source_run_id, source_artifact_id, source_artifact_kind, weight,
+        occurred_at, metadata_json,
     )
 
     if conn is not None:

--- a/workflow/runs.py
+++ b/workflow/runs.py
@@ -93,6 +93,22 @@ def _now() -> float:
     return time.time()
 
 
+def _resolve_owner_user_id(
+    base_path: str | Path,
+    daemon_id: str | None,
+) -> str:
+    clean_daemon_id = str(daemon_id or "").strip()
+    if not clean_daemon_id:
+        return ""
+    try:
+        from workflow.daemon_registry import get_daemon
+
+        daemon = get_daemon(base_path, daemon_id=clean_daemon_id)
+    except Exception:
+        return ""
+    return str(daemon.get("owner_user_id") or "")
+
+
 def _orphaned_run_grace_seconds() -> float | None:
     """Return the read-time orphan recovery grace window.
 
@@ -233,6 +249,7 @@ def initialize_runs_db(base_path: str | Path) -> Path:
         thread_id      TEXT NOT NULL,
         status         TEXT NOT NULL DEFAULT 'queued',
         actor          TEXT NOT NULL DEFAULT 'anonymous',
+        owner_user_id  TEXT NOT NULL DEFAULT '',
         inputs_json    TEXT NOT NULL DEFAULT '{}',
         output_json    TEXT NOT NULL DEFAULT '{}',
         error          TEXT NOT NULL DEFAULT '',
@@ -369,7 +386,10 @@ def initialize_runs_db(base_path: str | Path) -> Path:
         ON run_receipts(subject_id);
     """
     from workflow.branch_versions import BRANCH_VERSIONS_SCHEMA
-    from workflow.contribution_events import CONTRIBUTION_EVENTS_SCHEMA
+    from workflow.contribution_events import (
+        CONTRIBUTION_EVENTS_SCHEMA,
+        migrate_contribution_events_schema,
+    )
     from workflow.gate_events.schema import GATE_EVENT_SCHEMA
     from workflow.scheduler import SCHEDULER_SCHEMA
     schema = (
@@ -407,12 +427,14 @@ def initialize_runs_db(base_path: str | Path) -> Path:
             ("provider_used", "TEXT"),
             ("model",         "TEXT"),
             ("token_count",   "INTEGER"),
+            ("owner_user_id", "TEXT NOT NULL DEFAULT ''"),
             ("daemon_id",     "TEXT"),
             ("runtime_instance_id", "TEXT"),
             ("worker_id",     "TEXT"),
         ):
             if col not in existing_runs:
                 conn.execute(f"ALTER TABLE runs ADD COLUMN {col} {ddl}")
+        migrate_contribution_events_schema(conn)
         # Phase A item 6 (Task #65a) — branch_version_id on runs. NULL for
         # def-based runs (the existing path); populated only by
         # execute_branch_version_async for version-based runs. Required by
@@ -464,6 +486,9 @@ def _row_to_run(row: sqlite3.Row) -> dict[str, Any]:
         "thread_id": row["thread_id"],
         "status": row["status"],
         "actor": row["actor"],
+        "owner_user_id": (
+            row["owner_user_id"] if "owner_user_id" in col_names else ""
+        ),
         "inputs": json.loads(row["inputs_json"] or "{}"),
         "output": json.loads(row["output_json"] or "{}"),
         "error": row["error"],
@@ -722,25 +747,31 @@ def create_run(
     run_name: str = "",
     actor: str = "anonymous",
     branch_version_id: str | None = None,
+    owner_user_id: str | None = None,
     daemon_id: str | None = None,
     runtime_instance_id: str | None = None,
     worker_id: str | None = None,
 ) -> str:
     initialize_runs_db(base_path)
     run_id = uuid.uuid4().hex[:16]
+    resolved_owner_user_id = (
+        str(owner_user_id or "")
+        if owner_user_id is not None
+        else _resolve_owner_user_id(base_path, daemon_id)
+    )
     with _connect(base_path) as conn:
         conn.execute(
             """
             INSERT INTO runs (
                 run_id, branch_def_id, run_name, thread_id,
-                status, actor, inputs_json, started_at,
+                status, actor, owner_user_id, inputs_json, started_at,
                 branch_version_id, daemon_id, runtime_instance_id,
                 worker_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 run_id, branch_def_id, run_name, thread_id,
-                RUN_STATUS_QUEUED, actor,
+                RUN_STATUS_QUEUED, actor, resolved_owner_user_id,
                 json.dumps(inputs, default=str), _now(),
                 branch_version_id,
                 daemon_id,
@@ -807,7 +838,9 @@ def update_run_status(
         if status in _TERMINAL_STATUSES:
             try:
                 row = conn.execute(
-                    "SELECT actor, branch_def_id, branch_version_id "
+                    "SELECT actor, owner_user_id, daemon_id, "
+                    "runtime_instance_id, worker_id, branch_def_id, "
+                    "branch_version_id "
                     "FROM runs WHERE run_id = ?", (run_id,),
                 ).fetchone()
                 if row is not None:
@@ -827,6 +860,10 @@ def update_run_status(
                             event_id=f"execute_step:{run_id}:{status}",
                             event_type="execute_step",
                             actor_id=row["actor"] or "anonymous",
+                            owner_user_id=row["owner_user_id"] or "",
+                            daemon_id=row["daemon_id"] or "",
+                            runtime_instance_id=row["runtime_instance_id"] or "",
+                            worker_id=row["worker_id"] or "",
                             source_run_id=run_id,
                             source_artifact_id=artifact_id,
                             source_artifact_kind=artifact_kind,
@@ -2089,6 +2126,27 @@ def _invoke_graph(
     # per-run ``provider_calls`` system event (one entry per provider-served
     # node: provider, model, latency, attempts).
     provider_tracker: dict[str, Any] = {"last": None, "model": None, "calls": []}
+    run_identity = {
+        "owner_user_id": "",
+        "daemon_id": "",
+        "runtime_instance_id": "",
+        "worker_id": "",
+    }
+    with _connect(base_path) as conn:
+        identity_row = conn.execute(
+            """
+            SELECT owner_user_id, daemon_id, runtime_instance_id, worker_id
+            FROM runs WHERE run_id = ?
+            """,
+            (run_id,),
+        ).fetchone()
+    if identity_row is not None:
+        run_identity = {
+            "owner_user_id": identity_row["owner_user_id"] or "",
+            "daemon_id": identity_row["daemon_id"] or "",
+            "runtime_instance_id": identity_row["runtime_instance_id"] or "",
+            "worker_id": identity_row["worker_id"] or "",
+        }
 
     def _emit_node_status(node_id: str, status: str) -> None:
         if on_node_status is None:
@@ -2204,6 +2262,10 @@ def _invoke_graph(
                 event_id=f"design_used:{run_id}:{step}:{node_def_id}",
                 event_type="design_used",
                 actor_id=author,
+                owner_user_id=run_identity["owner_user_id"],
+                daemon_id=run_identity["daemon_id"],
+                runtime_instance_id=run_identity["runtime_instance_id"],
+                worker_id=run_identity["worker_id"],
                 source_run_id=run_id,
                 source_artifact_id=node_def_id,
                 source_artifact_kind="node_def",


### PR DESCRIPTION
Recreates auto-closed #1355 (GitHub closed it when #1354's base branch was deleted on merge). #1354 (Slice 1) is already merged. Host-approved.

PR-179 Slice 2 — additive, record-only: stamps the executor identity tuple (owner_user_id + daemon_id + runtime_instance_id + worker_id) on the economic primitives (attribution_credit via api/market.py mint + contribution_events, paid-bid claims, settlements). owner_user_id resolved from daemon_registry. Per host decision: record both, defer payment/reputation/selection policy to user-composed logic — NO settlement/credit math change, NO baked formula.

Codex-authored (mcp__codex__codex), Claude cross-family reviewed + tested. Verified identity does not change credit splits or settlement amounts; 167 affected tests pass (2 pre-existing MicroToken/float failures in untouched attribution/calc.py are unrelated). Plugin mirrors updated; ruff clean. merge-tree confirms clean merge into current main.

Brain home: PR-179 wiki page. 🤖 Generated with [Claude Code](https://claude.com/claude-code)