### PR TITLE
Fix MCP read path: emit real data in text content, not an empty-looking stub

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -65,36 +65,39 @@ logger = logging.getLogger("universe_server")
 _MCP_TEXT_CONTENT_MAX_CHARS = 6000
 
 
-def _summarize_structured_content(value: object) -> str:
-    """Small text-channel summary for large structured MCP payloads."""
-    if isinstance(value, dict):
-        parts: list[str] = []
-        for key in ("status", "action", "tool", "goal_id", "branch_def_id"):
-            item = value.get(key)
-            if isinstance(item, str) and item:
-                parts.append(f"{key}={item}")
-        for key in ("count", "returned", "total", "total_count"):
-            item = value.get(key)
-            if isinstance(item, int):
-                parts.append(f"{key}={item}")
-        list_counts = [
-            f"{key}={len(item)}"
-            for key, item in value.items()
-            if isinstance(item, list)
-        ]
-        parts.extend(list_counts[:4])
-        if parts:
-            return (
-                "Tool result: "
-                + "; ".join(parts)
-                + ". Full payload is in structuredContent."
-            )
-    if isinstance(value, list):
-        return (
-            f"Tool result: {len(value)} items. "
-            "Full payload is in structuredContent."
-        )
-    return "Tool result available in structuredContent."
+def _faithful_text_content(value: object) -> str:
+    """Build the text ``content`` block for an MCP tool result.
+
+    Text-only MCP clients read only the ``content`` text block and never parse
+    ``structuredContent`` — so the text must carry the *real* payload, never a
+    placeholder. Prior behaviour replaced oversized payloads with a lossy
+    key-count stub ("Full payload is in structuredContent."), which made reads
+    silently look empty to those clients (read_page bodies, get_status caveats,
+    goals lists, etc.).
+
+    Contract:
+    - Payload fits the text budget -> emit the full payload as JSON (pretty
+      when that also fits, else compact). Fully faithful, no data lost.
+    - Payload exceeds the budget -> render as much real, readable data as fits
+      and append an explicit truncation pointer to ``structuredContent`` for
+      the elided remainder. Still bounded (the 6000-char ceiling that already
+      governed the under-budget path), so ChatGPT's token budget is unchanged;
+      the difference is real data instead of a placeholder.
+    """
+    import json as _json
+
+    compact = _json.dumps(value, separators=(",", ":"), default=str)
+    if len(compact) <= _MCP_TEXT_CONTENT_MAX_CHARS:
+        pretty = _json.dumps(value, indent=2, default=str)
+        return pretty if len(pretty) <= _MCP_TEXT_CONTENT_MAX_CHARS else compact
+
+    marker = (
+        f"\n... [truncated: {len(compact)} chars total; "
+        "full payload in structuredContent]"
+    )
+    keep = max(0, _MCP_TEXT_CONTENT_MAX_CHARS - len(marker))
+    pretty = _json.dumps(value, indent=2, default=str)
+    return pretty[:keep] + marker
 
 
 def _structured_return(raw):
@@ -130,9 +133,7 @@ def _structured_return(raw):
     else:
         structured = {"result": raw}
 
