### PR TITLE
Centralize GitHub push-credential vending in auth provider (reland #1286)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/provider.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/provider.py
@@ -28,6 +28,109 @@ logger = logging.getLogger("universe_server.auth")
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+# GitHub destination-scoped secret vending
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Process-env GitHub capability tokens are centralized here so every
+# daemon-side consumer (the PR/push effector today; read/search later)
+# resolves a destination-scoped token through one helper instead of each
+# effector hand-parsing its own JSON-map env var. This is the operator
+# (process-env) capability tier; the per-universe credential vault
+# (``workflow.credential_vault``) remains the higher-priority source —
+# effectors check the vault first and fall through to this vended token.
+#
+# ``push`` reads the canonical ``WORKFLOW_GITHUB_PUSH_CAPABILITIES`` map
+# and accepts the older ``WORKFLOW_GITHUB_PR_CAPABILITIES`` as a legacy
+# fallback so existing hosts keep working while they migrate. ``read``
+# reads ``WORKFLOW_GITHUB_READ_CAPABILITIES`` (read scope is granted
+# separately from push by design).
+
+_GITHUB_SECRET_CAPABILITY_ENVS: dict[str, tuple[str, ...]] = {
+    "read": ("WORKFLOW_GITHUB_READ_CAPABILITIES",),
+    "push": (
+        "WORKFLOW_GITHUB_PUSH_CAPABILITIES",
+        "WORKFLOW_GITHUB_PR_CAPABILITIES",
+    ),
+}
+
+
+def _load_destination_secret_map(env_var: str) -> dict[str, str]:
+    """Load a destination-keyed secret map from one JSON env var.
+
+    Returns an empty dict when the env is unset, empty, or malformed.
+    Malformed JSON is logged loudly (hard rule #8) but never raises — a
+    parse failure means "no capability configured" for that env, which
+    collapses the caller to its dry-run / unauthenticated path. Keys and
+    values are whitespace-stripped; entries with an empty key or token
+    are dropped so a placeholder line cannot accidentally grant a
+    capability.
+    """
+    raw = os.environ.get(env_var, "").strip()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError) as exc:
+        logger.warning(
+            "%s is set but not valid JSON: %s. Destination-scoped GitHub "
+            "secrets from this env are unavailable.",
+            env_var,
+            exc,
+        )
+        return {}
+    if not isinstance(parsed, dict):
+        logger.warning(
+            "%s must decode to a JSON object (mapping destination -> "
+            "token); got %s.",
+            env_var,
+            type(parsed).__name__,
+        )
+        return {}
+    cleaned: dict[str, str] = {}
+    for key, value in parsed.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            continue
+        destination = key.strip()
+        token = value.strip()
+        if not destination or not token:
+            continue
+        cleaned[destination] = token
+    return cleaned
+
+
+def vend_github_destination_secret(
+    *, destination: str, capability: str = "read",
+) -> dict[str, Any]:
+    """Return a destination-scoped GitHub credential payload.
+
+    Looks up ``destination`` (exact, whitespace-stripped match) in the
+    capability map(s) for ``capability`` ("read" or "push"). The returned
+    dict carries routing metadata plus the resolved token (empty string
+    when none is configured). It is safe to pass within the daemon, but
+    callers MUST NOT echo the ``token`` field into run state or external
+    evidence (hard rule: capability tokens stay daemon-side).
+    """
+    destination_key = destination.strip()
+    capability_key = capability.strip().lower() or "read"
+    env_vars = _GITHUB_SECRET_CAPABILITY_ENVS.get(capability_key, ())
+    vendored: dict[str, Any] = {
+        "destination": destination_key,
+        "capability": capability_key,
+        "token": "",
+        "source_env_var": env_vars[0] if env_vars else "",
+    }
+    if not destination_key or not env_vars:
+        return vendored
+    for env_var in env_vars:
+        token = _load_destination_secret_map(env_var).get(destination_key, "")
+        if token:
+            vendored["token"] = token
+            vendored["source_env_var"] = env_var
+            break
+    return vendored
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 # Identity
 # ═══════════════════════════════════════════════════════════════════════════
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_pr.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/github_pr.py
@@ -30,14 +30,21 @@ Authority model (Phase 2)
 
 A real write fires only when ALL THREE gates are open:
 
