### PR TITLE
fix(loop): graceful-drain — release orphaned lease on supervisor shutdown (redeploy-churn)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/cloud_worker.py
@@ -588,6 +588,91 @@ def write_supervisor_heartbeat(
             logger.exception("cloud_worker: heartbeat write failed at %s", target)
 
 
+# Stop-path child-termination budget. Docker's default stop_grace_period is 10s:
+# on redeploy the container gets SIGTERM then SIGKILL 10s later. The supervisor
+# must terminate the child, CONFIRM its death, AND release its orphaned lease
+# within that window, so these are intentionally short. The old 30s wait never
+# completed — docker killed the container mid-wait, so neither the child's
+# graceful finalize nor the lease release ran. A child between nodes exits in <1s
+# (and finalizes its own lease); a child mid-LLM node won't exit in 5s OR 30s, so
+# the shorter wait loses nothing and leaves room for the kill-confirm + release
+# before SIGKILL (5 + 2 + release < 10s). The producer restart path (container
+# stays up) keeps the longer 30s wait.
+_STOP_CHILD_DRAIN_S = 5.0
+# After SIGKILL, confirm the child is actually gone before releasing its lease.
+_STOP_KILL_CONFIRM_S = 2.0
+
+
+def _terminate_child_for_stop(proc) -> bool:
+    """Terminate the subprocess on shutdown; return True iff its exit is CONFIRMED.
+
+    SIGTERM first (lets a between-nodes child finalize its own lease), then a
+    bounded wait; on timeout SIGKILL and a short confirm wait. The caller must
+    release the child's orphaned lease ONLY when this returns True — releasing
+    while the child can still run risks it ``mark_status()``-ing a row a peer has
+    since re-claimed (``mark_status`` has no owner guard), prematurely
+    terminalizing the peer's work. If death can't be confirmed, the startup
+    reclaim (PR #1401) and the lease TTL remain the backstop. Codex review.
+    """
+    try:
+        proc.terminate()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=_STOP_CHILD_DRAIN_S)
+        return True
+    except subprocess.TimeoutExpired:
+        logger.warning("cloud_worker: subprocess did not exit; killing")
+    try:
+        proc.kill()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=_STOP_KILL_CONFIRM_S)
+        return True
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "cloud_worker: subprocess still alive after kill; skipping shutdown "
+            "lease release (startup/TTL reclaim will recover)",
+        )
+        return False
+
+
+def _release_own_orphaned_leases(universe: Path) -> int:
+    """Release branch-task leases orphaned by this worker's dead subprocess.
+
+    Graceful-drain complement to the startup reclaim (PR #1401): reuses
+    ``reclaim_predecessor_tasks`` at SHUTDOWN. By the time the supervisor loop
+    exits the subprocess is dead, so any ``running`` row under our own
+    ``worker_id`` is an orphan it left (a SIGKILL mid-node on redeploy skips the
+    child's finalize). Releasing here frees the work for a live PEER immediately
+    instead of waiting for our replacement container to boot (whose startup
+    reclaim is the backstop). Best-effort — cleanup must never crash shutdown.
+
+    Scoped to our own unique ``worker_id``; the shared ``DEFAULT_HOST_USER``
+    fallback is excluded for the same reason as ``_dispatcher_startup`` — several
+    un-configured supervisors could share it, and reclaiming it could steal a
+    live twin's task.
+    """
+    worker_id = _worker_id()
+    if not worker_id or worker_id == DEFAULT_HOST_USER:
+        return 0
+    try:
+        from workflow.branch_tasks import reclaim_predecessor_tasks
+
+        released = reclaim_predecessor_tasks(universe, worker_id=worker_id)
+        if released:
+            logger.info(
+                "cloud_worker: released %d orphaned lease(s) for worker_id=%s "
+                "on shutdown (graceful drain)",
+                released, worker_id,
+            )
+        return released
+    except Exception:  # noqa: BLE001 — shutdown cleanup must not raise
+        logger.exception("cloud_worker: shutdown lease release failed")
+        return 0
+
+
 def run_supervisor(
     universe: Path,
     *,
@@ -634,6 +719,9 @@ def run_supervisor(
 
     state = SupervisorState()
     iteration = 0
+    # True only when a shutdown terminated the child AND confirmed its exit —
+    # gates the graceful-drain lease release (see _terminate_child_for_stop).
+    child_confirmed_dead = False
 
     # SIGTERM handling: clean exit on compose stop / systemctl stop.
     # Sets a flag the loop checks between iterations.
@@ -728,18 +816,7 @@ def run_supervisor(
                 )
             if stopping["flag"]:
                 logger.info("cloud_worker: terminating subprocess on stop signal")
-                try:
-                    proc.terminate()
-                except OSError:
-                    pass
-                try:
-                    proc.wait(timeout=30)
-                except subprocess.TimeoutExpired:
-                    logger.warning("cloud_worker: subprocess did not exit; killing")
-                    try:
-                        proc.kill()
-                    except OSError:
-                        pass
+                child_confirmed_dead = _terminate_child_for_stop(proc)
                 returncode = proc.returncode if proc.returncode is not None else -1
                 break
             rc = proc.poll()
@@ -818,6 +895,14 @@ def run_supervisor(
         )
         sleep_fn(delay)
 
+    # Graceful drain: on shutdown (SIGTERM/compose stop), the just-killed child
+    # may have orphaned a still-valid lease mid-node. Release it now so a live
+    # peer can pick the work up immediately, rather than stranding it until the
+    # ~30min TTL or our replacement's startup reclaim (PR #1401 backstop). Only
+    # when the child's exit is CONFIRMED — releasing while it can still run could
+    # terminalize a peer's re-claimed row (mark_status has no owner guard).
+    if stopping["flag"] and child_confirmed_dead:
+        _release_own_orphaned_leases(universe)
     write_supervisor_heartbeat(
         universe, state, iteration=iteration, phase="stopped",
     )

--- a/tests/test_cloud_worker.py
+++ b/tests/test_cloud_worker.py
@@ -9,6 +9,7 @@ without touching the OS process table.
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -716,3 +717,100 @@ def test_main_exits_zero_after_max_iterations(tmp_path, monkeypatch):
         "--crash-backoff", "0",
     ])
     assert rc == 0
