### PR TITLE
fix(loop): provider auth-health + worker self-quarantine (2026-06-25 loop-wedge)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
@@ -352,6 +352,36 @@ def _compute_auto_ship_health(
     return out
 
 
+# Subscription writers the loop relies on. Probed for auth-health so a dead
+# credential (the 2026-06-25 loop-wedge root cause — a worker whose claude-code
+# auth was missing claimed tasks and failed every one for ~3 weeks undetected)
+# is visible in get_status instead of buried in worker logs.
+_SUBSCRIPTION_WRITERS = ("codex", "claude-code")
+
+
+def _provider_auth_snapshot() -> dict[str, Any]:
+    """Presence-based auth health for the subscription writers + a roll-up.
+
+    Reads the same shared-volume auth paths the workers use (the main daemon
+    and workers share ``/data`` in the cloud deploy), so a writer whose creds
+    are missing surfaces here. ``all_writers_unauthenticated`` is the
+    actionable roll-up: when true the loop cannot produce at all.
+    """
+    from workflow.providers.base import subscription_auth_health
+
+    writers: dict[str, Any] = {}
+    known_states: list[str] = []
+    for name in _SUBSCRIPTION_WRITERS:
+        health = subscription_auth_health(name)
+        writers[name] = {"status": health["status"], "detail": health["detail"]}
+        if health["status"] in ("ok", "not_logged_in"):
+            known_states.append(health["status"])
+    all_down = bool(known_states) and all(
+        s == "not_logged_in" for s in known_states
+    )
+    return {"writers": writers, "all_writers_unauthenticated": all_down}
+
+
 def _compute_supervisor_liveness(
     udir: Any,
     *,
@@ -394,6 +424,36 @@ def _compute_supervisor_liveness(
         "warnings": [],
         "lease_data_available": True,
     }
+
+    # Provider auth health — surfaced before the queue read so a dead-writer
+    # roll-up is visible even if the queue read fails. Turns the loop_stalled
+    # warning's "provider auth?" suspicion into a concrete signal.
+    out["provider_auth"] = _provider_auth_snapshot()
+    _dead_writers = [
+        name
+        for name, info in out["provider_auth"]["writers"].items()
+        if info["status"] == "not_logged_in"
+    ]
+    if out["provider_auth"]["all_writers_unauthenticated"]:
+        out["warnings"].append(
+            "all_writers_unauthenticated: every subscription writer "
+            "(codex, claude-code) is unauthenticated — the loop cannot "
+            "produce. Re-seed provider auth on the worker volume. "
+            "(2026-06-25 loop-wedge root cause; workers now self-quarantine "
+            "rather than claim-and-poison the queue.)"
+        )
+    elif _dead_writers:
+        # Partial outage is the EXACT 2026-06-25 shape (claude dead, codex
+        # alive). Warn even though the loop still produces, so a degraded
+        # fleet is never silent (Hard Rule #8) — the dead workers
+        # self-quarantine and the loop runs at reduced writer capacity.
+        out["warnings"].append(
+            f"writer_unauthenticated: subscription writer(s) "
+            f"{', '.join(_dead_writers)} not logged in — those workers "
+            "self-quarantine (no claim, no poison) and the loop runs at "
+            "reduced writer capacity until re-seeded. (2026-06-25 partial "
+            "loop-wedge signature.)"
+        )
 
     try:
         from workflow.branch_tasks import read_queue
@@ -653,13 +713,21 @@ def get_status(universe_id: str = "") -> str:
     # always-local; codex+claude are subprocess-bound CLIs the daemon can drive;
     # xai/gemini/groq are API-key-backed network providers and are ignored
     # unless WORKFLOW_ALLOW_API_KEY_PROVIDERS is explicitly enabled.
+    # Claude is "bound" only when its binary AND subscription auth are present —
+    # the binary-only check let a dead-auth claude masquerade as bound (the
+    # 2026-06-25 blind spot). Codex already gates on auth.json below; mirror it.
+    from workflow.providers.base import subscription_auth_health as _auth_health
+    claude_authed = (
+        _shutil.which("claude")
+        and _auth_health("claude-code")["status"] != "not_logged_in"
+    )
     if os.environ.get("OLLAMA_HOST"):
         endpoint_hint = "ollama"
     elif api_key_enabled and os.environ.get("ANTHROPIC_BASE_URL"):
         endpoint_hint = "anthropic"
     elif _shutil.which("codex") and codex_auth_file.is_file():
         endpoint_hint = "codex"
-    elif _shutil.which("claude"):
+    elif claude_authed:
         endpoint_hint = "claude"
     elif api_key_enabled and os.environ.get("OPENAI_API_KEY") and _shutil.which("codex"):
         endpoint_hint = "codex"

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker.py
@@ -84,6 +84,11 @@ DEFAULT_MAX_BACKOFF_S = 300.0     # 5-min ceiling on exponential backoff.
 DEFAULT_BACKOFF_MULT = 2.0        # Doubling per consecutive crash.
 DEFAULT_POLL_INTERVAL_S = 0.5     # Subprocess monitor poll granularity.
 DEFAULT_PRODUCER_POLL_INTERVAL_S = 30.0  # Goal-pool pickup latency cap.
+# Re-check cadence while a worker is auth-quarantined. Short enough that a
+# re-seeded credential resumes claiming promptly; long enough that a dead-auth
+# worker doesn't spin. NOT escalated like crash backoff — auth-dead is a steady
+# state, not a crash, and must not feed the crash counter.
+DEFAULT_AUTH_QUARANTINE_BACKOFF_S = 60.0
 
 # Host identity. Matches AGENTS.md §Configuration →
 # UNIVERSE_SERVER_HOST_USER semantics. We default to "cloud-droplet"
@@ -208,18 +213,34 @@ def _worker_model_for_provider(provider_name: str) -> str:
 
 
 def _subscription_auth_available(provider_name: str) -> bool:
-    if provider_name == "codex":
-        codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
-        return (codex_home / "auth.json").is_file()
-    if provider_name == "claude-code":
-        if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip():
-            return True
-        config_dir = Path(os.environ.get("CLAUDE_CONFIG_DIR") or (Path.home() / ".claude"))
-        try:
-            return config_dir.is_dir() and any(config_dir.iterdir())
-        except OSError:
-            return False
-    return True
+    """True unless the provider's subscription credentials are missing.
+
+    Delegates to the shared ``subscription_auth_health`` probe so the worker
+    self-quarantine gate, the registry-visibility check, and ``get_status``
+    all read auth from one source of truth.
+    """
+    from workflow.providers.base import subscription_auth_health
+
+    return subscription_auth_health(provider_name).get("status") != "not_logged_in"
+
+
+def _worker_auth_health(daemon_args: list[str] | None) -> dict[str, str] | None:
+    """Resolve this worker's writer provider and its subscription-auth health.
+
+    Returns ``None`` when no specific writer is resolvable (a generic worker we
+    must not gate — it may legitimately route across the fallback chain).
+    Otherwise returns the ``subscription_auth_health`` dict for the worker's
+    pinned / ``--provider`` writer so the supervisor can self-quarantine a
+    dead-auth worker before it claims and poisons the queue.
+    """
+    provider = _provider_from_daemon_args(daemon_args) or os.environ.get(
+        "WORKFLOW_PIN_WRITER", ""
+    ).strip()
+    if not provider:
+        return None
+    from workflow.providers.base import subscription_auth_health
+
+    return subscription_auth_health(provider)
 
 
 def _register_worker_runtime(universe: Path, provider_name: str) -> str | None:
@@ -431,6 +452,9 @@ class SupervisorState:
         self.total_spawns = 0
         self.total_clean_exits = 0
         self.total_crashes = 0
+        # Times this worker skipped spawning a claim-subprocess because its
+        # writer provider was unauthenticated (auth self-quarantine).
+        self.auth_quarantine_count = 0
         self.started_at = _utcnow_iso()
         self.last_spawn_at = ""
         self.last_exit_rc: int | None = None
@@ -452,7 +476,8 @@ class SupervisorState:
             f"spawns={self.total_spawns} "
             f"clean={self.total_clean_exits} "
             f"crashes={self.total_crashes} "
-            f"consec={self.crash_count}"
+            f"consec={self.crash_count} "
+            f"auth_quarantined={self.auth_quarantine_count}"
         )
 
 
@@ -525,6 +550,7 @@ def run_supervisor(
     backoff_mult: float = DEFAULT_BACKOFF_MULT,
     poll_interval: float = DEFAULT_POLL_INTERVAL_S,
     producer_poll_interval: float = DEFAULT_PRODUCER_POLL_INTERVAL_S,
+    auth_quarantine_backoff: float = DEFAULT_AUTH_QUARANTINE_BACKOFF_S,
     max_iterations: int | None = None,
     daemon_args: list[str] | None = None,
     spawn_fn=None,
@@ -584,6 +610,28 @@ def run_supervisor(
         if max_iterations is not None and iteration >= max_iterations:
             break
         iteration += 1
+
+        # Pre-claim auth gate (2026-06-25 loop-wedge root cause): a worker
+        # whose writer provider is unauthenticated must NOT spawn the claim
+        # subprocess. A dead-auth worker claims tasks, fails every one, and
+        # corrupts the queue (failed > succeeded; genuine peer successes lost
+        # to Invalid-transition). Self-quarantine: skip the spawn, beat, back
+        # off, re-check — a re-seeded credential resumes claiming next tick.
+        auth = _worker_auth_health(daemon_args)
+        if auth is not None and auth.get("status") == "not_logged_in":
+            state.auth_quarantine_count += 1
+            logger.error(
+                "cloud_worker: writer provider %s is unauthenticated (%s) — "
+                "QUARANTINING worker, not claiming. Re-seed provider auth to "
+                "resume. (2026-06-25 loop-wedge prevention)",
+                auth.get("provider"), auth.get("detail"),
+            )
+            write_supervisor_heartbeat(
+                universe, state, iteration=iteration, phase="auth_quarantined",
+                planned_sleep_s=auth_quarantine_backoff,
+            )
+            sleep_fn(auth_quarantine_backoff)
+            continue
 
         try:
             proc = spawn_fn(universe)

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/base.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/providers/base.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import abc
 import os
 from dataclasses import dataclass
+from pathlib import Path
 
 
 @dataclass(frozen=True, slots=True)
@@ -104,6 +105,59 @@ def subprocess_env_for_provider(provider_name: str) -> dict[str, str]:
         # raise ValueError above and fail loudly.
         pass
     return env
+
+
+# Subscription-auth health. The 2026-06-25 loop-wedge root cause was a worker
+# whose claude-code auth was dead (no credentials) that kept claiming tasks
+# and failing every one, poisoning the queue for ~3 weeks undetected.
+# ``is_available()`` only checks the binary is on PATH (``shutil.which``); it
+# does NOT check login state. This helper checks login state so workers can
+# self-quarantine (cloud_worker) and get_status can surface dead writer auth
+# instead of leaving it buried in worker logs.
+#
+# Returns ``{"provider", "status", "detail"}`` where status is one of:
+#   "ok"            — subscription credentials are present
+#   "not_logged_in" — credentials are missing (the actionable failure)
+#   "unknown"       — no checkable subscription auth here (API-key providers,
+#                     ollama, or an unrecognized name); callers never gate on it
+#
+# NOTE: this is a credentials-PRESENCE probe, not a token-validity probe. It
+# reliably catches missing creds (the dominant failure, and the exact 2026-06-25
+# case); a present-but-expired token still reads "ok" here and surfaces via
+# call-time provider failures + the loop_stalled liveness warning.
+def subscription_auth_health(provider_name: str) -> dict[str, str]:
+    """Return presence-based subscription-auth health for *provider_name*."""
+    name = (provider_name or "").strip()
+    if name == "codex":
+        codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+        if (codex_home / "auth.json").is_file():
+            return {"provider": name, "status": "ok",
+                    "detail": f"auth.json present at {codex_home}"}
+        return {"provider": name, "status": "not_logged_in",
+                "detail": f"no auth.json at {codex_home}"}
+    if name == "claude-code":
+        if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip():
+            return {"provider": name, "status": "ok",
+                    "detail": "CLAUDE_CODE_OAUTH_TOKEN set"}
+        config_dir = Path(
+            os.environ.get("CLAUDE_CONFIG_DIR") or (Path.home() / ".claude")
+        )
+        # Deliberately conservative: any non-empty config dir reads "ok". For a
+        # quarantine gate, a false "not_logged_in" (quarantining a HEALTHY
+        # worker) is worse than a false "ok" (which still fails at call time and
+        # trips the loop_stalled warning). Only the empty/absent dir — the exact
+        # 2026-06-25 incident — yields "not_logged_in".
+        try:
+            if config_dir.is_dir() and any(config_dir.iterdir()):
+                return {"provider": name, "status": "ok",
+                        "detail": f"config dir populated at {config_dir}"}
+        except OSError as exc:
+            return {"provider": name, "status": "not_logged_in",
+                    "detail": f"config dir unreadable: {exc}"}
+        return {"provider": name, "status": "not_logged_in",
+                "detail": f"no token and empty/absent {config_dir}"}
+    return {"provider": name, "status": "unknown",
+            "detail": "no subscription-auth probe for this provider"}
 
 
 # bwrap failure signature emitted to stderr on Linux hosts that lack

--- a/tests/test_get_status_primitive.py
+++ b/tests/test_get_status_primitive.py
@@ -245,6 +245,9 @@ def _get_endpoint_hint(
         "OLLAMA_HOST", "ANTHROPIC_BASE_URL", "OPENAI_API_KEY",
         "XAI_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY",
         "WORKFLOW_ALLOW_API_KEY_PROVIDERS", "CODEX_HOME",
+        # claude is "bound" only with binary AND subscription auth; clear both
+        # auth sources so the default is not-authed and tests opt in explicitly.
+        "CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CONFIG_DIR",
     ):
         monkeypatch.delenv(key, raising=False)
     for key, val in env.items():
@@ -344,19 +347,33 @@ def test_llm_endpoint_bound_openai_key_without_codex_cli_falls_through(
 ) -> None:
     hint = _get_endpoint_hint(
         monkeypatch,
-        env={"OPENAI_API_KEY": "sk-test"},
+        env={"OPENAI_API_KEY": "sk-test", "CLAUDE_CODE_OAUTH_TOKEN": "tok"},
         which_map={"claude": "/usr/local/bin/claude"},
     )
     assert hint == "claude"
 
 
 def test_llm_endpoint_bound_claude_cli(monkeypatch) -> None:
+    # claude is bound only with binary AND subscription auth (auth-aware fix).
+    hint = _get_endpoint_hint(
+        monkeypatch,
+        env={"CLAUDE_CODE_OAUTH_TOKEN": "tok"},
+        which_map={"claude": "/usr/local/bin/claude"},
+    )
+    assert hint == "claude"
+
+
+def test_llm_endpoint_bound_claude_cli_present_but_unauthed_is_unset(
+    monkeypatch,
+) -> None:
+    # Binary present, NO auth → must NOT report claude as bound (the 2026-06-25
+    # blind spot the auth-aware fix closes).
     hint = _get_endpoint_hint(
         monkeypatch,
         env={},
         which_map={"claude": "/usr/local/bin/claude"},
     )
-    assert hint == "claude"
+    assert hint == "unset"
 
 
 def test_llm_endpoint_bound_unset_when_nothing_available(monkeypatch) -> None:
@@ -465,7 +482,7 @@ def test_llm_endpoint_bound_claude_beats_xai(monkeypatch) -> None:
     only feeds an SDK-keyed tertiary fallback. Claude wins."""
     hint = _get_endpoint_hint(
         monkeypatch,
-        env={"XAI_API_KEY": "xai-test"},
+        env={"XAI_API_KEY": "xai-test", "CLAUDE_CODE_OAUTH_TOKEN": "tok"},
         which_map={"claude": "/usr/local/bin/claude"},
     )
     assert hint == "claude"

--- a/tests/test_provider_auth_quarantine.py
+++ b/tests/test_provider_auth_quarantine.py
@@ -1,0 +1,254 @@
+"""Tests for the provider-auth health + worker self-quarantine feature.
+
+Behind the 2026-06-25 loop-wedge: a worker whose writer-provider credentials
+were missing kept claiming tasks and failing every one for ~3 weeks, poisoning
+the queue, with no signal in get_status. This feature:
+
+  1. ``subscription_auth_health`` — a presence-based auth probe (one source of
+     truth shared by the worker gate + get_status).
+  2. ``run_supervisor`` self-quarantine — a dead-auth worker skips spawning the
+     claim subprocess entirely (no claim, no poison).
+  3. ``_compute_supervisor_liveness`` provider_auth block — surfaces dead writer
+     auth + an ``all_writers_unauthenticated`` roll-up warning.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_WORKFLOW = Path(__file__).resolve().parent.parent / "workflow"
+if str(_WORKFLOW.parent) not in sys.path:
+    sys.path.insert(0, str(_WORKFLOW.parent))
+
+import workflow.cloud_worker as cw  # noqa: E402
+from workflow.api.status import _compute_supervisor_liveness  # noqa: E402
+from workflow.providers.base import subscription_auth_health  # noqa: E402
+
+# ---- minimal Popen stand-in (never claims real subprocesses) --------------
+
+
+class _FakeProc:
+    def __init__(self, returncode: int = 0):
+        self.returncode: int | None = None
+        self._rc = returncode
+
+    def poll(self):
+        self.returncode = self._rc
+        return self._rc
+
+    def wait(self, timeout=None):
+        self.returncode = self._rc
+        return self._rc
+
+
+def _sleep_recorder():
+    calls: list[float] = []
+    return calls, calls.append
+
+
+# ---- subscription_auth_health: codex --------------------------------------
+
+
+def test_codex_ok_when_auth_json_present(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    (tmp_path / "auth.json").write_text("{}", encoding="utf-8")
+    health = subscription_auth_health("codex")
+    assert health["status"] == "ok"
+    assert health["provider"] == "codex"
+
+
+def test_codex_not_logged_in_when_auth_json_absent(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    assert subscription_auth_health("codex")["status"] == "not_logged_in"
+
+
+# ---- subscription_auth_health: claude-code --------------------------------
+
+
+def test_claude_ok_with_oauth_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "tok")
+    # Empty config dir — the token must win regardless.
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    assert subscription_auth_health("claude-code")["status"] == "ok"
+
+
+def test_claude_ok_with_populated_config_dir(tmp_path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    (tmp_path / ".credentials.json").write_text("{}", encoding="utf-8")
+    assert subscription_auth_health("claude-code")["status"] == "ok"
+
+
+def test_claude_not_logged_in_when_no_token_and_empty_dir(tmp_path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "absent"))
+    assert subscription_auth_health("claude-code")["status"] == "not_logged_in"
+
+
+# ---- subscription_auth_health: unknown providers are never gated -----------
+
+
+def test_unknown_provider_is_unknown():
+    assert subscription_auth_health("gemini-free")["status"] == "unknown"
+
+
+def test_empty_provider_is_unknown():
+    assert subscription_auth_health("")["status"] == "unknown"
+
+
+# ---- run_supervisor self-quarantine ---------------------------------------
+
+
+def test_supervisor_quarantines_dead_auth_writer(tmp_path, monkeypatch):
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "no-creds"))
+    spawn_calls: list[Path] = []
+
+    def spawn(universe):
+        spawn_calls.append(universe)
+        return _FakeProc()
+
+    sleep_calls, sleep_fn = _sleep_recorder()
+    state = cw.run_supervisor(
+        tmp_path,
+        max_iterations=2,
+        daemon_args=["--provider", "claude-code"],
+        spawn_fn=spawn,
+        sleep_fn=sleep_fn,
+        auth_quarantine_backoff=42.0,
+    )
+    # The dead-auth worker must NEVER claim — that is the whole point.
+    assert spawn_calls == []
+    assert state.auth_quarantine_count == 2
+    assert sleep_calls == [42.0, 42.0]
+
+
+def test_supervisor_spawns_when_writer_auth_present(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "tok")
+    spawn_calls: list[Path] = []
+
+    def spawn(universe):
+        spawn_calls.append(universe)
+        return _FakeProc(returncode=0)
+
+    _, sleep_fn = _sleep_recorder()
+    state = cw.run_supervisor(
+        tmp_path,
+        max_iterations=1,
+        daemon_args=["--provider", "claude-code"],
+        spawn_fn=spawn,
+        sleep_fn=sleep_fn,
+    )
+    assert len(spawn_calls) == 1
+    assert state.auth_quarantine_count == 0
+
+
+def test_supervisor_does_not_gate_generic_worker(tmp_path, monkeypatch):
+    # No --provider and no pin → no resolvable writer → no gate (the worker may
+    # legitimately route across the fallback chain), so it spawns normally.
+    monkeypatch.delenv("WORKFLOW_PIN_WRITER", raising=False)
+    spawn_calls: list[Path] = []
+
+    def spawn(universe):
+        spawn_calls.append(universe)
+        return _FakeProc(returncode=0)
+
+    _, sleep_fn = _sleep_recorder()
+    state = cw.run_supervisor(
+        tmp_path, max_iterations=1, spawn_fn=spawn, sleep_fn=sleep_fn,
+    )
+    assert len(spawn_calls) == 1
+    assert state.auth_quarantine_count == 0
+
+
+# ---- supervisor_liveness provider_auth block ------------------------------
+
+
+def test_liveness_provider_auth_block_ok(tmp_path, monkeypatch):
+    codex_home = tmp_path / "codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "tok")
+
+    out = _compute_supervisor_liveness(tmp_path)
+    assert out["provider_auth"]["writers"]["codex"]["status"] == "ok"
+    assert out["provider_auth"]["writers"]["claude-code"]["status"] == "ok"
+    assert out["provider_auth"]["all_writers_unauthenticated"] is False
+    assert not any("all_writers_unauthenticated" in w for w in out["warnings"])
+
+
+def test_liveness_all_writers_unauthenticated_warns(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex-absent"))
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude-absent"))
+
+    out = _compute_supervisor_liveness(tmp_path)
+    assert out["provider_auth"]["all_writers_unauthenticated"] is True
+    assert any("all_writers_unauthenticated" in w for w in out["warnings"])
+
+
+def test_liveness_partial_writer_warns(tmp_path, monkeypatch):
+    # The exact 2026-06-25 shape: claude dead, codex alive. Must warn even
+    # though the loop still produces (Codex review finding #1).
+    codex_home = tmp_path / "codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude-absent"))
+
+    out = _compute_supervisor_liveness(tmp_path)
+    assert out["provider_auth"]["all_writers_unauthenticated"] is False
+    assert out["provider_auth"]["writers"]["claude-code"]["status"] == "not_logged_in"
+    assert out["provider_auth"]["writers"]["codex"]["status"] == "ok"
+    assert any("writer_unauthenticated" in w for w in out["warnings"])
+    assert not any("all_writers_unauthenticated" in w for w in out["warnings"])
+
+
+def test_supervisor_quarantines_via_pin_writer_env(tmp_path, monkeypatch):
+    # No --provider; the writer comes from WORKFLOW_PIN_WRITER (Codex #9).
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "no-creds"))
+    monkeypatch.setenv("WORKFLOW_PIN_WRITER", "claude-code")
+    spawn_calls: list[Path] = []
+
+    def spawn(universe):
+        spawn_calls.append(universe)
+        return _FakeProc()
+
+    _, sleep_fn = _sleep_recorder()
+    state = cw.run_supervisor(
+        tmp_path, max_iterations=1, spawn_fn=spawn, sleep_fn=sleep_fn,
+    )
+    assert spawn_calls == []
+    assert state.auth_quarantine_count == 1
+
+
+def test_supervisor_resumes_after_reauth(tmp_path, monkeypatch):
+    # Quarantined worker must resume claiming once creds are re-seeded — the
+    # gate re-checks every tick, no restart needed (Codex #9).
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    config_dir = tmp_path / "claude"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+    spawn_calls: list[Path] = []
+
+    def spawn(universe):
+        spawn_calls.append(universe)
+        return _FakeProc(returncode=0)
+
+    def sleep_fn(_delay):
+        # Re-seed credentials mid-quarantine; the next iteration should spawn.
+        config_dir.mkdir(exist_ok=True)
+        (config_dir / ".credentials.json").write_text("{}", encoding="utf-8")
+
+    state = cw.run_supervisor(
+        tmp_path,
+        max_iterations=2,
+        daemon_args=["--provider", "claude-code"],
+        spawn_fn=spawn,
+        sleep_fn=sleep_fn,
+    )
+    assert state.auth_quarantine_count == 1  # only the first iteration
+    assert len(spawn_calls) == 1             # second iteration claims

