### PR TITLE
feat(connector): read_graph target=branch — SEE-for-branches (read/edit symmetry)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -404,6 +404,7 @@ def read_graph(
     graph_id: str = "",
     goal_id: str = "",
     run_id: str = "",
+    branch_id: str = "",
     query: str = "",
     tags: str = "",
     author: str = "",
@@ -413,11 +414,14 @@ def read_graph(
     """Read Workflow graph state without changing it.
 
     Args:
-        target: What to read: status, graphs, graph, goals, goal, runs, or run.
+        target: What to read: status, graphs, graph, goals, goal, runs, run,
+            or branch.
         graph_id: Optional graph/universe identifier.
         goal_id: Optional shared-goal identifier.
         run_id: Run identifier for target=run (the single-run result read).
             Falls back to graph_id when omitted.
+        branch_id: Branch definition identifier for target=branch (read a
+            branch's full graph + node configs). Falls back to graph_id.
         query: Optional search text.
         tags: Optional comma-separated goal tag filter.
         author: Optional goal author filter.
@@ -444,10 +448,16 @@ def read_graph(
         # structured failure reason (status, output/external_write_results,
         # error, failure_class/suggested_action/actionable_by/error_detail).
         return _extensions_impl(action="get_run", run_id=(run_id or graph_id))
+    if normalized == "branch":
+        # SEE-for-branches: a founder reads their branch's full graph + node
+        # configs (timeout_seconds, model_hint, prompt_template, edges, state
+        # schema) so an edit via write_graph target=branch is informed, not
+        # blind. Completes the read/edit symmetry with PR-180.
+        return _extensions_impl(action="get_branch", branch_def_id=(branch_id or graph_id))
     return _unknown_target(
         "read_graph",
         target,
-        ("status", "graphs", "graph", "goals", "goal", "runs", "run"),
+        ("status", "graphs", "graph", "goals", "goal", "runs", "run", "branch"),
     )
 
 

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -453,6 +453,14 @@ def read_graph(
         # configs (timeout_seconds, model_hint, prompt_template, edges, state
         # schema) so an edit via write_graph target=branch is informed, not
         # blind. Completes the read/edit symmetry with PR-180.
+        #
+        # Visibility model (commons-first, deliberate — Codex review of #1404):
+        # public BranchDefinitions are a GLOBAL remix commons, readable cross
+        # universe by anyone (you remix what you can read). The confidentiality
+        # boundary is private branches, which get_branch already author-gates
+        # with a "not found" envelope (branches.py:443) so a non-author cannot
+        # even confirm existence. get_branch was already callable here via the
+        # deprecated 'extensions' tool; this only makes it first-class.
         return _extensions_impl(action="get_branch", branch_def_id=(branch_id or graph_id))
     return _unknown_target(
         "read_graph",

--- a/tests/test_read_graph_branch.py
+++ b/tests/test_read_graph_branch.py
@@ -1,0 +1,98 @@
+"""read_graph target=branch — the SEE-for-branches primitive.
+
+Completes the read/edit symmetry started by PR-180: PR-180 added
+read_graph target=run (SEE runs) + write_graph target=branch (EDIT branches);
+this adds read_graph target=branch (SEE branches) so a founder can inspect a
+branch's full node configs (timeout_seconds, model_hint, prompt_template,
+edges, state schema) before editing — informed edits, not blind ones.
+
+Within the PR-178 five-handle invariant: a new *target*, no new handle.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+
+import pytest
+
+ADVERTISED = {
+    "read_graph",
+    "write_graph",
+    "run_graph",
+    "read_page",
+    "write_page",
+    "get_status",
+}
+
+_BASIC_SPEC = {
+    "name": "Inspectable branch",
+    "entry_point": "ready",
+    "node_defs": [{
+        "node_id": "ready",
+        "display_name": "Ready",
+        "prompt_template": "Do the work.",
+        "timeout_seconds": 450.0,
+    }],
+    "edges": [
+        {"from": "START", "to": "ready"},
+        {"from": "ready", "to": "END"},
+    ],
+    "state_schema": [{"name": "x", "type": "str"}],
+}
+
+
+@pytest.fixture
+def server_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "founder")
+    from workflow import universe_server as us
+
+    importlib.reload(us)
+    yield us
+    importlib.reload(us)
+
+
+def test_five_handles_unchanged(server_env):
+    us = server_env
+    advertised = {t.name for t in asyncio.run(us.mcp.list_tools(run_middleware=True))}
+    assert advertised == ADVERTISED
+
+
+def test_read_graph_branch_routes_to_get_branch(server_env):
+    """target=branch reaches the get_branch handler (not unknown_target)."""
+    us = server_env
+    payload = json.loads(us.read_graph(target="branch", branch_id="no-such-branch"))
+    assert payload.get("error") != "unknown_target"
+    assert "not found" in payload.get("error", "").lower()
+
+
+def test_read_graph_branch_in_allowed_targets(server_env):
+    us = server_env
+    payload = json.loads(us.read_graph(target="bogus"))
+    assert payload["error"] == "unknown_target"
+    assert "branch" in payload["allowed_targets"]
+
+
+def test_read_graph_branch_returns_node_configs(server_env):
+    """The whole point: reading a branch surfaces editable node configs."""
+    us = server_env
+    built = json.loads(us.extensions(action="build_branch", spec_json=json.dumps(_BASIC_SPEC)))
+    bid = built["branch_def_id"]
+
+    branch = json.loads(us.read_graph(target="branch", branch_id=bid))
+    assert "error" not in branch, branch
+    node_ids = {n["node_id"] for n in branch.get("node_defs", [])}
+    assert "ready" in node_ids
+    ready = next(n for n in branch["node_defs"] if n["node_id"] == "ready")
+    # The config a founder needs to make an informed timeout edit is visible.
+    assert "timeout_seconds" in ready
+
+
+def test_read_graph_branch_falls_back_to_graph_id(server_env):
+    """branch_id omitted -> graph_id is used (lenient, matches target=run)."""
+    us = server_env
+    built = json.loads(us.extensions(action="build_branch", spec_json=json.dumps(_BASIC_SPEC)))
+    bid = built["branch_def_id"]
+    branch = json.loads(us.read_graph(target="branch", graph_id=bid))
+    assert branch.get("branch_def_id") == bid

