### PR TITLE
de-fantasy Tier B: flag-gated soul-loop worker routing (default OFF)

### DIFF
--- a/docs/design-notes/2026-06-25-tier-b-worker-spawn-defantasy.md
+++ b/docs/design-notes/2026-06-25-tier-b-worker-spawn-defantasy.md
@@ -92,9 +92,13 @@ only soul-loop executor used by this branch.
    `workflow/__main__.py` installs no SIGINT/SIGTERM handler. The supervisor
    stops subprocesses with `proc.terminate()` (SIGTERM) before `proc.kill()`
    (`cloud_worker.py`), so without a handler a supervisor-initiated restart
-   exits rc=-15, which `SupervisorState.record_exit` counts as a crash
-   (inflated backoff) and skips the graceful flush. Add a SIGTERM handler to
-   the soul-loop entrypoint as part of this gate.
+   exits rc=-15. The always-true consequence is that the graceful checkpoint
+   flush is skipped — no handler runs before exit. The crash-accounting impact
+   is path-dependent: on a supervisor *queue* restart `cloud_worker.py` forces
+   `returncode = 0`, so `SupervisorState.record_exit` does not count it as a
+   crash there; but on other supervisor-initiated SIGTERM paths the raw rc=-15
+   is recorded as a crash and inflates backoff. Add a SIGTERM handler to the
+   soul-loop entrypoint as part of this gate.
 4. Get opposite-provider review of the code, tests, and the hardening assessment.
 5. Enable the flag for one fresh dry-run universe only.
 6. Run a post-rollout public canary through the real chatbot connector surface

--- a/docs/design-notes/2026-06-25-tier-b-worker-spawn-defantasy.md
+++ b/docs/design-notes/2026-06-25-tier-b-worker-spawn-defantasy.md
@@ -85,7 +85,16 @@ only soul-loop executor used by this branch.
    and empty `effect_authority`.
 3. Run the AGENTS.md Section 14 concurrency/load proof against cloud-worker and
    host-worker overlap, including pending child BranchTasks, producer pumping,
-   restart/backoff behavior, and failure paths.
+   restart/backoff behavior, and failure paths. This proof MUST cover signal
+   handling for the `python -m workflow` subprocess: unlike the legacy
+   `fantasy_daemon` entrypoint (which installs a SIGTERM handler that sets
+   `_stop_event` for a graceful checkpoint flush — `fantasy_daemon/__main__.py`),
+   `workflow/__main__.py` installs no SIGINT/SIGTERM handler. The supervisor
+   stops subprocesses with `proc.terminate()` (SIGTERM) before `proc.kill()`
+   (`cloud_worker.py`), so without a handler a supervisor-initiated restart
+   exits rc=-15, which `SupervisorState.record_exit` counts as a crash
+   (inflated backoff) and skips the graceful flush. Add a SIGTERM handler to
+   the soul-loop entrypoint as part of this gate.
 4. Get opposite-provider review of the code, tests, and the hardening assessment.
 5. Enable the flag for one fresh dry-run universe only.
 6. Run a post-rollout public canary through the real chatbot connector surface