-    text = _json.dumps(structured, separators=(",", ":"), default=str)
-    if len(text) > _MCP_TEXT_CONTENT_MAX_CHARS:
-        text = _summarize_structured_content(structured)
+    text = _faithful_text_content(structured)
     return ToolResult(
         content=[TextContent(type="text", text=text)],
         structured_content=structured,

--- a/tests/test_universe_server_mcp_structured_results.py
+++ b/tests/test_universe_server_mcp_structured_results.py
@@ -20,7 +20,13 @@ def test_direct_wrappers_keep_json_string_contract() -> None:
 
 
 def test_mcp_tool_result_has_structured_content_and_text_content() -> None:
-    """ChatGPT/Apps SDK needs structuredContent without losing text content."""
+    """ChatGPT/Apps SDK needs structuredContent without losing text content.
+
+    The text block must carry the real payload. When the payload fits the
+    budget it is faithful JSON (parseable); when oversized it is real truncated
+    data with a pointer to structuredContent. Either way the payload's data is
+    present in text, never replaced by a placeholder stub.
+    """
     from workflow import universe_server as us
 
     async def _call_status():
@@ -32,13 +38,30 @@ def test_mcp_tool_result_has_structured_content_and_text_content() -> None:
     assert result.structured_content["schema_version"] == 1
     assert result.content
     assert result.content[0].type == "text"
-    assert json.loads(result.content[0].text)["schema_version"] == 1
+    text = result.content[0].text
+    # Real payload data is present in the text channel (not a placeholder).
+    assert "schema_version" in text
+    if "[truncated:" not in text:
+        # Small payloads stay fully faithful and parseable.
+        assert json.loads(text)["schema_version"] == 1
+    else:
+        # Oversized payloads carry real leading data + a pointer to the rest.
+        assert "structuredContent" in text
+        assert len(text) <= us._MCP_TEXT_CONTENT_MAX_CHARS
 
 
-def test_mcp_tool_large_result_keeps_full_structured_content_with_compact_text(
+def test_mcp_tool_large_result_keeps_full_structured_content_with_bounded_text(
     monkeypatch,
 ) -> None:
-    """Large list-style results must not mirror the whole payload in text."""
+    """Large results stay bounded in text but must carry REAL data, not a stub.
+
+    Text-only MCP clients read only the ``content`` text block. The prior
+    contract replaced oversized payloads with a <500-char key-count stub, which
+    made reads silently look empty to those clients. New contract: full payload
+    in ``structuredContent``, and the text block carries real leading data
+    bounded to the text budget with an explicit pointer to ``structuredContent``
+    for the elided remainder.
+    """
     from workflow import universe_server as us
 
     claims = [
@@ -73,6 +96,10 @@ def test_mcp_tool_large_result_keeps_full_structured_content_with_compact_text(
     assert result.structured_content["claims"] == claims
     assert result.structured_content["count"] == 12
     text = result.content[0].text
-    assert "Full payload is in structuredContent" in text
-    assert "x" * 1000 not in text
-    assert len(text) < 500
+    # structuredContent keeps the full payload (above). The text block must
+    # now carry REAL leading data + an explicit pointer to the remainder,
+    # bounded to the budget — not a lossy placeholder.
+    assert "structuredContent" in text  # pointer to the full payload
+    assert "truncated" in text  # explicit elision marker
+    assert "c-0" in text  # real leading data is present, not a stub
+    assert len(text) <= us._MCP_TEXT_CONTENT_MAX_CHARS

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -65,36 +65,39 @@ logger = logging.getLogger("universe_server")
 _MCP_TEXT_CONTENT_MAX_CHARS = 6000
 
 
-def _summarize_structured_content(value: object) -> str:
-    """Small text-channel summary for large structured MCP payloads."""
-    if isinstance(value, dict):
-        parts: list[str] = []
-        for key in ("status", "action", "tool", "goal_id", "branch_def_id"):
-            item = value.get(key)
-            if isinstance(item, str) and item:
-                parts.append(f"{key}={item}")
-        for key in ("count", "returned", "total", "total_count"):
-            item = value.get(key)
-            if isinstance(item, int):
-                parts.append(f"{key}={item}")
-        list_counts = [
-            f"{key}={len(item)}"
-            for key, item in value.items()
-            if isinstance(item, list)
-        ]
-        parts.extend(list_counts[:4])
-        if parts:
-            return (
-                "Tool result: "
-                + "; ".join(parts)
-                + ". Full payload is in structuredContent."
-            )
-    if isinstance(value, list):
-        return (
-            f"Tool result: {len(value)} items. "
-            "Full payload is in structuredContent."
-        )
-    return "Tool result available in structuredContent."
+def _faithful_text_content(value: object) -> str:
+    """Build the text ``content`` block for an MCP tool result.
+
+    Text-only MCP clients read only the ``content`` text block and never parse
+    ``structuredContent`` — so the text must carry the *real* payload, never a
+    placeholder. Prior behaviour replaced oversized payloads with a lossy
+    key-count stub ("Full payload is in structuredContent."), which made reads
+    silently look empty to those clients (read_page bodies, get_status caveats,
+    goals lists, etc.).
+
+    Contract:
+    - Payload fits the text budget -> emit the full payload as JSON (pretty
+      when that also fits, else compact). Fully faithful, no data lost.
+    - Payload exceeds the budget -> render as much real, readable data as fits
+      and append an explicit truncation pointer to ``structuredContent`` for
+      the elided remainder. Still bounded (the 6000-char ceiling that already
+      governed the under-budget path), so ChatGPT's token budget is unchanged;
+      the difference is real data instead of a placeholder.
+    """
+    import json as _json
+
+    compact = _json.dumps(value, separators=(",", ":"), default=str)
+    if len(compact) <= _MCP_TEXT_CONTENT_MAX_CHARS:
+        pretty = _json.dumps(value, indent=2, default=str)
+        return pretty if len(pretty) <= _MCP_TEXT_CONTENT_MAX_CHARS else compact
+
+    marker = (
+        f"\n... [truncated: {len(compact)} chars total; "
+        "full payload in structuredContent]"
+    )
+    keep = max(0, _MCP_TEXT_CONTENT_MAX_CHARS - len(marker))
+    pretty = _json.dumps(value, indent=2, default=str)
+    return pretty[:keep] + marker
 
 
 def _structured_return(raw):
@@ -130,9 +133,7 @@ def _structured_return(raw):
     else:
         structured = {"result": raw}
 
-    text = _json.dumps(structured, separators=(",", ":"), default=str)
-    if len(text) > _MCP_TEXT_CONTENT_MAX_CHARS:
-        text = _summarize_structured_content(structured)
+    text = _faithful_text_content(structured)
     return ToolResult(
         content=[TextContent(type="text", text=text)],
         structured_content=structured,


### PR DESCRIPTION
## Problem (Issue 2 — live founder connector session, 2026-06-25)

Several MCP tools returned their real payload only in `structuredContent` and put a lossy key-count stub in the `content` text block. Text-only MCP clients (which read `content` text, not `structuredContent`) saw **empty-looking reads** — `read_page` bodies, `get_status` caveats, `read_graph target=status`, `read_graph target=goals`. The connecting chatbot couldn't read affected output and didn't realize the responses were empty.

## Root cause

One shared response builder, `_structured_return` in `workflow/universe_server.py`, was **size-gated** at `_MCP_TEXT_CONTENT_MAX_CHARS` (6000): over that, it replaced the text block with `_summarize_structured_content` (a <100-char stub). The "renders full text only with few matches" the session observed was just bigger payloads crossing 6000 chars.

## Fix

Replace `_summarize_structured_content` with `_faithful_text_content`:
- **under budget** → emit the full payload as JSON (pretty if it also fits, else compact). Fully faithful.
- **over budget** → emit real truncated data + an explicit `[truncated: … full payload in structuredContent]` pointer.

The 6000-char ceiling (which already governed the under-budget path) is preserved, so **ChatGPT's token budget is unchanged** — the only difference is real data instead of a placeholder. The protective test is updated to the new contract (full payload in `structuredContent`; text carries real bounded data + pointer). Plugin mirror rebuilt.

## Verification
- `tests/test_universe_server_mcp_structured_results.py` updated + green.
- 168-test file-scoped MCP/universe-server regression slice green; ruff clean.
- **Codex opposite-provider review: APPROVE.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)