-1. **Capability token (env-sourced, daemon-side).** The host sets
-   ``WORKFLOW_GITHUB_PR_CAPABILITIES`` to a JSON map of
-   ``{"<owner>/<repo>": "<token>"}`` (round-2 fix for Codex P1.2 —
-   the round-1 ``WORKFLOW_GITHUB_PR_CAPABILITY_REPO_<OWNER>_<REPO>``
-   suffix encoding collapsed ``my.repo`` / ``my_repo`` / ``my-repo``
-   to the same env key and therefore the same token). The token is
-   read at invocation time and is never echoed into branch-visible
-   state.
+1. **Capability token (vault first, then secrets-vended env).** The
+   per-universe credential vault (``workflow.credential_vault``) is the
+   higher-priority source; a vault-bound universe never falls through to
+   the process-env tier. When no vault is bound, the shared auth provider
+   (``workflow.auth.provider.vend_github_destination_secret``) resolves a
+   destination-scoped GitHub ``push`` credential from
+   ``WORKFLOW_GITHUB_PUSH_CAPABILITIES`` (a JSON map of
+   ``{"<owner>/<repo>": "<token>"}``), accepting the older
+   ``WORKFLOW_GITHUB_PR_CAPABILITIES`` map as a legacy fallback during
+   migration. The JSON map keys by the literal ``owner/repo`` destination
+   (round-2 fix for Codex P1.2 — the round-1
+   ``WORKFLOW_GITHUB_PR_CAPABILITY_REPO_<OWNER>_<REPO>`` suffix encoding
+   collapsed ``my.repo`` / ``my_repo`` / ``my-repo`` to the same env key).
+   The token is read at invocation time and is never echoed into
+   branch-visible state.
 
 2. **Per-destination consent grant.** A row in the per-universe
    ``effector_consents`` table with ``(sink, destination, revoked_at
@@ -86,6 +93,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+from workflow.auth.provider import vend_github_destination_secret
 from workflow.effectors.authority import (
     DENIED as SOUL_AUTHORITY_DENIED,
 )
@@ -110,12 +118,19 @@ _ENABLE_ENV = "WORKFLOW_EXTERNAL_WRITE_ENABLED"
 # :func:`run_github_pr_effector` checks it before any gate, including
 # Phase-1 backward-compat packets.
 _DRY_RUN_ENV = "WORKFLOW_EXTERNAL_WRITE_DRY_RUN"
-# Round-2 P1.2 fix: capability tokens come from a single JSON-map env
-# var keyed by the literal ``owner/repo`` destination string. The
-# round-1 ``WORKFLOW_GITHUB_PR_CAPABILITY_REPO_<...>`` suffix encoding
-# collapsed distinct destinations (e.g. ``octo/my.repo`` and
-# ``octo/my_repo``) into the same env-var name; the JSON map keys by
-# the raw destination so two distinct destinations cannot collide.
+# GitHub push (write) credentials are resolved through the shared
+# auth/secrets provider (``workflow.auth.provider.vend_github_destination_secret``)
+# as a destination-keyed ``push`` capability. The canonical env map is
+# ``WORKFLOW_GITHUB_PUSH_CAPABILITIES``; the older PR-specific map
+# ``WORKFLOW_GITHUB_PR_CAPABILITIES`` is still accepted as a legacy
+# fallback (handled inside the vending helper) so existing hosts keep
+# working while they migrate. Round-2 P1.2 property preserved: the map
+# keys by the literal ``owner/repo`` destination string so distinct
+# destinations cannot collide on a suffix-encoded env-var name.
+_PUSH_CAPABILITIES_ENV = "WORKFLOW_GITHUB_PUSH_CAPABILITIES"
+# Legacy env-var name. Kept as the module-level constant the evidence
+# shape + test suite reference; the vending helper accepts it as a
+# fallback so a host that has not migrated keeps real writes working.
 _CAPABILITIES_ENV = "WORKFLOW_GITHUB_PR_CAPABILITIES"
 _GH_PR_TIMEOUT_S = 60.0
 _GITHUB_API = "https://api.github.com"
@@ -159,60 +174,37 @@ def _parse_packet(value: Any) -> dict[str, Any] | None:
     return packet
 
 
-def _load_capability_map() -> dict[str, str]:
-    """Parse ``WORKFLOW_GITHUB_PR_CAPABILITIES`` as a JSON object.
+def _vend_push_token(destination: str) -> str:
+    """Return the env-vended GitHub push token for ``destination``.
 
-    Returns an empty dict when the env is unset, empty, or malformed.
-    Malformed JSON is logged loudly so the host can spot a typo, but
-    the function never raises — a parse failure means "no capability
-    configured" which collapses to the dry-run path.
-
-    The map's keys are matched against the packet's ``destination``
-    field exactly (case-sensitive, whitespace-stripped). Two distinct
-    destinations therefore cannot share a token unless the host wires
-    both keys to the same value in the JSON map — explicit, audited
-    behavior, never silent collision.
+    Resolves through the shared auth/secrets provider as a
+    destination-scoped ``push`` capability. The helper reads the
+    canonical ``WORKFLOW_GITHUB_PUSH_CAPABILITIES`` map and falls back to
+    the legacy ``WORKFLOW_GITHUB_PR_CAPABILITIES`` map during migration.
+    Exact, whitespace-stripped destination match; never echoed into
+    branch-visible state. Empty string when no token is configured.
     """
-    raw = os.environ.get(_CAPABILITIES_ENV, "").strip()
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except (TypeError, ValueError) as exc:
-        logger.warning(
-            "%s is set but not valid JSON: %s. No capability tokens "
-            "will be available; all destination lookups will return "
-            "missing_capability. Fix the env var to enable real writes.",
-            _CAPABILITIES_ENV, exc,
-        )
-        return {}
-    if not isinstance(parsed, dict):
-        logger.warning(
-            "%s must decode to a JSON object (mapping destination -> "
-            "token); got %s. No capability tokens available.",
-            _CAPABILITIES_ENV, type(parsed).__name__,
-        )
-        return {}
-    # Strip values; drop empties so a host with placeholder keys does
-    # not accidentally grant capability for a destination they meant
-    # to leave inert.
-    cleaned: dict[str, str] = {}
-    for key, value in parsed.items():
-        if not isinstance(key, str) or not isinstance(value, str):
-            continue
-        token = value.strip()
-        if not token:
-            continue
-        cleaned[key.strip()] = token
-    return cleaned
+    vendored = vend_github_destination_secret(
+        destination=destination,
+        capability="push",
+    )
+    token = vendored.get("token")
+    if not isinstance(token, str):
+        return ""
+    return token.strip()
 
 
 def _read_capability(destination: str, universe_dir: Path | None = None) -> str:
     """Return the capability token for ``destination`` (empty string if missing).
 
-    Looked up by exact match against the JSON-map keys. Never echoed
-    into branch-visible state. Callers must NOT include this value in
-    returned evidence.
+    Two-tier resolution, vault first: the per-universe credential vault
+    (``workflow.credential_vault``) is the higher-priority source; when a
+    universe has a vault we never fall through to the process-env tier
+    (an empty vault means "this universe is not authorized", not "look at
+    the host env"). When no vault is bound, the env-vended ``push`` token
+    from the shared auth provider is used. Never echoed into
+    branch-visible state; callers must NOT include this value in returned
+    evidence.
     """
     if not destination:
         return ""
@@ -222,7 +214,7 @@ def _read_capability(destination: str, universe_dir: Path | None = None) -> str:
         token = resolve_github_token(universe_dir, destination, purpose="write")
         if token or vault_exists(universe_dir):
             return token
-    return _load_capability_map().get(destination, "")
+    return _vend_push_token(destination)
 
 
 def _resolve_universe_dir(base_path: str | Path | None) -> Path | None:
@@ -1275,11 +1267,13 @@ def run_github_pr_effector(
             ),
         }
 
-    # ── Gate 1: capability env ─────────────────────────────────────────
-    # Round-2 P1.2: lookup is by exact destination string against the
-    # JSON map. The dry-run evidence names the destination the host
-    # needs to add to the JSON map (the literal key) — never the
-    # collision-prone uppercased suffix.
+    # ── Gate 1: capability (vault first, then env-vended push token) ───
+    # Vault is the higher-priority source. When no vault is bound, the
+    # token is vended through the shared auth provider as a ``push``
+    # capability (canonical ``WORKFLOW_GITHUB_PUSH_CAPABILITIES`` map,
+    # legacy ``WORKFLOW_GITHUB_PR_CAPABILITIES`` fallback). Lookup is by
+    # exact destination string; the dry-run evidence names the literal
+    # destination key the host must add — never a collision-prone suffix.
     capability = _read_capability(destination, universe_dir)
     if not capability:
         return {
@@ -1287,14 +1281,20 @@ def run_github_pr_effector(
             "phase": "phase_2",
             "reason": "missing_capability",
             "destination": destination,
+            # ``capability_env_var`` stays the legacy name so existing
+            # evidence consumers that branch on it keep working;
+            # ``push_capability_env_var`` advertises the canonical map.
             "capability_env_var": _CAPABILITIES_ENV,
+            "push_capability_env_var": _PUSH_CAPABILITIES_ENV,
             "capability_vault": "per-universe credential vault",
             "legacy_capability_env_var": _CAPABILITIES_ENV,
             "capability_lookup_failed_for": destination,
             "hint": (
                 "Add a vcs/github/write credential to this universe's "
                 f"per-universe credential vault keyed by destination "
-                f'"{destination}".'
+                f'"{destination}", or set the {_PUSH_CAPABILITIES_ENV} '
+                f'JSON map keyed by "{destination}" on the daemon env '
+                f"(legacy {_CAPABILITIES_ENV} still accepted)."
             ),
             "intent": packet,
             "matched_output_key": matched_key,

--- a/tests/test_github_secret_vending.py
+++ b/tests/test_github_secret_vending.py
@@ -1,0 +1,222 @@
+"""Centralized GitHub destination-scoped secret vending (auth provider).
+
+Covers ``workflow.auth.provider.vend_github_destination_secret`` and the
+``github_pr`` effector's adapted ``_read_capability`` resolution order
+(per-universe vault first, then the env-vended ``push`` token with the
+legacy ``WORKFLOW_GITHUB_PR_CAPABILITIES`` fallback).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from workflow.auth.provider import (
+    _load_destination_secret_map,
+    vend_github_destination_secret,
+)
+from workflow.credential_vault import write_credential_vault
+from workflow.effectors.github_pr import _read_capability
+
+_DESTINATION = "Jonnyton/Workflow"
+
+_GITHUB_SECRET_ENVS = (
+    "WORKFLOW_GITHUB_PUSH_CAPABILITIES",
+    "WORKFLOW_GITHUB_PR_CAPABILITIES",
+    "WORKFLOW_GITHUB_READ_CAPABILITIES",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_github_secret_envs(monkeypatch):
+    """Strip host-shell GitHub capability env state for isolated tests."""
+    for name in _GITHUB_SECRET_ENVS:
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def universe_dir(tmp_path):
+    universe = tmp_path / "u-test"
+    universe.mkdir()
+    return universe
+
+
+# ---------------------------------------------------------------------------
+# _load_destination_secret_map
+# ---------------------------------------------------------------------------
+
+
+def test_load_secret_map_parses_json_object(monkeypatch):
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_PUSH_CAPABILITIES",
+        json.dumps({_DESTINATION: "tok-push", "octo/other": "tok-other"}),
+    )
+    parsed = _load_destination_secret_map("WORKFLOW_GITHUB_PUSH_CAPABILITIES")
+    assert parsed == {_DESTINATION: "tok-push", "octo/other": "tok-other"}
+
+
+def test_load_secret_map_unset_returns_empty():
+    assert _load_destination_secret_map("WORKFLOW_GITHUB_PUSH_CAPABILITIES") == {}
+
+
+def test_load_secret_map_malformed_json_returns_empty(monkeypatch):
+    monkeypatch.setenv("WORKFLOW_GITHUB_PUSH_CAPABILITIES", "{not valid json}")
+    assert _load_destination_secret_map("WORKFLOW_GITHUB_PUSH_CAPABILITIES") == {}
+
+
+def test_load_secret_map_non_object_returns_empty(monkeypatch):
+    for value in ("[]", '"a string"', "42", "null"):
+        monkeypatch.setenv("WORKFLOW_GITHUB_PUSH_CAPABILITIES", value)
+        assert _load_destination_secret_map("WORKFLOW_GITHUB_PUSH_CAPABILITIES") == {}
+
+
+def test_load_secret_map_strips_and_drops_empty_entries(monkeypatch):
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_PUSH_CAPABILITIES",
+        json.dumps(
+            {
+                "  octo/real  ": "  tok-real  ",
+                "octo/blank": "   ",
+                "  ": "tok-no-key",
+            }
+        ),
+    )
+    parsed = _load_destination_secret_map("WORKFLOW_GITHUB_PUSH_CAPABILITIES")
+    assert parsed == {"octo/real": "tok-real"}
+
+
+# ---------------------------------------------------------------------------
+# vend_github_destination_secret
+# ---------------------------------------------------------------------------
+
+
+def test_vend_push_uses_canonical_env(monkeypatch):
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_PUSH_CAPABILITIES",
+        json.dumps({_DESTINATION: "tok-push"}),
+    )
+    vended = vend_github_destination_secret(destination=_DESTINATION, capability="push")
+    assert vended["token"] == "tok-push"
+    assert vended["capability"] == "push"
+    assert vended["destination"] == _DESTINATION
+    assert vended["source_env_var"] == "WORKFLOW_GITHUB_PUSH_CAPABILITIES"
+
+
+def test_vend_push_falls_back_to_legacy_env(monkeypatch):
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_PR_CAPABILITIES",
+        json.dumps({_DESTINATION: "tok-legacy"}),
+    )
+    vended = vend_github_destination_secret(destination=_DESTINATION, capability="push")
+    assert vended["token"] == "tok-legacy"
+    assert vended["source_env_var"] == "WORKFLOW_GITHUB_PR_CAPABILITIES"
+
+
+def test_vend_push_canonical_env_wins_over_legacy(monkeypatch):
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_PUSH_CAPABILITIES",
+        json.dumps({_DESTINATION: "tok-push"}),
+    )
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_PR_CAPABILITIES",
+        json.dumps({_DESTINATION: "tok-legacy"}),
+    )
+    vended = vend_github_destination_secret(destination=_DESTINATION, capability="push")
+    assert vended["token"] == "tok-push"
+    assert vended["source_env_var"] == "WORKFLOW_GITHUB_PUSH_CAPABILITIES"
+
+
+def test_vend_read_uses_read_env_only(monkeypatch):
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_READ_CAPABILITIES",
+        json.dumps({_DESTINATION: "tok-read"}),
+    )
+    # A push token configured elsewhere must NOT leak into a read vend.
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_PUSH_CAPABILITIES",
+        json.dumps({_DESTINATION: "tok-push"}),
+    )
+    vended = vend_github_destination_secret(destination=_DESTINATION, capability="read")
+    assert vended["token"] == "tok-read"
+    assert vended["source_env_var"] == "WORKFLOW_GITHUB_READ_CAPABILITIES"
+
+
+def test_vend_missing_destination_returns_empty_token(monkeypatch):
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_PUSH_CAPABILITIES",
+        json.dumps({_DESTINATION: "tok-push"}),
+    )
+    vended = vend_github_destination_secret(destination="never/set", capability="push")
+    assert vended["token"] == ""
+
+
+def test_vend_empty_destination_returns_empty_token():
+    vended = vend_github_destination_secret(destination="", capability="push")
+    assert vended["token"] == ""
+
+
+def test_vend_unknown_capability_returns_empty_token(monkeypatch):
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_PUSH_CAPABILITIES",
+        json.dumps({_DESTINATION: "tok-push"}),
+    )
+    vended = vend_github_destination_secret(destination=_DESTINATION, capability="bogus")
+    assert vended["token"] == ""
+    assert vended["source_env_var"] == ""
+
+
+# ---------------------------------------------------------------------------
+# github_pr._read_capability — adapted resolution order
+# ---------------------------------------------------------------------------
+
+
+def test_read_capability_uses_push_env_when_no_universe(monkeypatch):
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_PUSH_CAPABILITIES",
+        json.dumps({_DESTINATION: "tok-push"}),
+    )
+    assert _read_capability(_DESTINATION) == "tok-push"
+
+
+def test_read_capability_legacy_env_still_works(monkeypatch):
+    """Backward compat: a host that has not migrated keeps real writes."""
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_PR_CAPABILITIES",
+        json.dumps({_DESTINATION: "tok-legacy"}),
+    )
+    assert _read_capability(_DESTINATION) == "tok-legacy"
+
+
+def test_read_capability_vault_beats_env(universe_dir, monkeypatch):
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_PUSH_CAPABILITIES",
+        json.dumps({_DESTINATION: "tok-push"}),
+    )
+    write_credential_vault(
+        universe_dir,
+        [
+            {
+                "credential_type": "vcs",
+                "service": "github",
+                "destination": _DESTINATION,
+                "purpose": "write",
+                "token": "vault-token",
+            }
+        ],
+    )
+    assert _read_capability(_DESTINATION, universe_dir) == "vault-token"
+
+
+def test_read_capability_empty_vault_blocks_env(universe_dir, monkeypatch):
+    """A bound-but-empty vault means 'not authorized', not 'fall to env'."""
+    monkeypatch.setenv(
+        "WORKFLOW_GITHUB_PUSH_CAPABILITIES",
+        json.dumps({_DESTINATION: "tok-push"}),
+    )
+    write_credential_vault(universe_dir, [])
+    assert _read_capability(_DESTINATION, universe_dir) == ""
+
+
+def test_read_capability_empty_destination_returns_empty():
+    assert _read_capability("") == ""