--- a/tests/test_read_graph_branch.py
+++ b/tests/test_read_graph_branch.py
@@ -96,3 +96,47 @@ def test_read_graph_branch_falls_back_to_graph_id(server_env):
     bid = built["branch_def_id"]
     branch = json.loads(us.read_graph(target="branch", graph_id=bid))
     assert branch.get("branch_def_id") == bid
+
+
+# ── Visibility model (commons-first) — Codex review of #1404 required proof ──
+# Public BranchDefinitions are a global remix commons (readable cross-user);
+# private branches are author-gated with a not-found envelope. These two tests
+# pin that boundary so the cross-universe read is a deliberate decision, not a
+# silent leak.
+
+def test_public_branch_is_commons_readable_cross_user(server_env, monkeypatch):
+    """A PUBLIC branch is readable by a different user (commons / remix model)."""
+    us = server_env
+    built = json.loads(us.extensions(action="build_branch", spec_json=json.dumps(_BASIC_SPEC)))
+    bid = built["branch_def_id"]
+
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "stranger")
+    importlib.reload(us)
+    branch = json.loads(us.read_graph(target="branch", branch_id=bid))
+    assert "error" not in branch, branch
+    assert branch.get("branch_def_id") == bid
+
+
+def test_private_branch_hidden_from_non_author(server_env, monkeypatch):
+    """A PRIVATE branch is author-gated: the author reads it, a stranger gets
+    the same not-found envelope (existence is not leaked)."""
+    us = server_env
+    built = json.loads(us.extensions(action="build_branch", spec_json=json.dumps(_BASIC_SPEC)))
+    bid = built["branch_def_id"]
+    # Make it private via the patch_branch primitive (set_visibility op).
+    patched = json.loads(us.write_graph(
+        target="branch",
+        branch_id=bid,
+        changes_json=json.dumps([{"op": "set_visibility", "visibility": "private"}]),
+    ))
+    assert "error" not in patched, patched
+
+    # Author can read their own private branch.
+    own = json.loads(us.read_graph(target="branch", branch_id=bid))
+    assert own.get("branch_def_id") == bid, own
+
+    # A different user cannot — and cannot even confirm it exists.
+    monkeypatch.setenv("UNIVERSE_SERVER_USER", "stranger")
+    importlib.reload(us)
+    blocked = json.loads(us.read_graph(target="branch", branch_id=bid))
+    assert "not found" in blocked.get("error", "").lower(), blocked

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -404,6 +404,7 @@ def read_graph(
     graph_id: str = "",
     goal_id: str = "",
     run_id: str = "",
+    branch_id: str = "",
     query: str = "",
     tags: str = "",
     author: str = "",
@@ -413,11 +414,14 @@ def read_graph(
     """Read Workflow graph state without changing it.
 
     Args:
-        target: What to read: status, graphs, graph, goals, goal, runs, or run.
+        target: What to read: status, graphs, graph, goals, goal, runs, run,
+            or branch.
         graph_id: Optional graph/universe identifier.
         goal_id: Optional shared-goal identifier.
         run_id: Run identifier for target=run (the single-run result read).
             Falls back to graph_id when omitted.
+        branch_id: Branch definition identifier for target=branch (read a
+            branch's full graph + node configs). Falls back to graph_id.
         query: Optional search text.
         tags: Optional comma-separated goal tag filter.
         author: Optional goal author filter.
@@ -444,10 +448,16 @@ def read_graph(
         # structured failure reason (status, output/external_write_results,
         # error, failure_class/suggested_action/actionable_by/error_detail).
         return _extensions_impl(action="get_run", run_id=(run_id or graph_id))
+    if normalized == "branch":
+        # SEE-for-branches: a founder reads their branch's full graph + node
+        # configs (timeout_seconds, model_hint, prompt_template, edges, state
+        # schema) so an edit via write_graph target=branch is informed, not
+        # blind. Completes the read/edit symmetry with PR-180.
+        return _extensions_impl(action="get_branch", branch_def_id=(branch_id or graph_id))
     return _unknown_target(
         "read_graph",
         target,
-        ("status", "graphs", "graph", "goals", "goal", "runs", "run"),
+        ("status", "graphs", "graph", "goals", "goal", "runs", "run", "branch"),
     )
 
 

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -453,6 +453,14 @@ def read_graph(
         # configs (timeout_seconds, model_hint, prompt_template, edges, state
         # schema) so an edit via write_graph target=branch is informed, not
         # blind. Completes the read/edit symmetry with PR-180.
+        #
+        # Visibility model (commons-first, deliberate — Codex review of #1404):
+        # public BranchDefinitions are a GLOBAL remix commons, readable cross
+        # universe by anyone (you remix what you can read). The confidentiality
+        # boundary is private branches, which get_branch already author-gates
+        # with a "not found" envelope (branches.py:443) so a non-author cannot
+        # even confirm existence. get_branch was already callable here via the
+        # deprecated 'extensions' tool; this only makes it first-class.
         return _extensions_impl(action="get_branch", branch_def_id=(branch_id or graph_id))
     return _unknown_target(
         "read_graph",


### PR DESCRIPTION
## What

Completes the founder read/edit loop started by **PR-180** (#1400). PR-180 shipped `read_graph target=run` (SEE runs) + `write_graph target=branch` (EDIT branches) but left an asymmetry: a founder could **edit** a branch but not **read** its node configs — so edits were blind. (I hit this live fixing the `localize` 300s timeout: I had to infer branch structure from a run's mermaid because I couldn't read the node's `timeout_seconds`/`model_hint`.)

## How

`read_graph target=branch` → the existing **read-only** `get_branch` handler (`workflow/api/branches.py:431`), returning the full branch dict incl. `node_defs` with each node's `timeout_seconds` / `model_hint` / `prompt_template` / edges / state schema. Informed edits, not blind ones.

- Within the PR-178 five-handle invariant (new *target*, no new handle).
- Scoped to `universe_server` `/mcp` founder surface **only** — NOT the directory-safe surface (`get_branch` exposes node source_code/prompts; same reasoning as PR-180's Codex review that kept `target=run`/`branch` off `directory_server`).
- `branch_id` param with `graph_id` fallback (matches `target=run`).

## Tests

`tests/test_read_graph_branch.py` (5): five-handle invariant; routes to `get_branch` (not `unknown_target`); allowed-targets updated; end-to-end build→read round-trip asserting node configs (incl. `timeout_seconds`) are visible; `branch_id`/`graph_id` fallback. ruff clean.

## Gates

- [ ] Codex opposite-provider review (connector surface). Dispatched.
- [ ] `mcp_public_canary --assert-handles` post-deploy (handle set unchanged → green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)