--- a/docs/design-notes/2026-06-25-tier-b-worker-spawn-defantasy.md
+++ b/docs/design-notes/2026-06-25-tier-b-worker-spawn-defantasy.md
@@ -1,0 +1,108 @@
+# Tier B worker-spawn de-fantasy scaffold
+
+Date: 2026-06-25
+Status: flag-gated scaffold; default-off
+Branch: `claude/defantasy-tierb-soulloop`
+
+## Context
+
+Tier B of `docs/audits/2026-06-24-fantasy-architecture-residue-audit.md`
+identified two production spawn paths that still privileged the fantasy daemon:
+
+- `workflow/__main__.py` allowed only `--domain fantasy_author` to execute.
+- `workflow/cloud_worker.py` default-spawned `python -m fantasy_daemon` for
+  every universe.
+
+`docs/design-notes/2026-06-03-soul-loop-dispatch-activation-plan.md` identified
+the intended execution path: a universe with `soul.md` and a declared
+`loop_branch_def_id` should run that branch through `workflow.runs.execute_branch`
+instead of building a second runner. The existing implementation in
+`fantasy_daemon/__main__.py::_try_execute_soul_loop` is gated by
+`WORKFLOW_SOUL_LOOP_DISPATCH`, so this branch wires production spawning to that
+dark path without changing the default.
+
+This PR does not flip `WORKFLOW_SOUL_LOOP_DISPATCH` on.
+
+## Assessment Of The Existing Dark Path
+
+What is already correct:
+
+- The flag defaults off via `_soul_loop_dispatch_enabled()`.
+- The branch id is resolved through `_universe_loop_dispatch`, the same resolver
+  used by the MCP submit path.
+- A declared non-legacy loop runs through `execute_branch`, so run status,
+  provider pumping inside the graph, in-node enqueue context, run records, and
+  run-level completion/failure semantics come from the normal branch executor.
+- Claimed child `BranchTask` rows still get first chance to run before the
+  root soul loop, preventing the driver from starving its own queued children.
+- Missing or invalid declared loop branches are handled as "cycle handled";
+  the daemon logs loudly and does not silently fall back to the fantasy cycle.
+
+What is not production-ready yet:
+
+- There is no BranchTask lease or BranchTask finalization for the root soul
+  loop because it is a root activation, not a claimed queue row. The relevant
+  finalization is run-level `execute_branch` status.
+- There is no claimed-task heartbeat/cancel observer for the root activation.
+  The cloud supervisor heartbeat still exists, but node-level heartbeat/cancel
+  semantics apply only to claimed BranchTasks.
+- A souled universe with no loop declaration currently falls through to the
+  legacy fantasy cycle in the daemon path. That is compatible with this
+  scaffold's "declared loop only" routing, but it is a default-on blocker
+  because the MCP path refuses `universe_loop_not_declared`.
+- Loop-dispatch resolver exceptions currently return `False` from the daemon's
+  `_try_execute_soul_loop`, which also falls through to the fantasy cycle. A
+  default-on rollout needs fail-closed behavior for malformed or unreadable
+  souled universes.
+- `workflow/__main__.py` still delegates to `fantasy_daemon.DaemonController`;
+  the runtime is not fully extracted. This branch only relaxes the non-fantasy
+  gate when the flag is on and the universe resolves to a declared non-legacy
+  soul loop.
+
+## Activation Approach
+
+The scaffold adds routing, not a new executor:
+
+- `workflow/cloud_worker.py` now chooses `python -m workflow` only when
+  `WORKFLOW_SOUL_LOOP_DISPATCH` is truthy and `_universe_loop_dispatch(universe)`
+  returns a real non-legacy branch id.
+- Flag off, no soul, no loop declaration, or the legacy fantasy loop all keep the
+  existing `python -m fantasy_daemon` subprocess path and call shape.
+- `workflow/__main__.py` accepts `--provider` so cloud-worker provider pinning
+  remains valid when the generic module route is selected.
+- `workflow/__main__.py` keeps rejecting non-fantasy domains unless the same
+  flag-on declared-soul-loop condition is true.
+
+The selected `python -m workflow` process still delegates into
+`DaemonController`, so the existing dark `_try_execute_soul_loop` path is the
+only soul-loop executor used by this branch.
+
+## Staged Rollout Plan
+
+1. Land this flag-gated scaffold with `WORKFLOW_SOUL_LOOP_DISPATCH` off in all
+   production environments.
+2. Run a local dry-run universe with `soul.md`, a declared `loop_branch_def_id`,
+   and empty `effect_authority`.
+3. Run the AGENTS.md Section 14 concurrency/load proof against cloud-worker and
+   host-worker overlap, including pending child BranchTasks, producer pumping,
+   restart/backoff behavior, and failure paths.
+4. Get opposite-provider review of the code, tests, and the hardening assessment.
+5. Enable the flag for one fresh dry-run universe only.
+6. Run a post-rollout public canary through the real chatbot connector surface
+   and record the rendered transcript/screenshot path.
+7. Check post-fix real-user or canary evidence before broadening. If no real
+   clean use is visible, leave a watch item instead of claiming default-on
+   readiness.
+8. Only after the above, consider changing the production default.
+
+## Required Gates Before Default-On
+
+- AGENTS.md Section 14 concurrency/load proof for worker overlap and restart
+  safety.
+- Post-rollout public canary through the live connector path.
+- Opposite-provider review.
+- Explicit reconciliation of the souled-but-no-loop behavior so daemon and MCP
+  semantics do not diverge.
+
+Until those gates are satisfied, `WORKFLOW_SOUL_LOOP_DISPATCH` remains an
+opt-in flag and fantasy/soulless universes keep the current production default.

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/__main__.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/__main__.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sys
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +114,42 @@ def _build_argparser() -> argparse.ArgumentParser:
         help="Disable desktop tray (for headless operation)",
     )
 
