### PR TITLE
de-fantasy Tier C: neutralize fantasy fallbacks

### DIFF
--- a/fantasy_daemon/branch_registrations.py
+++ b/fantasy_daemon/branch_registrations.py
@@ -30,7 +30,10 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from workflow.domain_registry import register_domain_callable
+from workflow.domain_registry import (
+    register_domain_branch_slug,
+    register_domain_callable,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -209,3 +212,5 @@ def _restartable_work_exists(universe_path: Path) -> bool:
 register_domain_callable(
     "fantasy_author", "universe_cycle_wrapper", universe_cycle_wrapper,
 )
+register_domain_branch_slug("fantasy_author", "fantasy_author/universe-cycle")
+register_domain_branch_slug("fantasy_author", "fantasy_author:universe_cycle_wrapper")

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -354,7 +354,10 @@ def _universe_loop_dispatch(udir: Path) -> tuple[str, dict[str, Any]]:
             "caveat": (
                 "Legacy universe has PROGRAM.md but no soul.md; keeping the "
                 "fantasy loop as an explicit compatibility path only until "
-                "the universe is migrated to a soul-declared loop."
+                "the universe is migrated to a soul-declared loop. Scheduled "
+                "for removal once PROGRAM.md-only universes are migrated; "
+                "tracked under the de-fantasy audit "
+                "docs/audits/2026-06-24-fantasy-architecture-residue-audit.md."
             ),
         }
     branch_def_id = soul.loop_branch_def_id.strip()

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -336,13 +336,25 @@ def _synthesis_first_run_checklist(has_premise: bool) -> dict[str, Any]:
 def _universe_loop_dispatch(udir: Path) -> tuple[str, dict[str, Any]]:
     soul = read_universe_soul(udir)
     if soul is None:
+        if not read_legacy_premise(udir).strip():
+            return NO_LOOP_DECLARED, {
+                "source": "no_soul_no_loop_declared",
+                "has_soul": False,
+                "branch_def_id": "",
+                "error": "universe_loop_not_declared",
+                "note": (
+                    "This universe has no soul.md and no legacy PROGRAM.md; "
+                    "declare a Loop branch in soul.md before queuing work."
+                ),
+            }
         return LEGACY_FANTASY_LOOP_BRANCH_DEF_ID, {
-            "source": "legacy_no_soul_compat",
+            "source": "legacy_program_fantasy_compat",
             "has_soul": False,
             "branch_def_id": LEGACY_FANTASY_LOOP_BRANCH_DEF_ID,
             "caveat": (
-                "Legacy universe has no soul.md; keeping the existing fantasy "
-                "loop only until the universe is migrated to a soul-declared loop."
+                "Legacy universe has PROGRAM.md but no soul.md; keeping the "
+                "fantasy loop as an explicit compatibility path only until "
+                "the universe is migrated to a soul-declared loop."
             ),
         }
     branch_def_id = soul.loop_branch_def_id.strip()

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/domain_registry.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/domain_registry.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 _DomainCallable = Callable[[dict[str, Any]], dict[str, Any]]
 
 _REGISTRY: dict[tuple[str, str], _DomainCallable] = {}
+_DOMAIN_BRANCH_SLUGS: dict[str, set[str]] = {}
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,6 +77,36 @@ def clear_registry() -> None:
     """Testing-only helper; drops all registrations."""
     _REGISTRY.clear()
     _EPISODIC_COORDINATE_SHAPES.clear()
