### PR TITLE
test: fix stale goal round-trip fixture missing branch_protocol

### DIFF
--- a/tests/test_storage_phase7_serializer.py
+++ b/tests/test_storage_phase7_serializer.py
@@ -282,6 +282,8 @@ def test_node_payload_always_includes_timeout_seconds():
 def test_goal_round_trip_is_identity():
     # Phase 6.3: `gate_ladder` rides through as a goal attribute,
     # defaulting to [] when absent. The round-trip always surfaces it.
+    # PR-129 (#991) adds `branch_protocol` as a parallel optional goal
+    # attribute with the same always-surfaced, [] default contract.
     original = {
         "goal_id": "goal_xyz",
         "name": "Produce academic paper",
@@ -292,6 +294,7 @@ def test_goal_round_trip_is_identity():
         "created_at": 1712000000.0,
         "updated_at": 1712000500.0,
         "gate_ladder": [],
+        "branch_protocol": [],
     }
     payload = goal_to_yaml_payload(original)
     reconstituted = goal_from_yaml_payload(payload)


### PR DESCRIPTION
## Diagnosis

`tests/test_storage_phase7_serializer.py::test_goal_round_trip_is_identity` failed on `origin/main`:

```
AssertionError: assert reconstituted == original
Left contains 1 more item:
{'branch_protocol': []}
```

The diverging field is **`branch_protocol`**. The reconstituted Goal (output of `goal_from_yaml_payload`) carried `branch_protocol: []`, which the test's `original` fixture omitted.

**Root cause — STALE TEST, not a code bug.** PR-129 / #991 (commit `632cbb59`, 2026-05-27, "Goal-bound branch protocols") added `branch_protocol` as an optional Goal attribute parallel to `gate_ladder`. In `workflow/catalog/serializer.py`, `goal_from_yaml_payload` *always* surfaces `branch_protocol` (defaulting to `[]`) — identical to how it always surfaces `gate_ladder`. That commit added a new test file (`tests/test_goals_ladder_shape.py`) but never updated this older round-trip fixture, which predates the attribute.

The serializer is faithful: it loses no data and round-trip identity is the correct property. The fixture was the stale layer.

## Fix

Added `"branch_protocol": []` to the `original` dict (layer fixed: **test only**), mirroring the existing `gate_ladder: []` entry and its always-surfaced contract comment. No `workflow/*` code changed, so no plugin-mirror rebuild was required.

## Evidence

- Before: `1 failed` (`branch_protocol` divergence shown above).
- After (targeted): `1 passed`.
- Whole file + parallel ladder-shape suite: `tests/test_storage_phase7_serializer.py tests/test_goals_ladder_shape.py` → `27 passed`.
- All runs used `-p no:cacheprovider` + a unique temp `WORKFLOW_DATA_DIR`.
- `python -m ruff check tests/test_storage_phase7_serializer.py` → `All checks passed!`

No product decision needed — straightforward fixture catch-up to an existing, reviewed contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)