--- a/workflow/auth/provider.py
+++ b/workflow/auth/provider.py
@@ -28,6 +28,109 @@ logger = logging.getLogger("universe_server.auth")
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+# GitHub destination-scoped secret vending
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Process-env GitHub capability tokens are centralized here so every
+# daemon-side consumer (the PR/push effector today; read/search later)
+# resolves a destination-scoped token through one helper instead of each
+# effector hand-parsing its own JSON-map env var. This is the operator
+# (process-env) capability tier; the per-universe credential vault
+# (``workflow.credential_vault``) remains the higher-priority source —
+# effectors check the vault first and fall through to this vended token.
+#
+# ``push`` reads the canonical ``WORKFLOW_GITHUB_PUSH_CAPABILITIES`` map
+# and accepts the older ``WORKFLOW_GITHUB_PR_CAPABILITIES`` as a legacy
+# fallback so existing hosts keep working while they migrate. ``read``
+# reads ``WORKFLOW_GITHUB_READ_CAPABILITIES`` (read scope is granted
+# separately from push by design).
+
+_GITHUB_SECRET_CAPABILITY_ENVS: dict[str, tuple[str, ...]] = {
+    "read": ("WORKFLOW_GITHUB_READ_CAPABILITIES",),
+    "push": (
+        "WORKFLOW_GITHUB_PUSH_CAPABILITIES",
+        "WORKFLOW_GITHUB_PR_CAPABILITIES",
+    ),
+}
+
+
+def _load_destination_secret_map(env_var: str) -> dict[str, str]:
+    """Load a destination-keyed secret map from one JSON env var.
+
+    Returns an empty dict when the env is unset, empty, or malformed.
+    Malformed JSON is logged loudly (hard rule #8) but never raises — a
+    parse failure means "no capability configured" for that env, which
+    collapses the caller to its dry-run / unauthenticated path. Keys and
+    values are whitespace-stripped; entries with an empty key or token
+    are dropped so a placeholder line cannot accidentally grant a
+    capability.
+    """
+    raw = os.environ.get(env_var, "").strip()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError) as exc:
+        logger.warning(
+            "%s is set but not valid JSON: %s. Destination-scoped GitHub "
+            "secrets from this env are unavailable.",
+            env_var,
+            exc,
+        )
+        return {}
+    if not isinstance(parsed, dict):
+        logger.warning(
+            "%s must decode to a JSON object (mapping destination -> "
+            "token); got %s.",
+            env_var,
+            type(parsed).__name__,
+        )
+        return {}
+    cleaned: dict[str, str] = {}
+    for key, value in parsed.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            continue
+        destination = key.strip()
+        token = value.strip()
+        if not destination or not token:
+            continue
+        cleaned[destination] = token
+    return cleaned
+
+
+def vend_github_destination_secret(
+    *, destination: str, capability: str = "read",
+) -> dict[str, Any]:
+    """Return a destination-scoped GitHub credential payload.
+
+    Looks up ``destination`` (exact, whitespace-stripped match) in the
+    capability map(s) for ``capability`` ("read" or "push"). The returned
+    dict carries routing metadata plus the resolved token (empty string
+    when none is configured). It is safe to pass within the daemon, but
+    callers MUST NOT echo the ``token`` field into run state or external
+    evidence (hard rule: capability tokens stay daemon-side).
+    """
+    destination_key = destination.strip()
+    capability_key = capability.strip().lower() or "read"
+    env_vars = _GITHUB_SECRET_CAPABILITY_ENVS.get(capability_key, ())
+    vendored: dict[str, Any] = {
+        "destination": destination_key,
+        "capability": capability_key,
+        "token": "",
+        "source_env_var": env_vars[0] if env_vars else "",
+    }
+    if not destination_key or not env_vars:
+        return vendored
+    for env_var in env_vars:
+        token = _load_destination_secret_map(env_var).get(destination_key, "")
+        if token:
+            vendored["token"] = token
+            vendored["source_env_var"] = env_var
+            break
+    return vendored
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 # Identity
 # ═══════════════════════════════════════════════════════════════════════════
 

