### PR TITLE
fix(lifecycle): wt.py done force-deletes proven-merged (squash) branches

### DIFF
--- a/scripts/wt.py
+++ b/scripts/wt.py
@@ -137,6 +137,19 @@ def _branch_of(path: Path) -> str | None:
     return proc.stdout.strip() if proc.returncode == 0 else None
 
 
+def _branch_delete_flag(merged: bool, force: bool) -> str:
+    """Choose ``git branch -d`` vs ``-D``.
+
+    ``-d`` is ancestor-based and refuses squash-merged branches (the repo's
+    default merge style) with "not fully merged" — which would leave the local
+    branch behind after teardown. Once ``is_merged_into`` has *proven* the
+    branch merged (squash-aware), or the caller passed ``--force``, force-delete
+    with ``-D``. Plain ``-d`` only applies when neither holds, but ``cmd_done``
+    bails out before teardown in that case, so it is effectively unreachable.
+    """
+    return "-D" if (merged or force) else "-d"
+
+
 def cmd_done(args: argparse.Namespace) -> int:
     root = repo_root()
     if args.target:
@@ -169,7 +182,7 @@ def cmd_done(args: argparse.Namespace) -> int:
     )
     if rm.returncode != 0:
         raise SystemExit(f"git worktree remove failed: {rm.stderr.strip()}")
-    flag = "-D" if args.force else "-d"
+    flag = _branch_delete_flag(merged, args.force)
     delb = _run(["git", "branch", flag, branch], cwd=root)
     log_event(
         root,

--- a/tests/test_wt.py
+++ b/tests/test_wt.py
@@ -1,0 +1,35 @@
+"""Tests for scripts/wt.py teardown helpers.
+
+Guards the branch-delete flag selection: ``git branch -d`` is ancestor-based
+and refuses squash-merged branches (this repo's default merge style), which
+would strand the local branch after ``wt.py done``. Once the merge is proven
+squash-aware, teardown must force-delete with ``-D``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(_SCRIPTS))  # so wt.py's sibling import (git_squash_merge) resolves
+_SPEC = importlib.util.spec_from_file_location("wt", _SCRIPTS / "wt.py")
+wt = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+sys.modules["wt"] = wt
+_SPEC.loader.exec_module(wt)
+
+
+def test_proven_merged_uses_force_delete():
+    # Squash-merged branch: proven merged but NOT an ancestor -> -d would refuse.
+    assert wt._branch_delete_flag(merged=True, force=False) == "-D"
+
+
+def test_force_uses_force_delete():
+    assert wt._branch_delete_flag(merged=False, force=True) == "-D"
+
+
+def test_unmerged_unforced_stays_safe_delete():
+    # Unreachable in cmd_done (it bails first), but the helper stays conservative.
+    assert wt._branch_delete_flag(merged=False, force=False) == "-d"


### PR DESCRIPTION
Follow-up to #1388.

## Problem
With #1388, `wt.py done` correctly *decides* a squash-merged lane is merged and removes its worktree. But the **local branch delete** still used `git branch -d`, which is itself ancestor-based and refuses a squash-merged branch with "not fully merged". So teardown removed the worktree but **left the local branch behind** — the same squash blind spot, one line over.

## Fix
Once `is_merged_into` has *proven* the branch merged (or `--force` was passed), force-delete with `-D`. Extracted `_branch_delete_flag(merged, force)` so the selection is unit-testable.

## Tests
`tests/test_wt.py` — proven-merged→`-D`, force→`-D`, unmerged-unforced→`-d` (conservative; unreachable in `cmd_done` which bails first). ruff clean. Scripts-only (no plugin-mirror impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)