+    parser.add_argument(
+        "--provider",
+        type=str,
+        default="",
+        help="Pin the supervised writer provider",
+    )
+
     return parser
+
+
+def _truthy_env(name: str) -> bool:
+    value = os.environ.get(name, "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _declared_soul_loop_dispatch_requested(universe: str | None) -> bool:
+    """Return True when the Phase 5 bridge may run a non-fantasy domain."""
+    if not universe or not _truthy_env("WORKFLOW_SOUL_LOOP_DISPATCH"):
+        return False
+    try:
+        from workflow.api.universe import (
+            LEGACY_FANTASY_LOOP_BRANCH_DEF_ID,
+            _universe_loop_dispatch,
+        )
+
+        loop_branch_def_id, _info = _universe_loop_dispatch(Path(universe))
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "Failed to resolve soul loop dispatch for universe %s",
+            universe,
+        )
+        return False
+    return bool(
+        loop_branch_def_id
+        and loop_branch_def_id != LEGACY_FANTASY_LOOP_BRANCH_DEF_ID
+    )
 
 
 def main() -> int:
@@ -161,14 +198,22 @@ def main() -> int:
     # the runtime. Once the runtime is extracted, this will build and execute
     # the domain's graph directly.
 
-    if args.domain != "fantasy_author":
+    declared_soul_loop = _declared_soul_loop_dispatch_requested(args.universe)
+    if args.domain != "fantasy_author" and not declared_soul_loop:
         logger.error(
             "Only fantasy_author domain is fully operational in this phase. "
             "Other domains can be registered but cannot yet be executed. "
-            "Use --domain fantasy_author or the domain will be looked up but "
-            "delegation will fail."
+            "Use --domain fantasy_author, or enable WORKFLOW_SOUL_LOOP_DISPATCH "
+            "for a universe with a declared soul loop."
         )
         return 1
+    if args.domain != "fantasy_author":
+        logger.info(
+            "Using Phase 5 bridge for domain %s because %s declares a "
+            "flag-enabled soul loop",
+            args.domain,
+            args.universe,
+        )
 
     try:
         from fantasy_daemon.__main__ import DaemonController
@@ -177,6 +222,7 @@ def main() -> int:
             universe_path=args.universe,
             db_path=args.db,
             no_tray=args.no_tray,
+            pinned_provider=args.provider,
         )
 
         # If --api flag is set, start the API server alongside the daemon
@@ -201,4 +247,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/__main__.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/__main__.py
@@ -237,8 +237,11 @@ def main() -> int:
                 "Run 'python -m fantasy_daemon serve' separately."
             )
 