--- a/workflow/api/status.py
+++ b/workflow/api/status.py
@@ -352,6 +352,36 @@ def _compute_auto_ship_health(
     return out
 
 
+# Subscription writers the loop relies on. Probed for auth-health so a dead
+# credential (the 2026-06-25 loop-wedge root cause — a worker whose claude-code
+# auth was missing claimed tasks and failed every one for ~3 weeks undetected)
+# is visible in get_status instead of buried in worker logs.
+_SUBSCRIPTION_WRITERS = ("codex", "claude-code")
+
+
+def _provider_auth_snapshot() -> dict[str, Any]:
+    """Presence-based auth health for the subscription writers + a roll-up.
+
+    Reads the same shared-volume auth paths the workers use (the main daemon
+    and workers share ``/data`` in the cloud deploy), so a writer whose creds
+    are missing surfaces here. ``all_writers_unauthenticated`` is the
+    actionable roll-up: when true the loop cannot produce at all.
+    """
+    from workflow.providers.base import subscription_auth_health
+
+    writers: dict[str, Any] = {}
+    known_states: list[str] = []
+    for name in _SUBSCRIPTION_WRITERS:
+        health = subscription_auth_health(name)
+        writers[name] = {"status": health["status"], "detail": health["detail"]}
+        if health["status"] in ("ok", "not_logged_in"):
+            known_states.append(health["status"])
+    all_down = bool(known_states) and all(
+        s == "not_logged_in" for s in known_states
+    )
+    return {"writers": writers, "all_writers_unauthenticated": all_down}
+
+
 def _compute_supervisor_liveness(
     udir: Any,
     *,
@@ -394,6 +424,36 @@ def _compute_supervisor_liveness(
         "warnings": [],
         "lease_data_available": True,
     }
+
+    # Provider auth health — surfaced before the queue read so a dead-writer
+    # roll-up is visible even if the queue read fails. Turns the loop_stalled
+    # warning's "provider auth?" suspicion into a concrete signal.
+    out["provider_auth"] = _provider_auth_snapshot()
+    _dead_writers = [
+        name
+        for name, info in out["provider_auth"]["writers"].items()
+        if info["status"] == "not_logged_in"
+    ]
+    if out["provider_auth"]["all_writers_unauthenticated"]:
+        out["warnings"].append(
+            "all_writers_unauthenticated: every subscription writer "
+            "(codex, claude-code) is unauthenticated — the loop cannot "
+            "produce. Re-seed provider auth on the worker volume. "
+            "(2026-06-25 loop-wedge root cause; workers now self-quarantine "
+            "rather than claim-and-poison the queue.)"
+        )
+    elif _dead_writers:
+        # Partial outage is the EXACT 2026-06-25 shape (claude dead, codex
+        # alive). Warn even though the loop still produces, so a degraded
+        # fleet is never silent (Hard Rule #8) — the dead workers
+        # self-quarantine and the loop runs at reduced writer capacity.
+        out["warnings"].append(
+            f"writer_unauthenticated: subscription writer(s) "
+            f"{', '.join(_dead_writers)} not logged in — those workers "
+            "self-quarantine (no claim, no poison) and the loop runs at "
+            "reduced writer capacity until re-seeded. (2026-06-25 partial "
+            "loop-wedge signature.)"
+        )
 
     try:
         from workflow.branch_tasks import read_queue
@@ -653,13 +713,21 @@ def get_status(universe_id: str = "") -> str:
     # always-local; codex+claude are subprocess-bound CLIs the daemon can drive;
     # xai/gemini/groq are API-key-backed network providers and are ignored
     # unless WORKFLOW_ALLOW_API_KEY_PROVIDERS is explicitly enabled.
+    # Claude is "bound" only when its binary AND subscription auth are present —
+    # the binary-only check let a dead-auth claude masquerade as bound (the
+    # 2026-06-25 blind spot). Codex already gates on auth.json below; mirror it.
+    from workflow.providers.base import subscription_auth_health as _auth_health
+    claude_authed = (
+        _shutil.which("claude")
+        and _auth_health("claude-code")["status"] != "not_logged_in"
+    )
     if os.environ.get("OLLAMA_HOST"):
         endpoint_hint = "ollama"
     elif api_key_enabled and os.environ.get("ANTHROPIC_BASE_URL"):
         endpoint_hint = "anthropic"
     elif _shutil.which("codex") and codex_auth_file.is_file():
         endpoint_hint = "codex"
-    elif _shutil.which("claude"):
+    elif claude_authed:
         endpoint_hint = "claude"
     elif api_key_enabled and os.environ.get("OPENAI_API_KEY") and _shutil.which("codex"):
         endpoint_hint = "codex"

--- a/workflow/cloud_worker.py
+++ b/workflow/cloud_worker.py
@@ -84,6 +84,11 @@ DEFAULT_MAX_BACKOFF_S = 300.0     # 5-min ceiling on exponential backoff.
 DEFAULT_BACKOFF_MULT = 2.0        # Doubling per consecutive crash.
 DEFAULT_POLL_INTERVAL_S = 0.5     # Subprocess monitor poll granularity.
 DEFAULT_PRODUCER_POLL_INTERVAL_S = 30.0  # Goal-pool pickup latency cap.
+# Re-check cadence while a worker is auth-quarantined. Short enough that a
+# re-seeded credential resumes claiming promptly; long enough that a dead-auth
+# worker doesn't spin. NOT escalated like crash backoff — auth-dead is a steady
+# state, not a crash, and must not feed the crash counter.
+DEFAULT_AUTH_QUARANTINE_BACKOFF_S = 60.0
 
 # Host identity. Matches AGENTS.md §Configuration →
 # UNIVERSE_SERVER_HOST_USER semantics. We default to "cloud-droplet"
@@ -208,18 +213,34 @@ def _worker_model_for_provider(provider_name: str) -> str:
 
 
 def _subscription_auth_available(provider_name: str) -> bool:
-    if provider_name == "codex":
-        codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
-        return (codex_home / "auth.json").is_file()
-    if provider_name == "claude-code":
-        if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip():
-            return True
-        config_dir = Path(os.environ.get("CLAUDE_CONFIG_DIR") or (Path.home() / ".claude"))
-        try:
-            return config_dir.is_dir() and any(config_dir.iterdir())
-        except OSError:
-            return False
-    return True
+    """True unless the provider's subscription credentials are missing.
+
+    Delegates to the shared ``subscription_auth_health`` probe so the worker
+    self-quarantine gate, the registry-visibility check, and ``get_status``
+    all read auth from one source of truth.
+    """
+    from workflow.providers.base import subscription_auth_health
+
+    return subscription_auth_health(provider_name).get("status") != "not_logged_in"
+
+
+def _worker_auth_health(daemon_args: list[str] | None) -> dict[str, str] | None:
+    """Resolve this worker's writer provider and its subscription-auth health.
+
+    Returns ``None`` when no specific writer is resolvable (a generic worker we
+    must not gate — it may legitimately route across the fallback chain).
+    Otherwise returns the ``subscription_auth_health`` dict for the worker's
+    pinned / ``--provider`` writer so the supervisor can self-quarantine a
+    dead-auth worker before it claims and poisons the queue.
+    """
+    provider = _provider_from_daemon_args(daemon_args) or os.environ.get(
+        "WORKFLOW_PIN_WRITER", ""
+    ).strip()
+    if not provider:
+        return None
+    from workflow.providers.base import subscription_auth_health
+
+    return subscription_auth_health(provider)
 
 
 def _register_worker_runtime(universe: Path, provider_name: str) -> str | None:
@@ -431,6 +452,9 @@ class SupervisorState:
         self.total_spawns = 0
         self.total_clean_exits = 0
         self.total_crashes = 0
+        # Times this worker skipped spawning a claim-subprocess because its
+        # writer provider was unauthenticated (auth self-quarantine).
+        self.auth_quarantine_count = 0
         self.started_at = _utcnow_iso()
         self.last_spawn_at = ""
         self.last_exit_rc: int | None = None
@@ -452,7 +476,8 @@ class SupervisorState:
             f"spawns={self.total_spawns} "
             f"clean={self.total_clean_exits} "
             f"crashes={self.total_crashes} "
-            f"consec={self.crash_count}"
+            f"consec={self.crash_count} "
+            f"auth_quarantined={self.auth_quarantine_count}"
         )
 
 
@@ -525,6 +550,7 @@ def run_supervisor(
     backoff_mult: float = DEFAULT_BACKOFF_MULT,
     poll_interval: float = DEFAULT_POLL_INTERVAL_S,
     producer_poll_interval: float = DEFAULT_PRODUCER_POLL_INTERVAL_S,
+    auth_quarantine_backoff: float = DEFAULT_AUTH_QUARANTINE_BACKOFF_S,
     max_iterations: int | None = None,
     daemon_args: list[str] | None = None,
     spawn_fn=None,
@@ -584,6 +610,28 @@ def run_supervisor(
         if max_iterations is not None and iteration >= max_iterations:
             break
         iteration += 1
+
+        # Pre-claim auth gate (2026-06-25 loop-wedge root cause): a worker
+        # whose writer provider is unauthenticated must NOT spawn the claim
+        # subprocess. A dead-auth worker claims tasks, fails every one, and
+        # corrupts the queue (failed > succeeded; genuine peer successes lost
+        # to Invalid-transition). Self-quarantine: skip the spawn, beat, back
+        # off, re-check — a re-seeded credential resumes claiming next tick.
+        auth = _worker_auth_health(daemon_args)
+        if auth is not None and auth.get("status") == "not_logged_in":
+            state.auth_quarantine_count += 1
+            logger.error(
+                "cloud_worker: writer provider %s is unauthenticated (%s) — "
+                "QUARANTINING worker, not claiming. Re-seed provider auth to "
+                "resume. (2026-06-25 loop-wedge prevention)",
+                auth.get("provider"), auth.get("detail"),
+            )
+            write_supervisor_heartbeat(
+                universe, state, iteration=iteration, phase="auth_quarantined",
+                planned_sleep_s=auth_quarantine_backoff,
+            )
+            sleep_fn(auth_quarantine_backoff)
+            continue
 
         try:
             proc = spawn_fn(universe)

--- a/workflow/providers/base.py
+++ b/workflow/providers/base.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import abc
 import os
 from dataclasses import dataclass
+from pathlib import Path
 
 
 @dataclass(frozen=True, slots=True)
@@ -104,6 +105,59 @@ def subprocess_env_for_provider(provider_name: str) -> dict[str, str]:
         # raise ValueError above and fail loudly.
         pass
     return env
+
+
+# Subscription-auth health. The 2026-06-25 loop-wedge root cause was a worker
+# whose claude-code auth was dead (no credentials) that kept claiming tasks
+# and failing every one, poisoning the queue for ~3 weeks undetected.
+# ``is_available()`` only checks the binary is on PATH (``shutil.which``); it
+# does NOT check login state. This helper checks login state so workers can
+# self-quarantine (cloud_worker) and get_status can surface dead writer auth
+# instead of leaving it buried in worker logs.
+#
+# Returns ``{"provider", "status", "detail"}`` where status is one of:
+#   "ok"            — subscription credentials are present
+#   "not_logged_in" — credentials are missing (the actionable failure)
+#   "unknown"       — no checkable subscription auth here (API-key providers,
+#                     ollama, or an unrecognized name); callers never gate on it
+#
+# NOTE: this is a credentials-PRESENCE probe, not a token-validity probe. It
+# reliably catches missing creds (the dominant failure, and the exact 2026-06-25
+# case); a present-but-expired token still reads "ok" here and surfaces via
+# call-time provider failures + the loop_stalled liveness warning.
+def subscription_auth_health(provider_name: str) -> dict[str, str]:
+    """Return presence-based subscription-auth health for *provider_name*."""
+    name = (provider_name or "").strip()
+    if name == "codex":
+        codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+        if (codex_home / "auth.json").is_file():
+            return {"provider": name, "status": "ok",
+                    "detail": f"auth.json present at {codex_home}"}
+        return {"provider": name, "status": "not_logged_in",
+                "detail": f"no auth.json at {codex_home}"}
+    if name == "claude-code":
+        if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip():
+            return {"provider": name, "status": "ok",
+                    "detail": "CLAUDE_CODE_OAUTH_TOKEN set"}
+        config_dir = Path(
+            os.environ.get("CLAUDE_CONFIG_DIR") or (Path.home() / ".claude")
+        )
+        # Deliberately conservative: any non-empty config dir reads "ok". For a
+        # quarantine gate, a false "not_logged_in" (quarantining a HEALTHY
+        # worker) is worse than a false "ok" (which still fails at call time and
+        # trips the loop_stalled warning). Only the empty/absent dir — the exact
+        # 2026-06-25 incident — yields "not_logged_in".
+        try:
+            if config_dir.is_dir() and any(config_dir.iterdir()):
+                return {"provider": name, "status": "ok",
+                        "detail": f"config dir populated at {config_dir}"}
+        except OSError as exc:
+            return {"provider": name, "status": "not_logged_in",
+                    "detail": f"config dir unreadable: {exc}"}
+        return {"provider": name, "status": "not_logged_in",
+                "detail": f"no token and empty/absent {config_dir}"}
+    return {"provider": name, "status": "unknown",
+            "detail": "no subscription-auth probe for this provider"}
 
 
 # bwrap failure signature emitted to stderr on Linux hosts that lack


### PR DESCRIPTION
## Provider auth-health + worker self-quarantine

Host-greenlit follow-up to the **2026-06-25 loop-wedge incident**: the community patch loop produced **zero terminal successes for ~3 weeks** and no alarm caught it. Root cause = a worker whose `claude-code` subscription auth was **dead** (`/data/.claude` empty) kept claiming tasks and failing every one, poisoning the shared queue (failed > succeeded; genuine codex-peer successes lost to `Invalid transition`). It was **invisible** — `is_available()` only checks the CLI binary is on PATH, never login state, and `get_status` surfaced nothing.

### What this adds
1. **`subscription_auth_health(provider)`** (`providers/base.py`) — one shared presence-based auth probe (`ok` / `not_logged_in` / `unknown`). codex→`auth.json`; claude-code→`CLAUDE_CODE_OAUTH_TOKEN` or non-empty `CLAUDE_CONFIG_DIR`. Single source of truth for the gate + status + endpoint hint.
2. **Worker self-quarantine** (`cloud_worker.run_supervisor`) — before spawning the claim subprocess, a worker whose writer provider is unauthenticated **skips claiming entirely** (no claim, no poison), heartbeats `phase=auth_quarantined`, backs off, and **re-checks each tick** (resumes on re-seed, no restart). Verified end-to-end against the compose fleet wiring (`--provider claude-code` → `daemon_args` → gate).
3. **Visibility** (`get_status` / `_compute_supervisor_liveness`) — a `provider_auth` block + warnings for **partial** (`writer_unauthenticated`, the exact incident shape) and **full** (`all_writers_unauthenticated`) outages. Turns the `loop_stalled` warning's "provider auth?" *suspicion* into a concrete signal — Hard Rule #8, never silent.
4. **`llm_endpoint_bound`** now requires claude binary **AND** auth (closes the binary-only blind spot in a user-facing field).

### Deliberately out of scope (conservative)
- Presence-check, not token-validity: a present-but-**expired** token still reads `ok` and surfaces via call-time failures + `loop_stalled`. A false `not_logged_in` would quarantine a *healthy* worker — the worse failure for a gate — so the probe errs toward `ok` when unsure.
- Generic (unpinned) workers aren't gated (the cloud fleet is fully pinned). Router-level fallback quarantine + duplicate-finalize counter are Slice-2 candidates.

### Verification
- **Codex cross-family review: ADAPT** → adopted the partial-outage warning, `endpoint_bound` auth-awareness, and test gaps; defended the conservative presence-check with rationale.
- **15 new tests** (`tests/test_provider_auth_quarantine.py`: probe matrix, supervisor quarantine via `--provider` + `WORKFLOW_PIN_WRITER`, resume-after-reauth, generic-worker bypass, partial + full liveness warnings) + endpoint-bound auth cases. 197 focused tests pass; `ruff` clean on touched files; plugin mirror rebuilt (probe-ok).

Net **+642 / −31**, 8 files. Merge GATED on host key + CI.

Source: `.agents/skills/loop-uptime-maintenance/incidents/2026-06-25-dispatcher-double-claim-wedge.md` (Q2c/Q3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
