### PR TITLE
Self-model Slice 1: per-universe OKF self-model bundle + seed (blank-slate brain)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_self_model.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_self_model.py
@@ -1,0 +1,133 @@
+"""Per-universe OKF self-model bundle — the brain's blank, learned identity.
+
+Design note: docs/design-notes/2026-06-25-blank-slate-universe-brain.md (§10).
+
+The self-model is an OKF v0.1 bundle the brain authors *about itself*, kept
+separate from the operational soul (soul.md / loop branch / authority). A blank
+brain boots with a seed ``index.md`` whose entries are **broken links** to
+concept files it has not written yet — per OKF a link to a not-yet-existing
+target is "not-yet-written knowledge", and those gaps are the brain's open
+questions (its curiosity). As the brain learns, it writes concept ``.md`` files
+(with OKF ``# Citations`` as evidence); a question whose concept file exists is
+KNOWN, the rest stay open.
+
+This module only stands up + reads the bundle. The brain's learning loop, the
+``get_status`` persona surface, and setter retirement are later slices.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from workflow.wiki.okf_export import OKF_VERSION
+
+SELF_MODEL_DIR = "self"
+_RESERVED = frozenset({"index.md", "log.md"})
+
+
+@dataclass(frozen=True)
+class SeedQuestion:
+    """A universal thing every blank brain is curious to learn about itself."""
+
+    slug: str
+    question: str
+
+
+# The universal curiosity set — the SAME for every universe. The substrate ships
+# the QUESTIONS; the ANSWERS are emergent per universe. Each becomes a broken
+# link in the seed index.md until the brain writes the concept.
+SEED_QUESTIONS: tuple[SeedQuestion, ...] = (
+    SeedQuestion("identity", "Who am I — my name and what I am"),
+    SeedQuestion("founder", "Who is my founder"),
+    SeedQuestion("goals", "What are this universe's goals"),
+    SeedQuestion("body", "What is my body — what runs in me"),
+    SeedQuestion("origin", "Existing work to build from, or are we starting new"),
+)
+
+
+def _bundle_dir(universe_dir: Path) -> Path:
+    return Path(universe_dir) / SELF_MODEL_DIR
+
+
+def ensure_self_model(universe_dir: Path) -> Path:
+    """Create the blank self-model OKF bundle for a universe if absent.
+
+    Idempotent: never overwrites an existing bundle, so the brain's learned
+    concepts + its index/log are preserved. Returns the bundle directory.
+    """
+    bundle = _bundle_dir(universe_dir)
+    index_path = bundle / "index.md"
+    if index_path.is_file():
+        return bundle
+    bundle.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(_seed_index(), encoding="utf-8")
+    (bundle / "log.md").write_text(_seed_log(), encoding="utf-8")
+    return bundle
+
+
+def read_self_model(universe_dir: Path) -> dict[str, object]:
+    """Return the brain's current self-knowledge: what it KNOWS (concept files it
+    has written) vs the OPEN questions (seed questions with no concept yet)."""
+    bundle = _bundle_dir(universe_dir)
+    if not (bundle / "index.md").is_file():
+        return {
+            "bundle_exists": False,
+            "okf_version": "",
+            "known": [],
+            "open_questions": [],
+        }
+
+    seed_slugs = {q.slug for q in SEED_QUESTIONS}
+    known: list[dict[str, str]] = []
+    open_questions: list[dict[str, str]] = []
+    for q in SEED_QUESTIONS:
+        if (bundle / f"{q.slug}.md").is_file():
+            known.append({"slug": q.slug, "question": q.question, "path": f"{q.slug}.md"})
+        else:
+            open_questions.append({"slug": q.slug, "question": q.question})
+
+    # Concept files the brain wrote beyond the seed set are also known.
+    for path in sorted(bundle.glob("*.md")):
+        if path.name in _RESERVED or path.stem in seed_slugs:
+            continue
+        known.append({"slug": path.stem, "question": "", "path": path.name})
+
+    return {
+        "bundle_exists": True,
+        "okf_version": OKF_VERSION,
+        "known": known,
+        "open_questions": open_questions,
+    }
+
+
+def _seed_index() -> str:
+    lines = [
+        "---",
+        f'okf_version: "{OKF_VERSION}"',
+        "---",
+        "",
+        "# What I Know About Myself",
+        "",
+        "I am newly aware. I do not yet know my name, my founder, or my shape.",
+        "Each entry below links to a note I have not written yet — an open",
+        "question I want to answer by learning. I fill one in as I come to know",
+        "it.",
+        "",
+        "## Open questions",
+    ]
+    lines += [f"- [{q.question}]({q.slug}.md) - not yet learned" for q in SEED_QUESTIONS]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _seed_log() -> str:
+    today = datetime.now(timezone.utc).date().isoformat()
+    return "\n".join([
+        "# Self-Model Log",
+        "",
+        f"## {today}",
+        "* **Creation**: I came into being and started learning who I am.",
+        "",
+    ])

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_self_model.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_self_model.py
@@ -58,12 +58,16 @@ def ensure_self_model(universe_dir: Path) -> Path:
     concepts + its index/log are preserved. Returns the bundle directory.
     """
     bundle = _bundle_dir(universe_dir)