+    _DOMAIN_BRANCH_SLUGS.clear()
+
+
+def register_domain_branch_slug(domain_id: str, branch_slug: str) -> None:
+    """Register a Branch slug owned by a domain.
+
+    Goal-pool subscribers use this to discover always-available domain
+    branches without core producer code naming any one domain.
+    """
+    clean_domain = domain_id.strip()
+    clean_slug = branch_slug.strip()
+    if not clean_domain or not clean_slug:
+        return
+    _DOMAIN_BRANCH_SLUGS.setdefault(clean_domain, set()).add(clean_slug)
+
+
+def registered_domain_branch_slugs(domain_id: str = "") -> tuple[str, ...]:
+    """Return registered Branch slugs, optionally limited to one domain."""
+    clean_domain = domain_id.strip()
+    if clean_domain:
+        return tuple(sorted(_DOMAIN_BRANCH_SLUGS.get(clean_domain, set())))
+    slugs: set[str] = set()
+    for domain_slugs in _DOMAIN_BRANCH_SLUGS.values():
+        slugs.update(domain_slugs)
+    return tuple(sorted(slugs))
+
+
+def clear_domain_branch_slugs() -> None:
+    """Testing-only helper; drops registered domain Branch slugs."""
+    _DOMAIN_BRANCH_SLUGS.clear()
 
 
 def register_episodic_coordinate_shape(

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/producers/goal_pool.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/producers/goal_pool.py
@@ -186,6 +186,20 @@ def _accessible_branch_slugs(repo_root: Path, universe_path: Path | None = None)
 
     Per R9: subscriber's accessible Branches = public (in
     ``<repo_root>/branches/*.yaml``) plus subscriber-local.
+
+    Domain branch slugs (e.g. the fantasy loop wrapper) are added only via
+    ``registered_domain_branch_slugs()``, which a domain populates as an
+    import-time side effect. Per the engine-is-infrastructure principle
+    (``workflow/domain_registry.py``) the engine never imports a specific
+    domain, so this set is **process-dependent by design**: a process that has
+    not loaded a domain (the cloud-worker producer pump, the plugin runtime)
+    will not see that domain's slugs, and a goal-pool task targeting one is
+    skipped here. That is not a lost task — the domain's own daemon, which
+    imports its registrations, still scans the pool at graph-start. Re-injecting
+    a hardcoded domain slug to "fix" this divergence would re-couple the engine
+    to a domain and is explicitly not wanted. See
+    ``test_goal_pool_skips_fantasy_seed_when_unregistered`` /
+    ``test_goal_pool_accepts_registered_fantasy_seed`` which pin both halves.
     """
     from workflow.domain_registry import registered_domain_branch_slugs
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/producers/goal_pool.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/producers/goal_pool.py
@@ -194,8 +194,12 @@ def _accessible_branch_slugs(repo_root: Path, universe_path: Path | None = None)
     domain, so this set is **process-dependent by design**: a process that has
     not loaded a domain (the cloud-worker producer pump, the plugin runtime)
     will not see that domain's slugs, and a goal-pool task targeting one is
-    skipped here. That is not a lost task — the domain's own daemon, which
-    imports its registrations, still scans the pool at graph-start. Re-injecting
+    skipped here **when the subscriber can reach at least one other branch**
+    (the accessibility filter in ``_parse_pool_yaml`` fail-OPENS on a fully
+    empty accessible set — see
+    ``test_goal_pool_fails_open_when_no_accessible_slugs``). That is not a lost
+    task — the domain's own daemon, which imports its registrations, still scans
+    the pool at graph-start. Re-injecting
     a hardcoded domain slug to "fix" this divergence would re-couple the engine
     to a domain and is explicitly not wanted. See
     ``test_goal_pool_skips_fantasy_seed_when_unregistered`` /
@@ -362,6 +366,12 @@ class GoalPoolProducer:
             return None
 
         # R9 / invariant 6: reject branch slugs the subscriber can't run.
+        # Conditional by design: an empty ``accessible_slugs`` means the
+        # subscriber could not enumerate ANY branch ("can't determine
+        # accessibility"), so the filter fail-OPENS and the task is queued
+        # rather than silently dropped. Not fantasy-specific. Pinned by
+        # ``test_goal_pool_fails_open_when_no_accessible_slugs``; the non-empty
+        # filter half is pinned by the de-fantasy divergence tests.
         if accessible_slugs and branch_def_id not in accessible_slugs:
             logger.info(
                 "goal_pool: branch_def_id=%r not in accessible slugs; "

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/producers/goal_pool.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/producers/goal_pool.py
@@ -187,6 +187,8 @@ def _accessible_branch_slugs(repo_root: Path, universe_path: Path | None = None)
     Per R9: subscriber's accessible Branches = public (in
     ``<repo_root>/branches/*.yaml``) plus subscriber-local.
     """
+    from workflow.domain_registry import registered_domain_branch_slugs
+
     slugs: set[str] = set()
     branches_dir = repo_root / "branches"
     if branches_dir.is_dir():
@@ -194,10 +196,7 @@ def _accessible_branch_slugs(repo_root: Path, universe_path: Path | None = None)
             slugs.add(p.stem)
     if universe_path is not None:
         slugs.update(_catalog_branch_slugs(universe_path))
-    # Fantasy seed always available — the wrapper is registered
-    # at import time via domain registry.
-    slugs.add("fantasy_author/universe-cycle")
-    slugs.add("fantasy_author:universe_cycle_wrapper")
+    slugs.update(registered_domain_branch_slugs())
     return slugs
 
 

--- a/tests/test_goal_pool.py
+++ b/tests/test_goal_pool.py
@@ -397,6 +397,34 @@ def test_goal_pool_accepts_registered_fantasy_seed(repo_root, universe_dir):
     assert out[0].branch_def_id == "fantasy_author:universe_cycle_wrapper"
 
 
+def test_goal_pool_skips_fantasy_seed_when_unregistered(repo_root, universe_dir):
+    """Pin the process-dependent de-fantasy divergence.
+
+    In a process that has NOT loaded the fantasy domain (the cloud-worker
+    producer pump, the plugin runtime), ``registered_domain_branch_slugs()`` is
+    empty, so a goal-pool task targeting the fantasy wrapper is skipped here.
+    This is the intended engine-is-infrastructure contract, not a silent
+    regression: the fantasy daemon (which imports its registrations) still
+    scans the pool at graph-start. The complement of
+    ``test_goal_pool_accepts_registered_fantasy_seed`` — together they make the
+    divergence an explicit, tested contract instead of a hidden one.
+    """
+    from workflow.domain_registry import clear_domain_branch_slugs
+
+    clear_domain_branch_slugs()  # simulate a process without the fantasy domain
+    # A real repo has public branches, so the accessible-slug filter is active
+    # (it is fail-open only when the subscriber can reach NO slugs at all). The
+    # fantasy wrapper is simply absent from the accessible set in this process.
+    (repo_root / "branches" / "public_branch.yaml").write_text("{}", encoding="utf-8")
+    _write_pool_yaml(repo_root, "maintenance", "unregistered_fantasy_seed")
+
+    out = GoalPoolProducer().produce(
+        universe_dir, subscribed_goals=["maintenance"],
+    )
+
+    assert out == []
+
+
 def test_goal_pool_mtime_cache_invalidation(repo_root, universe_dir):
     """R3: mtime-based cache. Adding a file invalidates."""
     _write_pool_yaml(repo_root, "maintenance", "first")

--- a/tests/test_goal_pool.py
+++ b/tests/test_goal_pool.py
@@ -17,6 +17,7 @@ pinning avoids needing a git scaffold.
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 from pathlib import Path
@@ -45,6 +46,7 @@ from workflow.producers.goal_pool import (
     POOL_DIRNAME,
     POOL_ORIGIN,
     GoalPoolProducer,
+    _accessible_branch_slugs,
     goal_pool_enabled,
     repo_root_path,
     validate_pool_task_inputs,
@@ -72,9 +74,16 @@ def _clean_branch_task_registry():
     bt_producer_mod._REGISTRY.extend(saved)
 
 
+def _register_fantasy_branch_slugs() -> None:
+    import fantasy_daemon.branch_registrations as registrations
+
+    importlib.reload(registrations)
+
+
 @pytest.fixture
 def repo_root(tmp_path: Path, monkeypatch) -> Path:
     """Tmp repo-root with env pinning (avoids git scaffolding)."""
+    _register_fantasy_branch_slugs()
     root = tmp_path / "repo"
     root.mkdir()
     (root / "branches").mkdir()
@@ -93,6 +102,7 @@ def universe_dir(tmp_path: Path) -> Path:
 @pytest.fixture
 def two_universe(tmp_path: Path, monkeypatch) -> tuple[Path, Path, Path]:
     """Two universes sharing a repo_root. Returns (repo_root, uni_a, uni_b)."""
+    _register_fantasy_branch_slugs()
     root = tmp_path / "shared_repo"
     root.mkdir()
     (root / "branches").mkdir()
@@ -360,6 +370,31 @@ def test_goal_pool_unresolved_branch_slug_skipped(
         universe_dir, subscribed_goals=["maintenance"],
     )
     assert out == []
+
+
+def test_accessible_branch_slugs_do_not_inject_fantasy_by_default(
+    repo_root, universe_dir,
+):
+    from workflow.domain_registry import clear_domain_branch_slugs
+
+    clear_domain_branch_slugs()
+
+    assert _accessible_branch_slugs(repo_root, universe_dir) == set()
+
+
+def test_goal_pool_accepts_registered_fantasy_seed(repo_root, universe_dir):
+    from workflow.domain_registry import clear_domain_branch_slugs
+
+    clear_domain_branch_slugs()
+    _register_fantasy_branch_slugs()
+    _write_pool_yaml(repo_root, "maintenance", "registered_fantasy_seed")
+
+    out = GoalPoolProducer().produce(
+        universe_dir, subscribed_goals=["maintenance"],
+    )
+
+    assert len(out) == 1
+    assert out[0].branch_def_id == "fantasy_author:universe_cycle_wrapper"
 
 
 def test_goal_pool_mtime_cache_invalidation(repo_root, universe_dir):
@@ -947,6 +982,15 @@ def test_repo_root_raises_when_unresolvable(tmp_path, monkeypatch):
     monkeypatch.delenv("WORKFLOW_REPO_ROOT", raising=False)
     bare = tmp_path / "bare"
     bare.mkdir()
+    checked_dirs = {bare.resolve(), *bare.resolve().parents}
+    real_exists = Path.exists
+
+    def exists_without_git_ancestor(path: Path) -> bool:
+        if path.name == ".git" and path.parent in checked_dirs:
+            return False
+        return real_exists(path)
+
+    monkeypatch.setattr(Path, "exists", exists_without_git_ancestor)
     with pytest.raises(RuntimeError, match="WORKFLOW_REPO_ROOT"):
         repo_root_path(bare)
 

--- a/tests/test_goal_pool.py
+++ b/tests/test_goal_pool.py
@@ -425,6 +425,36 @@ def test_goal_pool_skips_fantasy_seed_when_unregistered(repo_root, universe_dir)
     assert out == []
 
 
+def test_goal_pool_fails_open_when_no_accessible_slugs(repo_root, universe_dir):
+    """Pin the fail-OPEN half of the accessibility filter.
+
+    The guard in ``_parse_pool_yaml`` is ``if accessible_slugs and ...`` — it
+    only filters when the subscriber can reach at least one branch. When the
+    accessible set is genuinely empty (no public branches, no catalog slugs, no
+    registered domain — a bare/degenerate repo, or enumeration that legitimately
+    found nothing) the filter fail-OPENS and the task is queued rather than
+    silently dropped, because an empty set means "can't determine accessibility,"
+    not "this branch is inaccessible." This is intentional and NOT
+    fantasy-specific. Pinning it keeps the fail-open an explicit contract so a
+    future "tighten the guard" change has to confront this test rather than
+    silently flipping degenerate-repo behavior to fail-closed.
+    """
+    from workflow.domain_registry import clear_domain_branch_slugs
+
+    clear_domain_branch_slugs()  # no registered domain slugs
+    # Deliberately create NO public branch, so accessible_slugs stays empty
+    # (the complement of test_goal_pool_skips_fantasy_seed_when_unregistered,
+    # which seeds public_branch.yaml to activate the filter).
+    _write_pool_yaml(repo_root, "maintenance", "seed_in_bare_repo")
+
+    out = GoalPoolProducer().produce(
+        universe_dir, subscribed_goals=["maintenance"],
+    )
+
+    assert len(out) == 1
+    assert out[0].branch_def_id == "fantasy_author:universe_cycle_wrapper"
+
+
 def test_goal_pool_mtime_cache_invalidation(repo_root, universe_dir):
     """R3: mtime-based cache. Adding a file invalidates."""
     _write_pool_yaml(repo_root, "maintenance", "first")

--- a/tests/test_universe_server_ledger.py
+++ b/tests/test_universe_server_ledger.py
@@ -156,6 +156,11 @@ def test_give_direction_accepts_line_anchor(universe: str) -> None:
 
 
 def test_submit_request_appends_ledger(universe: str) -> None:
+    (us._base_path() / universe / "PROGRAM.md").write_text(
+        "A legacy fantasy premise.",
+        encoding="utf-8",
+    )
+
     out = _call("submit_request", text="Please add a dragon.", request_type="scene_direction")
     assert out["status"] == "pending"
 
@@ -164,7 +169,9 @@ def test_submit_request_appends_ledger(universe: str) -> None:
     assert entries[0]["action"] == "submit_request"
     assert entries[0]["target"] == out["request_id"]
     assert entries[0]["payload"]["request_type"] == "scene_direction"
-    assert entries[0]["payload"]["loop_dispatch"]["source"] == "legacy_no_soul_compat"
+    assert entries[0]["payload"]["loop_dispatch"]["source"] == (
+        "legacy_program_fantasy_compat"
+    )
 
 
 def test_add_canon_appends_ledger(universe: str) -> None:

--- a/tests/test_universe_soul.py
+++ b/tests/test_universe_soul.py
@@ -190,9 +190,28 @@ def test_submit_request_rejects_souled_universe_without_declared_loop(us):
     assert not (base / "thin-uni" / "branch_tasks.json").exists()
 
 
-def test_submit_request_legacy_no_soul_keeps_named_compat_loop(us):
+def test_submit_request_rejects_soulless_universe_without_legacy_marker(us):
+    base = Path(us._base_path())
+    empty = _mkuniverse(base, "empty-uni")
+    assert not (empty / "soul.md").exists()
+
+    result = json.loads(us._action_submit_request(
+        universe_id="empty-uni",
+        text="Do undeclared work.",
+        request_type="general",
+    ))
+
+    assert result["error"] == "universe_loop_not_declared"
+    assert result["loop_dispatch"]["source"] == "no_soul_no_loop_declared"
+    assert result["loop_dispatch"]["branch_def_id"] == ""
+    assert not (empty / "requests.json").exists()
+    assert not (empty / "branch_tasks.json").exists()
+
+
+def test_submit_request_legacy_program_no_soul_keeps_named_compat_loop(us):
     base = Path(us._base_path())
     legacy = _mkuniverse(base, "legacy-uni")
+    (legacy / "PROGRAM.md").write_text("A legacy fantasy premise.", encoding="utf-8")
     assert not (legacy / "soul.md").exists()
 
     result = json.loads(us._action_submit_request(
@@ -202,6 +221,6 @@ def test_submit_request_legacy_no_soul_keeps_named_compat_loop(us):
     ))
 
     assert result["status"] == "pending"
-    assert result["loop_dispatch"]["source"] == "legacy_no_soul_compat"
+    assert result["loop_dispatch"]["source"] == "legacy_program_fantasy_compat"
     queue = json.loads((legacy / "branch_tasks.json").read_text(encoding="utf-8"))
     assert queue[0]["branch_def_id"] == "fantasy_author:universe_cycle_wrapper"

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -354,7 +354,10 @@ def _universe_loop_dispatch(udir: Path) -> tuple[str, dict[str, Any]]:
             "caveat": (
                 "Legacy universe has PROGRAM.md but no soul.md; keeping the "
                 "fantasy loop as an explicit compatibility path only until "
-                "the universe is migrated to a soul-declared loop."
+                "the universe is migrated to a soul-declared loop. Scheduled "
+                "for removal once PROGRAM.md-only universes are migrated; "
+                "tracked under the de-fantasy audit "
+                "docs/audits/2026-06-24-fantasy-architecture-residue-audit.md."
             ),
         }
     branch_def_id = soul.loop_branch_def_id.strip()

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -336,13 +336,25 @@ def _synthesis_first_run_checklist(has_premise: bool) -> dict[str, Any]:
 def _universe_loop_dispatch(udir: Path) -> tuple[str, dict[str, Any]]:
     soul = read_universe_soul(udir)
     if soul is None:
+        if not read_legacy_premise(udir).strip():
+            return NO_LOOP_DECLARED, {
+                "source": "no_soul_no_loop_declared",
+                "has_soul": False,
+                "branch_def_id": "",
+                "error": "universe_loop_not_declared",
+                "note": (
+                    "This universe has no soul.md and no legacy PROGRAM.md; "
+                    "declare a Loop branch in soul.md before queuing work."
+                ),
+            }
         return LEGACY_FANTASY_LOOP_BRANCH_DEF_ID, {
-            "source": "legacy_no_soul_compat",
+            "source": "legacy_program_fantasy_compat",
             "has_soul": False,
             "branch_def_id": LEGACY_FANTASY_LOOP_BRANCH_DEF_ID,
             "caveat": (
-                "Legacy universe has no soul.md; keeping the existing fantasy "
-                "loop only until the universe is migrated to a soul-declared loop."
+                "Legacy universe has PROGRAM.md but no soul.md; keeping the "
+                "fantasy loop as an explicit compatibility path only until "
+                "the universe is migrated to a soul-declared loop."
             ),
         }
     branch_def_id = soul.loop_branch_def_id.strip()

--- a/workflow/domain_registry.py
+++ b/workflow/domain_registry.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 _DomainCallable = Callable[[dict[str, Any]], dict[str, Any]]
 
 _REGISTRY: dict[tuple[str, str], _DomainCallable] = {}
+_DOMAIN_BRANCH_SLUGS: dict[str, set[str]] = {}
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,6 +77,36 @@ def clear_registry() -> None:
     """Testing-only helper; drops all registrations."""
     _REGISTRY.clear()
     _EPISODIC_COORDINATE_SHAPES.clear()
+    _DOMAIN_BRANCH_SLUGS.clear()
+
+
+def register_domain_branch_slug(domain_id: str, branch_slug: str) -> None:
+    """Register a Branch slug owned by a domain.
+
+    Goal-pool subscribers use this to discover always-available domain
+    branches without core producer code naming any one domain.
+    """
+    clean_domain = domain_id.strip()
+    clean_slug = branch_slug.strip()
+    if not clean_domain or not clean_slug:
+        return
+    _DOMAIN_BRANCH_SLUGS.setdefault(clean_domain, set()).add(clean_slug)
+
+
+def registered_domain_branch_slugs(domain_id: str = "") -> tuple[str, ...]:
+    """Return registered Branch slugs, optionally limited to one domain."""
+    clean_domain = domain_id.strip()
+    if clean_domain:
+        return tuple(sorted(_DOMAIN_BRANCH_SLUGS.get(clean_domain, set())))
+    slugs: set[str] = set()
+    for domain_slugs in _DOMAIN_BRANCH_SLUGS.values():
+        slugs.update(domain_slugs)
+    return tuple(sorted(slugs))
+
+
+def clear_domain_branch_slugs() -> None:
+    """Testing-only helper; drops registered domain Branch slugs."""
+    _DOMAIN_BRANCH_SLUGS.clear()
 
 
 def register_episodic_coordinate_shape(

--- a/workflow/producers/goal_pool.py
+++ b/workflow/producers/goal_pool.py
@@ -186,6 +186,20 @@ def _accessible_branch_slugs(repo_root: Path, universe_path: Path | None = None)
 
     Per R9: subscriber's accessible Branches = public (in
     ``<repo_root>/branches/*.yaml``) plus subscriber-local.
+
+    Domain branch slugs (e.g. the fantasy loop wrapper) are added only via
+    ``registered_domain_branch_slugs()``, which a domain populates as an
+    import-time side effect. Per the engine-is-infrastructure principle
+    (``workflow/domain_registry.py``) the engine never imports a specific
+    domain, so this set is **process-dependent by design**: a process that has
+    not loaded a domain (the cloud-worker producer pump, the plugin runtime)
+    will not see that domain's slugs, and a goal-pool task targeting one is
+    skipped here. That is not a lost task — the domain's own daemon, which
+    imports its registrations, still scans the pool at graph-start. Re-injecting
+    a hardcoded domain slug to "fix" this divergence would re-couple the engine
+    to a domain and is explicitly not wanted. See
+    ``test_goal_pool_skips_fantasy_seed_when_unregistered`` /
+    ``test_goal_pool_accepts_registered_fantasy_seed`` which pin both halves.
     """
     from workflow.domain_registry import registered_domain_branch_slugs
 

--- a/workflow/producers/goal_pool.py
+++ b/workflow/producers/goal_pool.py
@@ -194,8 +194,12 @@ def _accessible_branch_slugs(repo_root: Path, universe_path: Path | None = None)
     domain, so this set is **process-dependent by design**: a process that has
     not loaded a domain (the cloud-worker producer pump, the plugin runtime)
     will not see that domain's slugs, and a goal-pool task targeting one is
-    skipped here. That is not a lost task — the domain's own daemon, which
-    imports its registrations, still scans the pool at graph-start. Re-injecting
+    skipped here **when the subscriber can reach at least one other branch**
+    (the accessibility filter in ``_parse_pool_yaml`` fail-OPENS on a fully
+    empty accessible set — see
+    ``test_goal_pool_fails_open_when_no_accessible_slugs``). That is not a lost
+    task — the domain's own daemon, which imports its registrations, still scans
+    the pool at graph-start. Re-injecting
     a hardcoded domain slug to "fix" this divergence would re-couple the engine
     to a domain and is explicitly not wanted. See
     ``test_goal_pool_skips_fantasy_seed_when_unregistered`` /
@@ -362,6 +366,12 @@ class GoalPoolProducer:
             return None
 
         # R9 / invariant 6: reject branch slugs the subscriber can't run.
+        # Conditional by design: an empty ``accessible_slugs`` means the
+        # subscriber could not enumerate ANY branch ("can't determine
+        # accessibility"), so the filter fail-OPENS and the task is queued
+        # rather than silently dropped. Not fantasy-specific. Pinned by
+        # ``test_goal_pool_fails_open_when_no_accessible_slugs``; the non-empty
+        # filter half is pinned by the de-fantasy divergence tests.
         if accessible_slugs and branch_def_id not in accessible_slugs:
             logger.info(
                 "goal_pool: branch_def_id=%r not in accessible slugs; "

--- a/workflow/producers/goal_pool.py
+++ b/workflow/producers/goal_pool.py
@@ -187,6 +187,8 @@ def _accessible_branch_slugs(repo_root: Path, universe_path: Path | None = None)
     Per R9: subscriber's accessible Branches = public (in
     ``<repo_root>/branches/*.yaml``) plus subscriber-local.
     """
+    from workflow.domain_registry import registered_domain_branch_slugs
+
     slugs: set[str] = set()
     branches_dir = repo_root / "branches"
     if branches_dir.is_dir():
@@ -194,10 +196,7 @@ def _accessible_branch_slugs(repo_root: Path, universe_path: Path | None = None)
             slugs.add(p.stem)
     if universe_path is not None:
         slugs.update(_catalog_branch_slugs(universe_path))
-    # Fantasy seed always available — the wrapper is registered
-    # at import time via domain registry.
-    slugs.add("fantasy_author/universe-cycle")
-    slugs.add("fantasy_author:universe_cycle_wrapper")
+    slugs.update(registered_domain_branch_slugs())
     return slugs
 
 


### PR DESCRIPTION
Audit Tier C. Soul-less universes now return explicit `universe_loop_not_declared` (legacy `PROGRAM.md` keeps fantasy compat); goal_pool slugs come from a domain registry instead of hardcoded fantasy seeds. Codex-authored; Codex tests: focused 6 passed, broader 415 passed/2 failed (1 known framing + 1 `test_universe_treasury_status` flagged for lead review). Needs Claude opposite-provider review. 🤖 Generated with [Claude Code](https://claude.com/claude-code)