### PR TITLE
Fix pytest collection error: stale _resolve_bugs_canonical import in test_wiki_alias_corner_cases

### DIFF
--- a/tests/test_wiki_alias_corner_cases.py
+++ b/tests/test_wiki_alias_corner_cases.py
@@ -1,4 +1,9 @@
-"""Tests for `_resolve_bugs_canonical` + `_wiki_write` alias resolution corner cases.
+"""Tests for `_resolve_filed_page_canonical` + `_wiki_write` alias resolution corner cases.
+
+`_resolve_filed_page_canonical(parent, slug, *, category=...)` is the
+generalized successor of the historical bugs-only `_resolve_bugs_canonical`
+helper (renamed + parametrized by category in #1280). For the ``bugs``
+category it preserves the same corner-case contract exercised below.
 
 Covers Wiki #32 corner-case fixes:
 
@@ -23,7 +28,7 @@ from pathlib import Path
 import pytest
 
 from workflow.api.wiki import (
-    _resolve_bugs_canonical,
+    _resolve_filed_page_canonical,
     _wiki_write,
 )
 
@@ -59,25 +64,25 @@ def wiki_dir(tmp_path, monkeypatch):
     return wiki_root
 
 
-# ── _resolve_bugs_canonical unit tests ────────────────────────────────────────
+# ── _resolve_filed_page_canonical unit tests (bugs category) ──────────────────
 
 
 class TestResolveBugsCanonical:
     def test_returns_none_when_no_match(self, wiki_dir):
         parent = wiki_dir / "pages" / "bugs"
-        assert _resolve_bugs_canonical(parent, "bug-001-nope") is None
+        assert _resolve_filed_page_canonical(parent, "bug-001-nope", category="bugs") is None
 
     def test_returns_none_for_missing_parent(self, tmp_path):
-        # _resolve_bugs_canonical iterates parent.glob; missing dir → empty
+        # _resolve_filed_page_canonical iterates parent.glob; missing dir → empty
         # list → None. Tested here so callers can rely on the contract.
         missing = tmp_path / "does" / "not" / "exist"
-        assert _resolve_bugs_canonical(missing, "bug-001-x") is None
+        assert _resolve_filed_page_canonical(missing, "bug-001-x", category="bugs") is None
 
     def test_exact_match_returns_path(self, wiki_dir):
         parent = wiki_dir / "pages" / "bugs"
         target = parent / "bug-001-example.md"
         target.write_text("x", encoding="utf-8")
-        result = _resolve_bugs_canonical(parent, "bug-001-example")
+        result = _resolve_filed_page_canonical(parent, "bug-001-example", category="bugs")
         assert result == target
 
     def test_wrong_case_canonical_resolved(self, wiki_dir):
@@ -85,7 +90,7 @@ class TestResolveBugsCanonical:
         parent = wiki_dir / "pages" / "bugs"
         canonical = parent / "BUG-007-foo-bar.md"
         canonical.write_text("x", encoding="utf-8")
-        result = _resolve_bugs_canonical(parent, "bug-007-foo-bar")
+        result = _resolve_filed_page_canonical(parent, "bug-007-foo-bar", category="bugs")
         assert result == canonical
 
     @_skip_case_insensitive
@@ -96,7 +101,7 @@ class TestResolveBugsCanonical:
         duplicate = parent / "bug-003-example.md"
         canonical.write_text("canonical", encoding="utf-8")
         duplicate.write_text("dup", encoding="utf-8")
-        result = _resolve_bugs_canonical(parent, "bug-003-example")
+        result = _resolve_filed_page_canonical(parent, "bug-003-example", category="bugs")
         assert result == canonical, (
             "When a lowercase duplicate and an uppercase canonical coexist, "
             "BUG-003 fix requires the uppercase canonical to be preferred."
@@ -109,7 +114,7 @@ class TestResolveBugsCanonical:
         canonical.write_text("x", encoding="utf-8")
         # Slug sanitization strips trailing hyphens; so the slug entering
         # alias-resolution is "bug-018-foo" not "bug-018-foo-".
-        result = _resolve_bugs_canonical(parent, "bug-018-foo")
+        result = _resolve_filed_page_canonical(parent, "bug-018-foo", category="bugs")
         assert result == canonical
 
     @_skip_case_insensitive
@@ -120,7 +125,7 @@ class TestResolveBugsCanonical:
         lower_no_dash = parent / "bug-018-foo.md"
         upper_dash.write_text("upper", encoding="utf-8")
         lower_no_dash.write_text("lower", encoding="utf-8")
-        result = _resolve_bugs_canonical(parent, "bug-018-foo")
+        result = _resolve_filed_page_canonical(parent, "bug-018-foo", category="bugs")
         assert result == upper_dash
 
     def test_exact_slug_preferred_over_trailing_hyphen(self, wiki_dir):
@@ -130,7 +135,7 @@ class TestResolveBugsCanonical:
         with_dash = parent / "bug-018-foo-.md"
         exact.write_text("exact", encoding="utf-8")
         with_dash.write_text("dash", encoding="utf-8")
-        result = _resolve_bugs_canonical(parent, "bug-018-foo")
+        result = _resolve_filed_page_canonical(parent, "bug-018-foo", category="bugs")
         assert result == exact
 
 


### PR DESCRIPTION
## Problem

`tests/test_wiki_alias_corner_cases.py` imported `_resolve_bugs_canonical` from `workflow.api.wiki`, but that symbol no longer exists. The stale import raised `ImportError` at **collection time**, which aborts the *entire* pytest run — not just this file.

## Diagnosis: renamed + generalized (not dropped)

Commit `0b9ffc67` ("Fix wiki write canonical resolution for all file_bug-backed pages", #1280) intentionally **renamed and parametrized** the helper:

- `_resolve_bugs_canonical(parent, slug)` → `_resolve_filed_page_canonical(parent, slug, *, category=...)`
- Same corner-case contract (BUG-003 lowercase-duplicate, BUG-018 trailing-hyphen, BUG-028 wrong-case), now generalized across every `file_bug`-backed category (bugs / feature-requests / design-proposals / patch-requests) via `_FILE_BUG_CATEGORY_PREFIXES`.
- The old rank key `(is_upper_bug, is_exact, name)` became `(has_filed_prefix, preserves_case, is_exact, name)`. For `category="bugs"`, `_FILE_BUG_CATEGORY_PREFIXES["bugs"]` yields the `BUG` prefix, so "uppercase `BUG-` canonical wins" is preserved.

This was a deliberate API change, so the fix is **test-only**: update the import to the current symbol and pass `category="bugs"` at each unit-test call site. The `_wiki_write` integration tests in the same file already passed `category="bugs"` and are untouched. No `workflow/*` change → no plugin-mirror rebuild needed.

## Evidence

```
python -m pytest tests/test_wiki_alias_corner_cases.py -p no:cacheprovider -o addopts="" -q
10 passed, 3 skipped in 0.81s
```

(The 3 skips are the case-sensitive coexistence scenarios, which the test's own `_skip_case_insensitive` marker skips on Windows NTFS.)

`ruff check tests/test_wiki_alias_corner_cases.py` → All checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)