### PR TITLE
fix(lifecycle): squash-merge-aware is_merged for wt.py + branch_janitor

### DIFF
--- a/scripts/branch_janitor.py
+++ b/scripts/branch_janitor.py
@@ -11,9 +11,9 @@ branches.
 Categories
 ----------
 PROTECTED    main/master/production/release/* — never touched.
-MERGED       ancestor of the base ref — its commits are already on main, so
-             deleting the branch loses nothing. Swept in --apply (or
-             --only-merged).
+MERGED       already merged into the base ref (ancestor *or* squash-merged) —
+             its changes are all on main, so deleting the branch loses nothing.
+             Swept in --apply (or --only-merged).
 STALE_FLAG   unmerged, no open PR, no commit in STALE_DAYS — reported only.
 STALE_DELETE flagged and still untouched past GRACE_DAYS — deleted in --apply.
 ACTIVE       has an open PR, or a commit younger than RECENT_DAYS, or simply
@@ -38,6 +38,10 @@ import subprocess
 import sys
 import time
 from dataclasses import asdict, dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from git_squash_merge import is_merged_into  # noqa: E402  (sibling-script import)
 
 PROTECTED_EXACT = {"main", "master", "production", "develop", "HEAD"}
 PROTECTED_PREFIXES = ("release/", "hotfix/")
@@ -127,8 +131,9 @@ def is_protected(name: str) -> bool:
 
 
 def is_merged(remote: str, name: str, base_ref: str) -> bool:
-    proc = _run(["git", "merge-base", "--is-ancestor", f"refs/remotes/{remote}/{name}", base_ref])
-    return proc.returncode == 0
+    # Squash-aware: PRs here squash-merge, so --is-ancestor alone would miss the
+    # default merge style and leave merged branches lingering until STALE_DELETE.
+    return is_merged_into(_run, f"refs/remotes/{remote}/{name}", base_ref)
 
 
 def classify(
@@ -148,7 +153,7 @@ def classify(
             continue
         if is_merged(remote, name, base_ref):
             verdicts.append(
-                BranchVerdict(name, "MERGED", age_days, "already an ancestor of base ref", ts)
+                BranchVerdict(name, "MERGED", age_days, "already merged into base ref", ts)
             )
             continue
         if name in prs:

--- a/scripts/git_squash_merge.py
+++ b/scripts/git_squash_merge.py
@@ -1,0 +1,76 @@
+"""Squash-merge-aware "is this branch already merged?" detection.
+
+Part of the branch lifecycle automation; see
+``docs/design-notes/2026-06-24-branch-lifecycle-automation.md``.
+
+GitHub squash-merges (this repo's default — ``delete_branch_on_merge=true``)
+rewrite history: the merged change lands as a brand-new commit on main, so
+``git merge-base --is-ancestor <branch> main`` returns false even though every
+change on the branch is already in main. The original Layer-1 (branch_janitor)
+and Layer-2 (wt.py) checks used ``--is-ancestor`` alone, so they were blind to
+the *default* merge style — the structural cause of merged branches/worktrees
+piling up (the safe teardown path refused the common case, so lanes were either
+``--force``-discarded or never torn down).
+
+This module adds the standard squash-detection fallback: synthesize a commit
+holding the branch's cumulative tree on top of the merge-base, then ask
+``git cherry`` whether that patch is already present on the base ref.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Protocol
+
+
+class _Completed(Protocol):
+    returncode: int
+    stdout: str
+
+
+Runner = Callable[[Sequence[str]], _Completed]
+
+
+def _first_line(text: str) -> str:
+    text = (text or "").strip()
+    return text.splitlines()[0].strip() if text else ""
+
+
+def is_merged_into(run: Runner, ref: str, base_ref: str) -> bool:
+    """Return True if every change in ``ref`` is already present on ``base_ref``.
+
+    Catches fast-forward / merge-commit merges (``ref`` is an ancestor of
+    ``base_ref``) *and* squash merges (``ref``'s cumulative diff is already
+    applied on ``base_ref``). ``run`` is a subprocess runner returning an object
+    with ``returncode`` and ``stdout`` (e.g. ``subprocess.run(..., text=True,
+    capture_output=True)``). Conservative on any git error: returns False so
+    callers refuse teardown rather than discard unmerged work.
+    """
+    # Cheap path: ancestor check catches fast-forward + merge-commit merges.
+    if run(["git", "merge-base", "--is-ancestor", ref, base_ref]).returncode == 0:
+        return True
+
+    # Squash path: is base_ref already carrying ref's cumulative patch?
+    mb = run(["git", "merge-base", ref, base_ref])
+    merge_base = _first_line(mb.stdout) if mb.returncode == 0 else ""
+    if not merge_base:
+        return False
+
+    tree = run(["git", "rev-parse", f"{ref}^{{tree}}"])
+    tree_id = _first_line(tree.stdout) if tree.returncode == 0 else ""
+    if not tree_id:
+        return False
+
+    dangling = run(["git", "commit-tree", tree_id, "-p", merge_base, "-m", "_"])
+    dangling_sha = _first_line(dangling.stdout) if dangling.returncode == 0 else ""
+    if not dangling_sha:
+        return False
+
+    cherry = run(["git", "cherry", base_ref, dangling_sha])
+    if cherry.returncode != 0:
+        return False
+    lines = [ln.strip() for ln in (cherry.stdout or "").splitlines() if ln.strip()]
+    # ``git cherry`` prefixes "- <sha>" when the patch is already upstream
+    # (merged) and "+ <sha>" when it is still missing. No output => the
+    # synthesized patch is empty (nothing to merge) => treat as merged.
+    return all(ln.startswith("-") for ln in lines)

--- a/scripts/wt.py
+++ b/scripts/wt.py
@@ -26,6 +26,9 @@ import sys
 import time
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from git_squash_merge import is_merged_into  # noqa: E402  (sibling-script import)
+
 PROVIDER_PREFIX = {
     "claude-code": "claude",
     "claude": "claude",
@@ -151,9 +154,9 @@ def cmd_done(args: argparse.Namespace) -> int:
     if not branch or branch == "HEAD":
         raise SystemExit(f"could not resolve branch for {wt_path}")
 
-    merged = _run(
-        ["git", "merge-base", "--is-ancestor", branch, args.base_ref], cwd=root
-    ).returncode == 0
+    # Squash-aware: this repo squash-merges PRs, so a plain --is-ancestor check
+    # would report every squash-merged lane as unmerged and refuse teardown.
+    merged = is_merged_into(lambda a: _run(a, cwd=root), branch, args.base_ref)
     if not merged and not args.force:
         raise SystemExit(
             f"branch '{branch}' is NOT merged into {args.base_ref}. "

--- a/tests/test_git_squash_merge.py
+++ b/tests/test_git_squash_merge.py
@@ -1,0 +1,166 @@
+"""Tests for scripts/git_squash_merge.py — squash-merge-aware merged detection.
+
+Regression guard: ``git merge-base --is-ancestor`` alone is blind to squash
+merges (this repo's default merge style via ``delete_branch_on_merge=true``),
+so worktree/branch teardown refused the common case and lanes piled up.
+``is_merged_into`` must see through a squash merge while staying conservative
+(False) on genuinely unmerged work.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "git_squash_merge",
+    Path(__file__).resolve().parent.parent / "scripts" / "git_squash_merge.py",
+)
+gsm = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+sys.modules["git_squash_merge"] = gsm
+_SPEC.loader.exec_module(gsm)
+
+
+class _Proc:
+    def __init__(self, returncode: int = 0, stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+# --- unit tests with a fake runner (no real git) ---
+
+
+def test_ancestor_short_circuits_to_merged():
+    calls = []
+
+    def run(args):
+        calls.append(args)
+        return _Proc(0)  # --is-ancestor succeeds
+
+    assert gsm.is_merged_into(run, "feat", "main") is True
+    # Should not bother with the squash fallback once ancestry is proven.
+    assert calls == [["git", "merge-base", "--is-ancestor", "feat", "main"]]
+
+
+def _squash_runner(cherry_stdout: str, cherry_rc: int = 0):
+    def run(args):
+        if args[1:3] == ["merge-base", "--is-ancestor"]:
+            return _Proc(1)  # not an ancestor (squash rewrote history)
+        if args[1] == "merge-base":
+            return _Proc(0, "BASE_SHA\n")
+        if args[1] == "rev-parse":
+            return _Proc(0, "TREE_SHA\n")
+        if args[1] == "commit-tree":
+            return _Proc(0, "DANGLING_SHA\n")
+        if args[1] == "cherry":
+            return _Proc(cherry_rc, cherry_stdout)
+        return _Proc(1)
+
+    return run
+
+
+def test_squash_detected_when_cherry_marks_patch_present():
+    assert gsm.is_merged_into(_squash_runner("- deadbeef\n"), "feat", "main") is True
+
+
+def test_not_merged_when_cherry_marks_patch_missing():
+    assert gsm.is_merged_into(_squash_runner("+ deadbeef\n"), "feat", "main") is False
+
+
+def test_empty_cherry_output_treated_as_merged():
+    assert gsm.is_merged_into(_squash_runner(""), "feat", "main") is True
+
+
+def test_conservative_false_when_merge_base_fails():
+    def run(args):
+        if args[1:3] == ["merge-base", "--is-ancestor"]:
+            return _Proc(1)
+        if args[1] == "merge-base":
+            return _Proc(128, "")  # no common ancestor / error
+        return _Proc(0, "x\n")
+
+    assert gsm.is_merged_into(run, "feat", "main") is False
+
+
+# --- integration tests against a real temporary git repo ---
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, encoding="utf-8"
+    )
+
+
+def _runner_for(repo: Path):
+    def run(args):
+        return subprocess.run(
+            args, cwd=repo, capture_output=True, text=True, encoding="utf-8"
+        )
+
+    return run
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "main")
+    _git(r, "config", "user.email", "t@example.com")
+    _git(r, "config", "user.name", "Test")
+    _git(r, "config", "commit.gpgsign", "false")
+    (r / "a.txt").write_text("base\n", encoding="utf-8")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-q", "-m", "base")
+    return r
+
+
+def _make_feature(repo: Path) -> None:
+    _git(repo, "checkout", "-q", "-b", "feat")
+    (repo / "b.txt").write_text("one\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "feat 1")
+    (repo / "b.txt").write_text("one\ntwo\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "feat 2")
+    _git(repo, "checkout", "-q", "main")
+
+
+def test_real_squash_merge_detected(repo: Path):
+    _make_feature(repo)
+    _git(repo, "merge", "--squash", "feat")
+    _git(repo, "commit", "-q", "-m", "squashed feat (#1)")
+
+    run = _runner_for(repo)
+    # The old check is blind to the squash:
+    assert run(["git", "merge-base", "--is-ancestor", "feat", "main"]).returncode != 0
+    # The new check sees the cumulative patch already on main:
+    assert gsm.is_merged_into(run, "feat", "main") is True
+
+
+def test_real_unmerged_branch_not_detected(repo: Path):
+    _make_feature(repo)  # nothing merged into main
+    assert gsm.is_merged_into(_runner_for(repo), "feat", "main") is False
+
+
+def test_real_ff_and_merge_commit_detected(repo: Path):
+    _make_feature(repo)
+    _git(repo, "merge", "--no-ff", "-m", "merge feat", "feat")
+    assert gsm.is_merged_into(_runner_for(repo), "feat", "main") is True
+
+
+def test_real_squash_then_extra_commit_not_fully_merged(repo: Path):
+    _make_feature(repo)
+    _git(repo, "merge", "--squash", "feat")
+    _git(repo, "commit", "-q", "-m", "squashed feat (#1)")
+    # New work lands on feat after the squash — branch is no longer fully merged.
+    _git(repo, "checkout", "-q", "feat")
+    (repo / "c.txt").write_text("post-merge work\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "feat 3")
+    _git(repo, "checkout", "-q", "main")
+    assert gsm.is_merged_into(_runner_for(repo), "feat", "main") is False


### PR DESCRIPTION
## Problem

The repo squash-merges PRs (`delete_branch_on_merge=true`), but both lifecycle-automation merged-checks detected "merged" via `git merge-base --is-ancestor` only:

- **Layer 1** — `branch_janitor.is_merged` (the `MERGED` "provably safe to delete" category)
- **Layer 2** — `wt.py done` (verify-merged-before-teardown gate)

`--is-ancestor` is **false for every squash merge** (the merged change is a brand-new commit on main). So the *safe* teardown/cleanup path refused the **default** merge style: worktrees/branches were either force-discarded (losing the safety) or never torn down. That is the structural root of the local worktree sprawl (~150 worktrees currently) — the exact drift this automation exists to prevent. The janitor only kept the remote side clean because GitHub's Layer-0 auto-delete catches most branches at merge time; the janitor's own `MERGED` backstop was half-blind.

## Fix

New `scripts/git_squash_merge.is_merged_into(run, ref, base_ref)`:
1. Cheap path: `--is-ancestor` (catches fast-forward + merge-commit merges).
2. Squash path: synthesize a commit with the branch's cumulative tree on top of the merge-base, then ask `git cherry` whether that patch is already on the base ref.

Both `wt.py done` and `branch_janitor.is_merged` now delegate to it. Conservative (returns `False`) on any git error, so callers refuse teardown rather than discard unmerged work. A branch that was squash-merged and then got *more* commits is correctly reported **not** fully merged.

## Tests

`tests/test_git_squash_merge.py` — unit (fake runner: ancestor short-circuit, cherry `-`/`+`, empty output, merge-base error) + **real temp-repo integration** proving `--is-ancestor`=False yet `is_merged_into`=True after an actual squash merge, plus fast-forward/merge-commit, genuinely-unmerged, and squash-then-extra-commit cases. `branch_janitor` + `worktree_status` suites unaffected. `ruff` clean. Scripts-only (no `workflow/*` runtime → no plugin-mirror impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)