### PR TITLE
test(consent): fix stale effector-visibility test after BUG-111 (not an authz bug)

### DIFF
--- a/tests/test_extensions_consent_actions.py
+++ b/tests/test_extensions_consent_actions.py
@@ -236,6 +236,14 @@ def test_grant_and_revoke_visible_to_effector(us_env, monkeypatch):
             "head_branch": "auto/x",
             "base_branch": "main",
             "draft": True,
+            # BUG-111 (commit 28b12b99): a real write materializes a
+            # head branch from the packet's change set BEFORE
+            # ``gh pr create``; an empty change set fails closed with
+            # ``missing_changes`` rather than opening an empty PR. This
+            # test exercises consent visibility, not the materialize
+            # path, so it carries a minimal change set and mocks
+            # ``_materialize_branch`` below.
+            "changes_json": {"PROBE.md": "probe\n"},
         },
         "idempotency_hint": "h-1",
     }
@@ -269,6 +277,9 @@ def test_grant_and_revoke_visible_to_effector(us_env, monkeypatch):
         stderr="",
     )
     with patch(
+        "workflow.effectors.github_pr._materialize_branch",
+        return_value={"materialized": True, "head_branch": "auto/x"},
+    ), patch(
         "workflow.effectors.github_pr.subprocess.run",
         return_value=fake,
     ):


### PR DESCRIPTION
## Diagnosis

`tests/test_extensions_consent_actions.py::test_grant_and_revoke_visible_to_effector` failed on `origin/main` with `AssertionError: assert None == 55`.

**Root cause: STALE TEST, not a consent/authorization defect.**

Tracing the actual evidence map (not just the assertion line), the effector returned:
```
{'error': 'packet.payload must carry changes_json ...', 'error_kind': 'missing_changes', ...}
```

That means the **consent grant was working correctly** — the grant cleared the consent gate and the effector reached the real-write path. The failure is downstream of consent:

- The test (commit `7922a216`, 2026-05-20, PR-122 Phase 2 Slice 1) mocked `subprocess.run` (`gh pr create`) and asserted a real write returned `pr_number=55`.
- The BUG-111 fix (commit `28b12b99`, 2026-05-28) inserted `_materialize_branch` **before** `gh pr create`. A real write now builds a head branch from the packet's change set and **fails closed** with `error_kind=missing_changes` when neither `changes_json` nor `edits_json` is present — rather than opening an empty PR.
- The test packet carried no `changes_json`, so the effector never reached the mocked `gh pr create`; `pr_number` was therefore absent (`None`).

The test predates the materialize requirement by 8 days. The contract changed under it; the assertion was never updated.

### Authorization implication

None that needs a fix. This is **not** an authorization-visibility regression — the consent gate behaved exactly as designed (grant visible → revoke closes it). The `missing_changes` guard is itself a correct fail-loud authorization-adjacent safety: an empty change set must not silently open a PR. The fix preserves the consent-visibility intent of the test while satisfying the post-BUG-111 contract.

## Fix (test layer only)

- Add a minimal `changes_json` to the test packet payload.
- Mock `_materialize_branch` to succeed — matching the established BUG-111 test pattern in `test_external_write_phase_2_atomicity.py::test_effector_materializes_packet_changes_before_creating_pr` — so the test stays focused on consent visibility rather than the Git Data API materialize path.

Test-only change; no `workflow/*` code touched, so no plugin-mirror rebuild required.

## Evidence

- **Before:** `test_grant_and_revoke_visible_to_effector` → FAILED (`assert None == 55`).
- **After:** target test passes; whole file `tests/test_extensions_consent_actions.py` = 10 passed; `tests/test_external_write_phase_2_atomicity.py` + `tests/test_github_pr_edits_json.py` = all pass (41 passed combined). Run with `-p no:cacheprovider` + unique temp `WORKFLOW_DATA_DIR`.
- **Ruff:** `ruff check tests/test_extensions_consent_actions.py` → All checks passed (line-length 100).

## Out-of-scope sibling failures (flagged, NOT fixed here)

Same BUG-111 stale-test root cause, confirmed pre-existing on pristine `origin/main` (verified by stashing this change and re-running):

- `tests/test_external_write_phase_2.py` — ~14 tests that drive the real-write path without `changes_json`.
- `tests/test_windows_desktop_effector.py::test_windows_packet_on_non_windows_returns_no_host_before_receipt`.

These touch different files outside this task's scope. Recommend a follow-up task to update them with the same materialize-aware pattern (or mock `_materialize_branch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)