--- a/workflow/effectors/github_pr.py
+++ b/workflow/effectors/github_pr.py
@@ -30,14 +30,21 @@ Authority model (Phase 2)
 
 A real write fires only when ALL THREE gates are open:
 
-1. **Capability token (env-sourced, daemon-side).** The host sets
-   ``WORKFLOW_GITHUB_PR_CAPABILITIES`` to a JSON map of
-   ``{"<owner>/<repo>": "<token>"}`` (round-2 fix for Codex P1.2 —
-   the round-1 ``WORKFLOW_GITHUB_PR_CAPABILITY_REPO_<OWNER>_<REPO>``
-   suffix encoding collapsed ``my.repo`` / ``my_repo`` / ``my-repo``
-   to the same env key and therefore the same token). The token is
-   read at invocation time and is never echoed into branch-visible
-   state.
+1. **Capability token (vault first, then secrets-vended env).** The
+   per-universe credential vault (``workflow.credential_vault``) is the
+   higher-priority source; a vault-bound universe never falls through to
+   the process-env tier. When no vault is bound, the shared auth provider
+   (``workflow.auth.provider.vend_github_destination_secret``) resolves a
+   destination-scoped GitHub ``push`` credential from
+   ``WORKFLOW_GITHUB_PUSH_CAPABILITIES`` (a JSON map of
+   ``{"<owner>/<repo>": "<token>"}``), accepting the older
+   ``WORKFLOW_GITHUB_PR_CAPABILITIES`` map as a legacy fallback during
+   migration. The JSON map keys by the literal ``owner/repo`` destination
+   (round-2 fix for Codex P1.2 — the round-1
+   ``WORKFLOW_GITHUB_PR_CAPABILITY_REPO_<OWNER>_<REPO>`` suffix encoding
+   collapsed ``my.repo`` / ``my_repo`` / ``my-repo`` to the same env key).
+   The token is read at invocation time and is never echoed into
+   branch-visible state.
 
 2. **Per-destination consent grant.** A row in the per-universe
    ``effector_consents`` table with ``(sink, destination, revoked_at
@@ -86,6 +93,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+from workflow.auth.provider import vend_github_destination_secret
 from workflow.effectors.authority import (
     DENIED as SOUL_AUTHORITY_DENIED,
 )
@@ -110,12 +118,19 @@ _ENABLE_ENV = "WORKFLOW_EXTERNAL_WRITE_ENABLED"
 # :func:`run_github_pr_effector` checks it before any gate, including
 # Phase-1 backward-compat packets.
 _DRY_RUN_ENV = "WORKFLOW_EXTERNAL_WRITE_DRY_RUN"
-# Round-2 P1.2 fix: capability tokens come from a single JSON-map env
-# var keyed by the literal ``owner/repo`` destination string. The
-# round-1 ``WORKFLOW_GITHUB_PR_CAPABILITY_REPO_<...>`` suffix encoding
-# collapsed distinct destinations (e.g. ``octo/my.repo`` and
-# ``octo/my_repo``) into the same env-var name; the JSON map keys by
-# the raw destination so two distinct destinations cannot collide.
+# GitHub push (write) credentials are resolved through the shared
+# auth/secrets provider (``workflow.auth.provider.vend_github_destination_secret``)
+# as a destination-keyed ``push`` capability. The canonical env map is
+# ``WORKFLOW_GITHUB_PUSH_CAPABILITIES``; the older PR-specific map
+# ``WORKFLOW_GITHUB_PR_CAPABILITIES`` is still accepted as a legacy
+# fallback (handled inside the vending helper) so existing hosts keep
+# working while they migrate. Round-2 P1.2 property preserved: the map
+# keys by the literal ``owner/repo`` destination string so distinct
+# destinations cannot collide on a suffix-encoded env-var name.
+_PUSH_CAPABILITIES_ENV = "WORKFLOW_GITHUB_PUSH_CAPABILITIES"
+# Legacy env-var name. Kept as the module-level constant the evidence
+# shape + test suite reference; the vending helper accepts it as a
+# fallback so a host that has not migrated keeps real writes working.
 _CAPABILITIES_ENV = "WORKFLOW_GITHUB_PR_CAPABILITIES"
 _GH_PR_TIMEOUT_S = 60.0
 _GITHUB_API = "https://api.github.com"
@@ -159,60 +174,37 @@ def _parse_packet(value: Any) -> dict[str, Any] | None:
     return packet
 
 
-def _load_capability_map() -> dict[str, str]:
-    """Parse ``WORKFLOW_GITHUB_PR_CAPABILITIES`` as a JSON object.
+def _vend_push_token(destination: str) -> str:
+    """Return the env-vended GitHub push token for ``destination``.
 
-    Returns an empty dict when the env is unset, empty, or malformed.
-    Malformed JSON is logged loudly so the host can spot a typo, but
-    the function never raises — a parse failure means "no capability
-    configured" which collapses to the dry-run path.
-
-    The map's keys are matched against the packet's ``destination``
-    field exactly (case-sensitive, whitespace-stripped). Two distinct
-    destinations therefore cannot share a token unless the host wires
-    both keys to the same value in the JSON map — explicit, audited
-    behavior, never silent collision.
+    Resolves through the shared auth/secrets provider as a
+    destination-scoped ``push`` capability. The helper reads the
+    canonical ``WORKFLOW_GITHUB_PUSH_CAPABILITIES`` map and falls back to
+    the legacy ``WORKFLOW_GITHUB_PR_CAPABILITIES`` map during migration.
+    Exact, whitespace-stripped destination match; never echoed into
+    branch-visible state. Empty string when no token is configured.
     """
-    raw = os.environ.get(_CAPABILITIES_ENV, "").strip()
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except (TypeError, ValueError) as exc:
-        logger.warning(
-            "%s is set but not valid JSON: %s. No capability tokens "
-            "will be available; all destination lookups will return "
-            "missing_capability. Fix the env var to enable real writes.",
-            _CAPABILITIES_ENV, exc,
-        )
-        return {}
-    if not isinstance(parsed, dict):
-        logger.warning(
-            "%s must decode to a JSON object (mapping destination -> "
-            "token); got %s. No capability tokens available.",
-            _CAPABILITIES_ENV, type(parsed).__name__,
-        )
-        return {}
-    # Strip values; drop empties so a host with placeholder keys does
-    # not accidentally grant capability for a destination they meant
-    # to leave inert.
-    cleaned: dict[str, str] = {}
-    for key, value in parsed.items():
-        if not isinstance(key, str) or not isinstance(value, str):
-            continue
-        token = value.strip()
-        if not token:
-            continue
-        cleaned[key.strip()] = token
-    return cleaned
+    vendored = vend_github_destination_secret(
+        destination=destination,
+        capability="push",
+    )
+    token = vendored.get("token")
+    if not isinstance(token, str):
+        return ""
+    return token.strip()
 
 
 def _read_capability(destination: str, universe_dir: Path | None = None) -> str:
     """Return the capability token for ``destination`` (empty string if missing).
 
-    Looked up by exact match against the JSON-map keys. Never echoed
-    into branch-visible state. Callers must NOT include this value in
-    returned evidence.
+    Two-tier resolution, vault first: the per-universe credential vault
+    (``workflow.credential_vault``) is the higher-priority source; when a
+    universe has a vault we never fall through to the process-env tier
+    (an empty vault means "this universe is not authorized", not "look at
+    the host env"). When no vault is bound, the env-vended ``push`` token
+    from the shared auth provider is used. Never echoed into
+    branch-visible state; callers must NOT include this value in returned
+    evidence.
     """
     if not destination:
         return ""
@@ -222,7 +214,7 @@ def _read_capability(destination: str, universe_dir: Path | None = None) -> str:
         token = resolve_github_token(universe_dir, destination, purpose="write")
         if token or vault_exists(universe_dir):
             return token
-    return _load_capability_map().get(destination, "")
+    return _vend_push_token(destination)
 
 
 def _resolve_universe_dir(base_path: str | Path | None) -> Path | None:
@@ -1275,11 +1267,13 @@ def run_github_pr_effector(
             ),
         }
 
-    # ── Gate 1: capability env ─────────────────────────────────────────
-    # Round-2 P1.2: lookup is by exact destination string against the
-    # JSON map. The dry-run evidence names the destination the host
-    # needs to add to the JSON map (the literal key) — never the
-    # collision-prone uppercased suffix.
+    # ── Gate 1: capability (vault first, then env-vended push token) ───
+    # Vault is the higher-priority source. When no vault is bound, the
+    # token is vended through the shared auth provider as a ``push``
+    # capability (canonical ``WORKFLOW_GITHUB_PUSH_CAPABILITIES`` map,
+    # legacy ``WORKFLOW_GITHUB_PR_CAPABILITIES`` fallback). Lookup is by
+    # exact destination string; the dry-run evidence names the literal
+    # destination key the host must add — never a collision-prone suffix.
     capability = _read_capability(destination, universe_dir)
     if not capability:
         return {
@@ -1287,14 +1281,20 @@ def run_github_pr_effector(
             "phase": "phase_2",
             "reason": "missing_capability",
             "destination": destination,
+            # ``capability_env_var`` stays the legacy name so existing
+            # evidence consumers that branch on it keep working;
+            # ``push_capability_env_var`` advertises the canonical map.
             "capability_env_var": _CAPABILITIES_ENV,
+            "push_capability_env_var": _PUSH_CAPABILITIES_ENV,
             "capability_vault": "per-universe credential vault",
             "legacy_capability_env_var": _CAPABILITIES_ENV,
             "capability_lookup_failed_for": destination,
             "hint": (
                 "Add a vcs/github/write credential to this universe's "
                 f"per-universe credential vault keyed by destination "
-                f'"{destination}".'
+                f'"{destination}", or set the {_PUSH_CAPABILITIES_ENV} '
+                f'JSON map keyed by "{destination}" on the daemon env '
+                f"(legacy {_CAPABILITIES_ENV} still accepted)."
             ),
             "intent": packet,
             "matched_output_key": matched_key,


### PR DESCRIPTION
Clean re-land of the stale **PR #1286** (`patch-loop/pages-...` @ `42569fa2`, 108+ commits behind main), adapted onto current `main`. Tracked by recovery issue #1346 ("Salvaged tasks from branch cleanup").

## Relevance verdict: ADAPTED (not a blind copy)

Between when `42569fa2` was cut and now, the **per-universe credential vault** (`workflow/credential_vault.py` + `resolve_github_token`) landed. The PR effector's `_read_capability(destination, universe_dir)` already does **vault-first, then env-map fallback**.

The stale branch predates the vault — its version dropped the `universe_dir` param and the vault path entirely, replacing the env tier with centralized vending. Blindly copying it would have **regressed the vault**. Instead this PR layers the centralization onto the current vault-first structure:

- The credential vault stays the higher-priority source.
- Only the process-env tier is routed through the new shared vending helper.

The two layers are complementary, not redundant: vault = per-universe secret store; vending = process-env (operator) capability tier.

## What changed

- `workflow/auth/provider.py`: add `vend_github_destination_secret()` + `_load_destination_secret_map()`. `"push"` reads canonical `WORKFLOW_GITHUB_PUSH_CAPABILITIES` with legacy `WORKFLOW_GITHUB_PR_CAPABILITIES` fallback; `"read"` reads `WORKFLOW_GITHUB_READ_CAPABILITIES`. Tokens stay daemon-side.
- `workflow/effectors/github_pr.py`: `_read_capability` keeps vault-first, routes the env tier through `_vend_push_token` -> the shared helper. `_load_capability_map` removed (its semantics now live in the provider). `missing_capability` evidence keeps `capability_env_var` pointed at the legacy name (consumer compat) and additively advertises `push_capability_env_var`.
- `tests/test_github_secret_vending.py`: new — vending helper (canonical/legacy/read env routing, malformed JSON, empty entries) + `_read_capability` resolution order (vault beats env, empty vault blocks env, legacy env still works).
- Plugin mirror rebuilt (`build_plugin.py`); pre-commit mirror parity verified.

## Backward compatibility

Legacy `WORKFLOW_GITHUB_PR_CAPABILITIES` still vends tokens (fallback). Existing `test_external_write_phase_2.py` capability tests stay green unchanged.

## Verification

- `tests/test_external_write_*`, `tests/test_github_pr_*`, `tests/test_github_secret_vending`, `tests/test_credential_vault`, `tests/test_optional_auth_mode`, `tests/test_action_scopes`, `tests/test_permission_decisions`, `tests/test_soul_scoped_effect_authority`: **192 passed** (`-p no:cacheprovider`, isolated `WORKFLOW_DATA_DIR`).
- `ruff check` on touched files (canonical + mirror + test): clean.

Recovery: issue #1346; supersedes PR #1286 (source SHA `42569fa2`). Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)