### PR TITLE
Fix dead PulseChain explorer link

### DIFF
--- a/WebSite/site-react/lib/token-info.json
+++ b/WebSite/site-react/lib/token-info.json
@@ -25,8 +25,8 @@
       "chain": "PulseChain",
       "label": "PulseChain",
       "address_main": "0x92a242f94db176082Df4D386B366f4217ab7fAFd",
-      "explorer": "https://pulsescan.finvesta.io/#/token/0x92a242f94db176082Df4D386B366f4217ab7fAFd",
-      "buy": "https://pulsescan.finvesta.io/#/token/0x92a242f94db176082Df4D386B366f4217ab7fAFd",
+      "explorer": "https://scan.pulsechain.com/address/0x92a242f94db176082Df4D386B366f4217ab7fAFd",
+      "buy": "https://scan.pulsechain.com/address/0x92a242f94db176082Df4D386B366f4217ab7fAFd",
       "primary": false,
       "workflow_status": "reference-only"
     },


### PR DESCRIPTION
Crawl found `pulsescan.finvesta.io` (PulseChain token explorer/buy link in token-info.json) unreachable. The token is live on PulseChain — repointed to the canonical `scan.pulsechain.com` (verified: contract = Destiny/Tiny ERC-20). Same chain + address, working host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)