### PR TITLE
test(api_market): fix stale goal/gates handler-count expectations (14/14)

### DIFF
--- a/tests/test_api_market.py
+++ b/tests/test_api_market.py
@@ -113,11 +113,12 @@ def test_attribution_actions_keys():
 # ── _GOAL_ACTIONS dispatch table ────────────────────────────────────────────
 
 
-def test_goal_actions_table_has_12_handlers():
+def test_goal_actions_table_has_14_handlers():
     # 9 base actions + archive_consultation (pre-existing on main) +
     # run_canonical (PR-127 M6 cutover Step 4) +
-    # set_selector (DESIGN-008 user-buildable selector primitive) = 12.
-    assert len(_GOAL_ACTIONS) == 12
+    # set_selector (DESIGN-008 user-buildable selector primitive) +
+    # define_protocol + get_protocol (goal-bound branch protocols) = 14.
+    assert len(_GOAL_ACTIONS) == 14
 
 
 def test_goal_actions_keys():
@@ -129,6 +130,8 @@ def test_goal_actions_keys():
         "run_canonical",
         # DESIGN-008 — user-buildable selector primitive.
         "set_selector",
+        # Goal-bound branch protocols.
+        "define_protocol", "get_protocol",
     }
     assert set(_GOAL_ACTIONS.keys()) == expected
 
@@ -192,8 +195,8 @@ def test_goals_unknown_action_lists_directory_aliases():
 # ── _GATES_ACTIONS dispatch table ───────────────────────────────────────────
 
 
-def test_gates_actions_table_has_11_handlers():
-    assert len(_GATES_ACTIONS) == 11
+def test_gates_actions_table_has_14_handlers():
+    assert len(_GATES_ACTIONS) == 14
 
 
 def test_gates_actions_keys():
@@ -203,6 +206,8 @@ def test_gates_actions_keys():
         "stake_bonus", "unstake_bonus", "release_bonus",
         # PR-126 M5 — claim from completed run's recommended_rung_claim.
         "claim_from_branch_run",
+        # Conformance-pack registry handlers.
+        "record_conformance_pack", "list_conformance_packs", "get_conformance_pack",
     }
     assert set(_GATES_ACTIONS.keys()) == expected
 


### PR DESCRIPTION
`tests/test_api_market.py` asserted `_GOAL_ACTIONS == 12` and `_GATES_ACTIONS == 11`, but both dispatch tables grew to **14** as real features landed — so 4 tests were red on `main`. It went unnoticed because full pytest isn't a CI gate here.

Stale expectations, not a code bug — confirmed the extra handlers are intentional shipped features:
- `_GOAL_ACTIONS` +`define_protocol`, `get_protocol` (goal-bound branch protocols)
- `_GATES_ACTIONS` +`record_conformance_pack`, `list_conformance_packs`, `get_conformance_pack` (conformance-pack registry)

Updates the two count tests (→14, renamed) and the two key-set tests; **no handler code changed**. `tests/test_api_market.py` now fully green (38 passed), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)