### PR TITLE
PR-OKF-BRAIN slice 1: read-only OKF exporter for curated wiki pages (additive)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/wiki/okf_export.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/wiki/okf_export.py
@@ -1,0 +1,431 @@
+"""Read-only OKF v0.1 export for promoted Workflow wiki pages."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from workflow.api.wiki import _parse_frontmatter, _wiki_root_for_universe
+
+OKF_VERSION = "0.1"
+
+_RESERVED_FILENAMES = frozenset({"index.md", "log.md"})
+_EXCLUDED_ROOTS = frozenset({"drafts", "raw", "daemon-wiki"})
+_WIKILINK_RE = re.compile(r"\[\[([^\[\]\n]+)\]\]")
+_H1_RE = re.compile(r"^\s*#\s+(.+?)\s*$", re.MULTILINE)
+_SAFE_PLAIN_SCALAR_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 _./:@+\-]*$")
+
+
+def export_universe_okf_bundle(universe_id: str, target_dir: str | Path) -> dict[str, Any]:
+    """Export one universe's promoted wiki pages as an OKF v0.1 bundle.
+
+    ``universe_id`` is resolved by ``workflow.api.wiki._wiki_root_for_universe``
+    so this exporter follows the same ``<universe_dir>/wiki`` convention as the
+    chatbot-facing wiki API without adding an MCP action or write path.
+    """
+    wiki_root = _wiki_root_for_universe(universe_id)
+    return export_okf_bundle(wiki_root, target_dir)
+
+
+def export_okf_bundle(wiki_root: str | Path, target_dir: str | Path) -> dict[str, Any]:
+    """Export a resolved wiki root's curated ``pages/**/*.md`` to ``target_dir``."""
+    source_root = Path(wiki_root).resolve()
+    bundle_root = Path(target_dir).resolve()
+    if not source_root.is_dir():
+        raise FileNotFoundError(f"Wiki root not found: {source_root}")
+    if _is_relative_to(bundle_root, source_root):
+        raise ValueError("target_dir must not be inside the source wiki root")
+
+    exported_sources, reserved_sources = _collect_exported_sources(source_root)
+    link_index = _build_link_index(exported_sources, source_root)
+    excluded_files = _collect_excluded_files(source_root)
+    concepts: list[dict[str, str]] = []
+    unresolved_links: list[dict[str, str]] = []
+
+    bundle_root.mkdir(parents=True, exist_ok=True)
+    for source_path in exported_sources:
+        source_rel = _source_rel_path(source_root, source_path)
+        bundle_rel = _bundle_rel_path(source_root, source_path)
+        raw = source_path.read_text(encoding="utf-8")
+        meta, body = _parse_frontmatter(raw)
+        concept_meta = _concept_frontmatter(meta, body, source_rel, bundle_rel, source_path)
+        converted_body = _convert_wikilinks(
+            body,
+            source=bundle_rel,
+            link_index=link_index,
+            unresolved_links=unresolved_links,
+        )
+        target_path = bundle_root / bundle_rel
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text(
+            _render_markdown(concept_meta, converted_body),
+            encoding="utf-8",
+        )
+        concepts.append({
+            "id": bundle_rel.removesuffix(".md"),
+            "path": bundle_rel,
+            "title": str(concept_meta["title"]),
+            "description": str(concept_meta.get("description", "")),
+            "timestamp": str(concept_meta["timestamp"]),
+        })
+
+    _write_index(bundle_root, concepts)
+    _write_log(bundle_root, concepts)
+
+    report = _conformance_report(
+        bundle_root=bundle_root,
+        source_root=source_root,
+        concepts=concepts,
+        excluded_files=excluded_files,
+        unresolved_links=unresolved_links,
+        reserved_sources=reserved_sources,
+    )
+    return report
+
+
+def _collect_exported_sources(wiki_root: Path) -> tuple[list[Path], list[str]]:
+    pages_dir = wiki_root / "pages"
+    if not pages_dir.is_dir():
+        return [], []
+    exported: list[Path] = []
+    reserved_sources: list[str] = []
+    for path in sorted(pages_dir.rglob("*.md")):
+        if not path.is_file():
+            continue
+        if path.name.lower() == "soul.md":
+            continue
+        if path.name.lower() in _RESERVED_FILENAMES:
+            reserved_sources.append(_source_rel_path(wiki_root, path))
+            continue
+        exported.append(path)
+    return exported, reserved_sources
+
+
+def _collect_excluded_files(wiki_root: Path) -> list[dict[str, str]]:
+    excluded: list[dict[str, str]] = []
+    for path in sorted(wiki_root.rglob("*.md")):
+        if not path.is_file():
+            continue
+        rel = _source_rel_path(wiki_root, path)
+        parts = Path(rel).parts
+        reason = ""
+        if path.name.lower() == "soul.md":
+            reason = "soul.md"
+        elif parts and parts[0] in _EXCLUDED_ROOTS:
+            reason = parts[0]
+        if reason:
+            excluded.append({"path": rel, "reason": reason})
+    return excluded
+
+
+def _build_link_index(sources: list[Path], wiki_root: Path) -> dict[str, str]:
+    index: dict[str, str] = {}
+    for source in sources:
+        bundle_rel = _bundle_rel_path(wiki_root, source)
+        concept_id = bundle_rel.removesuffix(".md")
+        keys = {
+            source.stem,
+            concept_id,
+            f"pages/{concept_id}",
+            bundle_rel,
+            f"pages/{bundle_rel}",
+        }
+        for key in keys:
+            normalized = _normalize_wikilink_target(key)
+            if normalized and normalized not in index:
+                index[normalized] = bundle_rel
+    return index
+
+
+def _concept_frontmatter(
+    meta: dict[str, str],
+    body: str,
+    source_rel: str,
+    bundle_rel: str,
+    source_path: Path,
+) -> dict[str, Any]:
+    concept_type = _first_nonempty(meta.get("type", ""), meta.get("kind", ""), "note")
+    title = _first_nonempty(meta.get("title", ""), _first_h1(body), _title_from_slug(bundle_rel))
+    timestamp = _first_nonempty(meta.get("updated", ""), _mtime_iso(source_path))
+
+    output: dict[str, Any] = {
+        "type": concept_type,
+        "title": title,
+        "timestamp": timestamp,
+        "workflow_original_path": source_rel,
+    }
+    for optional_key in ("description", "resource"):
+        value = meta.get(optional_key, "").strip()
+        if value:
+            output[optional_key] = value
+    tags = _parse_list_value(meta.get("tags", ""))
+    if tags:
+        output["tags"] = tags
+
+    category = Path(bundle_rel).parts[0] if len(Path(bundle_rel).parts) > 1 else ""
+    if category:
+        output.setdefault("workflow_category", category)
+    for key, value in meta.items():
+        normalized_key = _workflow_key(key)
+        if normalized_key and value.strip():
+            output[f"workflow_{normalized_key}"] = value.strip()
+    return output
+
+
+def _convert_wikilinks(
+    body: str,
+    *,
+    source: str,
+    link_index: dict[str, str],
+    unresolved_links: list[dict[str, str]],
+) -> str:
+    def replace(match: re.Match[str]) -> str:
+        raw_target = match.group(1).strip()
+        target, separator, alias = raw_target.partition("|")
+        target = target.strip()
+        label = alias.strip() if separator else target
+        resolved = link_index.get(_normalize_wikilink_target(target))
+        if not resolved:
+            unresolved_links.append({"source": source, "target": target})
+            return label
+        return f"[{label}](/{resolved})"
+
+    return _WIKILINK_RE.sub(replace, body)
+
+
+def _write_index(bundle_root: Path, concepts: list[dict[str, str]]) -> None:
+    lines = ["---", f'okf_version: "{OKF_VERSION}"', "---", "", "# Index", ""]
+    for concept in sorted(concepts, key=lambda item: item["path"]):
+        description = concept.get("description", "")
+        suffix = f" - {description}" if description else ""
+        lines.append(f"- [{concept['title']}]({concept['path']}){suffix}")
+    lines.append("")
+    (bundle_root / "index.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _write_log(bundle_root: Path, concepts: list[dict[str, str]]) -> None:
+    by_date: dict[str, list[dict[str, str]]] = {}
+    for concept in concepts:
+        date = _timestamp_date(concept.get("timestamp", ""))
+        by_date.setdefault(date, []).append(concept)
+    if not by_date:
+        today = datetime.now(timezone.utc).date().isoformat()
+        by_date[today] = []
+
+    lines = ["# Bundle Update Log", ""]
+    for date in sorted(by_date.keys(), reverse=True):
+        lines.append(f"## {date}")
+        entries = by_date[date]
+        if entries:
+            for concept in sorted(entries, key=lambda item: item["path"]):
+                lines.append(
+                    f"* **Export**: Added [{concept['title']}](/{concept['path']})."
+                )
+        else:
+            lines.append("* **Creation**: Created empty OKF export bundle.")
+        lines.append("")
+    (bundle_root / "log.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _conformance_report(
+    *,
+    bundle_root: Path,
+    source_root: Path,
+    concepts: list[dict[str, str]],
+    excluded_files: list[dict[str, str]],
+    unresolved_links: list[dict[str, str]],
+    reserved_sources: list[str],
+) -> dict[str, Any]:
+    issues: list[str] = []
+    reserved_files: dict[str, dict[str, Any]] = {}
+
+    for path in sorted(bundle_root.rglob("*.md")):
+        rel = path.relative_to(bundle_root).as_posix()
+        text = path.read_text(encoding="utf-8")
+        if path.name == "index.md":
+            valid, meta = _validate_index(rel, text)
+            reserved_files[rel] = {"valid": valid, **meta}
+            if not valid:
+                issues.append(f"{rel}: invalid index.md structure")
+            continue
+        if path.name == "log.md":
+            valid = _validate_log(text)
+            reserved_files[rel] = {"valid": valid}
+            if not valid:
+                issues.append(f"{rel}: invalid log.md structure")
+            continue
+
+        meta = _parse_yamlish_frontmatter(text)
+        if meta is None:
+            issues.append(f"{rel}: missing or unparseable frontmatter")
+        elif not meta.get("type", "").strip():
+            issues.append(f"{rel}: missing non-empty type")
+
+    for rel in reserved_sources:
+        issues.append(f"{rel}: source reserved filename was not exported as a concept")
+
+    return {
+        "okf_version": OKF_VERSION,
+        "source_wiki_root": source_root.as_posix(),
+        "target_dir": bundle_root.as_posix(),
+        "conformant": not any(
+            issue
+            for issue in issues
+            if "source reserved filename" not in issue
+        ),
+        "counts": {
+            "concepts_exported": len(concepts),
+            "excluded_by_privacy": len(excluded_files),
+            "unresolved_links": len(unresolved_links),
+        },
+        "concepts": concepts,
+        "excluded_files": excluded_files,
+        "unresolved_links": unresolved_links,
+        "reserved_files": reserved_files,
+        "issues": issues,
+    }
+
+
+def _validate_index(rel: str, text: str) -> tuple[bool, dict[str, str]]:
+    if rel == "index.md" and text.startswith("---\n"):
+        meta = _parse_yamlish_frontmatter(text)
+        okf_version = meta.get("okf_version", "") if meta else ""
+        return meta == {"okf_version": OKF_VERSION}, {"okf_version": okf_version}
+    return (not text.startswith("---\n")), {}
+
+
+def _validate_log(text: str) -> bool:
+    has_date_heading = bool(
+        re.search(r"^## \d{4}-\d{2}-\d{2}$", text, re.MULTILINE)
+    )
+    return not text.startswith("---\n") and has_date_heading
+
+
+def _parse_yamlish_frontmatter(text: str) -> dict[str, str] | None:
+    if not text.startswith("---\n"):
+        return None
+    try:
+        raw_meta, _body = text.removeprefix("---\n").split("\n---\n", 1)
+    except ValueError:
+        return None
+    meta: dict[str, str] = {}
+    current_key = ""
+    for line in raw_meta.splitlines():
+        if not line.strip():
+            continue
+        if line.startswith("  "):
+            continue
+        key, separator, value = line.partition(":")
+        if not separator or not key.strip():
+            return None
+        current_key = key.strip()
+        meta[current_key] = value.strip().strip('"')
+    return meta if current_key or not raw_meta.strip() else None
+
+
+def _render_markdown(meta: dict[str, Any], body: str) -> str:
+    lines = ["---"]
+    for key, value in meta.items():
+        lines.extend(_render_yaml_key_value(key, value))
+    lines.extend(["---", ""])
+    return "\n".join(lines) + body.lstrip("\n")
+
+
+def _render_yaml_key_value(key: str, value: Any) -> list[str]:
+    if isinstance(value, list):
+        if not value:
+            return []
+        return [f"{key}:"] + [f"  - {_format_yaml_scalar(item)}" for item in value]
+    text = str(value)
+    if "\n" in text:
+        return [f"{key}: |"] + [f"  {line}" for line in text.splitlines()]
+    return [f"{key}: {_format_yaml_scalar(text)}"]
+
+
+def _format_yaml_scalar(value: Any) -> str:
+    text = str(value).strip()
+    if not text:
+        return '""'
+    lowered = text.lower()
+    if (
+        _SAFE_PLAIN_SCALAR_RE.match(text)
+        and lowered not in {"null", "true", "false", "yes", "no", "on", "off"}
+    ):
+        return text
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _parse_list_value(value: str) -> list[str]:
+    text = value.strip()
+    if not text:
+        return []
+    if text.startswith("[") and text.endswith("]"):
+        text = text[1:-1]
+        return [item.strip().strip("'\"") for item in text.split(",") if item.strip()]
+    if "\n" in text:
+        items: list[str] = []
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("- "):
+                items.append(stripped[2:].strip().strip("'\""))
+        return [item for item in items if item]
+    return [text.strip("'\"")]
+
+
+def _first_h1(body: str) -> str:
+    match = _H1_RE.search(body)
+    return match.group(1).strip() if match else ""
+
+
+def _title_from_slug(bundle_rel: str) -> str:
+    return Path(bundle_rel).stem.replace("-", " ").replace("_", " ").title()
+
+
+def _first_nonempty(*values: str) -> str:
+    for value in values:
+        stripped = value.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _mtime_iso(path: Path) -> str:
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat().replace(
+        "+00:00",
+        "Z",
+    )
+
+
+def _timestamp_date(timestamp: str) -> str:
+    match = re.match(r"^(\d{4}-\d{2}-\d{2})", timestamp.strip())
+    if match:
+        return match.group(1)
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _workflow_key(key: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_]+", "_", key.strip().lower()).strip("_")
+
+
+def _normalize_wikilink_target(target: str) -> str:
+    normalized = target.strip().removeprefix("/").removesuffix(".md").replace("\\", "/")
+    return normalized.lower()
+
+
+def _source_rel_path(wiki_root: Path, path: Path) -> str:
+    return path.relative_to(wiki_root).as_posix()
+
+
+def _bundle_rel_path(wiki_root: Path, path: Path) -> str:
+    return path.relative_to(wiki_root / "pages").as_posix()
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True

--- a/tests/test_okf_export.py
+++ b/tests/test_okf_export.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from workflow.wiki.okf_export import export_universe_okf_bundle
+
+
+def _split_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    assert text.startswith("---\n")
+    raw_meta, body = text.split("\n---\n", 1)
+    meta: dict[str, str] = {}
+    for line in raw_meta.removeprefix("---\n").splitlines():
+        if not line.strip() or line.startswith("  "):
+            continue
+        key, _, value = line.partition(":")
+        meta[key.strip()] = value.strip().strip('"')
+    return meta, body
+
+
+@pytest.fixture
+def fixture_wiki(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    data_root = tmp_path / "data"
+    wiki_root = data_root / "alpha" / "wiki"
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(data_root))
+    monkeypatch.delenv("WORKFLOW_WIKI_PATH", raising=False)
+
+    (wiki_root / "pages" / "concepts").mkdir(parents=True)
+    (wiki_root / "drafts" / "concepts").mkdir(parents=True)
+    (wiki_root / "raw").mkdir(parents=True)
+    (wiki_root / "daemon-wiki").mkdir(parents=True)
+
+    (wiki_root / "pages" / "concepts" / "alpha.md").write_text(
+        "\n".join([
+            "---",
+            "title: Alpha Concept",
+            "kind: project-note",
+            "description: First exported concept.",
+            "updated: 2026-06-24T12:30:00Z",
+            "id: alpha-1",
+            "category: concepts",
+            "sources:",
+            "  - internal",
+            "status: promoted",
+            "tags: [alpha, demo]",
+            "---",
+            "# Alpha Heading",
+            "",
+            "See [[related]] and [[missing-target]].",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+    (wiki_root / "pages" / "concepts" / "related.md").write_text(
+        "\n".join([
+            "---",
+            "updated: 2026-06-23",
+            "---",
+            "# Related Concept",
+            "",
+            "Back to [[alpha]].",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+    (wiki_root / "pages" / "soul.md").write_text(
+        "---\ntype: secret\n---\nhost-private memory\n",
+        encoding="utf-8",
+    )
+    (wiki_root / "soul.md").write_text("host-private root memory\n", encoding="utf-8")
+    (wiki_root / "drafts" / "concepts" / "draft.md").write_text(
+        "---\ntype: draft\n---\ndraft body\n",
+        encoding="utf-8",
+    )
+    (wiki_root / "raw" / "raw.md").write_text("raw body\n", encoding="utf-8")
+    (wiki_root / "daemon-wiki" / "daemon.md").write_text("daemon body\n", encoding="utf-8")
+    return wiki_root, tmp_path / "bundle"
+
+
+def test_export_universe_okf_bundle_exports_curated_pages_only(
+    fixture_wiki: tuple[Path, Path],
+) -> None:
+    _, bundle_dir = fixture_wiki
+
+    report = export_universe_okf_bundle("alpha", bundle_dir)
+
+    json.dumps(report)
+    assert report["conformant"] is True
+    assert report["counts"]["concepts_exported"] == 2
+    assert (bundle_dir / "concepts" / "alpha.md").is_file()
+    assert (bundle_dir / "concepts" / "related.md").is_file()
+    assert not (bundle_dir / "drafts").exists()
+    assert not (bundle_dir / "raw").exists()
+    assert not (bundle_dir / "daemon-wiki").exists()
+    assert not list(bundle_dir.rglob("soul.md"))
+    assert report["counts"]["excluded_by_privacy"] >= 1
+
+
+def test_export_converts_wikilinks_to_absolute_okf_links_and_flags_unresolved(
+    fixture_wiki: tuple[Path, Path],
+) -> None:
+    _, bundle_dir = fixture_wiki
+
+    report = export_universe_okf_bundle("alpha", bundle_dir)
+    body = (bundle_dir / "concepts" / "alpha.md").read_text(encoding="utf-8")
+
+    assert "[related](/concepts/related.md)" in body
+    assert "[[missing-target]]" not in body
+    assert "](/missing-target.md)" not in body
+    assert "missing-target" in body
+    assert report["counts"]["unresolved_links"] == 1
+    assert report["unresolved_links"] == [{
+        "source": "concepts/alpha.md",
+        "target": "missing-target",
+    }]
+
+
+def test_export_guarantees_type_title_timestamp_and_workflow_keys(
+    fixture_wiki: tuple[Path, Path],
+) -> None:
+    _, bundle_dir = fixture_wiki
+
+    export_universe_okf_bundle("alpha", bundle_dir)
+    alpha_meta, _ = _split_frontmatter(
+        (bundle_dir / "concepts" / "alpha.md").read_text(encoding="utf-8")
+    )
+    related_meta, _ = _split_frontmatter(
+        (bundle_dir / "concepts" / "related.md").read_text(encoding="utf-8")
+    )
+
+    assert alpha_meta["type"] == "project-note"
+    assert alpha_meta["title"] == "Alpha Concept"
+    assert alpha_meta["timestamp"] == "2026-06-24T12:30:00Z"
+    assert alpha_meta["workflow_original_path"] == "pages/concepts/alpha.md"
+    assert alpha_meta["workflow_id"] == "alpha-1"
+    assert alpha_meta["workflow_category"] == "concepts"
+    assert alpha_meta["workflow_status"] == "promoted"
+    assert "workflow_sources" in alpha_meta
+
+    assert related_meta["type"] == "note"
+    assert related_meta["title"] == "Related Concept"
+    assert related_meta["timestamp"]
+
+
+def test_reserved_files_follow_okf_structure(fixture_wiki: tuple[Path, Path]) -> None:
+    _, bundle_dir = fixture_wiki
+
+    report = export_universe_okf_bundle("alpha", bundle_dir)
+    index_text = (bundle_dir / "index.md").read_text(encoding="utf-8")
+    log_text = (bundle_dir / "log.md").read_text(encoding="utf-8")
+
+    index_meta, index_body = _split_frontmatter(index_text)
+    assert index_meta == {"okf_version": "0.1"}
+    assert "- [Alpha Concept](concepts/alpha.md) - First exported concept." in index_body
+    assert "- [Related Concept](concepts/related.md)" in index_body
+    assert not log_text.startswith("---")
+    assert "## 2026-06-24" in log_text
+    assert "## 2026-06-23" in log_text
+    assert report["reserved_files"] == {
+        "index.md": {"okf_version": "0.1", "valid": True},
+        "log.md": {"valid": True},
+    }

--- a/workflow/wiki/okf_export.py
+++ b/workflow/wiki/okf_export.py
@@ -1,0 +1,431 @@
+"""Read-only OKF v0.1 export for promoted Workflow wiki pages."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from workflow.api.wiki import _parse_frontmatter, _wiki_root_for_universe
+
+OKF_VERSION = "0.1"
+
+_RESERVED_FILENAMES = frozenset({"index.md", "log.md"})
+_EXCLUDED_ROOTS = frozenset({"drafts", "raw", "daemon-wiki"})
+_WIKILINK_RE = re.compile(r"\[\[([^\[\]\n]+)\]\]")
+_H1_RE = re.compile(r"^\s*#\s+(.+?)\s*$", re.MULTILINE)
+_SAFE_PLAIN_SCALAR_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 _./:@+\-]*$")
+
+
+def export_universe_okf_bundle(universe_id: str, target_dir: str | Path) -> dict[str, Any]:
+    """Export one universe's promoted wiki pages as an OKF v0.1 bundle.
+
+    ``universe_id`` is resolved by ``workflow.api.wiki._wiki_root_for_universe``
+    so this exporter follows the same ``<universe_dir>/wiki`` convention as the
+    chatbot-facing wiki API without adding an MCP action or write path.
+    """
+    wiki_root = _wiki_root_for_universe(universe_id)
+    return export_okf_bundle(wiki_root, target_dir)
+
+
+def export_okf_bundle(wiki_root: str | Path, target_dir: str | Path) -> dict[str, Any]:
+    """Export a resolved wiki root's curated ``pages/**/*.md`` to ``target_dir``."""
+    source_root = Path(wiki_root).resolve()
+    bundle_root = Path(target_dir).resolve()
+    if not source_root.is_dir():
+        raise FileNotFoundError(f"Wiki root not found: {source_root}")
+    if _is_relative_to(bundle_root, source_root):
+        raise ValueError("target_dir must not be inside the source wiki root")
+
+    exported_sources, reserved_sources = _collect_exported_sources(source_root)
+    link_index = _build_link_index(exported_sources, source_root)
+    excluded_files = _collect_excluded_files(source_root)
+    concepts: list[dict[str, str]] = []
+    unresolved_links: list[dict[str, str]] = []
+
+    bundle_root.mkdir(parents=True, exist_ok=True)
+    for source_path in exported_sources:
+        source_rel = _source_rel_path(source_root, source_path)
+        bundle_rel = _bundle_rel_path(source_root, source_path)
+        raw = source_path.read_text(encoding="utf-8")
+        meta, body = _parse_frontmatter(raw)
+        concept_meta = _concept_frontmatter(meta, body, source_rel, bundle_rel, source_path)
+        converted_body = _convert_wikilinks(
+            body,
+            source=bundle_rel,
+            link_index=link_index,
+            unresolved_links=unresolved_links,
+        )
+        target_path = bundle_root / bundle_rel
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text(
+            _render_markdown(concept_meta, converted_body),
+            encoding="utf-8",
+        )
+        concepts.append({
+            "id": bundle_rel.removesuffix(".md"),
+            "path": bundle_rel,
+            "title": str(concept_meta["title"]),
+            "description": str(concept_meta.get("description", "")),
+            "timestamp": str(concept_meta["timestamp"]),
+        })
+
+    _write_index(bundle_root, concepts)
+    _write_log(bundle_root, concepts)
+
+    report = _conformance_report(
+        bundle_root=bundle_root,
+        source_root=source_root,
+        concepts=concepts,
+        excluded_files=excluded_files,
+        unresolved_links=unresolved_links,
+        reserved_sources=reserved_sources,
+    )
+    return report
+
+
+def _collect_exported_sources(wiki_root: Path) -> tuple[list[Path], list[str]]:
+    pages_dir = wiki_root / "pages"
+    if not pages_dir.is_dir():
+        return [], []
+    exported: list[Path] = []
+    reserved_sources: list[str] = []
+    for path in sorted(pages_dir.rglob("*.md")):
+        if not path.is_file():
+            continue
+        if path.name.lower() == "soul.md":
+            continue
+        if path.name.lower() in _RESERVED_FILENAMES:
+            reserved_sources.append(_source_rel_path(wiki_root, path))
+            continue
+        exported.append(path)
+    return exported, reserved_sources
+
+
+def _collect_excluded_files(wiki_root: Path) -> list[dict[str, str]]:
+    excluded: list[dict[str, str]] = []
+    for path in sorted(wiki_root.rglob("*.md")):
+        if not path.is_file():
+            continue
+        rel = _source_rel_path(wiki_root, path)
+        parts = Path(rel).parts
+        reason = ""
+        if path.name.lower() == "soul.md":
+            reason = "soul.md"
+        elif parts and parts[0] in _EXCLUDED_ROOTS:
+            reason = parts[0]
+        if reason:
+            excluded.append({"path": rel, "reason": reason})
+    return excluded
+
+
+def _build_link_index(sources: list[Path], wiki_root: Path) -> dict[str, str]:
+    index: dict[str, str] = {}
+    for source in sources:
+        bundle_rel = _bundle_rel_path(wiki_root, source)
+        concept_id = bundle_rel.removesuffix(".md")
+        keys = {
+            source.stem,
+            concept_id,
+            f"pages/{concept_id}",
+            bundle_rel,
+            f"pages/{bundle_rel}",
+        }
+        for key in keys:
+            normalized = _normalize_wikilink_target(key)
+            if normalized and normalized not in index:
+                index[normalized] = bundle_rel
+    return index
+
+
+def _concept_frontmatter(
+    meta: dict[str, str],
+    body: str,
+    source_rel: str,
+    bundle_rel: str,
+    source_path: Path,
+) -> dict[str, Any]:
+    concept_type = _first_nonempty(meta.get("type", ""), meta.get("kind", ""), "note")
+    title = _first_nonempty(meta.get("title", ""), _first_h1(body), _title_from_slug(bundle_rel))
+    timestamp = _first_nonempty(meta.get("updated", ""), _mtime_iso(source_path))
+
+    output: dict[str, Any] = {
+        "type": concept_type,
+        "title": title,
+        "timestamp": timestamp,
+        "workflow_original_path": source_rel,
+    }
+    for optional_key in ("description", "resource"):
+        value = meta.get(optional_key, "").strip()
+        if value:
+            output[optional_key] = value
+    tags = _parse_list_value(meta.get("tags", ""))
+    if tags:
+        output["tags"] = tags
+
+    category = Path(bundle_rel).parts[0] if len(Path(bundle_rel).parts) > 1 else ""
+    if category:
+        output.setdefault("workflow_category", category)
+    for key, value in meta.items():
+        normalized_key = _workflow_key(key)
+        if normalized_key and value.strip():
+            output[f"workflow_{normalized_key}"] = value.strip()
+    return output
+
+
+def _convert_wikilinks(
+    body: str,
+    *,
+    source: str,
+    link_index: dict[str, str],
+    unresolved_links: list[dict[str, str]],
+) -> str:
+    def replace(match: re.Match[str]) -> str:
+        raw_target = match.group(1).strip()
+        target, separator, alias = raw_target.partition("|")
+        target = target.strip()
+        label = alias.strip() if separator else target
+        resolved = link_index.get(_normalize_wikilink_target(target))
+        if not resolved:
+            unresolved_links.append({"source": source, "target": target})
+            return label
+        return f"[{label}](/{resolved})"
+
+    return _WIKILINK_RE.sub(replace, body)
+
+
+def _write_index(bundle_root: Path, concepts: list[dict[str, str]]) -> None:
+    lines = ["---", f'okf_version: "{OKF_VERSION}"', "---", "", "# Index", ""]
+    for concept in sorted(concepts, key=lambda item: item["path"]):
+        description = concept.get("description", "")
+        suffix = f" - {description}" if description else ""
+        lines.append(f"- [{concept['title']}]({concept['path']}){suffix}")
+    lines.append("")
+    (bundle_root / "index.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _write_log(bundle_root: Path, concepts: list[dict[str, str]]) -> None:
+    by_date: dict[str, list[dict[str, str]]] = {}
+    for concept in concepts:
+        date = _timestamp_date(concept.get("timestamp", ""))
+        by_date.setdefault(date, []).append(concept)
+    if not by_date:
+        today = datetime.now(timezone.utc).date().isoformat()
+        by_date[today] = []
+
+    lines = ["# Bundle Update Log", ""]
+    for date in sorted(by_date.keys(), reverse=True):
+        lines.append(f"## {date}")
+        entries = by_date[date]
+        if entries:
+            for concept in sorted(entries, key=lambda item: item["path"]):
+                lines.append(
+                    f"* **Export**: Added [{concept['title']}](/{concept['path']})."
+                )
+        else:
+            lines.append("* **Creation**: Created empty OKF export bundle.")
+        lines.append("")
+    (bundle_root / "log.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _conformance_report(
+    *,
+    bundle_root: Path,
+    source_root: Path,
+    concepts: list[dict[str, str]],
+    excluded_files: list[dict[str, str]],
+    unresolved_links: list[dict[str, str]],
+    reserved_sources: list[str],
+) -> dict[str, Any]:
+    issues: list[str] = []
+    reserved_files: dict[str, dict[str, Any]] = {}
+
+    for path in sorted(bundle_root.rglob("*.md")):
+        rel = path.relative_to(bundle_root).as_posix()
+        text = path.read_text(encoding="utf-8")
+        if path.name == "index.md":
+            valid, meta = _validate_index(rel, text)
+            reserved_files[rel] = {"valid": valid, **meta}
+            if not valid:
+                issues.append(f"{rel}: invalid index.md structure")
+            continue
+        if path.name == "log.md":
+            valid = _validate_log(text)
+            reserved_files[rel] = {"valid": valid}
+            if not valid:
+                issues.append(f"{rel}: invalid log.md structure")
+            continue
+
+        meta = _parse_yamlish_frontmatter(text)
+        if meta is None:
+            issues.append(f"{rel}: missing or unparseable frontmatter")
+        elif not meta.get("type", "").strip():
+            issues.append(f"{rel}: missing non-empty type")
+
+    for rel in reserved_sources:
+        issues.append(f"{rel}: source reserved filename was not exported as a concept")
+
+    return {
+        "okf_version": OKF_VERSION,
+        "source_wiki_root": source_root.as_posix(),
+        "target_dir": bundle_root.as_posix(),
+        "conformant": not any(
+            issue
+            for issue in issues
+            if "source reserved filename" not in issue
+        ),
+        "counts": {
+            "concepts_exported": len(concepts),
+            "excluded_by_privacy": len(excluded_files),
+            "unresolved_links": len(unresolved_links),
+        },
+        "concepts": concepts,
+        "excluded_files": excluded_files,
+        "unresolved_links": unresolved_links,
+        "reserved_files": reserved_files,
+        "issues": issues,
+    }
+
+
+def _validate_index(rel: str, text: str) -> tuple[bool, dict[str, str]]:
+    if rel == "index.md" and text.startswith("---\n"):
+        meta = _parse_yamlish_frontmatter(text)
+        okf_version = meta.get("okf_version", "") if meta else ""
+        return meta == {"okf_version": OKF_VERSION}, {"okf_version": okf_version}
+    return (not text.startswith("---\n")), {}
+
+
+def _validate_log(text: str) -> bool:
+    has_date_heading = bool(
+        re.search(r"^## \d{4}-\d{2}-\d{2}$", text, re.MULTILINE)
+    )
+    return not text.startswith("---\n") and has_date_heading
+
+
+def _parse_yamlish_frontmatter(text: str) -> dict[str, str] | None:
+    if not text.startswith("---\n"):
+        return None
+    try:
+        raw_meta, _body = text.removeprefix("---\n").split("\n---\n", 1)
+    except ValueError:
+        return None
+    meta: dict[str, str] = {}
+    current_key = ""
+    for line in raw_meta.splitlines():
+        if not line.strip():
+            continue
+        if line.startswith("  "):
+            continue
+        key, separator, value = line.partition(":")
+        if not separator or not key.strip():
+            return None
+        current_key = key.strip()
+        meta[current_key] = value.strip().strip('"')
+    return meta if current_key or not raw_meta.strip() else None
+
+
+def _render_markdown(meta: dict[str, Any], body: str) -> str:
+    lines = ["---"]
+    for key, value in meta.items():
+        lines.extend(_render_yaml_key_value(key, value))
+    lines.extend(["---", ""])
+    return "\n".join(lines) + body.lstrip("\n")
+
+
+def _render_yaml_key_value(key: str, value: Any) -> list[str]:
+    if isinstance(value, list):
+        if not value:
+            return []
+        return [f"{key}:"] + [f"  - {_format_yaml_scalar(item)}" for item in value]
+    text = str(value)
+    if "\n" in text:
+        return [f"{key}: |"] + [f"  {line}" for line in text.splitlines()]
+    return [f"{key}: {_format_yaml_scalar(text)}"]
+
+
+def _format_yaml_scalar(value: Any) -> str:
+    text = str(value).strip()
+    if not text:
+        return '""'
+    lowered = text.lower()
+    if (
+        _SAFE_PLAIN_SCALAR_RE.match(text)
+        and lowered not in {"null", "true", "false", "yes", "no", "on", "off"}
+    ):
+        return text
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _parse_list_value(value: str) -> list[str]:
+    text = value.strip()
+    if not text:
+        return []
+    if text.startswith("[") and text.endswith("]"):
+        text = text[1:-1]
+        return [item.strip().strip("'\"") for item in text.split(",") if item.strip()]
+    if "\n" in text:
+        items: list[str] = []
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("- "):
+                items.append(stripped[2:].strip().strip("'\""))
+        return [item for item in items if item]
+    return [text.strip("'\"")]
+
+
+def _first_h1(body: str) -> str:
+    match = _H1_RE.search(body)
+    return match.group(1).strip() if match else ""
+
+
+def _title_from_slug(bundle_rel: str) -> str:
+    return Path(bundle_rel).stem.replace("-", " ").replace("_", " ").title()
+
+
+def _first_nonempty(*values: str) -> str:
+    for value in values:
+        stripped = value.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _mtime_iso(path: Path) -> str:
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat().replace(
+        "+00:00",
+        "Z",
+    )
+
+
+def _timestamp_date(timestamp: str) -> str:
+    match = re.match(r"^(\d{4}-\d{2}-\d{2})", timestamp.strip())
+    if match:
+        return match.group(1)
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _workflow_key(key: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_]+", "_", key.strip().lower()).strip("_")
+
+
+def _normalize_wikilink_target(target: str) -> str:
+    normalized = target.strip().removeprefix("/").removesuffix(".md").replace("\\", "/")
+    return normalized.lower()
+
+
+def _source_rel_path(wiki_root: Path, path: Path) -> str:
+    return path.relative_to(wiki_root).as_posix()
+
+
+def _bundle_rel_path(wiki_root: Path, path: Path) -> str:
+    return path.relative_to(wiki_root / "pages").as_posix()
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True


### PR DESCRIPTION
## PR-OKF-BRAIN slice 1 — read-only OKF exporter for curated wiki pages (additive)

Internal, **read-only** export of one universe's promoted `pages/**` as a conformant **Open Knowledge Format (OKF) v0.1** bundle + a §9 conformance report. No storage/write-path change, no MCP action, NEW files only. This is the first concrete mechanism toward the **per-universe OKF bundle** topology the parallel brain-arch session is designing (each universe = its own OKF sub-brain nested in the shared brain).

### What it does
- `workflow/wiki/okf_export.py`: `export_universe_okf_bundle(universe_id, target_dir)` / `export_okf_bundle(wiki_root, target_dir)` → writes an OKF bundle + returns a conformance-report dict. Reuses `workflow.api.wiki._wiki_root_for_universe` (the existing per-universe `<universe_dir>/wiki` resolver) — no new path logic.
- **Privacy guard (hard):** source is `pages/**` ONLY; `soul.md`, `drafts/**`, `raw/**`, `daemon-wiki/**` are excluded (host-private-memory leak risk) and reported as excluded counts. Refuses if `target_dir` is inside the source wiki root.
- **OKF-conformant emit (verified vs SPEC.md):** guaranteed non-empty `type`; derived `title`; `timestamp` (`updated`|mtime); `workflow_*` producer-defined keys preserved (SPEC: consumers preserve unknown keys); `[[slug]]` → **absolute bundle-relative** `/path.md` links, unresolved flagged as plain text; root `index.md` declares `okf_version: "0.1"` (others none); `log.md` `## YYYY-MM-DD`; separate JSON conformance report per **OKF §9** (parseable YAML + non-empty type per concept; reserved-file structure).

### Explicitly out of scope (deferred)
`wiki(action="export_okf")` MCP action (separate public-primitive decision), OKF import-as-authority, write-path/auto-conformance, full storage change. No brain-v2 typed-memory or soul/economy substrate touched.

### Provenance & verification
- Design cross-reviewed by **Codex** earlier (verdict **ADAPT**); build **authored by Codex** (`mcp__codex__codex`); **Claude cross-family reviewed + independently tested**.
- Verified firsthand against the authoritative OKF **SPEC.md**.
- 4 tests pass (curated-only export; wikilink→absolute + unresolved flag; type/title/timestamp + workflow_* guaranteed; reserved-file OKF structure). `ruff` clean. Plugin mirror in parity (`build_plugin` import probe ok).

### Merge gate
New module under `workflow/` + mirror → **host merge key required**. Additive; nothing wired into the live surface (no MCP action).

Links: live-brain `drafts/research/okf-open-knowledge-format-brain-implications-2026-06-25.md` (finding + Codex ADAPT review + SPEC verification + brain-v2 coordination).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
