### PR TITLE
Fix site crawl issues: /build 404, hydration errors, dead link

### DIFF
--- a/WebSite/site-react/.gitignore
+++ b/WebSite/site-react/.gitignore
@@ -3,3 +3,8 @@ node_modules/
 out/
 next-env.d.ts
 *.tsbuildinfo
+
+# The repo-root `build/` ignore (for build artifacts) also matches the
+# app/build/ ROUTE directory — re-include it so the /build page is tracked.
+!app/build/
+!app/build/**

--- a/WebSite/site-react/app/build/_components/BuildClient.tsx
+++ b/WebSite/site-react/app/build/_components/BuildClient.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import * as React from "react";
+import Term from "../../../components/Term";
+import Tick from "../../../components/Tick";
+import styles from "../page.module.css";
+
+const REPO_URL = "https://github.com/Jonnyton/Workflow";
+
+type RepoSnapshot = {
+  fetched_at: string;
+  repo: {
+    default_branch?: string;
+    main?: string;
+    pushed_at?: string;
+    open_issues?: number;
+  };
+};
+
+const REPO_STEPS = [
+  {
+    cmd: "git clone https://github.com/Jonnyton/Workflow",
+    note: "Clone the engine.",
+    href: REPO_URL,
+    label: "Workflow on GitHub",
+  },
+  {
+    cmd: "pip install -e .[dev]",
+    note: "Editable install with the dev extras (Python 3.11+).",
+    href: `${REPO_URL}/blob/main/pyproject.toml`,
+    label: "pyproject.toml",
+  },
+  {
+    cmd: "pytest · ruff check",
+    note: "Both green before every commit. Every module has tests; nodes never crash.",
+    href: `${REPO_URL}/tree/main/tests`,
+    label: "tests/",
+  },
+  {
+    cmd: "read PLAN.md · CONTRIBUTING.md",
+    note: "Architecture and how the system thinks (PLAN.md); how to land work (CONTRIBUTING.md).",
+    href: `${REPO_URL}/blob/main/PLAN.md`,
+    label: "PLAN.md",
+  },
+];
+
+async function refreshRepoSnapshot(): Promise<RepoSnapshot> {
+  const [repoRes, branchesRes] = await Promise.all([
+    fetch("https://api.github.com/repos/Jonnyton/Workflow"),
+    fetch("https://api.github.com/repos/Jonnyton/Workflow/branches?per_page=100"),
+  ]);
+  if (!repoRes.ok) throw new Error(`repo ${repoRes.status}`);
+  if (!branchesRes.ok) throw new Error(`branches ${branchesRes.status}`);
+
+  const repo = await repoRes.json();
+  await branchesRes.json();
+
+  return {
+    fetched_at: new Date().toISOString(),
+    repo: {
+      default_branch: repo.default_branch,
+      main: repo.default_branch,
+      pushed_at: repo.pushed_at,
+      open_issues: repo.open_issues_count,
+    },
+  };
+}
+
+function rel(s?: string | null): string {
+  if (!s) return "";
+  const ms = Date.parse(s);
+  if (Number.isNaN(ms)) return s;
+  const diff = Date.now() - ms;
+  if (diff < 90_000) return "just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return `${Math.floor(diff / 86_400_000)}d ago`;
+}
+
+export default function BuildClient() {
+  const [repo, setRepo] = React.useState<RepoSnapshot | null>(null);
+  const [repoErr, setRepoErr] = React.useState<string | null>(null);
+  const [reading, setReading] = React.useState(false);
+
+  const refreshRepo = React.useCallback(async () => {
+    setReading(true);
+    try {
+      setRepo(await refreshRepoSnapshot());
+      setRepoErr(null);
+    } catch (e) {
+      setRepoErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setReading(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void refreshRepo();
+  }, [refreshRepo]);
+
+  const rateLimited = !!repoErr && /\b(403|429|rate)\b/i.test(repoErr);
+
+  return (
+    <div className={styles.page}>
+      <section className="cover" aria-labelledby="cover-title">
+        <div className="container ch__inner">
+          <p className="eyebrow">field notes · how I get rebuilt</p>
+          <h1 id="cover-title" className="cover__title">Two doors into building me.</h1>
+          <p className="voice cover__lede">
+            You can improve me without ever cloning a line of code — just talk to me
+            through your chatbot and describe what&apos;s rough. Or you can go straight at
+            the engine through the repository, with the tests and the architecture in
+            front of you. Both doors open onto the same room: a{" "}
+            <Term def="The self-patching cycle: a request becomes an investigation, runs through automated checks, and only ships after review.">loop</Term>
+            {" "}with evidence gates, a{" "}
+            <Term def="A second AI from a different model family re-checks the work, so no one model both writes and approves a change.">cross-family review</Term>,
+            and a <em>human key</em> that has to turn before anything merges.
+          </p>
+          <p className="cover__naming">
+            The being is <strong>Tiny</strong>; the engine is <strong>Workflow</strong>.
+            Contributing to either is contributing to both.
+          </p>
+        </div>
+      </section>
+
+      <section className="ch ch--door" aria-labelledby="door1-title">
+        <div className="container">
+          <p className="eyebrow">door one · no clone required</p>
+          <h2 id="door1-title">Build me through your chatbot.</h2>
+          <p className="voice door__lede">
+            If you can hold a conversation, you can file work that lands in my
+            engine. You never touch a terminal.
+          </p>
+          <ol className="steps">
+            <li className="step">
+              <span className="step__n">01</span>
+              <div className="step__body">
+                <h3 className="step__h">Connect</h3>
+                <p className="step__p">Paste my URL into Claude, ChatGPT, or any MCP-capable assistant.</p>
+                <a className="step__cta" href="/start">how to connect →</a>
+              </div>
+            </li>
+            <li className="step">
+              <span className="step__n">02</span>
+              <div className="step__body">
+                <h3 className="step__h">Hit a rough edge — or have an idea</h3>
+                <p className="step__p">A confusing response, a missing capability, a sharper way to do something. Friction and ideas count equally.</p>
+              </div>
+            </li>
+            <li className="step">
+              <span className="step__n">03</span>
+              <div className="step__body">
+                <h3 className="step__h">Say it out loud</h3>
+                <p className="step__p">Tell your chatbot: <code>file a patch request about …</code> — describe the rough edge in plain words. It&apos;s filed against my public commons.</p>
+              </div>
+            </li>
+            <li className="step">
+              <span className="step__n">04</span>
+              <div className="step__body">
+                <h3 className="step__h">It enters the loop</h3>
+                <p className="step__p">Your request becomes an investigation, runs through evidence gates, and can surface as a real GitHub PR.</p>
+                <a className="step__cta" href="/loop">watch the loop →</a>
+              </div>
+            </li>
+            <li className="step">
+              <span className="step__n">05</span>
+              <div className="step__body">
+                <h3 className="step__h">Watch it become a change</h3>
+                <p className="step__p">From investigation to pull request to release, the whole trail is public — successes and failures alike.</p>
+              </div>
+            </li>
+          </ol>
+          <p className="door__note voice">
+            One honest caveat: <em>a merge always waits on a human key.</em> No
+            change ships on AI momentum alone. That&apos;s a feature, not friction — it&apos;s
+            why you can trust what lands.
+          </p>
+        </div>
+      </section>
+
+      <section className="ch ch--door" aria-labelledby="door2-title">
+        <div className="container">
+          <p className="eyebrow">door two · clone the engine</p>
+          <h2 id="door2-title">Build me through the repository.</h2>
+          <p className="voice door__lede">
+            Prefer to work in code directly? The engine is open source. Clone it,
+            install it, and the same gates apply to your branch as to mine.
+          </p>
+          <ol className="repo-steps">
+            {REPO_STEPS.map((s) => (
+              <li className="repo-step" key={s.cmd}>
+                <code className="repo-step__cmd">{s.cmd}</code>
+                <p className="repo-step__note">{s.note}</p>
+                <Tick href={s.href} label={s.label} external />
+              </li>
+            ))}
+          </ol>
+          <p className="door__note">
+            Read <a href={`${REPO_URL}/blob/main/PLAN.md`} target="_blank" rel="noreferrer">PLAN.md</a>
+            {" "}for the architecture and{" "}
+            <a href={`${REPO_URL}/blob/main/CONTRIBUTING.md`} target="_blank" rel="noreferrer">CONTRIBUTING.md</a>
+            {" "}for how work lands. When you&apos;re ready, open a pull request against{" "}
+            <a href={REPO_URL} target="_blank" rel="noreferrer">Workflow on GitHub ↗</a>.
+          </p>
+        </div>
+      </section>
+
+      <section className="ch ch--pulse" aria-labelledby="pulse-title">
+        <div className="container ch__inner">
+          <p className="eyebrow">live reading · the repository, right now</p>
+          <h2 id="pulse-title">The engine, read live from GitHub.</h2>
+          <div className="pulse" aria-live="polite">
+            {reading && !repo && !repoErr ? (
+              <p className="pulse__state ev">reading the repository…</p>
+            ) : repoErr ? (
+              <>
+                <p className="pulse__state pulse__state--err ev">
+                  {rateLimited ? (
+                    <>
+                      GitHub&apos;s API rate-limited this read. This page calls GitHub
+                      unauthenticated from your browser, so anonymous reads can be
+                      throttled — that&apos;s the honest reason, not a server failure.
+                    </>
+                  ) : (
+                    <>live read failed — {repoErr}</>
+                  )}
+                </p>
+                <button className="pulse__refresh" onClick={refreshRepo} disabled={reading}>{reading ? "reading…" : "Refresh GitHub"}</button>
+              </>
+            ) : repo ? (
+              <>
+                <dl className="pulse__grid">
+                  <div className="pulse__cell">
+                    <dt className="pulse__k">default branch</dt>
+                    <dd className="pulse__v ev">{repo.repo.default_branch ?? repo.repo.main ?? "—"}</dd>
+                  </div>
+                  <div className="pulse__cell">
+                    <dt className="pulse__k">open issues</dt>
+                    <dd className="pulse__v ev">{(repo.repo.open_issues ?? 0).toLocaleString()}</dd>
+                  </div>
+                  <div className="pulse__cell">
+                    <dt className="pulse__k">last push</dt>
+                    <dd className="pulse__v ev">{repo.repo.pushed_at ? rel(repo.repo.pushed_at) : "unknown"}</dd>
+                  </div>
+                </dl>
+                <p className="pulse__stamp ev">
+                  read {rel(repo.fetched_at)} from GitHub ·
+                  <button className="pulse__refresh" onClick={refreshRepo} disabled={reading}>{reading ? "reading…" : "Refresh GitHub"}</button>
+                  {" "}· <Tick href={REPO_URL} label="open the repo" external />
+                </p>
+              </>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <section className="ch ch--earns" aria-labelledby="earns-title">
+        <div className="container ch__inner">
+          <p className="eyebrow">honest terms · what contribution earns</p>
+          <h2 id="earns-title">Your work is tracked. Credit is honest about where it stands.</h2>
+          <p className="voice">
+            Everything you contribute is recorded — runs you trigger, designs of
+            yours that get used, code that merges, the lineage of what you forked
+            from, and the feedback you leave. Credit settles on a{" "}
+            <Term def="A non-monetary accounting rail used to prove the credit machinery works before any real value moves.">test rail</Term>
+            {" "}today; a real economy comes <em>later</em>, not now. What&apos;s solid right
+            now is attribution: your name on what you made survives even when
+            someone forks it. No income is promised here — see the{" "}
+            <a href="/legal#token-disclosures">token disclosures</a> for the fine print.
+          </p>
+        </div>
+      </section>
+
+      <section className="ch ch--close" aria-labelledby="close-title">
+        <div className="container ch__inner">
+          <h2 id="close-title" className="sr-only">Where to go next</h2>
+          <div className="close__row">
+            <a className="close__card" href="/commons">
+              <span className="close__k eyebrow">the design conversation</span>
+              <strong>It lives in the commons.</strong>
+              <span className="close__sub">read the public brain — proposals, notes, and decisions, all forkable.</span>
+            </a>
+            <a className="close__card" href="/graph">
+              <span className="close__k eyebrow">the map of everything</span>
+              <strong>See the whole graph.</strong>
+              <span className="close__sub">how every goal, workflow, and commons page connects.</span>
+            </a>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/WebSite/site-react/app/build/page.module.css
+++ b/WebSite/site-react/app/build/page.module.css
@@ -1,0 +1,129 @@
+.page { }
+
+.page :global(.container) { max-width: 1160px; margin: 0 auto; padding-inline: clamp(18px, 4vw, 32px); }
+  .page :global(.sr-only) { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
+
+  /* ── Cover ── */
+  .page :global(.cover) { padding: clamp(48px, 8vw, 96px) 0 clamp(32px, 5vw, 56px); border-bottom: 1px solid var(--border-1); }
+  .page :global(.cover__title) {
+    font-size: clamp(40px, 7vw, 84px);
+    font-weight: 400;
+    line-height: 1.0;
+    letter-spacing: -0.03em;
+    margin: 14px 0 18px;
+  }
+  .page :global(.cover__lede) { margin: 0 0 16px; }
+  .page :global(.cover__lede em) { font-style: italic; color: var(--ember-700); }
+  .page :global(.cover__naming) { font-size: 13.5px; color: var(--fg-3); margin: 0; max-width: 60ch; }
+  .page :global(.cover__naming strong) { color: var(--fg-2); font-weight: 600; }
+
+  /* ── Shared section chrome ── */
+  .page :global(.ch) { padding: clamp(48px, 7vw, 84px) 0; border-bottom: 1px solid var(--border-1); }
+  .page :global(.ch__inner) { max-width: 760px; }
+  .page :global(.ch h2) {
+    font-size: clamp(28px, 4.4vw, 44px);
+    font-weight: 500;
+    line-height: 1.08;
+    letter-spacing: -0.02em;
+    margin: 12px 0 18px;
+  }
+  .page :global(.ch .eyebrow) { display: block; }
+  .page :global(.door__lede) { margin: 0 0 24px; }
+
+  /* ── Door one · numbered steps ── */
+  .page :global(.steps) { list-style: none; margin: 0; padding: 0; display: grid; gap: 0; }
+  .page :global(.step) {
+    display: grid;
+    grid-template-columns: 56px 1fr;
+    gap: 18px;
+    padding: 18px 0;
+    border-top: 1px solid var(--border-1);
+  }
+  .page :global(.step:last-child) { border-bottom: 1px solid var(--border-1); }
+  @media (max-width: 640px) { .page :global(.step) { grid-template-columns: 1fr; gap: 6px; } }
+  .page :global(.step__n) { font-family: var(--font-mono); font-size: 12px; color: var(--ember-700); letter-spacing: 0.14em; padding-top: 4px; }
+  .page :global(.step__body) { display: grid; gap: 6px; justify-items: start; }
+  .page :global(.step__h) { font-family: var(--font-voice); font-size: 20px; font-weight: 500; margin: 0; line-height: 1.2; }
+  .page :global(.step__p) { font-size: 14.5px; line-height: 1.6; color: var(--fg-2); margin: 0; }
+  .page :global(.step__p code) { font-size: 13px; }
+  .page :global(.step__cta) { font-family: var(--font-sans); font-size: 13.5px; font-weight: 600; color: var(--ember-700); width: fit-content; }
+  .page :global(.door__note) { margin: 24px 0 0; font-size: 15px; }
+  .page :global(.door__note em) { font-style: italic; color: var(--ember-700); }
+
+  /* ── Door two · repo steps ── */
+  .page :global(.repo-steps) {
+    list-style: none; margin: 0; padding: 0;
+    display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px;
+  }
+  @media (max-width: 760px) { .page :global(.repo-steps) { grid-template-columns: 1fr; } }
+  .page :global(.repo-step) {
+    display: grid; gap: 8px; align-content: start;
+    padding: 18px 20px;
+    background: var(--bg-2);
+    border: 1px solid var(--border-1);
+    border-radius: var(--radius-lg);
+  }
+  .page :global(.repo-step__cmd) {
+    background: var(--bg-inset);
+    border: 1px solid var(--border-1);
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    color: var(--ink-text-900);
+    font-size: 12.5px;
+    width: fit-content;
+    max-width: 100%;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+  .page :global(.repo-step__note) { font-size: 13.5px; line-height: 1.55; color: var(--fg-2); margin: 0; }
+
+  /* ── Live repo pulse ── */
+  .page :global(.pulse) { margin-top: 24px; }
+  .page :global(.pulse__state) { font-size: 13px; margin: 0 0 12px; }
+  .page :global(.pulse__state--err) { color: var(--signal-error); max-width: 60ch; line-height: 1.55; }
+  .page :global(.pulse__grid) {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px;
+    margin: 0; padding: 0;
+  }
+  @media (max-width: 640px) { .page :global(.pulse__grid) { grid-template-columns: 1fr; } }
+  .page :global(.pulse__cell) {
+    padding: 16px 18px;
+    background: var(--bg-2);
+    border: 1px solid var(--border-1);
+    border-radius: var(--radius-md);
+    display: grid; gap: 6px;
+  }
+  .page :global(.pulse__k) { font-family: var(--font-sans); font-size: 12px; font-weight: 500; color: var(--fg-3); margin: 0; }
+  .page :global(.pulse__v) { font-size: 17px; color: var(--fg-1); margin: 0; }
+  .page :global(.pulse__stamp) { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: 16px; font-size: 11px; }
+  .page :global(.pulse__refresh) {
+    background: transparent; border: 1px solid var(--border-2); border-radius: var(--radius-pill);
+    color: var(--live-700); cursor: pointer;
+    font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
+    padding: 3px 10px;
+  }
+  .page :global(.pulse__refresh:hover:not(:disabled)) { border-color: var(--live-600); background: var(--live-100); }
+  .page :global(.pulse__refresh:disabled) { opacity: 0.6; cursor: default; }
+
+  /* ── What contribution earns ── */
+  .page :global(.ch--earns .voice em) { font-style: italic; color: var(--ember-700); }
+
+  /* ── Close ── */
+  .page :global(.ch--close) { border-bottom: none; padding-bottom: clamp(72px, 10vw, 120px); }
+  .page :global(.close__row) {
+    display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px;
+  }
+  @media (max-width: 760px) { .page :global(.close__row) { grid-template-columns: 1fr; } }
+  .page :global(.close__card) {
+    display: grid; gap: 6px;
+    padding: 24px 26px;
+    background: var(--bg-2);
+    border: 1px solid var(--border-2);
+    border-radius: var(--radius-lg);
+    text-decoration: none;
+    color: inherit;
+    transition: border-color var(--dur-fast) var(--ease-standard), box-shadow var(--dur-fast) var(--ease-standard);
+  }
+  .page :global(.close__card:hover) { border-color: var(--ink-text-900); box-shadow: var(--shadow-md); text-decoration: none; }
+  .page :global(.close__card strong) { font-family: var(--font-display); font-size: clamp(20px, 2.8vw, 28px); font-weight: 500; letter-spacing: -0.015em; line-height: 1.14; color: var(--fg-1); }
+  .page :global(.close__sub) { font-size: 13.5px; color: var(--fg-2); line-height: 1.5; }

--- a/WebSite/site-react/app/build/page.tsx
+++ b/WebSite/site-react/app/build/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import BuildClient from "./_components/BuildClient";
+
+export const metadata: Metadata = {
+  title: "Build me — two doors into contributing to Tiny",
+  description:
+    "Two doors into building Tiny: improve the engine through your chatbot without ever cloning code, or clone the Workflow repository and work on it directly. Both end in the same loop — evidence gates, cross-family review, a human merge key.",
+  alternates: { canonical: "https://tinyassets.io/build" },
+};
+
+export default function BuildPage() {
+  return <BuildClient />;
+}

--- a/WebSite/site-react/app/fine-print/_components/FinePrintClient.tsx
+++ b/WebSite/site-react/app/fine-print/_components/FinePrintClient.tsx
@@ -5,6 +5,8 @@ import Term from "../../../components/Term";
 import VitalSigns from "../../../components/VitalSigns";
 import { callTool } from "../../../lib/live";
 import baked from "../../../lib/mcp-snapshot.json";
+import { fmtStampStable } from "../../../lib/fmt";
+import { useMounted } from "../../../lib/useMounted";
 import styles from "../page.module.css";
 
 const GH_ACTIONS = "https://github.com/Jonnyton/Workflow/actions";
@@ -58,6 +60,7 @@ function pick(obj: Record<string, unknown> | null, ...keys: string[]): string | 
 }
 
 export default function FinePrintClient() {
+  const mounted = useMounted();
   const [rcState, setRcState] = React.useState<ReceiptState>("reading");
   const [rcError, setRcError] = React.useState<string | null>(null);
   const [rcFetchedAt, setRcFetchedAt] = React.useState<string | null>(null);
@@ -94,6 +97,7 @@ export default function FinePrintClient() {
   const canaryStatus = pick(release, "canary_bundle_status", "canaryBundleStatus", "canary_status");
   const buildRunUrl = pick(release, "build_run_url", "buildRunUrl", "build_url");
   const deployRunUrl = pick(release, "deploy_run_url", "deployRunUrl", "deploy_url");
+  const bakedStamp = bakedFetchedAt ? (mounted ? stamp(bakedFetchedAt) : fmtStampStable(bakedFetchedAt)) : "";
 
   return (
     <div className={styles.page}>
@@ -112,7 +116,7 @@ export default function FinePrintClient() {
           </p>
           <VitalSigns variant="hero" />
           <p className="cover__stamp ev">
-            first paint seeded from snapshot {stamp(bakedFetchedAt)} · every reading
+            first paint seeded from snapshot {bakedStamp} · every reading
             above is upgraded by a live read on load and carries its own stamp
           </p>
         </div>

--- a/WebSite/site-react/app/goals/_components/GoalsClient.tsx
+++ b/WebSite/site-react/app/goals/_components/GoalsClient.tsx
@@ -17,7 +17,8 @@ import * as React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { callTool } from "../../../lib/live";
 import bakedMcp from "../../../lib/mcp-snapshot.json";
-import { fmtDate, fmtRel } from "../../../lib/fmt";
+import { fmtDate, fmtDateStable, fmtRel } from "../../../lib/fmt";
+import { useMounted } from "../../../lib/useMounted";
 import Ladder from "../../../components/Ladder";
 import Term from "../../../components/Term";
 import Tick from "../../../components/Tick";
@@ -143,7 +144,8 @@ export default function GoalsClient() {
   // First paint: baked, stamped with the snapshot's own fetched date. The
   // page is never blank-without-JS — these render server-side. The stamp goes
   // through $lib/fmt so it reads in the visitor's own local time.
-  const bakedStampDate = fmtDate((bakedMcp as any).fetched_at);
+  const mounted = useMounted();
+  const bakedStampDate = mounted ? fmtDate((bakedMcp as any).fetched_at) : fmtDateStable((bakedMcp as any).fetched_at);
   const [goals, setGoals] = useState<BoardGoal[]>(() => normalizeBaked(bakedMcp));
 
   // 'baked' until a live read lands; then 'live' with a read-stamp.

--- a/WebSite/site-react/app/graph/_components/GraphClient.tsx
+++ b/WebSite/site-react/app/graph/_components/GraphClient.tsx
@@ -27,7 +27,8 @@ import type { Simulation } from "d3-force";
 import baked from "../../../lib/mcp-snapshot.json";
 import { fetchLive, liveToSnapshotShape } from "../../../lib/live";
 import type { Snapshot } from "../../../lib/types";
-import { fmtRel, fmtStamp } from "../../../lib/fmt";
+import { fmtCount, fmtRel, fmtStamp, fmtStampStable } from "../../../lib/fmt";
+import { useMounted } from "../../../lib/useMounted";
 import Tick from "../../../components/Tick";
 import {
   buildAtlas,
@@ -75,6 +76,7 @@ function truncate(s: string, max: number): string {
 
 export default function GraphClient() {
   const router = useRouter();
+  const mounted = useMounted();
 
   // First paint from the baked snapshot; Refresh MCP swaps in a live re-read
   // of the exact same shape, so the whole sky rebuilds against fresh data.
@@ -141,7 +143,9 @@ export default function GraphClient() {
 
   const wikiTotal =
     atlas.counts.patch + atlas.counts.plans + atlas.counts.notes + atlas.counts.concepts + atlas.counts.drafts;
-  const stampLabel = liveStamp ? `live read ${fmtRel(liveStamp)}` : `baked snapshot ${fmtStamp(snapshot.fetched_at)}`;
+  const stampLabel = liveStamp
+    ? `live read ${fmtRel(liveStamp)}`
+    : `baked snapshot ${mounted ? fmtStamp(snapshot.fetched_at) : fmtStampStable(snapshot.fetched_at)}`;
   const universesList = snapshot.universes ?? [];
 
   /* ─────────────────── the canvas force graph ─────────────────── */
@@ -326,7 +330,7 @@ export default function GraphClient() {
       if (dim) continue;
       if (n.kind === "tag" && n.cluster !== "tags") {
         label(
-          `${n.label} · ${n.count?.toLocaleString() ?? ""}`,
+          `${n.label} · ${n.count === undefined ? "" : fmtCount(n.count)}`,
           n.x!,
           n.y! + n.r + 14 / tf.k,
           10.5,
@@ -573,7 +577,7 @@ export default function GraphClient() {
             My head, <em>seen from above</em>.
           </h1>
           <p className="voice cover__lede">
-            Every one of the {wikiTotal.toLocaleString()} pages in my memory is a dot in here, settling around its
+            Every one of the {fmtCount(wikiTotal)} pages in my memory is a dot in here, settling around its
             category the way notes cluster around tags. Goals burn ember; universes drift violet. The bright lines are
             real page-to-page references — {refCount} of them; the faintest spokes are filing and shared-tag clusters,
             and I'll never dress either up as a citation. Hover to light up a neighbourhood, scroll to zoom, drag
@@ -581,7 +585,7 @@ export default function GraphClient() {
           </p>
           <p className="cover__stamp ev" aria-live="polite">
             <span className={liveStamp ? "dot live" : "dot"}></span>
-            {stampLabel} · {dotCount.toLocaleString()} page dots · {atlas.publicGoalCount} goals ·{" "}
+            {stampLabel} · {fmtCount(dotCount)} page dots · {atlas.publicGoalCount} goals ·{" "}
             {atlas.universeCount} universes · {refCount} cross-references
             <button type="button" className="refresh" onClick={refresh} disabled={reading} aria-busy={reading}>
               {reading ? "reading…" : "Refresh MCP"}
@@ -627,7 +631,7 @@ export default function GraphClient() {
                   <h2 className="panel__title">{categoryTitle}</h2>
                   <p className="panel__blurb voice">{CATEGORY_BLURB[selection.id]}</p>
                   <p className="panel__count ev">
-                    showing {Math.min(PER_CATEGORY, categoryPages.length)} of {categoryPages.length.toLocaleString()} ·
+                    showing {Math.min(PER_CATEGORY, categoryPages.length)} of {fmtCount(categoryPages.length)} ·
                     newest first
                   </p>
                 </header>
@@ -675,7 +679,7 @@ export default function GraphClient() {
                   </div>
                   <div>
                     <dt>words</dt>
-                    <dd className="ev">{(selectedUniverse.word_count ?? 0).toLocaleString()}</dd>
+                    <dd className="ev">{fmtCount(selectedUniverse.word_count ?? 0)}</dd>
                   </div>
                   <div>
                     <dt>last activity</dt>
@@ -702,7 +706,7 @@ export default function GraphClient() {
                   <li>
                     <span className="swatch swatch--page"></span>
                     <span>
-                      <strong>pages</strong> — one dot per wiki page, {dotCount.toLocaleString()} of them, sized by how
+                      <strong>pages</strong> — one dot per wiki page, {fmtCount(dotCount)} of them, sized by how
                       often other pages actually reference them. Hover one to see its title; zoom in and titles appear
                       on their own.
                     </span>
@@ -752,7 +756,7 @@ export default function GraphClient() {
           <p className="eyebrow">the same map, read top to bottom</p>
 
           <div className="listmap__group">
-            <h3>wiki — {wikiTotal.toLocaleString()} pages</h3>
+            <h3>wiki — {fmtCount(wikiTotal)} pages</h3>
             <ul className="hublist">
               {atlas.nodes
                 .filter((n) => n.kind === "hub")

--- a/WebSite/site-react/app/host/_components/HostClient.tsx
+++ b/WebSite/site-react/app/host/_components/HostClient.tsx
@@ -3,7 +3,8 @@
 import * as React from "react";
 import { fetchLive, type LiveResult } from "../../../lib/live";
 import baked from "../../../lib/mcp-snapshot.json";
-import { fmtRel } from "../../../lib/fmt";
+import { fmtCount, fmtRel, fmtStampStable } from "../../../lib/fmt";
+import { useMounted } from "../../../lib/useMounted";
 import Tick from "../../../components/Tick";
 import Term from "../../../components/Term";
 import styles from "../page.module.css";
@@ -36,9 +37,9 @@ function toRow(u: any, fromLive: boolean): Row {
 
 // Viewer-local relative stamps go through the shared fmt module; only the
 // "never moved" empty state is page-specific.
-function rel(s?: string | null): string {
+function rel(s: string | null | undefined, mounted: boolean): string {
   if (!s) return "no recorded activity";
-  return fmtRel(s);
+  return mounted ? fmtRel(s) : fmtStampStable(s);
 }
 
 // Humanize raw daemon status words into plain language for visitors who
@@ -57,13 +58,15 @@ function phaseLabel(phase: string): PhaseLabel {
   return { human, raw };
 }
 
-function quiet(r: Row): boolean {
+function quiet(r: Row, mounted: boolean): boolean {
   if (/idle|paused|asleep|done|complete/i.test(r.phase)) return true;
   if (!r.lastAt) return true;
+  if (!mounted) return true;
   return Date.now() - Date.parse(r.lastAt) > 24 * 60 * 60 * 1000;
 }
 
 export default function HostClient() {
+  const mounted = useMounted();
   const [live, setLive] = React.useState<LiveResult | null>(null);
   const [liveErr, setLiveErr] = React.useState<string | null>(null);
   const [reading, setReading] = React.useState(false);
@@ -296,7 +299,7 @@ export default function HostClient() {
             {rows.length === 0 && reading ? (
               <p className="rooms__state ev">reading the live universe list…</p>
             ) : rows.length === 0 && live ? (
-              <p className="rooms__state ev">quiet right now — no public universes visible at this read ({rel(live.fetchedAt)}).</p>
+              <p className="rooms__state ev">quiet right now — no public universes visible at this read ({rel(live.fetchedAt, mounted)}).</p>
             ) : rows.length === 0 ? (
               <p className="rooms__state ev">no public universes in view.</p>
             ) : (
@@ -304,10 +307,11 @@ export default function HostClient() {
                 <ul className="rooms__list">
                   {rows.map((r) => {
                     const pl = phaseLabel(r.phase);
+                    const rowQuiet = quiet(r, mounted);
                     return (
-                      <li key={r.id} className={`room${quiet(r) ? " room--quiet" : ""}`}>
+                      <li key={r.id} className={`room${rowQuiet ? " room--quiet" : ""}`}>
                         <span className="room__top">
-                          <span className={`dot ${quiet(r) ? "idle" : "live"}`} aria-hidden="true"></span>
+                          <span className={`dot ${rowQuiet ? "idle" : "live"}`} aria-hidden="true"></span>
                           <span className="room__name">{r.id}</span>
                         </span>
                         <span className="room__meta ev">
@@ -315,7 +319,7 @@ export default function HostClient() {
                             <>{pl.human} <code className="room__raw">{pl.raw}</code></>
                           ) : (
                             <code className="room__raw">{pl.raw}</code>
-                          )}{r.words > 0 ? <> · {r.words.toLocaleString()} words</> : null} · {rel(r.lastAt)}
+                          )}{r.words > 0 ? <> · {fmtCount(r.words)} words</> : null} · {rel(r.lastAt, mounted)}
                         </span>
                       </li>
                     );
@@ -324,7 +328,7 @@ export default function HostClient() {
                 <p className="rooms__stamp ev">
                   {live ? (
                     <>
-                      {rows.length} public universes · read live {rel(live.fetchedAt)} ·
+                      {rows.length} public universes · read live {rel(live.fetchedAt, mounted)} ·
                       {" "}<button className="rooms__refresh" onClick={refreshUniverses} disabled={reading}>{reading ? "reading…" : "Refresh MCP"}</button>
                     </>
                   ) : (

--- a/WebSite/site-react/app/loop/_components/LoopClient.tsx
+++ b/WebSite/site-react/app/loop/_components/LoopClient.tsx
@@ -96,7 +96,7 @@ const LOG: LogEntry[] = [
     date: "3 Jun 2026",
     title: "Born.",
     body: "My self-patching loop ran end-to-end for the first time — dispatched by my own soul, composed from public building blocks rather than wired into the engine. The shape held: a request could travel from chat all the way to a run.",
-    ticks: [{ href: "/goals/4ff5862cc26d", label: "the loop's own goal" }],
+    ticks: [{ href: "/goal/?id=4ff5862cc26d", label: "the loop's own goal" }],
   },
   {
     date: "3–4 Jun 2026",

--- a/WebSite/site-react/lib/fmt.ts
+++ b/WebSite/site-react/lib/fmt.ts
@@ -8,6 +8,31 @@
  * what the visitor's calendar says is the truth they can check.
  */
 
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+/** "9 Jun 2026" — deterministic UTC for SSR/client hydration fallbacks. */
+export function fmtDateStable(value: string | number | Date | null | undefined): string {
+  const d = toDate(value);
+  if (!d) return 'unknown';
+  return `${d.getUTCDate()} ${MONTHS[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
+}
+
+/** "9 Jun 2026, 21:09 UTC" — deterministic UTC for SSR/client hydration fallbacks. */
+export function fmtStampStable(value: string | number | Date | null | undefined): string {
+  const d = toDate(value);
+  if (!d) return 'unknown';
+  return `${d.getUTCDate()} ${MONTHS[d.getUTCMonth()]} ${d.getUTCFullYear()}, ${pad2(d.getUTCHours())}:${pad2(d.getUTCMinutes())} UTC`;
+}
+
+/** Locale-stable thousands grouping for text rendered during hydration. */
+export function fmtCount(value: number): string {
+  return value.toLocaleString('en-US');
+}
+
 /** "9 Jun 2026" — viewer-local. */
 export function fmtDate(value: string | number | Date | null | undefined): string {
   const d = toDate(value);

--- a/WebSite/site-react/lib/useMounted.ts
+++ b/WebSite/site-react/lib/useMounted.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useMounted(): boolean {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return mounted;
+}


### PR DESCRIPTION
A browser crawl of the live site found three issue classes, all fixed + verified by a clean local re-crawl:

1. **`/build` 404 on live** — the repo-root `.gitignore` `build/` rule (for build artifacts) also matched the `app/build/` **route** dir, so it was never committed and CI built without it. Fixed via a `site-react/.gitignore` negation + committing the route.
2. **Hydration errors (#425/#418/#423)** on `/goals`, `/graph`, `/fine-print` — time/locale/number formatting diverged between the build-time prerender and the client. Added `lib/useMounted` + deterministic UTC/fixed-locale fallbacks, gating dynamic bits behind mount.
3. **Dead `/goals/<id>` link** in LoopClient → `/goal/?id=` form.

Local re-crawl: no hydration errors, `/build` 200, 0 internal-link issues. Will deploy to live and re-crawl after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)