-        # Run the daemon
-        return controller.run()
+        # Run the daemon. DaemonController exposes start() (the blocking
+        # daemon loop); there is no run(). start() returns None on clean
+        # shutdown, so main() returns 0.
+        controller.start()
+        return 0
 
     except Exception as e:
         logger.error("Failed to run daemon: %s", e)

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker.py
@@ -279,6 +279,53 @@ def _truthy_env(name: str) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _soul_loop_declared_for_universe(universe: Path) -> bool:
+    """Return True when the dark soul-loop worker route should be used."""
+    if not _truthy_env("WORKFLOW_SOUL_LOOP_DISPATCH"):
+        return False
+    try:
+        from workflow.api.universe import (
+            LEGACY_FANTASY_LOOP_BRANCH_DEF_ID,
+            _universe_loop_dispatch,
+        )
+
+        loop_branch_def_id, _info = _universe_loop_dispatch(universe)
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "cloud_worker: soul-loop dispatch resolution failed for %s",
+            universe,
+        )
+        return False
+    return bool(
+        loop_branch_def_id
+        and loop_branch_def_id != LEGACY_FANTASY_LOOP_BRANCH_DEF_ID
+    )
+
+
+def _daemon_module_for_universe(universe: Path) -> str:
+    if _soul_loop_declared_for_universe(universe):
+        return "workflow"
+    return "fantasy_daemon"
+
+
+def _spawn_daemon_for_universe(
+    universe: Path,
+    *,
+    extra_args: list[str] | None = None,
+) -> subprocess.Popen:
+    """Spawn the legacy daemon, or the workflow bridge for flagged soul loops."""
+    module = _daemon_module_for_universe(universe)
+    if module == "fantasy_daemon":
+        if extra_args is None:
+            return _spawn_fantasy_daemon(universe)
+        return _spawn_fantasy_daemon(universe, extra_args=extra_args)
+    return _spawn_fantasy_daemon(
+        universe,
+        module=module,
+        extra_args=extra_args,
+    )
+
+
 def _register_branch_task_producers_from_env() -> None:
     """Register flag-enabled producers in this worker process.
 
@@ -533,7 +580,7 @@ def run_supervisor(
     """Run the supervisor loop until max_iterations or SIGTERM.
 
     Each iteration:
-      1. Spawn fantasy_daemon against the universe.
+      1. Spawn the daemon against the universe.
       2. Wait for it to exit.
       3. Record exit as clean or crash.
       4. Sleep with exponential backoff after consecutive clean exits or
