### PR TITLE
fix(lifecycle): worktree_status squash-aware merged detection (3rd consumer)

### DIFF
--- a/scripts/worktree_status.py
+++ b/scripts/worktree_status.py
@@ -17,6 +17,9 @@ import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from git_squash_merge import is_merged_into  # noqa: E402  (sibling-script import)
+
 STALE_AFTER_SECONDS = 24 * 60 * 60
 MAIN_BRANCHES = {"main", "master", "production"}
 REQUIRED_PURPOSE_FIELDS = (
@@ -342,9 +345,14 @@ def _is_fully_merged(path: Path, entry: WorktreeEntry) -> bool:
     branch = entry.branch
     if _is_main_branch(branch):
         return False
+    # Squash-aware: PRs here squash-merge, so a plain --is-ancestor check would
+    # leave clean squash-merged lanes mislabelled instead of READY_TO_REMOVE.
+    # is_merged_into prepends "git"; run_git takes args without it, so drop a[0].
+    def _run(a: list[str]) -> subprocess.CompletedProcess[str]:
+        return run_git(list(a)[1:], path)
+
     for base in _merge_base_candidates(path):
-        result = run_git(["merge-base", "--is-ancestor", entry.head, base], path)
-        if result.returncode == 0:
+        if is_merged_into(_run, entry.head, base):
             return True
     return False
 
@@ -551,7 +559,10 @@ def sweep_commands(statuses: list[WorktreeStatus]) -> list[str]:
             continue
         commands.append(f"git worktree remove {shlex.quote(status.path)}")
         if status.state == "READY_TO_REMOVE" and _branch_can_be_deleted(status.branch):
-            commands.append(f"git branch -d {shlex.quote(status.branch)}")
+            # -D, not -d: READY_TO_REMOVE means proven-merged (squash-aware), but
+            # `git branch -d` is ancestor-based and would refuse a squash-merged
+            # branch, leaving it behind when the printed commands are run.
+            commands.append(f"git branch -D {shlex.quote(status.branch)}")
     return commands
 
 

--- a/tests/test_worktree_status.py
+++ b/tests/test_worktree_status.py
@@ -159,7 +159,9 @@ def test_ready_to_remove_sweep_commands_remove_worktree_and_local_branch() -> No
 
     assert commands == [
         "git worktree remove /tmp/wf-landed",
-        "git branch -d codex/landed-fix",
+        # -D (not -d): READY_TO_REMOVE is proven-merged, but -d is ancestor-based
+        # and would refuse a squash-merged branch.
+        "git branch -D codex/landed-fix",
     ]
 
 
@@ -197,6 +199,51 @@ def test_build_status_marks_fully_merged_branch_ready_to_remove(tmp_path: Path) 
     _git(repo, "checkout", "-q", "main")
     _git(repo, "merge", "-q", "--no-ff", "codex/topic", "-m", "merge topic")
     _git(repo, "worktree", "add", "-q", str(topic_path), "codex/topic")
+
+    status = worktree_status.build_status(
+        worktree_status.WorktreeEntry(
+            path=str(topic_path),
+            head=topic_head,
+            branch_ref="refs/heads/codex/topic",
+        ),
+        repo=repo,
+    )
+
+    assert status.state == "READY_TO_REMOVE"
+
+
+def test_build_status_marks_squash_merged_branch_ready_to_remove(tmp_path: Path) -> None:
+    # Squash merge: the branch head is NOT an ancestor of main, so the old
+    # --is-ancestor check would mislabel a clean, fully-landed lane. The
+    # squash-aware _is_fully_merged must still mark it READY_TO_REMOVE.
+    repo = tmp_path / "repo"
+    topic_path = tmp_path / "wf-topic"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "commit.gpgsign", "false")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-q", "-m", "base")
+    _git(repo, "checkout", "-q", "-b", "codex/topic")
+    (repo / "topic.txt").write_text("topic\n", encoding="utf-8")
+    _git(repo, "add", "topic.txt")
+    _git(repo, "commit", "-q", "-m", "topic")
+    topic_head = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "merge", "-q", "--squash", "codex/topic")
+    _git(repo, "commit", "-q", "-m", "squashed topic (#1)")
+    _git(repo, "worktree", "add", "-q", str(topic_path), "codex/topic")
+
+    # Sanity: the old ancestor-only check would say "not merged".
+    assert (
+        subprocess.run(
+            ["git", "merge-base", "--is-ancestor", topic_head, "main"],
+            cwd=repo,
+        ).returncode
+        != 0
+    )
 
     status = worktree_status.build_status(
         worktree_status.WorktreeEntry(


### PR DESCRIPTION
Completes the squash-aware sweep started in #1388 (janitor + `wt.py done`) and #1391 (`wt.py` branch delete).

## Problem
`worktree_status.py` was the **third** tool deciding "merged?" via `git merge-base --is-ancestor` (`_is_fully_merged`). Since this repo squash-merges, clean fully-landed lanes were under-reported as `READY_TO_REMOVE` — only the `upstream == "gone"` path (remote branch auto-deleted on merge) caught some. And `--sweep-orphaned`'s dry-run printed `git branch -d`, which is ancestor-based and would refuse a squash-merged branch when the operator runs the commands.

## Fix
- `_is_fully_merged` delegates to the shared `git_squash_merge.is_merged_into` (adapting `run_git`, which omits the leading `git`).
- `sweep_commands` emits `git branch -D` for proven-merged `READY_TO_REMOVE` lanes.

## Tests
New squash-merge integration test asserts `READY_TO_REMOVE` where the old `--is-ancestor` check returns non-zero; existing sweep test updated to `-D`. ruff clean. Scripts-only (no plugin-mirror impact).

After this, all three lifecycle consumers (Layer-1 janitor, Layer-2 `wt.py done`, and the `worktree_status` diagnostic/sweep) agree on squash-merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)