### PR TITLE
design-sync: repoint to 'Tiny Design System' project

### DIFF
--- a/WebSite/design-system/.design-sync/config.json
+++ b/WebSite/design-system/.design-sync/config.json
@@ -5,6 +5,6 @@
   "storybookStatic": ".design-sync/sb-reference",
   "storybookConfigDir": ".storybook",
   "buildCmd": "npm run build",
-  "projectId": "48072c27-c3d6-488c-8c6d-be873636e652",
+  "projectId": "a7672917-0a44-4947-a53c-b5314b222b42",
   "readmeHeader": ".design-sync/conventions.md"
 }


### PR DESCRIPTION
DesignSync can't rename projects, so the rename was done by creating 'Tiny Design System' and copying the synced 6-component DS into it. Repoints config.projectId. Old 'Workflow Design System' can be deleted in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)