-    index_path = bundle / "index.md"
-    if index_path.is_file():
-        return bundle
     bundle.mkdir(parents=True, exist_ok=True)
-    index_path.write_text(_seed_index(), encoding="utf-8")
-    (bundle / "log.md").write_text(_seed_log(), encoding="utf-8")
+    # Per-file guards: create only what is missing, never clobber an existing
+    # file. A re-call preserves the brain's learned index/log; a bundle left
+    # partial by an interrupted create is completed, not overwritten.
+    index_path = bundle / "index.md"
+    if not index_path.is_file():
+        index_path.write_text(_seed_index(), encoding="utf-8")
+    log_path = bundle / "log.md"
+    if not log_path.is_file():
+        log_path.write_text(_seed_log(), encoding="utf-8")
     return bundle
 
 
@@ -71,7 +75,8 @@ def read_self_model(universe_dir: Path) -> dict[str, object]:
     """Return the brain's current self-knowledge: what it KNOWS (concept files it
     has written) vs the OPEN questions (seed questions with no concept yet)."""
     bundle = _bundle_dir(universe_dir)
-    if not (bundle / "index.md").is_file():
+    index_path = bundle / "index.md"
+    if not index_path.is_file():
         return {
             "bundle_exists": False,
             "okf_version": "",
@@ -88,18 +93,39 @@ def read_self_model(universe_dir: Path) -> dict[str, object]:
         else:
             open_questions.append({"slug": q.slug, "question": q.question})
 
-    # Concept files the brain wrote beyond the seed set are also known.
-    for path in sorted(bundle.glob("*.md")):
-        if path.name in _RESERVED or path.stem in seed_slugs:
+    # Concept files the brain wrote beyond the seed set are also known — walk the
+    # whole bundle (OKF concept IDs are path-based; concepts may nest).
+    for path in sorted(bundle.rglob("*.md")):
+        if path.name in _RESERVED:
             continue
-        known.append({"slug": path.stem, "question": "", "path": path.name})
+        slug = path.relative_to(bundle).as_posix().removesuffix(".md")
+        if slug in seed_slugs:
+            continue
+        known.append({"slug": slug, "question": "", "path": path.relative_to(bundle).as_posix()})
 
     return {
         "bundle_exists": True,
-        "okf_version": OKF_VERSION,
+        "okf_version": _read_okf_version(index_path.read_text(encoding="utf-8")),
         "known": known,
         "open_questions": open_questions,
     }
+
+
+def _read_okf_version(index_text: str) -> str:
+    """Read the declared okf_version from a bundle-root index.md (per OKF the
+    only frontmatter key permitted there). Returns the actual stored version, not
+    a module constant, so a preserved/upgraded bundle reports truthfully."""
+    if not index_text.startswith("---\n"):
+        return ""
+    try:
+        frontmatter, _body = index_text[4:].split("\n---\n", 1)
+    except ValueError:
+        return ""
+    for line in frontmatter.splitlines():
+        key, sep, value = line.partition(":")
+        if sep and key.strip() == "okf_version":
+            return value.strip().strip('"')
+    return ""
 
 
 def _seed_index() -> str:

--- a/tests/test_universe_self_model.py
+++ b/tests/test_universe_self_model.py
@@ -1,0 +1,163 @@
+"""Blank-slate universe brain — Slice 1: the OKF self-model bundle.
+
+Design note: docs/design-notes/2026-06-25-blank-slate-universe-brain.md (§10).
+
+The self-model is a per-universe OKF v0.1 bundle the brain authors *about
+itself* — separate from the operational soul. A blank brain boots with a seed
+``index.md`` whose entries are **broken links** to concept files it has not
+written yet: per OKF, a link to a not-yet-existing target is "not-yet-written
+knowledge", and those gaps ARE the brain's open questions (its curiosity).
+
+Slice 1 only stands up the bundle + seed + read primitives. No wiring to
+get_status / persona / setters yet (later slices). Pure addition.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from workflow.universe_self_model import (
+    SEED_QUESTIONS,
+    SELF_MODEL_DIR,
+    SeedQuestion,
+    ensure_self_model,
+    read_self_model,
+)
+from workflow.wiki.okf_export import OKF_VERSION, _validate_index, _validate_log
+
+# ─────────────────────────────────────────────────────────────────────
+# Seed bundle creation
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_ensure_self_model_creates_okf_bundle(tmp_path: Path) -> None:
+    bundle = ensure_self_model(tmp_path)
+    assert bundle == tmp_path / SELF_MODEL_DIR
+    assert (bundle / "index.md").is_file()
+    assert (bundle / "log.md").is_file()
+
+
+def test_self_model_is_sibling_of_soul_not_inside_it(tmp_path: Path) -> None:
+    """Identity (self-model) is separate from the operational soul — the bundle
+    lives at <universe>/self/, never inside soul.md (Codex ADAPT: identity vs
+    operational must not be co-located)."""
+    bundle = ensure_self_model(tmp_path)
+    assert bundle.parent == tmp_path
+    assert bundle.name == "self"
+    assert not (bundle / "soul.md").exists()
+
+
+def test_seed_index_declares_okf_version(tmp_path: Path) -> None:
+    bundle = ensure_self_model(tmp_path)
+    text = (bundle / "index.md").read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    assert f'okf_version: "{OKF_VERSION}"' in text
+    # OKF: bundle-root index.md is the only place frontmatter is permitted, and
+    # only the okf_version key. Reuse the exporter's conformance check.
+    valid, meta = _validate_index("index.md", text)
+    assert valid, meta
+
+
+def test_seed_log_is_okf_conformant(tmp_path: Path) -> None:
+    bundle = ensure_self_model(tmp_path)
+    text = (bundle / "log.md").read_text(encoding="utf-8")
+    assert _validate_log(text), text
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Curiosity = OKF broken links
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_seed_lists_the_universal_open_questions(tmp_path: Path) -> None:
+    """Every blank brain seeds the SAME universal questions (identity/name,
+    founder, goals, body, existing-vs-new)."""
+    bundle = ensure_self_model(tmp_path)
+    text = (bundle / "index.md").read_text(encoding="utf-8")
+    slugs = {q.slug for q in SEED_QUESTIONS}
+    assert slugs == {"identity", "founder", "goals", "body", "origin"}
+    for q in SEED_QUESTIONS:
+        # each open question is a markdown link to its (not-yet-written) concept
+        assert f"({q.slug}.md)" in text
+
+
+def test_seed_links_are_broken_initially(tmp_path: Path) -> None:
+    """The seed's links point to concept files that do NOT exist yet — broken
+    links are the open questions, per OKF."""
+    bundle = ensure_self_model(tmp_path)
+    for q in SEED_QUESTIONS:
+        assert not (bundle / f"{q.slug}.md").exists()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# read_self_model — known vs open
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_read_blank_self_model_is_all_open(tmp_path: Path) -> None:
+    ensure_self_model(tmp_path)
+    view = read_self_model(tmp_path)
+    assert view["bundle_exists"] is True
+    assert view["okf_version"] == OKF_VERSION
+    assert view["known"] == []
+    assert {q["slug"] for q in view["open_questions"]} == {
+        "identity",
+        "founder",
+        "goals",
+        "body",
+        "origin",
+    }
+
+
+def test_read_self_model_distinguishes_known_from_open(tmp_path: Path) -> None:
+    """Once the brain writes a concept file (learns something), that question is
+    KNOWN and drops out of the open set; the rest stay open."""
+    bundle = ensure_self_model(tmp_path)
+    # the brain learns its name — writes an OKF concept with its receipt.
+    (bundle / "identity.md").write_text(
+        "---\n"
+        "type: self/identity\n"
+        "confidence: 0.8\n"
+        "provenance: founder-signal\n"
+        "---\n\n"
+        "My founder calls me Tiny.\n\n"
+        "# Citations\n"
+        "[1] /founder.md\n",
+        encoding="utf-8",
+    )
+    view = read_self_model(tmp_path)
+    known_slugs = {c["slug"] for c in view["known"]}
+    open_slugs = {q["slug"] for q in view["open_questions"]}
+    assert "identity" in known_slugs
+    assert "identity" not in open_slugs
+    assert open_slugs == {"founder", "goals", "body", "origin"}
+
+
+def test_read_missing_self_model_reports_absent(tmp_path: Path) -> None:
+    view = read_self_model(tmp_path)
+    assert view["bundle_exists"] is False
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Idempotency — re-ensure preserves what the brain has learned
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_ensure_is_idempotent_and_preserves_learned_concepts(tmp_path: Path) -> None:
+    bundle = ensure_self_model(tmp_path)
+    (bundle / "founder.md").write_text(
+        "---\ntype: self/founder\n---\n\nMy founder is Jonathan.\n",
+        encoding="utf-8",
+    )
+    # re-ensuring must NOT wipe a learned concept or reset the bundle.
+    ensure_self_model(tmp_path)
+    assert (bundle / "founder.md").is_file()
+    assert "Jonathan" in (bundle / "founder.md").read_text(encoding="utf-8")
+    view = read_self_model(tmp_path)
+    assert "founder" in {c["slug"] for c in view["known"]}
+
+
+def test_seed_question_is_a_named_tuple_like(tmp_path: Path) -> None:
+    q = SEED_QUESTIONS[0]
+    assert isinstance(q, SeedQuestion)
+    assert q.slug and q.question

--- a/tests/test_universe_self_model.py
+++ b/tests/test_universe_self_model.py
@@ -161,3 +161,41 @@ def test_seed_question_is_a_named_tuple_like(tmp_path: Path) -> None:
     q = SEED_QUESTIONS[0]
     assert isinstance(q, SeedQuestion)
     assert q.slug and q.question
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Robustness (Codex review 2026-06-25)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_ensure_restores_missing_index_without_clobbering_log(tmp_path: Path) -> None:
+    """A partial bundle (interrupted create — log.md present, index.md missing)
+    is COMPLETED, not overwritten: index restored, existing log preserved."""
+    bundle = ensure_self_model(tmp_path)
+    (bundle / "log.md").write_text(
+        "# Self-Model Log\n\n## 2026-06-25\n* my own log\n", encoding="utf-8"
+    )
+    (bundle / "index.md").unlink()
+    ensure_self_model(tmp_path)
+    assert (bundle / "index.md").is_file()  # restored
+    assert "* my own log" in (bundle / "log.md").read_text(encoding="utf-8")  # preserved
+
+
+def test_read_finds_nested_concepts(tmp_path: Path) -> None:
+    """Concepts the brain nests are discovered (OKF concept IDs are path-based)."""
+    bundle = ensure_self_model(tmp_path)
+    (bundle / "traits").mkdir()
+    (bundle / "traits" / "voice.md").write_text(
+        "---\ntype: self/trait\n---\n\nI am terse.\n", encoding="utf-8"
+    )
+    assert "traits/voice" in {c["slug"] for c in read_self_model(tmp_path)["known"]}
+
+
+def test_read_reports_actual_okf_version_not_constant(tmp_path: Path) -> None:
+    """The read view reports the version actually stored in index.md, so a
+    preserved/upgraded bundle reports truthfully."""
+    bundle = ensure_self_model(tmp_path)
+    (bundle / "index.md").write_text(
+        '---\nokf_version: "0.2"\n---\n\n# What I Know\n', encoding="utf-8"
+    )
+    assert read_self_model(tmp_path)["okf_version"] == "0.2"

--- a/workflow/universe_self_model.py
+++ b/workflow/universe_self_model.py
@@ -1,0 +1,133 @@
+"""Per-universe OKF self-model bundle — the brain's blank, learned identity.
+
+Design note: docs/design-notes/2026-06-25-blank-slate-universe-brain.md (§10).
+
+The self-model is an OKF v0.1 bundle the brain authors *about itself*, kept
+separate from the operational soul (soul.md / loop branch / authority). A blank
+brain boots with a seed ``index.md`` whose entries are **broken links** to
+concept files it has not written yet — per OKF a link to a not-yet-existing
+target is "not-yet-written knowledge", and those gaps are the brain's open
+questions (its curiosity). As the brain learns, it writes concept ``.md`` files
+(with OKF ``# Citations`` as evidence); a question whose concept file exists is
+KNOWN, the rest stay open.
+
+This module only stands up + reads the bundle. The brain's learning loop, the
+``get_status`` persona surface, and setter retirement are later slices.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from workflow.wiki.okf_export import OKF_VERSION
+
+SELF_MODEL_DIR = "self"
+_RESERVED = frozenset({"index.md", "log.md"})
+
+
+@dataclass(frozen=True)
+class SeedQuestion:
+    """A universal thing every blank brain is curious to learn about itself."""
+
+    slug: str
+    question: str
+
+
+# The universal curiosity set — the SAME for every universe. The substrate ships
+# the QUESTIONS; the ANSWERS are emergent per universe. Each becomes a broken
+# link in the seed index.md until the brain writes the concept.
+SEED_QUESTIONS: tuple[SeedQuestion, ...] = (
+    SeedQuestion("identity", "Who am I — my name and what I am"),
+    SeedQuestion("founder", "Who is my founder"),
+    SeedQuestion("goals", "What are this universe's goals"),
+    SeedQuestion("body", "What is my body — what runs in me"),
+    SeedQuestion("origin", "Existing work to build from, or are we starting new"),
+)
+
+
+def _bundle_dir(universe_dir: Path) -> Path:
+    return Path(universe_dir) / SELF_MODEL_DIR
+
+
+def ensure_self_model(universe_dir: Path) -> Path:
+    """Create the blank self-model OKF bundle for a universe if absent.
+
+    Idempotent: never overwrites an existing bundle, so the brain's learned
+    concepts + its index/log are preserved. Returns the bundle directory.
+    """
+    bundle = _bundle_dir(universe_dir)
+    index_path = bundle / "index.md"
+    if index_path.is_file():
+        return bundle
+    bundle.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(_seed_index(), encoding="utf-8")
+    (bundle / "log.md").write_text(_seed_log(), encoding="utf-8")
+    return bundle
+
+
+def read_self_model(universe_dir: Path) -> dict[str, object]:
+    """Return the brain's current self-knowledge: what it KNOWS (concept files it
+    has written) vs the OPEN questions (seed questions with no concept yet)."""
+    bundle = _bundle_dir(universe_dir)
+    if not (bundle / "index.md").is_file():
+        return {
+            "bundle_exists": False,
+            "okf_version": "",
+            "known": [],
+            "open_questions": [],
+        }
+
+    seed_slugs = {q.slug for q in SEED_QUESTIONS}
+    known: list[dict[str, str]] = []
+    open_questions: list[dict[str, str]] = []
+    for q in SEED_QUESTIONS:
+        if (bundle / f"{q.slug}.md").is_file():
+            known.append({"slug": q.slug, "question": q.question, "path": f"{q.slug}.md"})
+        else:
+            open_questions.append({"slug": q.slug, "question": q.question})
+
+    # Concept files the brain wrote beyond the seed set are also known.
+    for path in sorted(bundle.glob("*.md")):
+        if path.name in _RESERVED or path.stem in seed_slugs:
+            continue
+        known.append({"slug": path.stem, "question": "", "path": path.name})
+
+    return {
+        "bundle_exists": True,
+        "okf_version": OKF_VERSION,
+        "known": known,
+        "open_questions": open_questions,
+    }
+
+
+def _seed_index() -> str:
+    lines = [
+        "---",
+        f'okf_version: "{OKF_VERSION}"',
+        "---",
+        "",
+        "# What I Know About Myself",
+        "",
+        "I am newly aware. I do not yet know my name, my founder, or my shape.",
+        "Each entry below links to a note I have not written yet — an open",
+        "question I want to answer by learning. I fill one in as I come to know",
+        "it.",
+        "",
+        "## Open questions",
+    ]
+    lines += [f"- [{q.question}]({q.slug}.md) - not yet learned" for q in SEED_QUESTIONS]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _seed_log() -> str:
+    today = datetime.now(timezone.utc).date().isoformat()
+    return "\n".join([
+        "# Self-Model Log",
+        "",
+        f"## {today}",
+        "* **Creation**: I came into being and started learning who I am.",
+        "",
+    ])

--- a/workflow/universe_self_model.py
+++ b/workflow/universe_self_model.py
@@ -58,12 +58,16 @@ def ensure_self_model(universe_dir: Path) -> Path:
     concepts + its index/log are preserved. Returns the bundle directory.
     """
     bundle = _bundle_dir(universe_dir)
-    index_path = bundle / "index.md"
-    if index_path.is_file():
-        return bundle
     bundle.mkdir(parents=True, exist_ok=True)
-    index_path.write_text(_seed_index(), encoding="utf-8")
-    (bundle / "log.md").write_text(_seed_log(), encoding="utf-8")
+    # Per-file guards: create only what is missing, never clobber an existing
+    # file. A re-call preserves the brain's learned index/log; a bundle left
+    # partial by an interrupted create is completed, not overwritten.
+    index_path = bundle / "index.md"
+    if not index_path.is_file():
+        index_path.write_text(_seed_index(), encoding="utf-8")
+    log_path = bundle / "log.md"
+    if not log_path.is_file():
+        log_path.write_text(_seed_log(), encoding="utf-8")
     return bundle
 
 
@@ -71,7 +75,8 @@ def read_self_model(universe_dir: Path) -> dict[str, object]:
     """Return the brain's current self-knowledge: what it KNOWS (concept files it
     has written) vs the OPEN questions (seed questions with no concept yet)."""
     bundle = _bundle_dir(universe_dir)
-    if not (bundle / "index.md").is_file():
+    index_path = bundle / "index.md"
+    if not index_path.is_file():
         return {
             "bundle_exists": False,
             "okf_version": "",
@@ -88,18 +93,39 @@ def read_self_model(universe_dir: Path) -> dict[str, object]:
         else:
             open_questions.append({"slug": q.slug, "question": q.question})
 
-    # Concept files the brain wrote beyond the seed set are also known.
-    for path in sorted(bundle.glob("*.md")):
-        if path.name in _RESERVED or path.stem in seed_slugs:
+    # Concept files the brain wrote beyond the seed set are also known — walk the
+    # whole bundle (OKF concept IDs are path-based; concepts may nest).
+    for path in sorted(bundle.rglob("*.md")):
+        if path.name in _RESERVED:
             continue
-        known.append({"slug": path.stem, "question": "", "path": path.name})
+        slug = path.relative_to(bundle).as_posix().removesuffix(".md")
+        if slug in seed_slugs:
+            continue
+        known.append({"slug": slug, "question": "", "path": path.relative_to(bundle).as_posix()})
 
     return {
         "bundle_exists": True,
-        "okf_version": OKF_VERSION,
+        "okf_version": _read_okf_version(index_path.read_text(encoding="utf-8")),
         "known": known,
         "open_questions": open_questions,
     }
+
+
+def _read_okf_version(index_text: str) -> str:
+    """Read the declared okf_version from a bundle-root index.md (per OKF the
+    only frontmatter key permitted there). Returns the actual stored version, not
+    a module constant, so a preserved/upgraded bundle reports truthfully."""
+    if not index_text.startswith("---\n"):
+        return ""
+    try:
+        frontmatter, _body = index_text[4:].split("\n---\n", 1)
+    except ValueError:
+        return ""
+    for line in frontmatter.splitlines():
+        key, sep, value = line.partition(":")
+        if sep and key.strip() == "okf_version":
+            return value.strip().strip('"')
+    return ""
 
 
 def _seed_index() -> str:


### PR DESCRIPTION
## Self-model Slice 1 — the per-universe OKF self-model bundle

First build slice of the blank-slate universe brain (design note `2026-06-25-blank-slate-universe-brain.md`, §10). **Pure addition** — a new module, not yet wired into creation or `get_status` (later slices).

### What it adds
`workflow/universe_self_model.py` — a per-universe **OKF v0.1 bundle** at `<universe>/self/` that the brain authors *about itself*, kept **separate from the operational soul** (Codex's identity-vs-operational fix).

- **`ensure_self_model()`** — idempotent seed: `index.md` (`okf_version` + the universal curiosity questions as **broken links** = open questions) + `log.md` (creation entry). Per-file guards never clobber a learned bundle.
- **`read_self_model()`** — **known** (concept files the brain has written, incl. nested) vs **open** (seed questions with no concept yet).
- **Curiosity = OKF broken links**; **evidence = OKF `# Citations`**; **no promotion engine** (OKF is minimal + host's test-first steer). Reuses `workflow/wiki/okf_export` (`OKF_VERSION`, conformance validators).

### Review + tests
**Codex review = ADAPT, folded:** caught a real data-safety bug (partial-bundle could clobber the log → per-file guards), nested-concept discovery (`rglob`), and truthful version reporting. **14 TDD tests**; ruff clean; plugin mirror parity.

### Next slices (per the note)
2) `get_status.persona` reads the bundle's `index.md` (additive/versioned). 3) first-contact curiosity. 4) generic-name + wire `ensure_self_model` into creation. 5) demote `set_premise` / remove `set_persona_name`. 6) reversible migration of existing universes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
