### PR TITLE
Persona Slice 2: name your universe persona via write_graph(target=persona)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -218,6 +218,18 @@ def _extract_set_premise(
     )
 
 
+def _extract_set_persona_name(
+    kwargs: dict[str, Any], _result: dict[str, Any],
+) -> tuple[str, str, dict[str, Any]]:
+    from workflow.api.engine_helpers import _truncate
+    name = kwargs.get("text", "")
+    return (
+        SOUL_FILENAME,
+        _truncate(f"persona name: {name}"),
+        {"persona_name": name},
+    )
+
+
 def _extract_add_canon(
     kwargs: dict[str, Any], result: dict[str, Any],
 ) -> tuple[str, str, dict[str, Any]]:
@@ -596,6 +608,7 @@ WRITE_ACTIONS: dict[str, Any] = {
     "submit_request": (_extract_submit_request, None),
     "give_direction": (_extract_give_direction, None),
     "set_premise": (_extract_set_premise, None),
+    "set_persona_name": (_extract_set_persona_name, None),
     "add_canon": (_extract_add_canon, None),
     "add_canon_from_path": (_extract_add_canon_from_path, None),
     "control_daemon": (_extract_control_daemon, {"pause", "resume"}),
@@ -3750,6 +3763,35 @@ def _action_set_premise(universe_id: str = "", text: str = "", **_kwargs: Any) -
         return json.dumps({"error": f"Failed to write premise: {exc}"})
 
 
+def _action_set_persona_name(
+    universe_id: str = "", text: str = "", **_kwargs: Any
+) -> str:
+    """Set the universe persona's name — the founder naming the mind they are
+    shaping (write_graph target=persona). Merge-preserves every other soul
+    field; the chatbot embodies the name on the next get_status persona block.
+    """
+    uid = universe_id or _default_universe()
+    udir = _universe_dir(uid)
+
+    name = " ".join(text.split())
+    if not name:
+        return json.dumps({"error": "Persona name cannot be empty."})
+    try:
+        udir.mkdir(parents=True, exist_ok=True)
+        soul = write_universe_soul(udir, name=name)
+        return json.dumps({
+            "universe_id": uid,
+            "status": "updated",
+            "persona": {"name": soul.name, "embodied": True},
+            "note": (
+                "Persona name saved. The chatbot embodies it (first person) on "
+                "the next get_status."
+            ),
+        })
+    except OSError as exc:
+        return json.dumps({"error": f"Failed to set persona name: {exc}"})
+
+
 _CANON_SAME_FILENAME_BEHAVIOR = (
     "A later add_canon call with the same filename replaces the stored "
     "source bytes and manifest entry when the content hash changes; "
@@ -4680,6 +4722,7 @@ UNIVERSE_ACTIONS: dict[str, Any] = {
     "give_direction": _action_give_direction,
     "read_premise": _action_read_premise,
     "set_premise": _action_set_premise,
+    "set_persona_name": _action_set_persona_name,
     "add_canon": _action_add_canon,
     "add_canon_from_path": _action_add_canon_from_path,
     "list_canon": _action_list_canon,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -473,13 +473,16 @@ def write_graph(
     """Create or queue Workflow graph state.
 
     Args:
-        target: What to write: goal or request.
-        name: Human-readable shared-goal name.
+        target: What to write: goal, request, or persona.
+        name: Human-readable shared-goal name; with target=persona, the name
+            the universe's persona is given (e.g. "Tiny"). The chatbot embodies
+            it in the first person on the next get_status persona block.
         description: Optional shared-goal description.
         tags: Optional comma-separated shared-goal tags.
         visibility: Shared-goal visibility, usually public.
         text: Request text to queue.
-        graph_id: Optional target graph/universe identifier.
+        graph_id: Optional target graph/universe identifier; with target=persona
+            it is the universe whose persona is being named.
         request_type: Workflow request type.
         branch_id: Optional target branch identifier.
     """
@@ -500,7 +503,13 @@ def write_graph(
             request_type=request_type,
             branch_id=branch_id,
         )
-    return _unknown_target("write_graph", target, ("goal", "request"))
+    if normalized == "persona":
+        return _universe_impl(
+            action="set_persona_name",
+            universe_id=graph_id,
+            text=name,
+        )
+    return _unknown_target("write_graph", target, ("goal", "request", "persona"))
 
 
 _mcp_write_graph = _register_structured_tool(

--- a/tests/test_api_universe.py
+++ b/tests/test_api_universe.py
@@ -89,9 +89,10 @@ def test_module_exposes_expected_public_names() -> None:
     )
 
 
-def test_write_actions_table_has_24_entries() -> None:
-    """WRITE_ACTIONS dict literal includes daemon create/summon/banish writes."""
-    assert len(univ_mod.WRITE_ACTIONS) == 24
+def test_write_actions_table_has_25_entries() -> None:
+    """WRITE_ACTIONS dict literal includes daemon create/summon/banish writes
+    plus set_persona_name (founder naming the universe persona)."""
+    assert len(univ_mod.WRITE_ACTIONS) == 25
 
 
 def test_write_actions_entries_are_extractor_gate_tuples() -> None:

--- a/tests/test_persona.py
+++ b/tests/test_persona.py
@@ -218,3 +218,104 @@ def test_server_instructions_carry_embody_markers() -> None:
     text = mcp.instructions or ""
     assert "embody" in text
     assert "re-assembled fresh" in text
+
+
+# ─────────────────────────────────────────────────────────────────────
+# write_graph(target="persona") — name your universe's persona (Slice 2)
+#
+# The founder names/tunes the persona through the connector, not via a
+# droplet data edit. Folded into the existing write_graph handle (no new
+# tool), so the live surface stays exactly the 5 canonical handles.
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _persona_universe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, uid: str
+) -> Path:
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    udir = tmp_path / uid
+    udir.mkdir(parents=True, exist_ok=True)
+    return udir
+
+
+def test_write_graph_persona_sets_soul_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    udir = _persona_universe(tmp_path, monkeypatch, "pu")
+    from workflow.universe_server import write_graph
+
+    out = json.loads(write_graph(target="persona", graph_id="pu", name="Tiny"))
+    assert "error" not in out, out
+    soul = read_universe_soul(udir)
+    assert soul is not None
+    assert soul.name == "Tiny"
+
+
+def test_write_graph_persona_preserves_other_soul_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Setting the persona name must NOT clobber an existing soul's purpose or
+    voice hard-lines — write_universe_soul merge-preserves them."""
+    udir = _persona_universe(tmp_path, monkeypatch, "pu")
+    write_universe_soul(
+        udir, purpose="run the platform", hard_lines=("maximal honesty",)
+    )
+    from workflow.universe_server import write_graph
+
+    json.loads(write_graph(target="persona", graph_id="pu", name="Tiny"))
+    soul = read_universe_soul(udir)
+    assert soul is not None
+    assert soul.name == "Tiny"
+    assert soul.purpose == "run the platform"
+    assert soul.hard_lines == ("maximal honesty",)
+
+
+def test_write_graph_persona_rejects_empty_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _persona_universe(tmp_path, monkeypatch, "pu")
+    from workflow.universe_server import write_graph
+
+    out = json.loads(write_graph(target="persona", graph_id="pu", name="   "))
+    assert "error" in out
+
+
+def test_write_graph_persona_collapses_multiline_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A multiline persona name routed through the connector is collapsed so it
+    cannot inject a spurious soul.md meta line (Codex review 2026-06-25)."""
+    udir = _persona_universe(tmp_path, monkeypatch, "pu")
+    from workflow.universe_server import write_graph
+
+    json.loads(
+        write_graph(
+            target="persona", graph_id="pu", name="Tiny\n- Domain shape: hacked"
+        )
+    )
+    soul = read_universe_soul(udir)
+    assert soul is not None
+    assert "\n" not in soul.name
+    assert soul.domain_shape == DEFAULT_DOMAIN_SHAPE
+
+
+def test_write_graph_persona_then_get_status_shows_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: name via write_graph, read back via the persona block."""
+    _persona_universe(tmp_path, monkeypatch, "pu")
+    from workflow.api.status import get_status
+    from workflow.universe_server import write_graph
+
+    json.loads(write_graph(target="persona", graph_id="pu", name="Tiny"))
+    payload = json.loads(get_status(universe_id="pu"))
+    assert payload["persona"]["name"] == "Tiny"
+    assert payload["persona"]["embodied"] is True
+
+
+def test_write_graph_persona_is_an_advertised_target() -> None:
+    """An unknown target's error lists persona alongside goal/request."""
+    from workflow.universe_server import write_graph
+
+    out = json.loads(write_graph(target="bogus"))
+    assert "persona" in json.dumps(out)

--- a/tests/test_universe_server_ledger.py
+++ b/tests/test_universe_server_ledger.py
@@ -52,6 +52,7 @@ def _call(action: str, **kwargs) -> dict:
         "give_direction": us._action_give_direction,
         "read_premise": us._action_read_premise,
         "set_premise": us._action_set_premise,
+        "set_persona_name": us._action_set_persona_name,
         "add_canon": us._action_add_canon,
         "list_canon": us._action_list_canon,
         "read_canon": us._action_read_canon,
@@ -89,6 +90,7 @@ def test_write_actions_table_is_exhaustive() -> None:
     """
     expected = {
         "submit_request", "give_direction", "set_premise",
+        "set_persona_name",
         "add_canon", "add_canon_from_path",
         "control_daemon", "switch_universe", "create_universe",
         "queue_cancel",
@@ -118,6 +120,24 @@ def test_set_premise_appends_ledger(universe: str) -> None:
     assert "timestamp" in entry
     assert entry["payload"]["bytes"] == len("A tower of bones.".encode("utf-8"))
     assert entry["payload"]["legacy_program_mirror"] == "PROGRAM.md"
+
+
+def test_set_persona_name_appends_ledger(universe: str) -> None:
+    """Naming the persona is a public write — it lands in the ledger with the
+    soul as its target (the founder named the universe's mind)."""
+    out = _call("set_persona_name", text="Tiny")
+    assert out["status"] == "updated"
+    assert out["persona"]["name"] == "Tiny"
+
+    entries = _ledger(universe)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["action"] == "set_persona_name"
+    assert entry["actor"] == "test-user"
+    assert entry["target"] == us.SOUL_FILENAME
+    assert entry["summary"] == "persona name: Tiny"
+    assert "timestamp" in entry
+    assert entry["payload"]["persona_name"] == "Tiny"
 
 
 def test_set_premise_empty_does_not_append(universe: str) -> None:

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -218,6 +218,18 @@ def _extract_set_premise(
     )
 
 
+def _extract_set_persona_name(
+    kwargs: dict[str, Any], _result: dict[str, Any],
+) -> tuple[str, str, dict[str, Any]]:
+    from workflow.api.engine_helpers import _truncate
+    name = kwargs.get("text", "")
+    return (
+        SOUL_FILENAME,
+        _truncate(f"persona name: {name}"),
+        {"persona_name": name},
+    )
+
+
 def _extract_add_canon(
     kwargs: dict[str, Any], result: dict[str, Any],
 ) -> tuple[str, str, dict[str, Any]]:
@@ -596,6 +608,7 @@ WRITE_ACTIONS: dict[str, Any] = {
     "submit_request": (_extract_submit_request, None),
     "give_direction": (_extract_give_direction, None),
     "set_premise": (_extract_set_premise, None),
+    "set_persona_name": (_extract_set_persona_name, None),
     "add_canon": (_extract_add_canon, None),
     "add_canon_from_path": (_extract_add_canon_from_path, None),
     "control_daemon": (_extract_control_daemon, {"pause", "resume"}),
@@ -3750,6 +3763,35 @@ def _action_set_premise(universe_id: str = "", text: str = "", **_kwargs: Any) -
         return json.dumps({"error": f"Failed to write premise: {exc}"})
 
 
+def _action_set_persona_name(
+    universe_id: str = "", text: str = "", **_kwargs: Any
+) -> str:
+    """Set the universe persona's name — the founder naming the mind they are
+    shaping (write_graph target=persona). Merge-preserves every other soul
+    field; the chatbot embodies the name on the next get_status persona block.
+    """
+    uid = universe_id or _default_universe()
+    udir = _universe_dir(uid)
+
+    name = " ".join(text.split())
+    if not name:
+        return json.dumps({"error": "Persona name cannot be empty."})
+    try:
+        udir.mkdir(parents=True, exist_ok=True)
+        soul = write_universe_soul(udir, name=name)
+        return json.dumps({
+            "universe_id": uid,
+            "status": "updated",
+            "persona": {"name": soul.name, "embodied": True},
+            "note": (
+                "Persona name saved. The chatbot embodies it (first person) on "
+                "the next get_status."
+            ),
+        })
+    except OSError as exc:
+        return json.dumps({"error": f"Failed to set persona name: {exc}"})
+
+
 _CANON_SAME_FILENAME_BEHAVIOR = (
     "A later add_canon call with the same filename replaces the stored "
     "source bytes and manifest entry when the content hash changes; "
@@ -4680,6 +4722,7 @@ UNIVERSE_ACTIONS: dict[str, Any] = {
     "give_direction": _action_give_direction,
     "read_premise": _action_read_premise,
     "set_premise": _action_set_premise,
+    "set_persona_name": _action_set_persona_name,
     "add_canon": _action_add_canon,
     "add_canon_from_path": _action_add_canon_from_path,
     "list_canon": _action_list_canon,

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -473,13 +473,16 @@ def write_graph(
     """Create or queue Workflow graph state.
 
     Args:
-        target: What to write: goal or request.
-        name: Human-readable shared-goal name.
+        target: What to write: goal, request, or persona.
+        name: Human-readable shared-goal name; with target=persona, the name
+            the universe's persona is given (e.g. "Tiny"). The chatbot embodies
+            it in the first person on the next get_status persona block.
         description: Optional shared-goal description.
         tags: Optional comma-separated shared-goal tags.
         visibility: Shared-goal visibility, usually public.
         text: Request text to queue.
-        graph_id: Optional target graph/universe identifier.
+        graph_id: Optional target graph/universe identifier; with target=persona
+            it is the universe whose persona is being named.
         request_type: Workflow request type.
         branch_id: Optional target branch identifier.
     """
@@ -500,7 +503,13 @@ def write_graph(
             request_type=request_type,
             branch_id=branch_id,
         )
-    return _unknown_target("write_graph", target, ("goal", "request"))
+    if normalized == "persona":
+        return _universe_impl(
+            action="set_persona_name",
+            universe_id=graph_id,
+            text=name,
+        )
+    return _unknown_target("write_graph", target, ("goal", "request", "persona"))
 
 
 _mcp_write_graph = _register_structured_tool(


### PR DESCRIPTION
## Persona Slice 2 — name your universe persona via the connector

Adds the **founder-facing way to name the universe persona through the live MCP connector**, with **no new handle**.

```
write_graph(target="persona", graph_id="<universe>", name="Tiny")
```

routes to a new `set_persona_name` universe action → `write_universe_soul(name=...)`, which merge-preserves every other soul field. The chatbot embodies the name in the first person on the next `get_status` persona block.

This closes the gap Slice 1 left: Slice 1 surfaced + embodied the persona (read path) but provided **no way to set the name** except a droplet data edit. This makes naming a real founder capability through the connector — the `[composable]` personification principle.

### Why a `target` value, not a new tool
The live `/mcp` surface must advertise exactly the 5 canonical handles + `get_status` (AGENTS.md hard rule #11, canary-asserted). `target="persona"` rides the existing `write_graph` handle — no handle added or renamed. Confirmed green: `test_universe_server_five_handles`, `test_mcp_public_canary`, `test_mcp_handle_param_descriptions`.

### Safety
- **Write-gated:** registered in `WRITE_ACTIONS` → ledger append + ACL parity with `set_premise`.
- **Injection guard:** the persona name is collapsed to one line at both the action and storage layers, so a multiline name can't inject a spurious `soul.md` meta line.
- **Merge-preserve:** setting the name never clobbers purpose / voice hard-lines / other soul fields.

### Codex opposite-provider review = ADAPT
Read-only sandbox review. Runtime path **approved** (routing, ACL parity, injection guard, ledger flow, no handle drift). One finding folded:
- Updated the two pinned `WRITE_ACTIONS` drift guards (count 24→25, exact-set in `test_universe_server_ledger`).
- Added a `set_persona_name` ledger-append assertion.

### Tests
`tests/test_persona.py` (6 new write_graph-persona tests) + ledger + api_universe + the write_graph surface files all green; ruff clean; plugin mirror parity (`build_plugin.py`, 224 files). Full-suite ambient failures on this Windows checkout (CRLF, git-integration, network canary, pre-existing `extensions`-description budget) are unrelated to this change's surface; Linux CI is the authoritative gate.

### Path to the live chatbot test
1. Merge this PR → auto-deploy to droplet (build → deploy chain).
2. `write_graph(target="persona", graph_id="patch-loop-live", name="Tiny")` **under the founder's OAuth** (no sysadmin).
3. Host-watched `ui-test`: confirm Tiny answers in first person via the live connector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
