### PR TITLE
design-sync config for claude.ai/design

### DIFF
--- a/WebSite/design-system/.design-sync/NOTES.md
+++ b/WebSite/design-system/.design-sync/NOTES.md
@@ -1,0 +1,30 @@
+# design-sync notes — @tiny/design-system
+
+First sync: 2026-06-25. Shape = storybook. 3 components (Button, StatusPill,
+RitualLabel), all stories graded `match` against the reference storybook.
+
+## Setup facts
+
+- `buildCmd`: `npm run build` (emits dist/ + tokens/tiny.tokens.json + manifest).
+- Converter entry: `dist/index.js` (in the package's own source repo, so `--entry`
+  is required — there is no `node_modules/@tiny/design-system`).
+- Global: `window.TinyDS`. No `.storybook/preview` decorators → no `cfg.provider`
+  needed (the design language is global CSS vars, not a React context/ThemeProvider).
+- Fonts are remote (`[FONT_REMOTE]`): Inter / Newsreader / IBM Plex Mono via a
+  Google Fonts `@import` in styles.css — the host serves them at runtime, so both
+  the storybook reference and the previews render the real fonts.
+
+## Re-sync risks (what to re-verify next run)
+
+- **Target project is the re-adopted "Workflow Design System" (48072c27…)** — a
+  pre-existing, formerly hand-authored project. The first sync DELETED its old
+  April content (JSX kit, diagrams, preview cards) and replaced it with this
+  bundle. There is no `_ds_sync.json` anchor from before this sync, so the first
+  run reviewed `list_files` to build the delete set; subsequent runs use the
+  anchor we uploaded.
+- Project rename to "Tiny Design System" is a manual UI step (the DesignSync tool
+  can't rename) — if the project name still says "Workflow Design System", that
+  rename hasn't happened; it does not affect the sync.
+- Only 3 primitives are synced so far. The live site has more components
+  (cards, readout panels, VitalSigns, nav, etc.) that are NOT yet in the DS
+  package — adding them to `src/components/` + stories will grow the next sync.

--- a/WebSite/design-system/.design-sync/config.json
+++ b/WebSite/design-system/.design-sync/config.json
@@ -1,0 +1,10 @@
+{
+  "pkg": "@tiny/design-system",
+  "globalName": "TinyDS",
+  "shape": "storybook",
+  "storybookStatic": ".design-sync/sb-reference",
+  "storybookConfigDir": ".storybook",
+  "buildCmd": "npm run build",
+  "projectId": "48072c27-c3d6-488c-8c6d-be873636e652",
+  "readmeHeader": ".design-sync/conventions.md"
+}

--- a/WebSite/design-system/.design-sync/conventions.md
+++ b/WebSite/design-system/.design-sync/conventions.md
@@ -1,0 +1,63 @@
+# Tiny — "Field Notes" design system (how to build with it)
+
+A naturalist's logbook crossed with a scientific instrument: warm paper ground,
+ink text, calm and deliberate. One load-bearing rule — **claim vs evidence is
+typographic**: prose uses serif/sans; live data, ids, and timestamps are
+**always mono**.
+
+## Setup (no provider needed)
+
+There is NO React context/ThemeProvider. The whole look is global CSS custom
+properties. Import the stylesheet **once** at the app root — it carries the
+design tokens (`:root` vars), the base reset, and the vocabulary classes:
+
+```tsx
+import "@tiny/design-system/styles.css";
+import { Button, StatusPill, RitualLabel } from "@tiny/design-system";
+```
+
+Without that import, components render unstyled (the tokens they reference
+won't exist).
+
+## Styling idiom: tokens + vocabulary classes (NOT utility classes)
+
+This is **not** a Tailwind/utility system and has **no class-name component
+props**. Style your own layout glue two ways:
+
+1. **CSS custom properties** — the design language. Real names (see
+   `tokens/tiny.tokens.json` for the full set):
+   - color: `--bg-0`..`--bg-3` (paper grounds), `--fg-1`..`--fg-4` (ink, strong→faint),
+     `--ember-600`/`--accent` (the ONE action color), `--live-600` (RESERVED for genuine
+     liveness), `--violet-600` (lineage/souls), `--border-1`/`--border-2`, `--panel`/`--on-panel` (dark readout)
+   - type: `--font-voice` (Newsreader serif), `--font-sans` (Inter), `--font-mono` (IBM Plex Mono — for ALL evidence)
+   - space `--s-1`..`--s-24` (4px base), radius `--radius-sm`/`--radius-md`, `--shadow-sm/md/lg`
+2. **Global vocabulary classes** (defined in `styles.css`, use as plain strings):
+   `container` (max-width page wrap), `voice` (Tiny's first-person prose), `ev`
+   (inline evidence/mono), `eyebrow` (mono small-caps section kicker), `dot` +
+   `dot live|idle|error` (liveness dot), `readout` + `stat`/`stat__num`/`stat__label`
+   (the dark instrument panel where data is SHOWN).
+
+Hard rules: green (`--live-*`) only for real liveness; mono for every number/id/
+timestamp; exactly one ember `Button variant="primary"` per surface; idle/asleep
+is a first-class state, not an error.
+
+## Components (real exports)
+
+- **Button** — `variant` primary|secondary|ghost|link, `size` sm|md|lg, `href` (renders an anchor). primary = the one ember action.
+- **StatusPill** — `kind` live|idle|paid|self|error, `pulse` (only when truly live). Mono caps capsule; dot color follows the liveness rule.
+- **RitualLabel** — small-caps mono kicker (same as the `.eyebrow` class), optional `color`.
+
+Read each component's `*.prompt.md` for usage rules and `styles.css` (the bound
+copy) before styling. Example:
+
+```tsx
+<section className="container">
+  <span className="eyebrow">Live evidence</span>
+  <h1>Name a goal. Watch it run.</h1>
+  <p className="voice">I turn chat into <em>finished work</em>.</p>
+  <div style={{ display: "flex", gap: "var(--s-3)", alignItems: "center" }}>
+    <StatusPill kind="live" pulse>live</StatusPill>
+    <Button variant="primary" href="/start">Connect a chatbot</Button>
+  </div>
+</section>
+```

--- a/WebSite/design-system/.gitignore
+++ b/WebSite/design-system/.gitignore
@@ -2,3 +2,11 @@ node_modules/
 dist/
 storybook-static/
 *.tsbuildinfo
+
+# design-sync (claude.ai/design) — transient build/verification artifacts
+.design-sync/sb-reference/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules
+.ds-sync/
+ds-bundle/


### PR DESCRIPTION
Commits the durable /design-sync state for `@tiny/design-system` so future re-syncs are fast/deterministic (config, conventions header, notes). Build artifacts gitignored. The actual sync to claude.ai/design project 48072c27 is already live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)