@@ -543,16 +590,19 @@ def run_supervisor(
     ``max_iterations`` is an injection seam for tests — leave None in
     production for an unbounded loop. ``spawn_fn`` + ``sleep_fn`` are
     test seams so the loop can be exercised without subprocess I/O.
-    None defaults resolve to the module-level ``_spawn_fantasy_daemon``
+    None defaults resolve to the module-level ``_spawn_daemon_for_universe``
     + ``time.sleep`` at call time (not import time), so tests can
     monkeypatch the module attribute freely.
     """
     if spawn_fn is None:
         if daemon_args:
             def spawn_fn(universe: Path) -> subprocess.Popen:
-                return _spawn_fantasy_daemon(universe, extra_args=daemon_args)
+                return _spawn_daemon_for_universe(
+                    universe,
+                    extra_args=daemon_args,
+                )
         else:
-            spawn_fn = _spawn_fantasy_daemon
+            spawn_fn = _spawn_daemon_for_universe
     if sleep_fn is None:
         sleep_fn = time.sleep
 

--- a/tests/test_soul_loop_dispatch.py
+++ b/tests/test_soul_loop_dispatch.py
@@ -248,8 +248,11 @@ def test_workflow_cli_allows_non_fantasy_domain_for_declared_soul_loop(
         def __init__(self, **kwargs):
             created.append(kwargs)
 
-        def run(self):
-            return 0
+        # Mirror the REAL DaemonController interface: it exposes start()
+        # (blocking daemon loop, returns None), NOT run(). A fake with run()
+        # masked a production AttributeError — keep this matched to reality.
+        def start(self):
+            return None
 
     monkeypatch.setenv("WORKFLOW_SOUL_LOOP_DISPATCH", "on")
     monkeypatch.setattr(
@@ -291,3 +294,17 @@ def test_workflow_cli_allows_non_fantasy_domain_for_declared_soul_loop(
         "no_tray": True,
         "pinned_provider": "codex",
     }]
+
+
+def test_workflow_main_invokes_a_real_daemon_controller_method():
+    """Guard: __main__ must call a method the real DaemonController exposes.
+
+    A fake controller can satisfy main() with any method name, so the
+    monkeypatched test above cannot catch the activated path calling a method
+    the production class lacks. This asserts the real interface directly: the
+    soul-loop entrypoint blocks on start(); there is no run().
+    """
+    from fantasy_daemon.__main__ import DaemonController
+
+    assert hasattr(DaemonController, "start")
+    assert not hasattr(DaemonController, "run")

--- a/tests/test_soul_loop_dispatch.py
+++ b/tests/test_soul_loop_dispatch.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import fantasy_daemon.__main__ as dm
+import workflow.cloud_worker as cw
 
 LEGACY = "fantasy_author:universe_cycle_wrapper"
 
@@ -164,3 +165,129 @@ def test_declared_loop_not_found_refuses_no_fantasy_fallback(
     # through to the fantasy cycle, and must not execute anything.
     assert handled is True
     assert captured == []
+
+
+# Production worker routing stays flag-gated.
+
+def test_cloud_worker_defaults_to_fantasy_spawn_when_flag_off(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.delenv("WORKFLOW_SOUL_LOOP_DISPATCH", raising=False)
+    calls: list[dict[str, object]] = []
+
+    def fake_spawn(universe, *, module="fantasy_daemon", extra_args=None):
+        calls.append({
+            "universe": universe,
+            "module": module,
+            "extra_args": list(extra_args or []),
+        })
+        return SimpleNamespace(poll=lambda: 0, returncode=0)
+
+    monkeypatch.setattr(cw, "_spawn_fantasy_daemon", fake_spawn)
+
+    cw._spawn_daemon_for_universe(tmp_path, extra_args=["--provider", "codex"])
+
+    assert calls == [{
+        "universe": tmp_path,
+        "module": "fantasy_daemon",
+        "extra_args": ["--provider", "codex"],
+    }]
+
+
+def test_cloud_worker_routes_declared_soul_loop_to_workflow_module(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setenv("WORKFLOW_SOUL_LOOP_DISPATCH", "on")
+    monkeypatch.setattr(
+        "workflow.api.universe._universe_loop_dispatch",
+        lambda udir: ("branch-123", {"has_soul": True}),
+    )
+    calls: list[dict[str, object]] = []
+
+    def fake_spawn(universe, *, module="fantasy_daemon", extra_args=None):
+        calls.append({
+            "universe": universe,
+            "module": module,
+            "extra_args": list(extra_args or []),
+        })
+        return SimpleNamespace(poll=lambda: 0, returncode=0)
+
+    monkeypatch.setattr(cw, "_spawn_fantasy_daemon", fake_spawn)
+
+    cw._spawn_daemon_for_universe(tmp_path, extra_args=["--provider", "codex"])
+
+    assert calls == [{
+        "universe": tmp_path,
+        "module": "workflow",
+        "extra_args": ["--provider", "codex"],
+    }]
+
+
+def test_cloud_worker_keeps_legacy_module_for_soulless_or_legacy_loop(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setenv("WORKFLOW_SOUL_LOOP_DISPATCH", "on")
+    monkeypatch.setattr(
+        "workflow.api.universe._universe_loop_dispatch",
+        lambda udir: (LEGACY, {"has_soul": False}),
+    )
+
+    assert cw._daemon_module_for_universe(tmp_path) == "fantasy_daemon"
+
+
+def test_workflow_cli_allows_non_fantasy_domain_for_declared_soul_loop(
+    monkeypatch, tmp_path,
+):
+    import sys
+
+    import workflow.__main__ as workflow_main
+
+    created: list[dict[str, object]] = []
+
+    class FakeController:
+        def __init__(self, **kwargs):
+            created.append(kwargs)
+
+        def run(self):
+            return 0
+
+    monkeypatch.setenv("WORKFLOW_SOUL_LOOP_DISPATCH", "on")
+    monkeypatch.setattr(
+        "workflow.api.universe._universe_loop_dispatch",
+        lambda udir: ("branch-123", {"has_soul": True}),
+    )
+    monkeypatch.setattr("workflow.discovery.auto_register", lambda registry: None)
+    monkeypatch.setattr(
+        "workflow.registry.default_registry.get",
+        lambda domain: SimpleNamespace(name=domain),
+    )
+    monkeypatch.setattr(
+        "workflow.registry.default_registry.list_domains",
+        lambda: ["research_daemon"],
+    )
+    monkeypatch.setattr(
+        "fantasy_daemon.__main__.DaemonController",
+        FakeController,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "python -m workflow",
+            "--domain",
+            "research_daemon",
+            "--universe",
+            str(tmp_path),
+            "--no-tray",
+            "--provider",
+            "codex",
+        ],
+    )
+
+    assert workflow_main.main() == 0
+    assert created == [{
+        "universe_path": str(tmp_path),
+        "db_path": None,
+        "no_tray": True,
+        "pinned_provider": "codex",
+    }]

--- a/workflow/__main__.py
+++ b/workflow/__main__.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sys
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +114,42 @@ def _build_argparser() -> argparse.ArgumentParser:
         help="Disable desktop tray (for headless operation)",
     )
 
+    parser.add_argument(
+        "--provider",
+        type=str,
+        default="",
+        help="Pin the supervised writer provider",
+    )
+
     return parser
+
+
+def _truthy_env(name: str) -> bool:
+    value = os.environ.get(name, "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _declared_soul_loop_dispatch_requested(universe: str | None) -> bool:
+    """Return True when the Phase 5 bridge may run a non-fantasy domain."""
+    if not universe or not _truthy_env("WORKFLOW_SOUL_LOOP_DISPATCH"):
+        return False
+    try:
+        from workflow.api.universe import (
+            LEGACY_FANTASY_LOOP_BRANCH_DEF_ID,
+            _universe_loop_dispatch,
+        )
+
+        loop_branch_def_id, _info = _universe_loop_dispatch(Path(universe))
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "Failed to resolve soul loop dispatch for universe %s",
+            universe,
+        )
+        return False
+    return bool(
+        loop_branch_def_id
+        and loop_branch_def_id != LEGACY_FANTASY_LOOP_BRANCH_DEF_ID
+    )
 
 
 def main() -> int:
@@ -161,14 +198,22 @@ def main() -> int:
     # the runtime. Once the runtime is extracted, this will build and execute
     # the domain's graph directly.
 
-    if args.domain != "fantasy_author":
+    declared_soul_loop = _declared_soul_loop_dispatch_requested(args.universe)
+    if args.domain != "fantasy_author" and not declared_soul_loop:
         logger.error(
             "Only fantasy_author domain is fully operational in this phase. "
             "Other domains can be registered but cannot yet be executed. "
-            "Use --domain fantasy_author or the domain will be looked up but "
-            "delegation will fail."
+            "Use --domain fantasy_author, or enable WORKFLOW_SOUL_LOOP_DISPATCH "
+            "for a universe with a declared soul loop."
         )
         return 1
+    if args.domain != "fantasy_author":
+        logger.info(
+            "Using Phase 5 bridge for domain %s because %s declares a "
+            "flag-enabled soul loop",
+            args.domain,
+            args.universe,
+        )
 
     try:
         from fantasy_daemon.__main__ import DaemonController
@@ -177,6 +222,7 @@ def main() -> int:
             universe_path=args.universe,
             db_path=args.db,
             no_tray=args.no_tray,
+            pinned_provider=args.provider,
         )
 
         # If --api flag is set, start the API server alongside the daemon
@@ -201,4 +247,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/workflow/__main__.py
+++ b/workflow/__main__.py
@@ -237,8 +237,11 @@ def main() -> int:
                 "Run 'python -m fantasy_daemon serve' separately."
             )
 
-        # Run the daemon
-        return controller.run()
+        # Run the daemon. DaemonController exposes start() (the blocking
+        # daemon loop); there is no run(). start() returns None on clean
+        # shutdown, so main() returns 0.
+        controller.start()
+        return 0
 
     except Exception as e:
         logger.error("Failed to run daemon: %s", e)

--- a/workflow/cloud_worker.py
+++ b/workflow/cloud_worker.py
@@ -279,6 +279,53 @@ def _truthy_env(name: str) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _soul_loop_declared_for_universe(universe: Path) -> bool:
+    """Return True when the dark soul-loop worker route should be used."""
+    if not _truthy_env("WORKFLOW_SOUL_LOOP_DISPATCH"):
+        return False
+    try:
+        from workflow.api.universe import (
+            LEGACY_FANTASY_LOOP_BRANCH_DEF_ID,
+            _universe_loop_dispatch,
+        )
+
+        loop_branch_def_id, _info = _universe_loop_dispatch(universe)
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "cloud_worker: soul-loop dispatch resolution failed for %s",
+            universe,
+        )
+        return False
+    return bool(
+        loop_branch_def_id
+        and loop_branch_def_id != LEGACY_FANTASY_LOOP_BRANCH_DEF_ID
+    )
+
+
+def _daemon_module_for_universe(universe: Path) -> str:
+    if _soul_loop_declared_for_universe(universe):
+        return "workflow"
+    return "fantasy_daemon"
+
+
+def _spawn_daemon_for_universe(
+    universe: Path,
+    *,
+    extra_args: list[str] | None = None,
+) -> subprocess.Popen:
+    """Spawn the legacy daemon, or the workflow bridge for flagged soul loops."""
+    module = _daemon_module_for_universe(universe)
+    if module == "fantasy_daemon":
+        if extra_args is None:
+            return _spawn_fantasy_daemon(universe)
+        return _spawn_fantasy_daemon(universe, extra_args=extra_args)
+    return _spawn_fantasy_daemon(
+        universe,
+        module=module,
+        extra_args=extra_args,
+    )
+
+
 def _register_branch_task_producers_from_env() -> None:
     """Register flag-enabled producers in this worker process.
 
@@ -533,7 +580,7 @@ def run_supervisor(
     """Run the supervisor loop until max_iterations or SIGTERM.
 
     Each iteration:
-      1. Spawn fantasy_daemon against the universe.
+      1. Spawn the daemon against the universe.
       2. Wait for it to exit.
       3. Record exit as clean or crash.
       4. Sleep with exponential backoff after consecutive clean exits or
@@ -543,16 +590,19 @@ def run_supervisor(
     ``max_iterations`` is an injection seam for tests — leave None in
     production for an unbounded loop. ``spawn_fn`` + ``sleep_fn`` are
     test seams so the loop can be exercised without subprocess I/O.
-    None defaults resolve to the module-level ``_spawn_fantasy_daemon``
+    None defaults resolve to the module-level ``_spawn_daemon_for_universe``
     + ``time.sleep`` at call time (not import time), so tests can
     monkeypatch the module attribute freely.
     """
     if spawn_fn is None:
         if daemon_args:
             def spawn_fn(universe: Path) -> subprocess.Popen:
-                return _spawn_fantasy_daemon(universe, extra_args=daemon_args)
+                return _spawn_daemon_for_universe(
+                    universe,
+                    extra_args=daemon_args,
+                )
         else:
-            spawn_fn = _spawn_fantasy_daemon
+            spawn_fn = _spawn_daemon_for_universe
     if sleep_fn is None:
         sleep_fn = time.sleep
 


### PR DESCRIPTION
Audit Tier B. cloud_worker/__main__ route a souled universe's declared loop through `execute_branch` when `WORKFLOW_SOUL_LOOP_DISPATCH` is on; **default unchanged** (fantasy spawn). Design note + gate plan included. **NOT default-on** — blocked on AGENTS.md §14 concurrency/load proof + post-rollout canary + opposite-provider review + daemon/MCP semantics reconciliation for undeclared/malformed souled universes. Codex tests: test_soul_loop_dispatch 12 passed, test_cloud_worker 42 passed. 🤖 Generated with [Claude Code](https://claude.com/claude-code)