### PR TITLE
test: align branch-API tests with BUG-091 state_schema declaration rule

### DIFF
--- a/tests/test_build_branch_nested_graph_shape.py
+++ b/tests/test_build_branch_nested_graph_shape.py
@@ -50,7 +50,15 @@ def _two_node_spec_nested_graph() -> dict:
     return {
         "name": "pr-037-regression-nested",
         "tags": ["test"],
-        "state_schema": [{"name": "x", "type": "str"}],
+        # ``y`` is declared alongside ``x`` because node ``classify`` writes
+        # output_key ``y`` and ``end_marker`` reads input_key ``y``. Per
+        # BUG-091 (#924) every node input_key / output_key must be a declared
+        # state_schema field when a non-empty schema exists, otherwise the key
+        # is silently dropped from LangGraph's synthesized TypedDict at runtime.
+        "state_schema": [
+            {"name": "x", "type": "str"},
+            {"name": "y", "type": "str"},
+        ],
         "graph": {
             "entry_point": "classify",
             "nodes": [

--- a/tests/test_patch_branch_node_keys.py
+++ b/tests/test_patch_branch_node_keys.py
@@ -93,6 +93,19 @@ def _node(branch: dict, nid: str) -> dict:
     raise AssertionError(f"node '{nid}' not on branch")
 
 
+def _key_atoms(raw) -> list:
+    """Normalize a raw input_keys/output_keys value the same way the API does.
+
+    Used by the test scaffolding to declare every key in state_schema so the
+    BUG-091 (#924) validator accepts the spec. Returns the coerced key list, or
+    an empty list when the value is None / unparseable.
+    """
+    if raw is None:
+        return []
+    keys, err = _coerce_node_keys(raw, "input_keys")
+    return [] if err else keys
+
+
 def test_patch_branch_normalizes_string_key_fields_in_persisted_and_preview_paths(
     ext_env,
 ):
@@ -213,12 +226,19 @@ class TestPatchBranchUpdateNodeKeys:
     def test_update_node_accepts_list(self, ext_env):
         us, base = ext_env
         bid = _build(us)
-        res = _patch(us, bid, [{
-            "op": "update_node",
-            "node_id": "capture",
-            "input_keys": ["alpha", "beta"],
-            "output_keys": ["gamma"],
-        }])
+        # Declare the fields the node will read/write: per BUG-091 (#924) every
+        # node input_key / output_key must be a declared state_schema field.
+        res = _patch(us, bid, [
+            {"op": "add_state_field", "field_name": "alpha", "field_type": "str"},
+            {"op": "add_state_field", "field_name": "beta", "field_type": "str"},
+            {"op": "add_state_field", "field_name": "gamma", "field_type": "str"},
+            {
+                "op": "update_node",
+                "node_id": "capture",
+                "input_keys": ["alpha", "beta"],
+                "output_keys": ["gamma"],
+            },
+        ])
         assert res.get("status") != "rejected", res
         node = _node(_load(us, base, bid), "capture")
         assert node["input_keys"] == ["alpha", "beta"]
@@ -228,11 +248,16 @@ class TestPatchBranchUpdateNodeKeys:
         """Regression: 'node.output' used to become ['n','o','d','e',...]."""
         us, base = ext_env
         bid = _build(us)
-        res = _patch(us, bid, [{
-            "op": "update_node",
-            "node_id": "capture",
-            "input_keys": "node.output",
-        }])
+        # Declare the field the bare-string key resolves to (BUG-091 / #924).
+        res = _patch(us, bid, [
+            {"op": "add_state_field", "field_name": "node.output",
+             "field_type": "str"},
+            {
+                "op": "update_node",
+                "node_id": "capture",
+                "input_keys": "node.output",
+            },
+        ])
         assert res.get("status") != "rejected", res
         node = _node(_load(us, base, bid), "capture")
         assert node["input_keys"] == ["node.output"], (
@@ -242,11 +267,17 @@ class TestPatchBranchUpdateNodeKeys:
     def test_update_node_csv_string(self, ext_env):
         us, base = ext_env
         bid = _build(us)
-        res = _patch(us, bid, [{
-            "op": "update_node",
-            "node_id": "capture",
-            "input_keys": "a, b, c",
-        }])
+        # Declare the CSV-derived fields (BUG-091 / #924).
+        res = _patch(us, bid, [
+            {"op": "add_state_field", "field_name": "a", "field_type": "str"},
+            {"op": "add_state_field", "field_name": "b", "field_type": "str"},
+            {"op": "add_state_field", "field_name": "c", "field_type": "str"},
+            {
+                "op": "update_node",
+                "node_id": "capture",
+                "input_keys": "a, b, c",
+            },
+        ])
         assert res.get("status") != "rejected", res
         node = _node(_load(us, base, bid), "capture")
         assert node["input_keys"] == ["a", "b", "c"]
@@ -254,11 +285,16 @@ class TestPatchBranchUpdateNodeKeys:
     def test_update_node_json_encoded_list(self, ext_env):
         us, base = ext_env
         bid = _build(us)
-        res = _patch(us, bid, [{
-            "op": "update_node",
-            "node_id": "capture",
-            "input_keys": '["alpha","beta"]',
-        }])
+        # Declare the JSON-list-derived fields (BUG-091 / #924).
+        res = _patch(us, bid, [
+            {"op": "add_state_field", "field_name": "alpha", "field_type": "str"},
+            {"op": "add_state_field", "field_name": "beta", "field_type": "str"},
+            {
+                "op": "update_node",
+                "node_id": "capture",
+                "input_keys": '["alpha","beta"]',
+            },
+        ])
         assert res.get("status") != "rejected", res
         node = _node(_load(us, base, bid), "capture")
         assert node["input_keys"] == ["alpha", "beta"]
@@ -332,9 +368,24 @@ class TestAddNodeSpecKeys:
         }
         if output_keys is not None:
             add_op["output_keys"] = output_keys
+        # Per BUG-091 (#924) every node input_key / output_key must be a
+        # declared state_schema field. ``x`` is declared by ``_build``; declare
+        # any other key the scribe node introduces so the branch validates.
+        declared = {"x"}
+        decl_ops = []
+        for raw in (input_keys, output_keys):
+            for key in _key_atoms(raw):
+                if key and key not in declared:
+                    declared.add(key)
+                    decl_ops.append({
+                        "op": "add_state_field",
+                        "field_name": key,
+                        "field_type": "str",
+                    })
         # Wire scribe reachable: remove capture->END, add capture->scribe,
         # add scribe->END so branch validates.
         return [
+            *decl_ops,
             add_op,
             {"op": "remove_edge", "from": "capture", "to": "END"},
             {"op": "add_edge", "from": "capture", "to": "scribe"},
@@ -443,7 +494,8 @@ class TestAddNodeSpecKeys:
         us, _ = ext_env
         bid = _build(us)
         ops = self._add_scribe_ops(input_keys=["x"], output_keys=["draft"])
-        ops[0]["llm_policy"] = {"preferred": {}}
+        add_op = next(o for o in ops if o["op"] == "add_node")
+        add_op["llm_policy"] = {"preferred": {}}
 
         res = _patch(us, bid, ops)
 


### PR DESCRIPTION
## Summary

Fixes 11 tests that were RED on `origin/main`. Both clusters were **stale tests**, not code regressions — they asserted a pre-BUG-091 contract that was intentionally tightened.

## Diagnosis (per cluster)

### Root cause (shared)
BUG-091 (#924, commit `3f813f9b`, 2026-05-27, Codex writer / Claude checker) added a validator in `BranchDefinition.validate()`: **when a non-empty `state_schema` exists, every node `input_keys`/`output_keys` entry must be a declared `state_schema` field.** Keys absent from LangGraph's synthesized TypedDict are silently dropped at runtime, so undeclared keys are a real bug. The validator + its tests (`tests/test_branches.py::test_validate_{input,output}_key_must_be_declared_when_state_schema_exists`, `test_validate_legacy_empty_state_schema_remains_allowed`) are the current authoritative contract and pass green.

The 11 failing tests submitted specs that declared a partial `state_schema` but referenced node keys not in it, so the validator (correctly) rejected them.

### Cluster 1 — `tests/test_build_branch_nested_graph_shape.py` (5 tests)
- **Verdict: stale test.** Authored 2026-05-12, *before* BUG-091. The fixture declares `state_schema=[{x}]` but node `classify` writes `output_key: y` and `end_marker` reads `input_key: y`.
- **Fix (test layer):** declare `y` alongside `x`. The nodes already use it; this is a valid spec, not a behavior change. Tests still verify their PR-037 intent (nested `graph` shape acceptance, top-level precedence, entry_point fallback, conditional edges, round-trip fork).

### Cluster 2 — `tests/test_patch_branch_node_keys.py` (6 tests)
- **Verdict: stale test.** The 6 failing methods added/updated nodes with keys (`alpha`/`beta`/`gamma`, `node.output`, `a`/`b`/`c`, `draft`, `capture.text`) never declared in `state_schema`.
- **Fix (test layer):** prepend `add_state_field` ops for each introduced key — mirroring the pattern already used by the passing `test_patch_branch_normalizes_string_key_fields_in_persisted_and_preview_paths`. `_add_scribe_ops` now derives + declares the keys it introduces via a `_key_atoms` helper that reuses the real `_coerce_node_keys`, so declarations always match what the node persists. `test_add_node_rejects_invalid_llm_policy` was updated to target the `add_node` op by type rather than `ops[0]` (the helper now prepends `add_state_field` ops).

## Why fix tests, not code
The validator is correct, reviewed (Codex+Claude), and load-bearing (prevents silent runtime data loss). The two test files simply predate / didn't account for the tightened contract. No canonical `workflow/*` code changed → no plugin mirror rebuild needed.

## Evidence

Before (origin/main): `11 failed, 29 passed` across the two files.

After:
- Target files: `40 passed`.
- Broad suite (`test_branches`, `test_patch_branch_*`, `test_build_branch_*`): `174 passed`, no new failures.
- `ruff check` (line-length 100): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)