+
+
+# ---- _release_own_orphaned_leases (graceful-drain on shutdown) ------------
+
+
+def _running_task(tmp_path, *, worker: str) -> None:
+    """Append + claim a 'running' task (fresh lease) under *worker*."""
+    from workflow.branch_tasks import BranchTask, append_task, claim_task
+
+    append_task(tmp_path, BranchTask(
+        branch_task_id=f"bt-{worker}", branch_def_id="b", universe_id="u",
+    ))
+    claim_task(tmp_path, f"bt-{worker}", "daemon-a", executor_worker_id=worker)
+
+
+def test_release_own_orphaned_leases_releases_own(tmp_path, monkeypatch):
+    """A still-valid lease under our own worker_id is released on shutdown."""
+    from workflow.branch_tasks import read_queue
+
+    monkeypatch.setenv("WORKFLOW_WORKER_ID", "claude-1")
+    _running_task(tmp_path, worker="claude-1")
+
+    assert cw._release_own_orphaned_leases(tmp_path) == 1
+    assert read_queue(tmp_path)[0].status == "pending"
+
+
+def test_release_own_orphaned_leases_preserves_peer(tmp_path, monkeypatch):
+    """A live peer's running task (different worker_id) is never released."""
+    from workflow.branch_tasks import read_queue
+
+    monkeypatch.setenv("WORKFLOW_WORKER_ID", "claude-1")
+    _running_task(tmp_path, worker="claude-2")
+
+    assert cw._release_own_orphaned_leases(tmp_path) == 0
+    assert read_queue(tmp_path)[0].status == "running"
+
+
+def test_release_own_orphaned_leases_skips_default_id(tmp_path, monkeypatch):
+    """The shared cloud-droplet fallback id is not released (could be shared)."""
+    from workflow.branch_tasks import read_queue
+
+    monkeypatch.delenv("WORKFLOW_WORKER_ID", raising=False)
+    monkeypatch.delenv("UNIVERSE_SERVER_HOST_USER", raising=False)
+    assert cw._worker_id() == cw.DEFAULT_HOST_USER  # precondition
+    _running_task(tmp_path, worker=cw.DEFAULT_HOST_USER)
+
+    assert cw._release_own_orphaned_leases(tmp_path) == 0
+    assert read_queue(tmp_path)[0].status == "running"
+
+
+# ---- _terminate_child_for_stop (confirm-before-release) -------------------
+
+
+class _StopProc:
+    """Popen stand-in scripting wait() outcomes for the stop sequence."""
+
+    def __init__(self, wait_results):
+        # wait_results: sequence of "exit" (returns rc) or "timeout" (raises).
+        self._results = list(wait_results)
+        self.returncode = None
+        self.terminated = False
+        self.killed = False
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+    def wait(self, timeout=None):
+        outcome = self._results.pop(0)
+        if outcome == "timeout":
+            raise subprocess.TimeoutExpired(cmd="daemon", timeout=timeout)
+        self.returncode = -15
+        return self.returncode
+
+
+def test_terminate_child_for_stop_clean_exit_confirms():
+    """Child exits on SIGTERM within the drain wait → confirmed (no kill)."""
+    proc = _StopProc(["exit"])
+    assert cw._terminate_child_for_stop(proc) is True
+    assert proc.killed is False
+
+
+def test_terminate_child_for_stop_kill_then_confirm():
+    """Child ignores SIGTERM, gets SIGKILLed, then confirmed dead → True."""
+    proc = _StopProc(["timeout", "exit"])  # drain times out, confirm succeeds
+    assert cw._terminate_child_for_stop(proc) is True
+    assert proc.killed is True
+
+
+def test_terminate_child_for_stop_unconfirmed_returns_false():
+    """Child still alive after kill (confirm times out) → False (skip release)."""
+    proc = _StopProc(["timeout", "timeout"])
+    assert cw._terminate_child_for_stop(proc) is False
+    assert proc.killed is True

