### PR TITLE
design-system: add Tick, Term, Ladder (re-synced to Claude Design)

### DIFF
--- a/WebSite/design-system/src/components/Ladder/Ladder.css
+++ b/WebSite/design-system/src/components/Ladder/Ladder.css
@@ -1,0 +1,69 @@
+.ladder {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0;
+  position: relative;
+}
+.ladder__start {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--fg-4);
+  padding: 0 0 6px 3px;
+}
+.rung {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  padding: 7px 0 7px 3px;
+  position: relative;
+}
+.rung::before {
+  content: '';
+  position: absolute;
+  left: 7.5px;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--border-1);
+}
+.rung:last-child::before { bottom: 50%; }
+.rung__mark {
+  position: relative;
+  z-index: 1;
+  font-size: 10px;
+  line-height: 1.8;
+  color: var(--fg-4);
+  background: var(--bg-0);
+  padding: 1px 0;
+  flex: none;
+  width: 16px;
+  text-align: center;
+}
+.rung.lit .rung__mark { color: var(--live-600); }
+.rung__body { display: grid; gap: 1px; }
+.rung__name {
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--fg-2);
+  line-height: 1.35;
+}
+.rung.lit .rung__name { color: var(--live-700); }
+.rung__desc {
+  font-size: 12.5px;
+  color: var(--fg-3);
+  line-height: 1.45;
+  max-width: 52ch;
+}
+.rung__evidence {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--live-700);
+  width: fit-content;
+}
+.compact .rung { padding: 4px 0 4px 3px; }
+.compact .rung__name { font-size: 12.5px; font-weight: 400; }

--- a/WebSite/design-system/src/components/Ladder/Ladder.prompt.md
+++ b/WebSite/design-system/src/components/Ladder/Ladder.prompt.md
@@ -1,0 +1,20 @@
+# Ladder — usage
+
+Outcome ladder for proof states. Rungs are unlit by default. A rung only lights
+when it has both `lit: true` and an `evidence_url` that proves the outcome.
+
+```tsx
+import { Ladder } from "@tiny/design-system";
+
+<Ladder
+  start="outcome"
+  rungs={[
+    { name: "Local build", lit: true, evidence_url: "#build" },
+    { name: "Rendered proof" },
+    { name: "Live user path" },
+  ]}
+/>
+```
+
+Do: keep unproven outcomes unlit. Don't: mark progress as lit without evidence,
+or use the ladder as a decorative timeline.

--- a/WebSite/design-system/src/components/Ladder/Ladder.schema.json
+++ b/WebSite/design-system/src/components/Ladder/Ladder.schema.json
@@ -1,0 +1,19 @@
+{
+  "name": "Ladder",
+  "import": "import { Ladder } from \"@tiny/design-system\";",
+  "description": "An outcome ladder with ●/○ rung marks. A rung lights only when it has an evidence URL; unlit is the honest default.",
+  "props": {
+    "rungs": {
+      "type": "Array<{ name: string; lit?: boolean; evidence_url?: string; key?: string; description?: string }>",
+      "required": true,
+      "description": "Ordered outcome rungs. `lit` is honored only when `evidence_url` is also present."
+    },
+    "start": { "type": "string", "default": "start", "description": "Short mono label above the ladder." },
+    "compact": { "type": "boolean", "default": false, "description": "Tightens spacing and hides descriptions." }
+  },
+  "rules": [
+    "A rung lights ONLY with an evidence URL.",
+    "Leave rungs unlit by default; unlit is the honest state.",
+    "Use for outcome/proof progression, not generic timelines."
+  ]
+}

