### PR TITLE
Tier-A: extract LLM-call primitive out of the fantasy domain (WIP)

### DIFF
--- a/docs/design-notes/2026-06-24-tier-a-provider-bridge-extraction-plan.md
+++ b/docs/design-notes/2026-06-24-tier-a-provider-bridge-extraction-plan.md
@@ -59,6 +59,35 @@ production-path; get sign-off (host + Codex) on fixing vs. preserving.
 the fantasy functions; have them `from workflow.providers.call import call_provider`
 and read force-mock via `is_force_mock()` (not the old module global).
 
+**⚠ True consumer surface is ~35 files, not 8 (corrected after full-repo grep —
+the audit + first Codex pass undercounted the fantasy-domain side).** Removing
+`last_provider` / `_FORCE_MOCK` / `_real_router` / `_call_router_with_retry`
+from the old module is **ATOMIC** — `from X import name` binds a snapshot, so
+there is no safe partial; every consumer of a removed symbol must move in the
+same commit. `call_provider` / `call_for_*` callers can keep importing from
+`phases._provider_stub` (it legitimately re-imports `call_provider` for its own
+use and keeps `call_for_*`), but ENGINE `call_provider` imports must still move
+to `workflow.providers.call` to satisfy the de-fantasy goal + import guard.
+
+Removed-symbol consumers that MUST move atomically:
+- `last_provider` -> `get_last_provider()`:
+  `domains/fantasy_daemon/phases/worldbuild.py:489,539,608,909`,
+  `workflow/ingestion/extractors.py:260/315`,
+  `fantasy_daemon/__main__.py:1962` (via nodes shim).
+- `_FORCE_MOCK` -> `is_force_mock()` / `set_force_mock()`:
+  `workflow/memory/reflexion.py:205,260`,
+  `workflow/retrieval/agentic_search.py:381`, `tests/conftest.py:19`, and the
+  test files below.
+- Daemon injection `fantasy_daemon/__main__.py:1176-1178` ->
+  `set_provider_router(self._router)` (fixes bug #1).
+- Delete `fantasy_daemon/nodes/_provider_stub.py` (star-import shim);
+  repoint its importers (`fantasy_daemon/__main__.py:1962,2227`).
+- `scripts/rebuild_sporemarch_kg.py:92` (`call_provider`).
+- Domain `call_provider` importers (`commit,consolidate,reflect,worldbuild,
+  writer_tools`) — repoint to `workflow.providers.call` for cleanliness
+  (optional for correctness since phases re-exports, required for the guard if
+  the guard ever covers `domains/`).
+
 **Daemon injection:** `fantasy_daemon/__main__.py:1176-1178` →
 `from workflow.providers.call import set_provider_router; set_provider_router(self._router)`
 (fixes bug #1). Remove/repoint `fantasy_daemon/nodes/_provider_stub.py` (the

--- a/docs/design-notes/2026-06-24-tier-a-provider-bridge-extraction-plan.md
+++ b/docs/design-notes/2026-06-24-tier-a-provider-bridge-extraction-plan.md
@@ -1,0 +1,96 @@
+# Tier-A: provider-bridge extraction — execution plan
+
+**Filed:** 2026-06-24 · **Branch:** `claude/defantasy-tier-a-provider-bridge`
+**Parent:** `docs/audits/2026-06-24-fantasy-architecture-residue-audit.md` (Tier A).
+**Status:** foundation landed; repoint pending a behavior-change decision +
+opposite-provider review. NOT behavior-preserving in two places (flagged below).
+
+## Done (this slice)
+
+`workflow/providers/call.py` — the engine's domain-agnostic LLM-call primitive,
+extracted from `domains/fantasy_daemon/phases/_provider_stub.py`. Carries
+`call_provider`, the retry wrapper, the fallback-router builder, and an explicit
+accessor API: `set_provider_router` / `get_provider_router` /
+`set_force_mock` / `is_force_mock` / `get_last_provider`. Zero `domains.*`
+imports. Unit-tested in isolation (`tests/test_providers_call.py`, 5 tests) —
+pins the injection seam and the live-`last_provider` accessor.
+
+The fantasy-specific half (`call_for_plan/draft/extraction`, `_mock_*`,
+`_format_*`) STAYS in the domain and will import `call_provider` from the new
+module.
+
+## ⚠ Two latent bugs this refactor surfaces (need a decision before repoint)
+
+These mean the repoint is NOT a pure behavior-preserving move. Both are
+production-path; get sign-off (host + Codex) on fixing vs. preserving.
+
+1. **Daemon router injection is currently a no-op.**
+   `fantasy_daemon/__main__.py:1176-1178` does
+   `import fantasy_daemon.nodes._provider_stub as stub; stub._real_router = self._router`.
+   But `fantasy_daemon/nodes/_provider_stub.py` is `from ...phases._provider_stub import *`,
+   and `import *` excludes underscore names — so `_real_router` is set on the
+   *nodes* module, a different object from `phases._provider_stub` where
+   `call_provider` reads `_real_router`. **The daemon's per-universe
+   `_build_provider_router()` is silently ignored; production runs on the
+   import-time fallback router.** Fixing it (route the daemon's router into the
+   live bridge via `set_provider_router`) is correct but changes production
+   provider selection — flag loudly, test, and stage.
+
+2. **`last_provider` is an import-time snapshot.**
+   `ingestion/extractors.py:260` does `from ... import call_provider, last_provider`
+   then `_write_canon_file(..., model=last_provider)` at :315 — always `""`,
+   so synthesized canon files record an empty model marker. The accessor
+   (`get_last_provider()`) fixes it to the real provider name.
+
+## Repoint checklist (remaining)
+
+**Engine call sites (8) → `from workflow.providers.call import ...`:**
+- `workflow/api/runs.py:542, 1110, 1520` (`call_provider`)
+- `workflow/api/selector_dispatch.py:733` (`call_provider`)
+- `workflow/evaluation/editorial.py:119` (`call_provider`)
+- `workflow/knowledge/raptor.py:340` (`call_provider`)
+- `workflow/ingestion/extractors.py:260` (`call_provider`; replace `last_provider`
+  use at :315 with `get_last_provider()` — see bug #2)
+- `workflow/memory/reflexion.py:205-210, 260-265` (`_FORCE_MOCK` → `is_force_mock()`)
+- `workflow/retrieval/agentic_search.py:381-387` (`_provider_stub._FORCE_MOCK`
+  → `call.is_force_mock()`; `_provider_stub.call_provider` → `call.call_provider`)
+
+**Fantasy domain:** reduce `domains/fantasy_daemon/phases/_provider_stub.py` to
+the fantasy functions; have them `from workflow.providers.call import call_provider`
+and read force-mock via `is_force_mock()` (not the old module global).
+
+**Daemon injection:** `fantasy_daemon/__main__.py:1176-1178` →
+`from workflow.providers.call import set_provider_router; set_provider_router(self._router)`
+(fixes bug #1). Remove/repoint `fantasy_daemon/nodes/_provider_stub.py` (the
+star-import shim) — no-shims rule: delete it in this arc, not leave a re-export.
+
+**Test infra (the load-bearing part):**
+- `tests/conftest.py:17-19` — set force-mock on the new module:
+  `from workflow.providers import call; call.set_force_mock(True)`. Keep the
+  fantasy module's mock path honoring `is_force_mock()` so its `call_for_*`
+  fallbacks still fire.
+- Test files referencing `_provider_stub` / the old path — audit each; those
+  mocking `call_provider` or toggling `_FORCE_MOCK` repoint to
+  `workflow.providers.call`:
+  `conftest, test_canonical_branch_mcp, test_commit_kg_integration,
+  test_goals_set_selector, test_integration, test_nodes_real,
+  test_provider_retry, test_rollback, test_stability,
+  test_text_channel_id_redaction`, and (Codex review, missed in the first pass)
+  `test_grok_provider_registration, test_provider_binary_probe,
+  test_provider_stub_registration, test_ingestion, test_knowledge_graph,
+  test_universe_nodes`.
+- **Packaging mirror:** regenerate
+  `packaging/claude-plugin/.../runtime/workflow/` (run
+  `python packaging/claude-plugin/build_plugin.py`) so the packaged runtime
+  ships the new module + repointed imports, not the old coupling.
+
+**Prevention:** add the staged/ratcheted `workflow/** !-> domains.*` import
+guard (audit Prevention). After this slice the only remaining offenders are the
+Tier-C/D sites; the guard's allowlist shrinks as each tier lands.
+
+## Gate
+
+The real proof is the **full suite green** (7,856 tests) — this sandbox can't
+run it (collection error on an unrelated module + no network for some
+providers), so the repoint must be verified where the full suite runs.
+Opposite-provider (Codex) review required before landing per AGENTS.md.

--- a/domains/fantasy_daemon/phases/_provider_stub.py
+++ b/domains/fantasy_daemon/phases/_provider_stub.py
@@ -1,111 +1,36 @@
-"""Provider bridge for graph nodes.
+"""Fantasy-domain prompt assembly + provider calls for graph nodes.
 
-Routes all LLM calls through the real ``ProviderRouter`` using its
-synchronous ``call_sync`` method.  Falls back to deterministic mock
-output when ``_FORCE_MOCK`` is True (tests) or when all providers are
-exhausted.
+The general, domain-agnostic LLM-call primitive (``call_provider``, the router,
+force-mock, ``last_provider``) now lives in :mod:`workflow.providers.call` — the
+engine's shared bridge. This module keeps the *fantasy-specific* prompt builders
+and deterministic mock fixtures, and routes its LLM calls through that general
+primitive.
 
-This module lives in ``nodes/`` (graph-core's directory) to respect
-file ownership boundaries.
+``call_provider`` is re-exported here (it is imported for this module's own
+``call_for_*`` helpers) so existing fantasy-domain callers that do
+``from ..._provider_stub import call_provider`` keep working. Engine code must
+import from :mod:`workflow.providers.call` directly (de-fantasy import boundary).
+Read force-mock via ``is_force_mock()`` rather than a module global.
 """
 
 from __future__ import annotations
 
 import json
-import logging
 from typing import Any
 
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
+from workflow.providers.call import call_provider, is_force_mock
 
-logger = logging.getLogger(__name__)
-
-# Set to True to skip real provider calls and use mock responses.
-# Tests should set this before importing nodes.
-_FORCE_MOCK = False
-
-# ---------------------------------------------------------------------------
-# Import the real provider router
-# ---------------------------------------------------------------------------
-
-_real_router = None
-
-# Tracks which provider was used for the most recent call.
-# Used by reflect/worldbuild to enforce model quality tiers.
-last_provider: str = ""
-
-try:
-    from workflow.providers.router import ProviderRouter as _RealRouter
-
-    _real_router = _RealRouter()
-
-    # Register available providers so the router works without the daemon.
-    # The daemon's DaemonController.start() overwrites _real_router with its
-    # own fully-configured instance, so these registrations are only the
-    # fallback for standalone / script usage.
-
-    try:
-        from workflow.providers.claude_provider import ClaudeProvider
-        if ClaudeProvider.is_available():
-            _real_router.register(ClaudeProvider())
-            logger.info("Registered ClaudeProvider")
-        else:
-            logger.debug("claude binary not found — ClaudeProvider skipped")
-    except Exception:
-        logger.debug("ClaudeProvider not available")
-
-    try:
-        from workflow.providers.codex_provider import CodexProvider
-        if CodexProvider.is_available():
-            _real_router.register(CodexProvider())
-            logger.info("Registered CodexProvider")
-        else:
-            logger.debug("codex binary not found — CodexProvider skipped")
-    except Exception:
-        logger.debug("CodexProvider not available")
-
-    try:
-        from workflow.providers.ollama_provider import OllamaProvider
-        _real_router.register(OllamaProvider())
-        logger.info("Registered OllamaProvider")
-    except Exception:
-        logger.debug("OllamaProvider not available")
-
-    try:
-        from workflow.providers.gemini_provider import GeminiProvider
-        _real_router.register(GeminiProvider())
-        logger.info("Registered GeminiProvider")
-    except Exception:
-        logger.debug("GeminiProvider not available")
-
-    try:
-        from workflow.providers.groq_provider import GroqProvider
-        _real_router.register(GroqProvider())
-        logger.info("Registered GroqProvider")
-    except Exception:
-        logger.debug("GroqProvider not available")
-
-    try:
-        from workflow.providers.grok_provider import GrokProvider
-        _real_router.register(GrokProvider())
-        logger.info("Registered GrokProvider")
-    except Exception:
-        logger.debug("GrokProvider not available")
-
-    logger.info(
-        "ProviderRouter ready with providers: %s",
-        _real_router.available_providers,
-    )
-except ImportError:
-    logger.info("Real ProviderRouter not available; using stub provider")
+__all__ = [
+    "call_provider",
+    "is_force_mock",
+    "call_for_plan",
+    "call_for_draft",
+    "call_for_extraction",
+]
 
 
 # ---------------------------------------------------------------------------
-# Mock provider responses
+# Prompt-context formatters
 # ---------------------------------------------------------------------------
 
 
@@ -252,6 +177,11 @@ def _format_memory_context(memory_ctx: dict[str, Any]) -> str:
     return "# Story Memory\n\n" + "\n\n".join(parts) + "\n\n"
 
 
+# ---------------------------------------------------------------------------
+# Deterministic mock fixtures (used when force-mock is on)
+# ---------------------------------------------------------------------------
+
+
 def _mock_plan_response(orient_result: dict[str, Any]) -> str:
     """Generate a deterministic mock plan response.
 
@@ -356,103 +286,8 @@ def _mock_extraction_response(prose: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Public API
+# Fantasy-domain provider calls (route through workflow.providers.call)
 # ---------------------------------------------------------------------------
-
-
-def _call_router_with_retry(role: str, prompt: str, system: str) -> str:
-    """Call the real router with tenacity retry on transient exhaustion.
-
-    Retries up to 3 times with exponential backoff (2s, 4s, 8s) when
-    all providers are temporarily exhausted. This handles the common case
-    where rate-limit cooldowns expire between attempts.
-    """
-    from workflow.exceptions import AllProvidersExhaustedError
-
-    @retry(
-        retry=retry_if_exception_type(AllProvidersExhaustedError),
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=2, max=8),
-        reraise=True,
-    )
-    def _attempt() -> str:
-        global last_provider
-        result = _real_router.call_sync(role, prompt, system)
-        last_provider = result.provider
-        return result.text
-
-    return _attempt()
-
-
-def call_provider(
-    prompt: str,
-    system: str = "",
-    *,
-    role: str = "writer",
-    fallback_response: str | None = None,
-) -> str:
-    """Call an LLM provider with automatic fallback.
-
-    Uses the real ProviderRouter's ``call_sync`` method which runs the
-    async fallback chain in a dedicated thread.  Falls back to mock
-    output only when all providers are exhausted.
-
-    On transient exhaustion (all providers in cooldown), retries up to 3
-    times with exponential backoff before giving up.
-
-    Parameters
-    ----------
-    prompt : str
-        The user prompt.
-    system : str
-        System prompt.
-    role : str
-        The role for routing (writer, judge, extract).
-    fallback_response : str or None
-        If all providers fail, return this string.  If None, returns
-        a generic placeholder.
-
-    Returns
-    -------
-    str
-        The provider's response text.
-    """
-    if _FORCE_MOCK:
-        if fallback_response is not None:
-            return fallback_response
-        return "[Mock response -- _FORCE_MOCK is True]"
-
-    provider_error: Exception | None = None
-
-    # Use the real router's synchronous entry point with retry
-    if _real_router is not None:
-        try:
-            return _call_router_with_retry(role, prompt, system)
-        except Exception as e:
-            provider_error = e
-            logger.error(
-                "All providers exhausted for role=%s after retries: %s", role, e,
-            )
-
-    # Fallback: only use mock content if an explicit fallback was provided.
-    # In production (no _FORCE_MOCK), callers should pass fallback_response=None
-    # so provider exhaustion surfaces as the real provider error instead of
-    # masquerading as an empty LLM response downstream.
-    if fallback_response is not None:
-        logger.warning(
-            "Using fallback response for role=%s (%d chars)",
-            role, len(fallback_response),
-        )
-        return fallback_response
-    if provider_error is not None:
-        raise provider_error
-
-    from workflow.exceptions import AllProvidersExhaustedError
-
-    raise AllProvidersExhaustedError(
-        f"No provider router available for role={role!r} and no fallback_response "
-        "was provided."
-    )
 
 
 def call_for_plan(
@@ -519,7 +354,7 @@ def call_for_plan(
         "Generate 3-5 alternative beat sheets for this scene."
     )
 
-    fallback = _mock_plan_response(orient_result) if _FORCE_MOCK else None
+    fallback = _mock_plan_response(orient_result) if is_force_mock() else None
     result = call_provider(
         prompt,
         system,
@@ -561,7 +396,7 @@ def call_for_draft(
     if writer_context:
         prompt += writer_context
         prompt += "Write the scene prose now."
-        fallback = _mock_draft_response(plan_output) if _FORCE_MOCK else None
+        fallback = _mock_draft_response(plan_output) if is_force_mock() else None
         result = call_provider(
             prompt,
             system,
@@ -639,7 +474,7 @@ def call_for_draft(
 
     prompt += "Write the scene prose now."
 
-    fallback = _mock_draft_response(plan_output) if _FORCE_MOCK else None
+    fallback = _mock_draft_response(plan_output) if is_force_mock() else None
     result = call_provider(
         prompt,
         system,
@@ -661,7 +496,7 @@ def call_for_extraction(prose: str, pov_character: str | None = None) -> str:
 
     prompt = build_extraction_prompt(prose, pov_character)
 
-    fallback = _mock_extraction_response(prose) if _FORCE_MOCK else None
+    fallback = _mock_extraction_response(prose) if is_force_mock() else None
     result = call_provider(
         prompt,
         FACT_EXTRACTION_SYSTEM,

--- a/domains/fantasy_daemon/phases/worldbuild.py
+++ b/domains/fantasy_daemon/phases/worldbuild.py
@@ -486,7 +486,7 @@ def _handle_new_element(
     state: dict[str, Any],
 ) -> None:
     """Create a focused canon document for a newly discovered element."""
-    from domains.fantasy_daemon.phases._provider_stub import call_provider, last_provider
+    from workflow.providers.call import call_provider, get_last_provider
 
     topic_slug = safe_canon_slug(topic)
     topic_label = topic.replace("_", " ").title()
@@ -520,7 +520,7 @@ def _handle_new_element(
     )
     if content:
         filename = safe_canon_filename(topic_slug)
-        _write_canon_file(canon_dir, filename, content, model=last_provider)
+        _write_canon_file(canon_dir, filename, content, model=get_last_provider())
         logger.info("Created canon for new element: %s", filename)
 
 
@@ -536,7 +536,7 @@ def _handle_contradiction(
     Asks the LLM which version makes for a better, more coherent universe
     given the full premise and context. Does NOT default to either side.
     """
-    from domains.fantasy_daemon.phases._provider_stub import call_provider, last_provider
+    from workflow.providers.call import call_provider, get_last_provider
 
     topic_slug = safe_canon_slug(topic)
 
@@ -591,7 +591,7 @@ def _handle_contradiction(
         filepath = _resolve_within_canon(canon_dir, canon_filename, kind="existing file")
         filepath.write_text(new_content, encoding="utf-8")
         # Update provenance marker
-        _write_canon_marker(canon_dir, canon_filename, model=last_provider)
+        _write_canon_marker(canon_dir, canon_filename, model=get_last_provider())
         logger.info(
             "Resolved contradiction in %s: %s", canon_filename, detail[:80]
         )
@@ -605,7 +605,7 @@ def _handle_expansion(
     state: dict[str, Any],
 ) -> None:
     """Expand an existing thin canon document with new details from prose."""
-    from domains.fantasy_daemon.phases._provider_stub import call_provider, last_provider
+    from workflow.providers.call import call_provider, get_last_provider
 
     topic_slug = safe_canon_slug(topic)
 
@@ -652,7 +652,7 @@ def _handle_expansion(
     if new_content and new_content != canon_content:
         filepath = _resolve_within_canon(canon_dir, canon_filename, kind="existing file")
         filepath.write_text(new_content, encoding="utf-8")
-        _write_canon_marker(canon_dir, canon_filename, model=last_provider)
+        _write_canon_marker(canon_dir, canon_filename, model=get_last_provider())
         logger.info(
             "Expanded %s with: %s", canon_filename, detail[:80]
         )
@@ -906,9 +906,9 @@ def _generate_canon_documents(state: dict[str, Any]) -> list[str]:
                 topic, premise, direction_notes, existing_topics
             )
             if content:
-                from domains.fantasy_daemon.phases._provider_stub import last_provider
+                from workflow.providers.call import get_last_provider
                 filename = safe_canon_filename(topic)
-                _write_canon_file(canon_dir, filename, content, model=last_provider)
+                _write_canon_file(canon_dir, filename, content, model=get_last_provider())
                 # Verify the file actually exists on disk. ``filename`` already
                 # passed ``safe_canon_filename`` + ``_write_canon_file``
                 # containment; route the existence check through the same

--- a/domains/fantasy_daemon/phases/writer_tools.py
+++ b/domains/fantasy_daemon/phases/writer_tools.py
@@ -81,7 +81,7 @@ def _select_tool_names(
 
     allowed = {tool.name for tool in tools}
     defaults = _default_tool_names(phase, state, tools)
-    if _provider_stub._FORCE_MOCK:
+    if _provider_stub.is_force_mock():
         return defaults
 
     plan_output = state.get("plan_output") or {}

--- a/fantasy_daemon/__main__.py
+++ b/fantasy_daemon/__main__.py
@@ -1173,9 +1173,9 @@ class DaemonController:
 
         # Inject router into the provider stub module so nodes can use it
         try:
-            import fantasy_daemon.nodes._provider_stub as stub
+            from workflow.providers.call import set_provider_router
 
-            stub._real_router = self._router
+            set_provider_router(self._router)
         except ImportError:
             pass
 
@@ -1959,7 +1959,8 @@ class DaemonController:
 
         # Track the most recently used LLM provider
         try:
-            from fantasy_daemon.nodes._provider_stub import last_provider
+            from workflow.providers.call import get_last_provider
+            last_provider = get_last_provider()
             if last_provider:
                 self._last_provider_used = last_provider
         except ImportError:
@@ -2224,7 +2225,7 @@ class DaemonController:
         active characters, open plot threads, and recent creative
         decisions.  Falls back to the chapter summary alone on failure.
         """
-        from fantasy_daemon.nodes._provider_stub import call_provider
+        from workflow.providers.call import call_provider
 
         chapter_summary = output.get("chapter_summary", "")
         if not chapter_summary:

--- a/fantasy_daemon/nodes/_provider_stub.py
+++ b/fantasy_daemon/nodes/_provider_stub.py
@@ -1,2 +1,0 @@
-"""Shim: use domains.fantasy_daemon.phases._provider_stub instead."""
-from domains.fantasy_daemon.phases._provider_stub import *  # noqa: F401,F403

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/runs.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/runs.py
@@ -539,7 +539,7 @@ def _action_run_branch(kwargs: dict[str, Any]) -> str:
     # Real provider — lazy import so test envs without providers work.
     provider_call: Any = None
     try:
-        from domains.fantasy_daemon.phases._provider_stub import (
+        from workflow.providers.call import (
             call_provider as provider_call,
         )
     except ImportError:
@@ -1107,7 +1107,7 @@ def _action_resume_run(kwargs: dict[str, Any]) -> str:
 
     provider_call: Any = None
     try:
-        from domains.fantasy_daemon.phases._provider_stub import (
+        from workflow.providers.call import (
             call_provider as provider_call,
         )
     except ImportError:
@@ -1517,7 +1517,7 @@ def _action_run_branch_version(kwargs: dict[str, Any]) -> str:
     # Real provider — lazy import so test envs without providers work.
     provider_call: Any = None
     try:
-        from domains.fantasy_daemon.phases._provider_stub import (
+        from workflow.providers.call import (
             call_provider as provider_call,
         )
     except ImportError:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/selector_dispatch.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/selector_dispatch.py
@@ -730,7 +730,7 @@ def dispatch_selector(
     # ``_action_run_branch_version``.
     if provider_call is None:
         try:
-            from domains.fantasy_daemon.phases._provider_stub import (
+            from workflow.providers.call import (
                 call_provider as _default_provider_call,
             )
             provider_call = _default_provider_call

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/evaluation/editorial.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/evaluation/editorial.py
@@ -116,7 +116,7 @@ def read_editorial(
         return None
 
     if provider_call is None:
-        from domains.fantasy_daemon.phases._provider_stub import call_provider
+        from workflow.providers.call import call_provider
         provider_call = call_provider
 
     # Build prompt with context sections

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/ingestion/extractors.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/ingestion/extractors.py
@@ -257,8 +257,8 @@ def synthesize_source(
     list[str]
         Filenames of synthesized documents.
     """
-    from domains.fantasy_daemon.phases._provider_stub import call_provider, last_provider
     from domains.fantasy_daemon.phases.worldbuild import _write_canon_file
+    from workflow.providers.call import call_provider, get_last_provider
 
     if not source_text.strip():
         return []
@@ -312,7 +312,7 @@ def synthesize_source(
                 pass
 
         _write_canon_file(
-            canon_dir, doc_filename, content, model=last_provider,
+            canon_dir, doc_filename, content, model=get_last_provider(),
         )
         generated.append(doc_filename)
         logger.info(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/knowledge/raptor.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/knowledge/raptor.py
@@ -337,7 +337,7 @@ def rebuild_raptor_from_canon(
 
     # Async wrapper for the sync provider stub
     async def _summarize(prompt: str, system: str, role: str) -> str:
-        from domains.fantasy_daemon.phases._provider_stub import call_provider
+        from workflow.providers.call import call_provider
         return call_provider(prompt, system, role=role, fallback_response="")
 
     # Build tree

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/memory/reflexion.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/memory/reflexion.py
@@ -202,12 +202,9 @@ class ReflexionEngine:
 
         Returns the LLM response or empty string if unavailable.
         """
-        from domains.fantasy_daemon.phases._provider_stub import (
-            _FORCE_MOCK,
-            call_provider,
-        )
+        from workflow.providers.call import call_provider, is_force_mock
 
-        if _FORCE_MOCK:
+        if is_force_mock():
             return ""
 
         scene_id = (
@@ -257,12 +254,9 @@ class ReflexionEngine:
 
         Returns the LLM response or empty string if unavailable.
         """
-        from domains.fantasy_daemon.phases._provider_stub import (
-            _FORCE_MOCK,
-            call_provider,
-        )
+        from workflow.providers.call import call_provider, is_force_mock
 
-        if _FORCE_MOCK:
+        if is_force_mock():
             return ""
 
         scene_id = (

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/call.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/call.py
@@ -3,10 +3,10 @@
 Routes all provider calls through the shared :class:`ProviderRouter`
 (synchronous ``call_sync``), with a deterministic mock path for tests and an
 explicit fallback when providers are exhausted. This is the engine's single,
-domain-agnostic LLM-call primitive — it must never import any ``domains.*``
-package. (The legacy home was
-``domains/fantasy_daemon/phases/_provider_stub.py``; see
-``docs/audits/2026-06-24-fantasy-architecture-residue-audit.md`` Tier A.)
+domain-agnostic LLM-call primitive — engine code must reach the LLM only
+through this module, never through a domain package. (It was previously hosted
+inside the fantasy domain; the relocation is the de-fantasy audit's Tier A:
+``docs/audits/2026-06-24-fantasy-architecture-residue-audit.md``.)
 
 The router is injectable: a long-running host (e.g. a daemon) builds its own
 fully-configured :class:`ProviderRouter` and installs it via

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/call.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/call.py
@@ -1,0 +1,255 @@
+"""General LLM-call bridge for the engine.
+
+Routes all provider calls through the shared :class:`ProviderRouter`
+(synchronous ``call_sync``), with a deterministic mock path for tests and an
+explicit fallback when providers are exhausted. This is the engine's single,
+domain-agnostic LLM-call primitive — it must never import any ``domains.*``
+package. (The legacy home was
+``domains/fantasy_daemon/phases/_provider_stub.py``; see
+``docs/audits/2026-06-24-fantasy-architecture-residue-audit.md`` Tier A.)
+
+The router is injectable: a long-running host (e.g. a daemon) builds its own
+fully-configured :class:`ProviderRouter` and installs it via
+:func:`set_provider_router`. A bare import builds a best-effort fallback router
+from whatever provider binaries/keys are present, so scripts and tests work
+without a daemon.
+
+Use the accessors (:func:`get_last_provider`, :func:`is_force_mock`) rather than
+``from ... import last_provider`` / ``_FORCE_MOCK``: the import-the-name pattern
+binds an import-time snapshot that never reflects later reassignment (the latent
+bug at ``ingestion/extractors.py``, where ``model=last_provider`` always wrote
+an empty string).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+if TYPE_CHECKING:
+    from workflow.providers.router import ProviderRouter
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Mutable module state (use the accessors below; do not import these names)
+# ---------------------------------------------------------------------------
+
+# Skip real provider calls and return mock/fallback output. Tests set this via
+# set_force_mock() in conftest.
+_force_mock = False
+
+# The router call_provider() routes through. None until a router is built or
+# injected. A daemon overwrites it via set_provider_router().
+_real_router: "Optional[ProviderRouter]" = None
+
+# Provider name used by the most recent call. Read via get_last_provider().
+_last_provider: str = ""
+
+
+def set_force_mock(value: bool) -> None:
+    """Enable/disable the mock path (tests)."""
+    global _force_mock
+    _force_mock = bool(value)
+
+
+def is_force_mock() -> bool:
+    """Whether call_provider() short-circuits to mock/fallback output."""
+    return _force_mock
+
+
+def set_provider_router(router: "Optional[ProviderRouter]") -> None:
+    """Install the router call_provider() routes through.
+
+    This is the daemon-injection seam: ``DaemonController`` builds a fully
+    configured router and installs it here so the engine's LLM calls use the
+    host's provider configuration instead of the import-time fallback.
+    """
+    global _real_router
+    _real_router = router
+
+
+def get_provider_router() -> "Optional[ProviderRouter]":
+    """The router currently installed (fallback or daemon-injected)."""
+    return _real_router
+
+
+def get_last_provider() -> str:
+    """Provider name used by the most recent call_provider() — live, not a snapshot."""
+    return _last_provider
+
+
+# ---------------------------------------------------------------------------
+# Fallback router for standalone / script / test usage
+# ---------------------------------------------------------------------------
+
+
+def _build_fallback_router() -> "Optional[ProviderRouter]":
+    """Best-effort router registering whatever providers are available.
+
+    A daemon overwrites this via :func:`set_provider_router`, so these
+    registrations only serve standalone/script/test usage. Each provider import
+    is independently guarded so a missing optional dependency never breaks the
+    bridge.
+    """
+    try:
+        from workflow.providers.router import ProviderRouter
+    except ImportError:
+        logger.info("Real ProviderRouter not available; using mock-only provider")
+        return None
+
+    router = ProviderRouter()
+
+    try:
+        from workflow.providers.claude_provider import ClaudeProvider
+        if ClaudeProvider.is_available():
+            router.register(ClaudeProvider())
+            logger.info("Registered ClaudeProvider")
+        else:
+            logger.debug("claude binary not found - ClaudeProvider skipped")
+    except Exception:
+        logger.debug("ClaudeProvider not available")
+
+    try:
+        from workflow.providers.codex_provider import CodexProvider
+        if CodexProvider.is_available():
+            router.register(CodexProvider())
+            logger.info("Registered CodexProvider")
+        else:
+            logger.debug("codex binary not found - CodexProvider skipped")
+    except Exception:
+        logger.debug("CodexProvider not available")
+
+    try:
+        from workflow.providers.ollama_provider import OllamaProvider
+        router.register(OllamaProvider())
+        logger.info("Registered OllamaProvider")
+    except Exception:
+        logger.debug("OllamaProvider not available")
+
+    try:
+        from workflow.providers.gemini_provider import GeminiProvider
+        router.register(GeminiProvider())
+        logger.info("Registered GeminiProvider")
+    except Exception:
+        logger.debug("GeminiProvider not available")
+
+    try:
+        from workflow.providers.groq_provider import GroqProvider
+        router.register(GroqProvider())
+        logger.info("Registered GroqProvider")
+    except Exception:
+        logger.debug("GroqProvider not available")
+
+    try:
+        from workflow.providers.grok_provider import GrokProvider
+        router.register(GrokProvider())
+        logger.info("Registered GrokProvider")
+    except Exception:
+        logger.debug("GrokProvider not available")
+
+    logger.info(
+        "ProviderRouter ready with providers: %s",
+        router.available_providers,
+    )
+    return router
+
+
+_real_router = _build_fallback_router()
+
+
+# ---------------------------------------------------------------------------
+# Public call primitive
+# ---------------------------------------------------------------------------
+
+
+def _call_router_with_retry(role: str, prompt: str, system: str) -> str:
+    """Call the installed router with tenacity retry on transient exhaustion.
+
+    Retries up to 3 times with exponential backoff (2s, 4s, 8s) when all
+    providers are temporarily exhausted (rate-limit cooldowns expiring between
+    attempts).
+    """
+    from workflow.exceptions import AllProvidersExhaustedError
+
+    @retry(
+        retry=retry_if_exception_type(AllProvidersExhaustedError),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=8),
+        reraise=True,
+    )
+    def _attempt() -> str:
+        global _last_provider
+        result = _real_router.call_sync(role, prompt, system)
+        _last_provider = result.provider
+        return result.text
+
+    return _attempt()
+
+
+def call_provider(
+    prompt: str,
+    system: str = "",
+    *,
+    role: str = "writer",
+    fallback_response: str | None = None,
+) -> str:
+    """Call an LLM provider with automatic fallback.
+
+    Routes through the installed :class:`ProviderRouter`'s synchronous
+    ``call_sync`` (which runs the async fallback chain in a dedicated thread).
+    On transient exhaustion, retries up to 3 times with exponential backoff.
+    Falls back to mock/``fallback_response`` only when forced or exhausted.
+
+    Parameters
+    ----------
+    prompt:
+        The user prompt.
+    system:
+        System prompt.
+    role:
+        Routing role (writer, judge, extract).
+    fallback_response:
+        Returned if all providers fail. If ``None`` in production, provider
+        exhaustion surfaces as the real error rather than masquerading as an
+        empty LLM response downstream.
+    """
+    if _force_mock:
+        if fallback_response is not None:
+            return fallback_response
+        # Preserve the exact legacy string (callers/tests may assert on it).
+        return "[Mock response -- _FORCE_MOCK is True]"
+
+    provider_error: Exception | None = None
+
+    if _real_router is not None:
+        try:
+            return _call_router_with_retry(role, prompt, system)
+        except Exception as e:
+            provider_error = e
+            logger.error(
+                "All providers exhausted for role=%s after retries: %s", role, e,
+            )
+
+    if fallback_response is not None:
+        logger.warning(
+            "Using fallback response for role=%s (%d chars)",
+            role, len(fallback_response),
+        )
+        return fallback_response
+    if provider_error is not None:
+        raise provider_error
+
+    from workflow.exceptions import AllProvidersExhaustedError
+
+    raise AllProvidersExhaustedError(
+        f"No provider router available for role={role!r} and no fallback_response "
+        "was provided."
+    )

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/retrieval/agentic_search.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/retrieval/agentic_search.py
@@ -378,13 +378,13 @@ def build_phase_query(
 
 def _build_provider_call() -> Callable[[str, str, str], Any] | None:
     """Return the async decomposition callable when real providers are enabled."""
-    from domains.fantasy_daemon.phases import _provider_stub
+    from workflow.providers import call as provider_call
 
-    if _provider_stub._FORCE_MOCK:
+    if provider_call.is_force_mock():
         return None
 
     async def _async_provider_call(prompt: str, system: str, role: str) -> str:
-        return _provider_stub.call_provider(
+        return provider_call.call_provider(
             prompt,
             system,
             role=role,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,9 @@ import pytest
 from langgraph.checkpoint.sqlite import SqliteSaver
 
 # Force mock provider responses in all tests to avoid real API calls
-import domains.fantasy_daemon.phases._provider_stub as _provider_stub
+from workflow.providers import call as _provider_call
 
-_provider_stub._FORCE_MOCK = True
+_provider_call.set_force_mock(True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_grok_provider_registration.py
+++ b/tests/test_grok_provider_registration.py
@@ -16,7 +16,7 @@ import pytest
 
 
 def _reload_stub():
-    mod_name = "domains.fantasy_daemon.phases._provider_stub"
+    mod_name = "workflow.providers.call"
     if mod_name in sys.modules:
         del sys.modules[mod_name]
     return importlib.import_module(mod_name)
@@ -24,7 +24,7 @@ def _reload_stub():
 
 @pytest.fixture
 def reset_stub():
-    mod_name = "domains.fantasy_daemon.phases._provider_stub"
+    mod_name = "workflow.providers.call"
     saved = sys.modules.pop(mod_name, None)
     yield
     sys.modules.pop(mod_name, None)

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -394,7 +394,7 @@ class TestSynthesizeSource:
         })
 
         with patch(
-            "domains.fantasy_daemon.phases._provider_stub.call_provider",
+            "workflow.providers.call.call_provider",
             return_value=mock_response,
         ):
             result = synthesize_source(
@@ -429,7 +429,7 @@ class TestSynthesizeSource:
         })
 
         with patch(
-            "domains.fantasy_daemon.phases._provider_stub.call_provider",
+            "workflow.providers.call.call_provider",
             return_value=mock_response,
         ):
             result = synthesize_source(
@@ -453,7 +453,7 @@ class TestSynthesizeSource:
         canon_dir.mkdir()
 
         with patch(
-            "domains.fantasy_daemon.phases._provider_stub.call_provider",
+            "workflow.providers.call.call_provider",
             return_value="# Worldbuilding\n\nSome content here.",
         ):
             result = synthesize_source(
@@ -592,7 +592,7 @@ class TestSynthesisWithVerification:
                 })
 
         with patch(
-            "domains.fantasy_daemon.phases._provider_stub.call_provider",
+            "workflow.providers.call.call_provider",
             side_effect=mock_provider,
         ):
             result = synthesize_source(
@@ -729,7 +729,7 @@ class TestSynthesizeBiteByBite:
             return '{"gaps": []}'
 
         with patch(
-            "domains.fantasy_daemon.phases._provider_stub.call_provider",
+            "workflow.providers.call.call_provider",
             side_effect=mock_provider,
         ):
             result = synthesize_source(large_source, "big_world.md", canon_dir)
@@ -755,7 +755,7 @@ class TestSynthesizeBiteByBite:
             return '{"gaps": []}'
 
         with patch(
-            "domains.fantasy_daemon.phases._provider_stub.call_provider",
+            "workflow.providers.call.call_provider",
             side_effect=mock_provider,
         ):
             result = synthesize_source(
@@ -796,7 +796,7 @@ class TestSynthesizeBiteByBite:
             return '{"gaps": []}'
 
         with patch(
-            "domains.fantasy_daemon.phases._provider_stub.call_provider",
+            "workflow.providers.call.call_provider",
             side_effect=mock_provider,
         ):
             result = synthesize_source(large_source, "partial.md", canon_dir)
@@ -869,7 +869,7 @@ class TestWorldbuildSynthesisSignal:
         })
 
         with patch(
-            "domains.fantasy_daemon.phases._provider_stub.call_provider",
+            "workflow.providers.call.call_provider",
             return_value=mock_response,
         ):
             acted, consumed = _act_on_signals_incremental(signals, state)
@@ -887,7 +887,7 @@ class TestWorldbuildSynthesisSignal:
         })
 
         with patch(
-            "domains.fantasy_daemon.phases._provider_stub.call_provider",
+            "workflow.providers.call.call_provider",
             return_value=mock_response,
         ):
             generated = synthesize_source(
@@ -932,7 +932,7 @@ class TestWorldbuildSynthesisSignal:
 
         # Provider returns empty string -> synthesis fails
         with patch(
-            "domains.fantasy_daemon.phases._provider_stub.call_provider",
+            "workflow.providers.call.call_provider",
             return_value="",
         ):
             acted, consumed = _act_on_signals_incremental(signals, state)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -24,9 +24,10 @@ import pytest
 from langgraph.checkpoint.sqlite import SqliteSaver
 
 import domains.fantasy_daemon.phases._provider_stub as _provider_stub  # noqa: E402
+from workflow.providers import call as _provider_call  # noqa: E402
 
 # Force mock provider responses
-_provider_stub._FORCE_MOCK = True
+_provider_call.set_force_mock(True)
 
 from domains.fantasy_daemon.graphs.scene import build_scene_graph  # noqa: E402
 from domains.fantasy_daemon.phases.commit import commit  # noqa: E402
@@ -169,7 +170,7 @@ class TestOrientRetrievalIntegration:
         if mock_router_cls.called:
             kwargs = mock_router_cls.call_args[1]
             provider_call = kwargs.get("provider_call")
-            if provider_stub._FORCE_MOCK:
+            if provider_stub.is_force_mock():
                 assert provider_call is None
             else:
                 assert provider_call is not None
@@ -417,7 +418,7 @@ class TestProviderIntegration:
 
     def test_force_mock_returns_deterministic(self):
         """When _FORCE_MOCK is True, providers return mock responses."""
-        assert _provider_stub._FORCE_MOCK is True
+        assert _provider_stub.is_force_mock() is True
         result = _provider_stub.call_provider("test prompt", role="writer")
         assert isinstance(result, str)
         assert len(result) > 0

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -739,7 +739,7 @@ class TestRAPTOR:
 
         try:
             with patch(
-                "domains.fantasy_daemon.phases._provider_stub.call_provider",
+                "workflow.providers.call.call_provider",
                 return_value="Summary of the cluster.",
             ):
                 tree = rebuild_raptor_from_canon(
@@ -788,7 +788,7 @@ class TestRAPTOR:
                 no_tray=True,
             )
             with patch(
-                "domains.fantasy_daemon.phases._provider_stub.call_provider",
+                "workflow.providers.call.call_provider",
                 return_value="Summary of cluster.",
             ):
                 controller._build_raptor_tree()

--- a/tests/test_provider_binary_probe.py
+++ b/tests/test_provider_binary_probe.py
@@ -18,7 +18,7 @@ import pytest
 
 
 def _reload_stub():
-    mod_name = "domains.fantasy_daemon.phases._provider_stub"
+    mod_name = "workflow.providers.call"
     if mod_name in sys.modules:
         del sys.modules[mod_name]
     return importlib.import_module(mod_name)
@@ -26,7 +26,7 @@ def _reload_stub():
 
 @pytest.fixture
 def reset_stub():
-    mod_name = "domains.fantasy_daemon.phases._provider_stub"
+    mod_name = "workflow.providers.call"
     saved = sys.modules.pop(mod_name, None)
     yield
     sys.modules.pop(mod_name, None)

--- a/tests/test_provider_retry.py
+++ b/tests/test_provider_retry.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from domains.fantasy_daemon.phases import _provider_stub
 from workflow.exceptions import AllProvidersExhaustedError
+from workflow.providers import call as _provider_stub
 
 
 class TestProviderRetry:
@@ -17,15 +17,15 @@ class TestProviderRetry:
         # errors mid-execution, unlike setup_method/teardown_method which
         # leaves _FORCE_MOCK=False permanent on a mid-setup crash and
         # contaminates downstream tests (notably test_writer_tools).
-        monkeypatch.setattr(_provider_stub, "_FORCE_MOCK", False)
+        monkeypatch.setattr(_provider_stub, "_force_mock", False)
 
     def test_force_mock_bypasses_retry(self, monkeypatch):
-        monkeypatch.setattr(_provider_stub, "_FORCE_MOCK", True)
+        monkeypatch.setattr(_provider_stub, "_force_mock", True)
         result = _provider_stub.call_provider("test", fallback_response="mock")
         assert result == "mock"
 
     def test_force_mock_default_response(self, monkeypatch):
-        monkeypatch.setattr(_provider_stub, "_FORCE_MOCK", True)
+        monkeypatch.setattr(_provider_stub, "_force_mock", True)
         result = _provider_stub.call_provider("test")
         assert "[Mock response" in result
 

--- a/tests/test_provider_stub_registration.py
+++ b/tests/test_provider_stub_registration.py
@@ -18,7 +18,7 @@ import pytest
 
 def _reload_stub():
     """Force a fresh import of the stub so module-level registration reruns."""
-    mod_name = "domains.fantasy_daemon.phases._provider_stub"
+    mod_name = "workflow.providers.call"
     if mod_name in sys.modules:
         del sys.modules[mod_name]
     return importlib.import_module(mod_name)
@@ -26,7 +26,7 @@ def _reload_stub():
 
 @pytest.fixture
 def reset_stub():
-    mod_name = "domains.fantasy_daemon.phases._provider_stub"
+    mod_name = "workflow.providers.call"
     saved = sys.modules.pop(mod_name, None)
     yield
     sys.modules.pop(mod_name, None)

--- a/tests/test_providers_call.py
+++ b/tests/test_providers_call.py
@@ -1,0 +1,85 @@
+"""Unit tests for the general LLM-call bridge (workflow/providers/call.py).
+
+This is the Tier-A extraction of the engine's domain-agnostic LLM-call
+primitive out of domains/fantasy_daemon/phases/_provider_stub.py. The two
+behaviors Codex flagged as relocation traps are pinned here:
+- the injected router (daemon seam) must be what call_provider() routes through;
+- get_last_provider() must be live, not an import-time snapshot.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from workflow.providers import call as provider_call
+
+
+@pytest.fixture(autouse=True)
+def _restore_bridge_state():
+    saved_router = provider_call.get_provider_router()
+    saved_mock = provider_call.is_force_mock()
+    saved_last = provider_call.get_last_provider()
+    yield
+    provider_call.set_provider_router(saved_router)
+    provider_call.set_force_mock(saved_mock)
+    provider_call._last_provider = saved_last
+
+
+class _FakeResult:
+    def __init__(self, text: str, provider: str) -> None:
+        self.text = text
+        self.provider = provider
+
+
+class _FakeRouter:
+    def __init__(self, text: str = "real-text", provider: str = "claude") -> None:
+        self._text = text
+        self._provider = provider
+        self.calls: list[tuple[str, str, str]] = []
+
+    def call_sync(self, role: str, prompt: str, system: str) -> _FakeResult:
+        self.calls.append((role, prompt, system))
+        return _FakeResult(self._text, self._provider)
+
+
+def test_force_mock_returns_fallback_then_placeholder() -> None:
+    provider_call.set_force_mock(True)
+    assert provider_call.call_provider("p", fallback_response="FB") == "FB"
+    assert "Mock response" in provider_call.call_provider("p")
+
+
+def test_injected_router_is_used_by_call_provider() -> None:
+    """Daemon-injection seam: set_provider_router() must be what call_provider() uses."""
+    provider_call.set_force_mock(False)
+    fake = _FakeRouter(text="injected-output", provider="codex")
+    provider_call.set_provider_router(fake)
+    out = provider_call.call_provider("hello", "sys", role="writer")
+    assert out == "injected-output"
+    assert fake.calls == [("writer", "hello", "sys")]
+
+
+def test_get_last_provider_reflects_latest_call_not_snapshot() -> None:
+    """get_last_provider() returns the provider of the MOST RECENT call — fixes the
+    bug where `from ... import last_provider` bound an import-time "" snapshot."""
+    provider_call.set_force_mock(False)
+    provider_call.set_provider_router(_FakeRouter(provider="gemini"))
+    provider_call.call_provider("x")
+    assert provider_call.get_last_provider() == "gemini"
+    provider_call.set_provider_router(_FakeRouter(provider="grok"))
+    provider_call.call_provider("y")
+    assert provider_call.get_last_provider() == "grok"
+
+
+def test_no_router_no_fallback_raises() -> None:
+    from workflow.exceptions import AllProvidersExhaustedError
+
+    provider_call.set_force_mock(False)
+    provider_call.set_provider_router(None)
+    with pytest.raises(AllProvidersExhaustedError):
+        provider_call.call_provider("x")
+
+
+def test_fallback_response_used_when_router_absent() -> None:
+    provider_call.set_force_mock(False)
+    provider_call.set_provider_router(None)
+    assert provider_call.call_provider("x", fallback_response="FB") == "FB"

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -15,9 +15,9 @@ from typing import Any
 
 from langgraph.checkpoint.sqlite import SqliteSaver
 
-import domains.fantasy_daemon.phases._provider_stub as _provider_stub  # noqa: E402
+from workflow.providers import call as _provider_stub  # noqa: E402
 
-_provider_stub._FORCE_MOCK = True
+_provider_stub.set_force_mock(True)
 
 from domains.fantasy_daemon.graphs.scene import build_scene_graph  # noqa: E402
 from domains.fantasy_daemon.phases.book_close import book_close  # noqa: E402

--- a/workflow/api/runs.py
+++ b/workflow/api/runs.py
@@ -539,7 +539,7 @@ def _action_run_branch(kwargs: dict[str, Any]) -> str:
     # Real provider — lazy import so test envs without providers work.
     provider_call: Any = None
     try:
-        from domains.fantasy_daemon.phases._provider_stub import (
+        from workflow.providers.call import (
             call_provider as provider_call,
         )
     except ImportError:
@@ -1107,7 +1107,7 @@ def _action_resume_run(kwargs: dict[str, Any]) -> str:
 
     provider_call: Any = None
     try:
-        from domains.fantasy_daemon.phases._provider_stub import (
+        from workflow.providers.call import (
             call_provider as provider_call,
         )
     except ImportError:
@@ -1517,7 +1517,7 @@ def _action_run_branch_version(kwargs: dict[str, Any]) -> str:
     # Real provider — lazy import so test envs without providers work.
     provider_call: Any = None
     try:
-        from domains.fantasy_daemon.phases._provider_stub import (
+        from workflow.providers.call import (
             call_provider as provider_call,
         )
     except ImportError:

--- a/workflow/api/selector_dispatch.py
+++ b/workflow/api/selector_dispatch.py
@@ -730,7 +730,7 @@ def dispatch_selector(
     # ``_action_run_branch_version``.
     if provider_call is None:
         try:
-            from domains.fantasy_daemon.phases._provider_stub import (
+            from workflow.providers.call import (
                 call_provider as _default_provider_call,
             )
             provider_call = _default_provider_call

--- a/workflow/evaluation/editorial.py
+++ b/workflow/evaluation/editorial.py
@@ -116,7 +116,7 @@ def read_editorial(
         return None
 
     if provider_call is None:
-        from domains.fantasy_daemon.phases._provider_stub import call_provider
+        from workflow.providers.call import call_provider
         provider_call = call_provider
 
     # Build prompt with context sections

--- a/workflow/ingestion/extractors.py
+++ b/workflow/ingestion/extractors.py
@@ -257,8 +257,8 @@ def synthesize_source(
     list[str]
         Filenames of synthesized documents.
     """
-    from domains.fantasy_daemon.phases._provider_stub import call_provider, last_provider
     from domains.fantasy_daemon.phases.worldbuild import _write_canon_file
+    from workflow.providers.call import call_provider, get_last_provider
 
     if not source_text.strip():
         return []
@@ -312,7 +312,7 @@ def synthesize_source(
                 pass
 
         _write_canon_file(
-            canon_dir, doc_filename, content, model=last_provider,
+            canon_dir, doc_filename, content, model=get_last_provider(),
         )
         generated.append(doc_filename)
         logger.info(

--- a/workflow/knowledge/raptor.py
+++ b/workflow/knowledge/raptor.py
@@ -337,7 +337,7 @@ def rebuild_raptor_from_canon(
 
     # Async wrapper for the sync provider stub
     async def _summarize(prompt: str, system: str, role: str) -> str:
-        from domains.fantasy_daemon.phases._provider_stub import call_provider
+        from workflow.providers.call import call_provider
         return call_provider(prompt, system, role=role, fallback_response="")
 
     # Build tree

--- a/workflow/memory/reflexion.py
+++ b/workflow/memory/reflexion.py
@@ -202,12 +202,9 @@ class ReflexionEngine:
 
         Returns the LLM response or empty string if unavailable.
         """
-        from domains.fantasy_daemon.phases._provider_stub import (
-            _FORCE_MOCK,
-            call_provider,
-        )
+        from workflow.providers.call import call_provider, is_force_mock
 
-        if _FORCE_MOCK:
+        if is_force_mock():
             return ""
 
         scene_id = (
@@ -257,12 +254,9 @@ class ReflexionEngine:
 
         Returns the LLM response or empty string if unavailable.
         """
-        from domains.fantasy_daemon.phases._provider_stub import (
-            _FORCE_MOCK,
-            call_provider,
-        )
+        from workflow.providers.call import call_provider, is_force_mock
 
-        if _FORCE_MOCK:
+        if is_force_mock():
             return ""
 
         scene_id = (

--- a/workflow/providers/call.py
+++ b/workflow/providers/call.py
@@ -3,10 +3,10 @@
 Routes all provider calls through the shared :class:`ProviderRouter`
 (synchronous ``call_sync``), with a deterministic mock path for tests and an
 explicit fallback when providers are exhausted. This is the engine's single,
-domain-agnostic LLM-call primitive — it must never import any ``domains.*``
-package. (The legacy home was
-``domains/fantasy_daemon/phases/_provider_stub.py``; see
-``docs/audits/2026-06-24-fantasy-architecture-residue-audit.md`` Tier A.)
+domain-agnostic LLM-call primitive — engine code must reach the LLM only
+through this module, never through a domain package. (It was previously hosted
+inside the fantasy domain; the relocation is the de-fantasy audit's Tier A:
+``docs/audits/2026-06-24-fantasy-architecture-residue-audit.md``.)
 
 The router is injectable: a long-running host (e.g. a daemon) builds its own
 fully-configured :class:`ProviderRouter` and installs it via

--- a/workflow/providers/call.py
+++ b/workflow/providers/call.py
@@ -1,0 +1,255 @@
+"""General LLM-call bridge for the engine.
+
+Routes all provider calls through the shared :class:`ProviderRouter`
+(synchronous ``call_sync``), with a deterministic mock path for tests and an
+explicit fallback when providers are exhausted. This is the engine's single,
+domain-agnostic LLM-call primitive — it must never import any ``domains.*``
+package. (The legacy home was
+``domains/fantasy_daemon/phases/_provider_stub.py``; see
+``docs/audits/2026-06-24-fantasy-architecture-residue-audit.md`` Tier A.)
+
+The router is injectable: a long-running host (e.g. a daemon) builds its own
+fully-configured :class:`ProviderRouter` and installs it via
+:func:`set_provider_router`. A bare import builds a best-effort fallback router
+from whatever provider binaries/keys are present, so scripts and tests work
+without a daemon.
+
+Use the accessors (:func:`get_last_provider`, :func:`is_force_mock`) rather than
+``from ... import last_provider`` / ``_FORCE_MOCK``: the import-the-name pattern
+binds an import-time snapshot that never reflects later reassignment (the latent
+bug at ``ingestion/extractors.py``, where ``model=last_provider`` always wrote
+an empty string).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+if TYPE_CHECKING:
+    from workflow.providers.router import ProviderRouter
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Mutable module state (use the accessors below; do not import these names)
+# ---------------------------------------------------------------------------
+
+# Skip real provider calls and return mock/fallback output. Tests set this via
+# set_force_mock() in conftest.
+_force_mock = False
+
+# The router call_provider() routes through. None until a router is built or
+# injected. A daemon overwrites it via set_provider_router().
+_real_router: "Optional[ProviderRouter]" = None
+
+# Provider name used by the most recent call. Read via get_last_provider().
+_last_provider: str = ""
+
+
+def set_force_mock(value: bool) -> None:
+    """Enable/disable the mock path (tests)."""
+    global _force_mock
+    _force_mock = bool(value)
+
+
+def is_force_mock() -> bool:
+    """Whether call_provider() short-circuits to mock/fallback output."""
+    return _force_mock
+
+
+def set_provider_router(router: "Optional[ProviderRouter]") -> None:
+    """Install the router call_provider() routes through.
+
+    This is the daemon-injection seam: ``DaemonController`` builds a fully
+    configured router and installs it here so the engine's LLM calls use the
+    host's provider configuration instead of the import-time fallback.
+    """
+    global _real_router
+    _real_router = router
+
+
+def get_provider_router() -> "Optional[ProviderRouter]":
+    """The router currently installed (fallback or daemon-injected)."""
+    return _real_router
+
+
+def get_last_provider() -> str:
+    """Provider name used by the most recent call_provider() — live, not a snapshot."""
+    return _last_provider
+
+
+# ---------------------------------------------------------------------------
+# Fallback router for standalone / script / test usage
+# ---------------------------------------------------------------------------
+
+
+def _build_fallback_router() -> "Optional[ProviderRouter]":
+    """Best-effort router registering whatever providers are available.
+
+    A daemon overwrites this via :func:`set_provider_router`, so these
+    registrations only serve standalone/script/test usage. Each provider import
+    is independently guarded so a missing optional dependency never breaks the
+    bridge.
+    """
+    try:
+        from workflow.providers.router import ProviderRouter
+    except ImportError:
+        logger.info("Real ProviderRouter not available; using mock-only provider")
+        return None
+
+    router = ProviderRouter()
+
+    try:
+        from workflow.providers.claude_provider import ClaudeProvider
+        if ClaudeProvider.is_available():
+            router.register(ClaudeProvider())
+            logger.info("Registered ClaudeProvider")
+        else:
+            logger.debug("claude binary not found - ClaudeProvider skipped")
+    except Exception:
+        logger.debug("ClaudeProvider not available")
+
+    try:
+        from workflow.providers.codex_provider import CodexProvider
+        if CodexProvider.is_available():
+            router.register(CodexProvider())
+            logger.info("Registered CodexProvider")
+        else:
+            logger.debug("codex binary not found - CodexProvider skipped")
+    except Exception:
+        logger.debug("CodexProvider not available")
+
+    try:
+        from workflow.providers.ollama_provider import OllamaProvider
+        router.register(OllamaProvider())
+        logger.info("Registered OllamaProvider")
+    except Exception:
+        logger.debug("OllamaProvider not available")
+
+    try:
+        from workflow.providers.gemini_provider import GeminiProvider
+        router.register(GeminiProvider())
+        logger.info("Registered GeminiProvider")
+    except Exception:
+        logger.debug("GeminiProvider not available")
+
+    try:
+        from workflow.providers.groq_provider import GroqProvider
+        router.register(GroqProvider())
+        logger.info("Registered GroqProvider")
+    except Exception:
+        logger.debug("GroqProvider not available")
+
+    try:
+        from workflow.providers.grok_provider import GrokProvider
+        router.register(GrokProvider())
+        logger.info("Registered GrokProvider")
+    except Exception:
+        logger.debug("GrokProvider not available")
+
+    logger.info(
+        "ProviderRouter ready with providers: %s",
+        router.available_providers,
+    )
+    return router
+
+
+_real_router = _build_fallback_router()
+
+
+# ---------------------------------------------------------------------------
+# Public call primitive
+# ---------------------------------------------------------------------------
+
+
+def _call_router_with_retry(role: str, prompt: str, system: str) -> str:
+    """Call the installed router with tenacity retry on transient exhaustion.
+
+    Retries up to 3 times with exponential backoff (2s, 4s, 8s) when all
+    providers are temporarily exhausted (rate-limit cooldowns expiring between
+    attempts).
+    """
+    from workflow.exceptions import AllProvidersExhaustedError
+
+    @retry(
+        retry=retry_if_exception_type(AllProvidersExhaustedError),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=8),
+        reraise=True,
+    )
+    def _attempt() -> str:
+        global _last_provider
+        result = _real_router.call_sync(role, prompt, system)
+        _last_provider = result.provider
+        return result.text
+
+    return _attempt()
+
+
+def call_provider(
+    prompt: str,
+    system: str = "",
+    *,
+    role: str = "writer",
+    fallback_response: str | None = None,
+) -> str:
+    """Call an LLM provider with automatic fallback.
+
+    Routes through the installed :class:`ProviderRouter`'s synchronous
+    ``call_sync`` (which runs the async fallback chain in a dedicated thread).
+    On transient exhaustion, retries up to 3 times with exponential backoff.
+    Falls back to mock/``fallback_response`` only when forced or exhausted.
+
+    Parameters
+    ----------
+    prompt:
+        The user prompt.
+    system:
+        System prompt.
+    role:
+        Routing role (writer, judge, extract).
+    fallback_response:
+        Returned if all providers fail. If ``None`` in production, provider
+        exhaustion surfaces as the real error rather than masquerading as an
+        empty LLM response downstream.
+    """
+    if _force_mock:
+        if fallback_response is not None:
+            return fallback_response
+        # Preserve the exact legacy string (callers/tests may assert on it).
+        return "[Mock response -- _FORCE_MOCK is True]"
+
+    provider_error: Exception | None = None
+
+    if _real_router is not None:
+        try:
+            return _call_router_with_retry(role, prompt, system)
+        except Exception as e:
+            provider_error = e
+            logger.error(
+                "All providers exhausted for role=%s after retries: %s", role, e,
+            )
+
+    if fallback_response is not None:
+        logger.warning(
+            "Using fallback response for role=%s (%d chars)",
+            role, len(fallback_response),
+        )
+        return fallback_response
+    if provider_error is not None:
+        raise provider_error
+
+    from workflow.exceptions import AllProvidersExhaustedError
+
+    raise AllProvidersExhaustedError(
+        f"No provider router available for role={role!r} and no fallback_response "
+        "was provided."
+    )

--- a/workflow/retrieval/agentic_search.py
+++ b/workflow/retrieval/agentic_search.py
@@ -378,13 +378,13 @@ def build_phase_query(
 
 def _build_provider_call() -> Callable[[str, str, str], Any] | None:
     """Return the async decomposition callable when real providers are enabled."""
-    from domains.fantasy_daemon.phases import _provider_stub
+    from workflow.providers import call as provider_call
 
-    if _provider_stub._FORCE_MOCK:
+    if provider_call.is_force_mock():
         return None
 
     async def _async_provider_call(prompt: str, system: str, role: str) -> str:
-        return _provider_stub.call_provider(
+        return provider_call.call_provider(
             prompt,
             system,
             role=role,


### PR DESCRIPTION
**Draft / WIP — CI is the verification gate (the 7,856-test suite can't run in the dev sandbox).**

De-fantasy Tier A from `docs/audits/2026-06-24-fantasy-architecture-residue-audit.md`: the general engine imports its LLM-call primitive from `domains/fantasy_daemon/phases/_provider_stub.py`. This branch extracts the domain-agnostic half into `workflow/providers/call.py` and (in follow-up commits) repoints all consumers.

## Landed so far (foundation — additive, safe)
- `workflow/providers/call.py` — the extracted general bridge with an explicit accessor API (`set_provider_router` / `get_provider_router` / `set_force_mock` / `is_force_mock` / `get_last_provider`). Zero `domains.*` imports.
- `tests/test_providers_call.py` — 5 isolated tests pinning the injection seam + live `last_provider`. Green locally; ruff clean.
- `docs/design-notes/2026-06-24-tier-a-provider-bridge-extraction-plan.md` — execution plan.
- **Codex review (foundation): ADAPT → folded** (restored exact legacy mock string; corrected the consumer surface).

## Two latent bugs this exposes (host-approved to fix, staged + canary)
1. **Daemon router injection is a no-op** — `fantasy_daemon/__main__.py:1176-1178` sets `_real_router` on the nodes star-import shim, which excludes underscore names, so `call_provider` never sees the daemon's configured router. **Production silently runs on the import-time fallback router.** Codex independently confirmed via probe.
2. **`last_provider` import-time snapshot** — `extractors.py:315` writes `model=""` into canon markers.

Both fixed via the accessor/`set_provider_router` seam. These change production provider selection → staged behind the universe soul + post-deploy canary.

## Remaining (atomic repoint — ~35 files)
The real consumer surface is ~35 files (the audit's "8 sites" undercounted the whole fantasy-domain side; `worldbuild.py` alone has 7). Removing `last_provider`/`_FORCE_MOCK` is atomic. Full list in the design note. These commits land next, with CI as the gate; opposite-provider (Codex) review on the full diff before un-drafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)