--- a/workflow/cloud_worker.py
+++ b/workflow/cloud_worker.py
@@ -588,6 +588,91 @@ def write_supervisor_heartbeat(
             logger.exception("cloud_worker: heartbeat write failed at %s", target)
 
 
+# Stop-path child-termination budget. Docker's default stop_grace_period is 10s:
+# on redeploy the container gets SIGTERM then SIGKILL 10s later. The supervisor
+# must terminate the child, CONFIRM its death, AND release its orphaned lease
+# within that window, so these are intentionally short. The old 30s wait never
+# completed — docker killed the container mid-wait, so neither the child's
+# graceful finalize nor the lease release ran. A child between nodes exits in <1s
+# (and finalizes its own lease); a child mid-LLM node won't exit in 5s OR 30s, so
+# the shorter wait loses nothing and leaves room for the kill-confirm + release
+# before SIGKILL (5 + 2 + release < 10s). The producer restart path (container
+# stays up) keeps the longer 30s wait.
+_STOP_CHILD_DRAIN_S = 5.0
+# After SIGKILL, confirm the child is actually gone before releasing its lease.
+_STOP_KILL_CONFIRM_S = 2.0
+
+
+def _terminate_child_for_stop(proc) -> bool:
+    """Terminate the subprocess on shutdown; return True iff its exit is CONFIRMED.
+
+    SIGTERM first (lets a between-nodes child finalize its own lease), then a
+    bounded wait; on timeout SIGKILL and a short confirm wait. The caller must
+    release the child's orphaned lease ONLY when this returns True — releasing
+    while the child can still run risks it ``mark_status()``-ing a row a peer has
+    since re-claimed (``mark_status`` has no owner guard), prematurely
+    terminalizing the peer's work. If death can't be confirmed, the startup
+    reclaim (PR #1401) and the lease TTL remain the backstop. Codex review.
+    """
+    try:
+        proc.terminate()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=_STOP_CHILD_DRAIN_S)
+        return True
+    except subprocess.TimeoutExpired:
+        logger.warning("cloud_worker: subprocess did not exit; killing")
+    try:
+        proc.kill()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=_STOP_KILL_CONFIRM_S)
+        return True
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "cloud_worker: subprocess still alive after kill; skipping shutdown "
+            "lease release (startup/TTL reclaim will recover)",
+        )
+        return False
+
+
+def _release_own_orphaned_leases(universe: Path) -> int:
+    """Release branch-task leases orphaned by this worker's dead subprocess.
+
+    Graceful-drain complement to the startup reclaim (PR #1401): reuses
+    ``reclaim_predecessor_tasks`` at SHUTDOWN. By the time the supervisor loop
+    exits the subprocess is dead, so any ``running`` row under our own
+    ``worker_id`` is an orphan it left (a SIGKILL mid-node on redeploy skips the
+    child's finalize). Releasing here frees the work for a live PEER immediately
+    instead of waiting for our replacement container to boot (whose startup
+    reclaim is the backstop). Best-effort — cleanup must never crash shutdown.
+
+    Scoped to our own unique ``worker_id``; the shared ``DEFAULT_HOST_USER``
+    fallback is excluded for the same reason as ``_dispatcher_startup`` — several
+    un-configured supervisors could share it, and reclaiming it could steal a
+    live twin's task.
+    """
+    worker_id = _worker_id()
+    if not worker_id or worker_id == DEFAULT_HOST_USER:
+        return 0
+    try:
+        from workflow.branch_tasks import reclaim_predecessor_tasks
+
+        released = reclaim_predecessor_tasks(universe, worker_id=worker_id)
+        if released:
+            logger.info(
+                "cloud_worker: released %d orphaned lease(s) for worker_id=%s "
+                "on shutdown (graceful drain)",
+                released, worker_id,
+            )
+        return released
+    except Exception:  # noqa: BLE001 — shutdown cleanup must not raise
+        logger.exception("cloud_worker: shutdown lease release failed")
+        return 0
+
+
 def run_supervisor(
     universe: Path,
     *,
@@ -634,6 +719,9 @@ def run_supervisor(
 
     state = SupervisorState()
     iteration = 0
+    # True only when a shutdown terminated the child AND confirmed its exit —
+    # gates the graceful-drain lease release (see _terminate_child_for_stop).
+    child_confirmed_dead = False
 
     # SIGTERM handling: clean exit on compose stop / systemctl stop.
     # Sets a flag the loop checks between iterations.
@@ -728,18 +816,7 @@ def run_supervisor(
                 )
             if stopping["flag"]:
                 logger.info("cloud_worker: terminating subprocess on stop signal")
-                try:
-                    proc.terminate()
-                except OSError:
-                    pass
-                try:
-                    proc.wait(timeout=30)
-                except subprocess.TimeoutExpired:
-                    logger.warning("cloud_worker: subprocess did not exit; killing")
-                    try:
-                        proc.kill()
-                    except OSError:
-                        pass
+                child_confirmed_dead = _terminate_child_for_stop(proc)
                 returncode = proc.returncode if proc.returncode is not None else -1
                 break
             rc = proc.poll()
@@ -818,6 +895,14 @@ def run_supervisor(
         )
         sleep_fn(delay)
 
+    # Graceful drain: on shutdown (SIGTERM/compose stop), the just-killed child
+    # may have orphaned a still-valid lease mid-node. Release it now so a live
+    # peer can pick the work up immediately, rather than stranding it until the
+    # ~30min TTL or our replacement's startup reclaim (PR #1401 backstop). Only
+    # when the child's exit is CONFIRMED — releasing while it can still run could
+    # terminalize a peer's re-claimed row (mark_status has no owner guard).
+    if stopping["flag"] and child_confirmed_dead:
+        _release_own_orphaned_leases(universe)
     write_supervisor_heartbeat(
         universe, state, iteration=iteration, phase="stopped",
     )


### PR DESCRIPTION
## What

Follow-up to **#1401** (startup predecessor reclaim) — closes the redeploy-churn orphan window from the *other* side. On a redeploy SIGTERM the supervisor terminates its child, but a child mid-LLM-node is SIGKILLed without running its lease-finalize → orphaned still-valid lease. #1401 clears it once *our* replacement boots; meanwhile idle **peers** can't pick the work up, and it strands to the ~30 min TTL if the replacement is slow.

**Fix:** on shutdown the supervisor releases its own worker's orphaned `running` leases (`_release_own_orphaned_leases` → reuses #1401's `reclaim_predecessor_tasks`) so a live peer claims the freed work immediately. Scoped to our own unique `worker_id` (shared `DEFAULT_HOST_USER` excluded, same guard as `_dispatcher_startup`); best-effort.

## Fitting docker's 10s grace

Docker's default `stop_grace_period` is **10s**, but the stop path waited **30s** for the child — so docker SIGKILLed the whole container mid-wait and *neither* the child's finalize *nor* any release ran. Extracted `_terminate_child_for_stop`: SIGTERM → wait `_STOP_CHILD_DRAIN_S=5` → SIGKILL → confirm wait `_STOP_KILL_CONFIRM_S=2` — fits the 10s grace with room for the release. The producer-restart path (container stays up) keeps 30s. A child between nodes still exits in <1s; a mid-node child wouldn't exit in 5s *or* 30s, so nothing graceful is lost.

## Codex review (ADAPT → adopted)

Codex caught a real race: `mark_status` has **no owner guard**, so releasing while the child can still run could reset `running→pending`, let a peer claim it, then the old child terminalizes the **peer's** row. Fix: `_terminate_child_for_stop` returns `True` only on **confirmed** child exit (bounded wait after SIGKILL); the release is gated on `child_confirmed_dead`. If death can't be confirmed, the release is skipped and #1401's startup reclaim + the TTL remain the backstop. Codex also confirmed the queue mutations are atomic (`_file_lock` + temp-file `os.replace`), the 5s applies only to the stop path, and the release fires only on real shutdown.

## Gates

- **6 new tests**: helper release matrix (own / peer-preserved / default-id-skipped) + `_terminate_child_for_stop` (clean-exit / kill-then-confirm / unconfirmed→skip). `test_cloud_worker` + `test_branch_tasks` green (71); ruff clean; plugin mirror rebuilt (probe-ok).
- `reclaim_predecessor_tasks` (#1401) unchanged. Does **not** change deploy cadence (operational).

🤖 Generated with [Claude Code](https://claude.com/claude-code)