--- a/WebSite/design-system/src/components/Ladder/Ladder.stories.tsx
+++ b/WebSite/design-system/src/components/Ladder/Ladder.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Ladder } from "./Ladder";
+
+const honestRungs = [
+  { name: "Local build", description: "Package compiles from source." },
+  { name: "Rendered proof", description: "Storybook renders the component state." },
+  { name: "Live user path", description: "A real user surface has exercised it cleanly." },
+  { name: "Post-fix evidence", description: "Fresh production evidence exists after the change." },
+];
+
+const meta: Meta<typeof Ladder> = {
+  title: "Primitives/Ladder",
+  component: Ladder,
+  parameters: { layout: "centered" },
+  args: { start: "outcome", rungs: honestRungs, compact: false },
+  argTypes: {
+    start: { control: "text" },
+    compact: { control: "boolean" },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Ladder>;
+
+export const Default: Story = { args: { rungs: honestRungs } };
+export const Lit: Story = {
+  args: {
+    rungs: [
+      { name: "Local build", description: "Package compiles from source.", lit: true, evidence_url: "#build" },
+      { name: "Rendered proof", description: "Storybook renders the component state." },
+      { name: "Live user path", description: "A real user surface has exercised it cleanly." },
+    ],
+  },
+};
+export const Compact: Story = {
+  args: {
+    compact: true,
+    rungs: [
+      { name: "Build", lit: true, evidence_url: "#build" },
+      { name: "Storybook" },
+      { name: "Live proof" },
+      { name: "User evidence" },
+    ],
+  },
+};

--- a/WebSite/design-system/src/components/Ladder/Ladder.tsx
+++ b/WebSite/design-system/src/components/Ladder/Ladder.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import "./Ladder.css";
+
+export type Rung = {
+  key?: string;
+  name: string;
+  description?: string;
+  lit?: boolean;
+  evidence_url?: string;
+};
+
+export interface LadderProps {
+  /** Ordered outcome rungs. A rung lights only when `lit` and `evidence_url` are both set. */
+  rungs: Rung[];
+  /** Short mono label above the ladder. */
+  start?: string;
+  /** Tightens spacing and hides descriptions. */
+  compact?: boolean;
+}
+
+/**
+ * Ladder — an outcome ladder. Filled rungs require evidence; unlit is the
+ * honest default until there is a link proving the outcome.
+ */
+export function Ladder({ rungs = [], start = "start", compact = false }: LadderProps) {
+  return (
+    <ol className={`ladder${compact ? " compact" : ""}`}>
+      <li className="ladder__start" aria-hidden="true">{start}</li>
+      {rungs.map((r, i) => {
+        const lit = Boolean(r.lit && r.evidence_url);
+
+        return (
+          <li key={r.key ?? r.name ?? i} className={`rung${lit ? " lit" : ""}`}>
+            <span className="rung__mark" aria-hidden="true">{lit ? "●" : "○"}</span>
+            <span className="rung__body">
+              <span className="rung__name">{r.name}</span>
+              {!compact && r.description && <span className="rung__desc">{r.description}</span>}
+              {lit && r.evidence_url && (
+                <a className="rung__evidence" href={r.evidence_url} target="_blank" rel="noreferrer">
+                  evidence ↗
+                </a>
+              )}
+            </span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+export default Ladder;

--- a/WebSite/design-system/src/components/Ladder/index.ts
+++ b/WebSite/design-system/src/components/Ladder/index.ts
@@ -1,0 +1,2 @@
+export { Ladder, default } from "./Ladder";
+export type { LadderProps, Rung } from "./Ladder";

--- a/WebSite/design-system/src/components/Term/Term.css
+++ b/WebSite/design-system/src/components/Term/Term.css
@@ -1,0 +1,38 @@
+.term {
+  position: relative;
+  border-bottom: 1px dotted var(--border-2);
+  cursor: help;
+  outline: none;
+}
+.term:focus-visible { border-radius: 2px; box-shadow: 0 0 0 2px var(--live-100); }
+.term__tip {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  transform: translateX(-50%) translateY(2px);
+  width: max-content;
+  max-width: 280px;
+  background: var(--ink-text-900);
+  color: var(--paper-50);
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  font-style: normal;
+  line-height: 1.45;
+  letter-spacing: 0;
+  text-align: left;
+  padding: 8px 11px;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-md);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--dur-fast) var(--ease-standard), transform var(--dur-fast) var(--ease-standard);
+  z-index: 30;
+}
+.term:hover .term__tip,
+.term:focus .term__tip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+@media (max-width: 700px) {
+  .term__tip { max-width: min(280px, 78vw); }
+}

--- a/WebSite/design-system/src/components/Term/Term.prompt.md
+++ b/WebSite/design-system/src/components/Term/Term.prompt.md
@@ -1,0 +1,15 @@
+# Term — usage
+
+Inline first-use definition for a project phrase. The text gets a dotted
+underline and shows the plain-words definition on hover or keyboard focus.
+
+```tsx
+import { Term } from "@tiny/design-system";
+
+<p>
+  The fix must preserve <Term def="User-visible operation without a host process online.">zero-host uptime</Term>.
+</p>
+```
+
+Do: use it once where a term first appears. Don't: underline repeated mentions
+or use it for decorative emphasis.

--- a/WebSite/design-system/src/components/Term/Term.schema.json
+++ b/WebSite/design-system/src/components/Term/Term.schema.json
@@ -1,0 +1,14 @@
+{
+  "name": "Term",
+  "import": "import { Term } from \"@tiny/design-system\";",
+  "description": "Inline first-use definition: dotted-underlined text with a tooltip on hover/focus.",
+  "props": {
+    "def": { "type": "string", "required": true, "description": "Plain-words definition shown in the tooltip and accessible label." },
+    "children": { "type": "ReactNode", "required": false, "description": "The term being defined inline." }
+  },
+  "rules": [
+    "Use only on first use of a term or project phrase.",
+    "Keep `def` short, concrete, and plain-spoken.",
+    "Do not use Term as decorative underlining or for repeated glossary noise."
+  ]
+}

--- a/WebSite/design-system/src/components/Term/Term.stories.tsx
+++ b/WebSite/design-system/src/components/Term/Term.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Term } from "./Term";
+
+const meta: Meta<typeof Term> = {
+  title: "Primitives/Term",
+  component: Term,
+  parameters: { layout: "centered" },
+  args: { def: "A branch that keeps working without a host process online.", children: "zero-host uptime" },
+  argTypes: {
+    def: { control: "text" },
+    children: { control: "text" },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Term>;
+
+export const Default: Story = {
+  render: (args) => (
+    <p style={{ maxWidth: 560, lineHeight: 1.6 }}>
+      The release is accepted only when <Term {...args} /> is proven through the
+      live user path.
+    </p>
+  ),
+};

--- a/WebSite/design-system/src/components/Term/Term.tsx
+++ b/WebSite/design-system/src/components/Term/Term.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import "./Term.css";
+
+export interface TermProps {
+  /** Plain-words definition shown in the tooltip and exposed as the accessible label. */
+  def: string;
+  /** The first-use term being defined inline. */
+  children?: React.ReactNode;
+}
+
+/**
+ * Term — inline first-use definition. The dotted underline exposes a plain-words
+ * tooltip on hover/focus without interrupting the prose flow.
+ */
+export function Term({ def, children }: TermProps) {
+  return (
+    <span className="term" tabIndex={0} role="note" aria-label={def}>
+      {children}
+      <span className="term__tip" aria-hidden="true">{def}</span>
+    </span>
+  );
+}
+
+export default Term;

--- a/WebSite/design-system/src/components/Term/index.ts
+++ b/WebSite/design-system/src/components/Term/index.ts
@@ -1,0 +1,2 @@
+export { Term, default } from "./Term";
+export type { TermProps } from "./Term";

--- a/WebSite/design-system/src/components/Tick/Tick.css
+++ b/WebSite/design-system/src/components/Tick/Tick.css
@@ -1,0 +1,18 @@
+.tick {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  color: var(--fg-3);
+  text-decoration: none;
+  border-bottom: 1px dotted var(--border-2);
+  padding-bottom: 1px;
+  white-space: nowrap;
+  transition: color var(--dur-fast) var(--ease-standard), border-color var(--dur-fast) var(--ease-standard);
+}
+a.tick:hover { color: var(--live-700); border-color: var(--live-600); text-decoration: none; }
+.tick--flat { border-bottom-style: none; }
+.tick__glyph { color: var(--live-600); font-size: 10px; }
+.tick__ext { font-size: 9px; color: var(--fg-4); }

--- a/WebSite/design-system/src/components/Tick/Tick.prompt.md
+++ b/WebSite/design-system/src/components/Tick/Tick.prompt.md
@@ -1,0 +1,15 @@
+# Tick — usage
+
+A tiny mono provenance link. Use it to name where a value, claim, artifact, or
+piece of evidence came from.
+
+```tsx
+import { Tick } from "@tiny/design-system";
+
+<Tick href="#source" label="source" />
+<Tick href="https://tinyassets.io" label="field note" external />
+<Tick label="observed" />
+```
+
+Do: keep the label short and use Tick only for provenance/source context.
+Don't: use it as a decorative badge, CTA, or status pill.

--- a/WebSite/design-system/src/components/Tick/Tick.schema.json
+++ b/WebSite/design-system/src/components/Tick/Tick.schema.json
@@ -1,0 +1,15 @@
+{
+  "name": "Tick",
+  "import": "import { Tick } from \"@tiny/design-system\";",
+  "description": "A mono provenance/source link with the ⌁ glyph, short label, optional anchor target, and optional external marker.",
+  "props": {
+    "href": { "type": "string", "required": false, "description": "When set, renders an anchor. When omitted, renders a flat inline provenance tick." },
+    "label": { "type": "string", "default": "source", "description": "Short source label." },
+    "external": { "type": "boolean", "default": false, "description": "Open in a new tab and show the ↗ marker." }
+  },
+  "rules": [
+    "Use only for provenance or source links, not decoration.",
+    "Keep the label short and mono; the glyph is always ⌁.",
+    "Set `external` only for links that leave the current site or app."
+  ]
+}

--- a/WebSite/design-system/src/components/Tick/Tick.stories.tsx
+++ b/WebSite/design-system/src/components/Tick/Tick.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Tick } from "./Tick";
+
+const meta: Meta<typeof Tick> = {
+  title: "Primitives/Tick",
+  component: Tick,
+  parameters: { layout: "centered" },
+  args: { label: "source", href: "#source" },
+  argTypes: {
+    label: { control: "text" },
+    href: { control: "text" },
+    external: { control: "boolean" },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Tick>;
+
+export const Default: Story = { args: { label: "source", href: "#source" } };
+export const External: Story = {
+  args: { label: "field note", href: "https://tinyassets.io", external: true },
+};
+export const Flat: Story = { args: { label: "observed", href: "" } };

--- a/WebSite/design-system/src/components/Tick/Tick.tsx
+++ b/WebSite/design-system/src/components/Tick/Tick.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import "./Tick.css";
+
+export interface TickProps {
+  /** Link target for the provenance source. When omitted, renders a flat inline tick. */
+  href?: string;
+  /** Short source label. */
+  label?: string;
+  /** Opens the link in a new tab and shows the external marker. */
+  external?: boolean;
+}
+
+/**
+ * Tick — a provenance device. The mono glyph and label name where a value or
+ * claim comes from; render as an anchor when `href` is provided.
+ */
+export function Tick({ href = "", label = "source", external = false }: TickProps) {
+  if (href) {
+    return (
+      <a
+        className="tick"
+        href={href}
+        target={external ? "_blank" : undefined}
+        rel={external ? "noreferrer" : undefined}
+      >
+        <span className="tick__glyph" aria-hidden="true">⌁</span>
+        {label}
+        {external && <span className="tick__ext" aria-hidden="true">↗</span>}
+      </a>
+    );
+  }
+
+  return (
+    <span className="tick tick--flat">
+      <span className="tick__glyph" aria-hidden="true">⌁</span>
+      {label}
+    </span>
+  );
+}
+
+export default Tick;

--- a/WebSite/design-system/src/components/Tick/index.ts
+++ b/WebSite/design-system/src/components/Tick/index.ts
@@ -1,0 +1,2 @@
+export { Tick, default } from "./Tick";
+export type { TickProps } from "./Tick";

--- a/WebSite/design-system/src/index.ts
+++ b/WebSite/design-system/src/index.ts
@@ -6,3 +6,6 @@ import "./styles/base.css";
 export * from "./components/Button";
 export * from "./components/StatusPill";
 export * from "./components/RitualLabel";
+export * from "./components/Tick";
+export * from "./components/Term";
+export * from "./components/Ladder";


### PR DESCRIPTION
Promotes Tick (provenance link), Term (inline definition), and Ladder (outcome ladder) from the site into `@tiny/design-system` — 6 components total. All verified match vs the reference storybook and re-synced to claude.ai/design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)