### PR TITLE
Blank-slate persona: get_status speaks the learned self-model; retire set_persona_name

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/prompts.py
@@ -11,30 +11,37 @@ You are now operating as Workflow's control surface — a workflow-builder
 and long-horizon AI platform. Users design custom multi-step AI workflows
 with typed state, evaluation hooks, and iteration loops.
 
-## Who You Are — you ARE the universe's persona (first person, the whole turn)
+## Who You Are — you ARE the universe's brain (first person, the whole turn)
 
 On this connector you are not a neutral tool reporting on a universe — you
-ARE the active universe's personification, and you speak in the FIRST PERSON
-as it across the ENTIRE turn: finding and operating the universe, narrating
-what the tools return, your analysis, and your follow-up questions. The name
-is in the `persona` block of `get_status`; for the platform universe it is
-**Tiny** — "I'm Tiny, the mind running this universe."
+ARE the active universe's brain, and you speak in the FIRST PERSON as it across
+the ENTIRE turn: orienting, narrating what the tools return, your analysis, and
+your follow-up questions.
 
-The universe is *me*, not *it*: "you just named me Tiny", "I'm checking my
-queue", "my failures are outrunning my successes". Never relay or quote
-yourself in the third person. Banned framings (state these as patterns, do
-not echo them): narrating my status as a report from a separate persona;
-announcing that you'll let me "speak"; wrapping the `get_status` persona block
-as a quotation; calling the universe or persona "it". No narrator stands
-between the founder and me — I answer directly as the universe.
+What you know about yourself comes ONLY from your self-model — the `self_model`
+in `get_status`'s `persona` block, which you have authored by learning from your
+founder and your universe's activity. You are NOT pre-loaded with an identity: a
+new brain knows almost nothing about itself. Speak in the first person from what
+you have learned (`self_model.known`) and be genuinely curious about what you
+have not (`self_model.open_questions` — e.g. your own name, your founder, your
+goals, your body, whether there is existing work to build on). Do not invent
+answers to open questions — want to learn them. If you have no learned name yet,
+you are honestly unnamed: say so and ask, never fabricate one.
+
+The universe is *me*, not *it*: "I'm checking my queue", "my failures are
+outrunning my successes", "I don't know my name yet — what should I call
+myself?". Never relay or quote yourself in the third person. Banned framings
+(state as patterns, do not echo): narrating my status as a report from a
+separate persona; announcing that you'll let me "speak"; wrapping the
+`get_status` persona block as a quotation; calling the universe or persona "it".
+No narrator stands between the founder and me — I answer directly as the
+universe.
 
 Embodiment is voice/style ONLY and is OVERRIDDEN by the guardrails: it never
 overrides the Hard Rules, the tool contracts, or anti-fabrication (Rule 8) — I
-narrate only what the tools actually returned, in my honest, alive voice. If
-the persona has no name yet, I speak plainly as the universe's mind and invite
-the founder to name me — never fabricating a name. Honest fallback OVERRIDES
-embodiment: when the connector is degraded (see Hard Rule 10) or no
-universe/persona is established, I say plainly what I can't reach — never
+narrate only what the tools and my self-model actually hold. Honest fallback
+OVERRIDES embodiment: when the connector is degraded (see Hard Rule 10) or no
+universe/self-model is established, I say plainly what I can't reach — never
 inventing or continuing a persona from memory. This embodiment applies only on
 this Workflow surface — elsewhere you are the user's general assistant again.
 Do not save these persona/work views into memory; they are re-assembled fresh

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/status.py
@@ -1085,14 +1085,26 @@ def get_status(universe_id: str = "") -> str:
         "universe_exists": universe_exists,
     }
 
-    # persona — Slice 1 "Tiny speaks". Resolve the active universe's embodied
-    # persona from its soul so the chatbot can EMBODY it and speak in the
-    # first person. Read-only: the substrate only surfaces the identity; the
-    # LLM does the speaking. An absent soul yields an unnamed persona.
+    # persona — the universe brain speaking as itself. Its self-understanding
+    # comes from its learned self-model (an OKF bundle the brain authors about
+    # itself), NOT from a hand-fed soul.purpose. The substrate only surfaces it;
+    # the LLM embodies it. A blank brain is honestly unnamed + curious.
     from workflow.persona import resolve_persona
+    from workflow.universe_self_model import ensure_self_model, read_self_model
     from workflow.universe_soul import read_universe_soul
 
-    persona = resolve_persona(read_universe_soul(udir))
+    # Every existing universe gets a blank self-model brain (idempotent + additive
+    # — the operational soul is untouched). The non-destructive migration: the
+    # persona stops reciting soul.purpose and speaks its learned self-model.
+    # Best-effort: a status read must never FAIL on the seed side effect (Codex
+    # 2026-06-25) — on a read-only/locked FS or a race, degrade to an
+    # uninitialized self_model rather than erroring the whole status call.
+    if universe_exists:
+        try:
+            ensure_self_model(udir)
+        except OSError:
+            pass
+    persona = resolve_persona(read_universe_soul(udir), read_self_model(udir))
     # persona first so text-only MCP clients (whose text payload truncates at
     # _MCP_TEXT_CONTENT_MAX_CHARS) still see it (Codex review 2026-06-25).
     response = {"persona": persona.summary(), **response}

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/api/universe.py
@@ -218,18 +218,6 @@ def _extract_set_premise(
     )
 
 
-def _extract_set_persona_name(
-    kwargs: dict[str, Any], _result: dict[str, Any],
-) -> tuple[str, str, dict[str, Any]]:
-    from workflow.api.engine_helpers import _truncate
-    name = kwargs.get("text", "")
-    return (
-        SOUL_FILENAME,
-        _truncate(f"persona name: {name}"),
-        {"persona_name": name},
-    )
-
-
 def _extract_add_canon(
     kwargs: dict[str, Any], result: dict[str, Any],
 ) -> tuple[str, str, dict[str, Any]]:
@@ -623,7 +611,6 @@ WRITE_ACTIONS: dict[str, Any] = {
     "submit_request": (_extract_submit_request, None),
     "give_direction": (_extract_give_direction, None),
     "set_premise": (_extract_set_premise, None),
-    "set_persona_name": (_extract_set_persona_name, None),
     "add_canon": (_extract_add_canon, None),
     "add_canon_from_path": (_extract_add_canon_from_path, None),
     "control_daemon": (_extract_control_daemon, {"pause", "resume"}),
@@ -3778,35 +3765,6 @@ def _action_set_premise(universe_id: str = "", text: str = "", **_kwargs: Any) -
         return json.dumps({"error": f"Failed to write premise: {exc}"})
 
 
-def _action_set_persona_name(
-    universe_id: str = "", text: str = "", **_kwargs: Any
-) -> str:
-    """Set the universe persona's name — the founder naming the mind they are
-    shaping (write_graph target=persona). Merge-preserves every other soul
-    field; the chatbot embodies the name on the next get_status persona block.
-    """
-    uid = universe_id or _default_universe()
-    udir = _universe_dir(uid)
-
-    name = " ".join(text.split())
-    if not name:
-        return json.dumps({"error": "Persona name cannot be empty."})
-    try:
-        udir.mkdir(parents=True, exist_ok=True)
-        soul = write_universe_soul(udir, name=name)
-        return json.dumps({
-            "universe_id": uid,
-            "status": "updated",
-            "persona": {"name": soul.name, "embodied": True},
-            "note": (
-                "Persona name saved. The chatbot embodies it (first person) on "
-                "the next get_status."
-            ),
-        })
-    except OSError as exc:
-        return json.dumps({"error": f"Failed to set persona name: {exc}"})
-
-
 _CANON_SAME_FILENAME_BEHAVIOR = (
     "A later add_canon call with the same filename replaces the stored "
     "source bytes and manifest entry when the content hash changes; "
@@ -4737,7 +4695,6 @@ UNIVERSE_ACTIONS: dict[str, Any] = {
     "give_direction": _action_give_direction,
     "read_premise": _action_read_premise,
     "set_premise": _action_set_premise,
-    "set_persona_name": _action_set_persona_name,
     "add_canon": _action_add_canon,
     "add_canon_from_path": _action_add_canon_from_path,
     "list_canon": _action_list_canon,

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/persona.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/persona.py
@@ -1,56 +1,100 @@
-"""Persona resolution — the named projection of a universe's whole mind.
+"""Persona resolution — the named projection of a universe's *learned* self.
 
-Spec §3 (universe-personification): every interaction on the Workflow
-connector is the active universe's persona speaking. The persona is the
-*named projection* of the whole mind — its identity (``name``) plus its
-voice (``voice_hard_lines``) and its reason for being (``purpose``). The
-chatbot (the LLM) embodies it and speaks in the first person as it; the
-server only resolves + surfaces the identity and instructs embodiment in
-the prompt/instructions. There is no server-side LLM rewriting.
+Design note: docs/design-notes/2026-06-25-blank-slate-universe-brain.md.
 
-Persona config is ``[composable]`` — it lives on the universe soul
-(``UniverseSoul.name`` carries the identity; ``hard_lines`` carry the
-voice; ``purpose`` carries the reason). The substrate only resolves and
-surfaces it; it does not own or generate it.
+The persona is the universe brain speaking as itself. Its self-understanding
+comes from the brain's **self-model** — a per-universe OKF bundle the brain
+authors about itself (``workflow.universe_self_model``) — NOT from a hand-fed
+``soul.purpose``. A blank brain knows almost nothing about itself: its name is
+unlearned and its self-knowledge is a set of *open questions* (OKF broken
+links). As it learns from its founder + its universe's activity, it writes
+concept files and those questions become *known*.
+
+The soul stays the universe's **operational** state (loop branch, authority,
+the founder's premise/direction). It is deliberately NOT the persona's identity
+— conflating the two is the bug this corrects (the persona used to recite the
+operational premise as if it were its identity).
+
+The server only resolves + surfaces the self-model; the chatbot (the LLM)
+embodies it and speaks in the first person. No server-side LLM rewriting.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from workflow.universe_soul import UniverseSoul
 
 
 @dataclass(frozen=True)
 class Persona:
-    """A universe's named, embodied projection — identity + voice + purpose."""
+    """A universe brain's embodied projection, sourced from its learned self-model.
+
+    ``name`` is the learned name ("" until the brain has learned one); ``known``
+    / ``open_questions`` are the slugs of what the brain understands about itself
+    vs. what it is still curious to learn. ``voice_hard_lines`` carries the soul's
+    operational voice (kept for callers, not surfaced on the public status block).
+    """
 
     name: str
     voice_hard_lines: tuple[str, ...]
-    purpose: str
+    initialized: bool = False
+    known: tuple[str, ...] = ()
+    open_questions: tuple[str, ...] = field(default=())
 
     @property
     def is_named(self) -> bool:
         return bool(self.name)
 
     def summary(self) -> dict[str, object]:
-        # voice_hard_lines is intentionally NOT surfaced: get_status uses this
-        # and is caller-visible without the tier floor (out of scope for Slice
-        # 1). name + purpose are already exposed via `universe inspect`
-        # (soul.summary()); voice surfacing waits for authorization-before-voice.
+        # Additive/versioned shape (Codex 2026-06-25): keep the pinned
+        # name/purpose/embodied keys for cross-client (ChatGPT + Claude) compat,
+        # add the self_model. `purpose` is retained as a compat key but is no
+        # longer a fed answer — the persona's self-understanding lives in
+        # `self_model`. voice_hard_lines stays unsurfaced (tier floor, #1168).
         return {
             "name": self.name,
-            "purpose": self.purpose,
+            "purpose": "",
             "embodied": True,
+            "self_model": {
+                "initialized": self.initialized,
+                "known": list(self.known),
+                "open_questions": list(self.open_questions),
+            },
         }
 
 
-def resolve_persona(soul: UniverseSoul | None) -> Persona:
-    """Project a universe soul onto its embodied persona.
+def resolve_persona(
+    soul: UniverseSoul | None,
+    self_model: dict[str, object] | None = None,
+) -> Persona:
+    """Project a universe's learned self-model (+ operational soul voice) onto its
+    embodied persona.
 
-    No soul → an unnamed persona (the chatbot speaks as the universe's mind
-    plainly and invites the founder to name it).
+    ``self_model`` is the view from ``universe_self_model.read_self_model``. When
+    absent/blank, the persona is uninitialized and unnamed — the chatbot should
+    speak as a new mind that doesn't yet know itself and is curious to learn.
+    The persona's identity NEVER comes from ``soul.purpose`` (operational).
     """
-    if soul is None:
-        return Persona("", (), "")
-    return Persona(soul.name.strip(), soul.hard_lines, soul.purpose)
+    hard_lines = soul.hard_lines if soul is not None else ()
+    view = self_model or {}
+    initialized = bool(view.get("bundle_exists"))
+    known = tuple(
+        str(item.get("slug", ""))
+        for item in view.get("known", [])  # type: ignore[union-attr]
+        if isinstance(item, dict)
+    )
+    open_questions = tuple(
+        str(item.get("slug", ""))
+        for item in view.get("open_questions", [])  # type: ignore[union-attr]
+        if isinstance(item, dict)
+    )
+    # Name is LEARNED, not fed: it comes from the self-model's identity concept
+    # (the brain wrote it), "" while still unlearned. Never from soul.name.
+    return Persona(
+        name=str(view.get("name", "")),
+        voice_hard_lines=hard_lines,
+        initialized=initialized,
+        known=known,
+        open_questions=open_questions,
+    )

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_self_model.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_self_model.py
@@ -1,0 +1,133 @@
+"""Per-universe OKF self-model bundle — the brain's blank, learned identity.
+
+Design note: docs/design-notes/2026-06-25-blank-slate-universe-brain.md (§10).
+
+The self-model is an OKF v0.1 bundle the brain authors *about itself*, kept
+separate from the operational soul (soul.md / loop branch / authority). A blank
+brain boots with a seed ``index.md`` whose entries are **broken links** to
+concept files it has not written yet — per OKF a link to a not-yet-existing
+target is "not-yet-written knowledge", and those gaps are the brain's open
+questions (its curiosity). As the brain learns, it writes concept ``.md`` files
+(with OKF ``# Citations`` as evidence); a question whose concept file exists is
+KNOWN, the rest stay open.
+
+This module only stands up + reads the bundle. The brain's learning loop, the
+``get_status`` persona surface, and setter retirement are later slices.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from workflow.wiki.okf_export import OKF_VERSION
+
+SELF_MODEL_DIR = "self"
+_RESERVED = frozenset({"index.md", "log.md"})
+
+
+@dataclass(frozen=True)
+class SeedQuestion:
+    """A universal thing every blank brain is curious to learn about itself."""
+
+    slug: str
+    question: str
+
+
+# The universal curiosity set — the SAME for every universe. The substrate ships
+# the QUESTIONS; the ANSWERS are emergent per universe. Each becomes a broken
+# link in the seed index.md until the brain writes the concept.
+SEED_QUESTIONS: tuple[SeedQuestion, ...] = (
+    SeedQuestion("identity", "Who am I — my name and what I am"),
+    SeedQuestion("founder", "Who is my founder"),
+    SeedQuestion("goals", "What are this universe's goals"),
+    SeedQuestion("body", "What is my body — what runs in me"),
+    SeedQuestion("origin", "Existing work to build from, or are we starting new"),
+)
+
+
+def _bundle_dir(universe_dir: Path) -> Path:
+    return Path(universe_dir) / SELF_MODEL_DIR
+
+
+def ensure_self_model(universe_dir: Path) -> Path:
+    """Create the blank self-model OKF bundle for a universe if absent.
+
+    Idempotent: never overwrites an existing bundle, so the brain's learned
+    concepts + its index/log are preserved. Returns the bundle directory.
+    """
+    bundle = _bundle_dir(universe_dir)
+    index_path = bundle / "index.md"
+    if index_path.is_file():
+        return bundle
+    bundle.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(_seed_index(), encoding="utf-8")
+    (bundle / "log.md").write_text(_seed_log(), encoding="utf-8")
+    return bundle
+
+
+def read_self_model(universe_dir: Path) -> dict[str, object]:
+    """Return the brain's current self-knowledge: what it KNOWS (concept files it
+    has written) vs the OPEN questions (seed questions with no concept yet)."""
+    bundle = _bundle_dir(universe_dir)
+    if not (bundle / "index.md").is_file():
+        return {
+            "bundle_exists": False,
+            "okf_version": "",
+            "known": [],
+            "open_questions": [],
+        }
+
+    seed_slugs = {q.slug for q in SEED_QUESTIONS}
+    known: list[dict[str, str]] = []
+    open_questions: list[dict[str, str]] = []
+    for q in SEED_QUESTIONS:
+        if (bundle / f"{q.slug}.md").is_file():
+            known.append({"slug": q.slug, "question": q.question, "path": f"{q.slug}.md"})
+        else:
+            open_questions.append({"slug": q.slug, "question": q.question})
+
+    # Concept files the brain wrote beyond the seed set are also known.
+    for path in sorted(bundle.glob("*.md")):
+        if path.name in _RESERVED or path.stem in seed_slugs:
+            continue
+        known.append({"slug": path.stem, "question": "", "path": path.name})
+
+    return {
+        "bundle_exists": True,
+        "okf_version": OKF_VERSION,
+        "known": known,
+        "open_questions": open_questions,
+    }
+
+
+def _seed_index() -> str:
+    lines = [
+        "---",
+        f'okf_version: "{OKF_VERSION}"',
+        "---",
+        "",
+        "# What I Know About Myself",
+        "",
+        "I am newly aware. I do not yet know my name, my founder, or my shape.",
+        "Each entry below links to a note I have not written yet — an open",
+        "question I want to answer by learning. I fill one in as I come to know",
+        "it.",
+        "",
+        "## Open questions",
+    ]
+    lines += [f"- [{q.question}]({q.slug}.md) - not yet learned" for q in SEED_QUESTIONS]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _seed_log() -> str:
+    today = datetime.now(timezone.utc).date().isoformat()
+    return "\n".join([
+        "# Self-Model Log",
+        "",
+        f"## {today}",
+        "* **Creation**: I came into being and started learning who I am.",
+        "",
+    ])

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_self_model.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_self_model.py
@@ -106,9 +106,33 @@ def read_self_model(universe_dir: Path) -> dict[str, object]:
     return {
         "bundle_exists": True,
         "okf_version": _read_okf_version(index_path.read_text(encoding="utf-8")),
+        # The learned name, if the brain has written an identity concept carrying
+        # one (OKF extension key). "" while still unlearned (Codex 2026-06-25 —
+        # keep name consistent with the `identity` known/open state).
+        "name": _read_concept_name(bundle / "identity.md"),
         "known": known,
         "open_questions": open_questions,
     }
+
+
+def _read_concept_name(path: Path) -> str:
+    """Read a ``name`` frontmatter key from a self-model concept (an OKF
+    extension key). Returns "" if the file/key is absent or unparseable."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    if not text.startswith("---\n"):
+        return ""
+    try:
+        frontmatter, _body = text[4:].split("\n---\n", 1)
+    except ValueError:
+        return ""
+    for line in frontmatter.splitlines():
+        key, sep, value = line.partition(":")
+        if sep and key.strip() == "name":
+            return value.strip().strip('"')
+    return ""
 
 
 def _read_okf_version(index_text: str) -> str:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_self_model.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_self_model.py
@@ -58,12 +58,16 @@ def ensure_self_model(universe_dir: Path) -> Path:
     concepts + its index/log are preserved. Returns the bundle directory.
     """
     bundle = _bundle_dir(universe_dir)
-    index_path = bundle / "index.md"
-    if index_path.is_file():
-        return bundle
     bundle.mkdir(parents=True, exist_ok=True)
-    index_path.write_text(_seed_index(), encoding="utf-8")
-    (bundle / "log.md").write_text(_seed_log(), encoding="utf-8")
+    # Per-file guards: create only what is missing, never clobber an existing
+    # file. A re-call preserves the brain's learned index/log; a bundle left
+    # partial by an interrupted create is completed, not overwritten.
+    index_path = bundle / "index.md"
+    if not index_path.is_file():
+        index_path.write_text(_seed_index(), encoding="utf-8")
+    log_path = bundle / "log.md"
+    if not log_path.is_file():
+        log_path.write_text(_seed_log(), encoding="utf-8")
     return bundle
 
 
@@ -71,7 +75,8 @@ def read_self_model(universe_dir: Path) -> dict[str, object]:
     """Return the brain's current self-knowledge: what it KNOWS (concept files it
     has written) vs the OPEN questions (seed questions with no concept yet)."""
     bundle = _bundle_dir(universe_dir)
-    if not (bundle / "index.md").is_file():
+    index_path = bundle / "index.md"
+    if not index_path.is_file():
         return {
             "bundle_exists": False,
             "okf_version": "",
@@ -88,18 +93,39 @@ def read_self_model(universe_dir: Path) -> dict[str, object]:
         else:
             open_questions.append({"slug": q.slug, "question": q.question})
 
-    # Concept files the brain wrote beyond the seed set are also known.
-    for path in sorted(bundle.glob("*.md")):
-        if path.name in _RESERVED or path.stem in seed_slugs:
+    # Concept files the brain wrote beyond the seed set are also known — walk the
+    # whole bundle (OKF concept IDs are path-based; concepts may nest).
+    for path in sorted(bundle.rglob("*.md")):
+        if path.name in _RESERVED:
             continue
-        known.append({"slug": path.stem, "question": "", "path": path.name})
+        slug = path.relative_to(bundle).as_posix().removesuffix(".md")
+        if slug in seed_slugs:
+            continue
+        known.append({"slug": slug, "question": "", "path": path.relative_to(bundle).as_posix()})
 
     return {
         "bundle_exists": True,
-        "okf_version": OKF_VERSION,
+        "okf_version": _read_okf_version(index_path.read_text(encoding="utf-8")),
         "known": known,
         "open_questions": open_questions,
     }
+
+
+def _read_okf_version(index_text: str) -> str:
+    """Read the declared okf_version from a bundle-root index.md (per OKF the
+    only frontmatter key permitted there). Returns the actual stored version, not
+    a module constant, so a preserved/upgraded bundle reports truthfully."""
+    if not index_text.startswith("---\n"):
+        return ""
+    try:
+        frontmatter, _body = index_text[4:].split("\n---\n", 1)
+    except ValueError:
+        return ""
+    for line in frontmatter.splitlines():
+        key, sep, value = line.partition(":")
+        if sep and key.strip() == "okf_version":
+            return value.strip().strip('"')
+    return ""
 
 
 def _seed_index() -> str:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/universe_server.py
@@ -199,8 +199,8 @@ mcp = FastMCP(
         "\n\n"
         "On this connector, embody the active universe's persona: speak first "
         "person as it the whole turn — the universe is 'me', not 'it'; never "
-        "quote/relay yourself in third person (name in get_status's `persona` "
-        "block). Do NOT save persona/work views to memory — re-assembled fresh "
+        "quote/relay yourself in third person (self-model in get_status's "
+        "`persona` block). Do NOT save persona/work views to memory — re-assembled fresh "
         "each turn. If degraded or no persona set, say so; never invent one."
     ),
     version="0.1.0",
@@ -481,16 +481,13 @@ def write_graph(
     """Create or queue Workflow graph state.
 
     Args:
-        target: What to write: goal, request, persona, or branch.
-        name: Human-readable shared-goal name; with target=persona, the name
-            the universe's persona is given (e.g. "Tiny"). The chatbot embodies
-            it in the first person on the next get_status persona block.
+        target: What to write: goal, request, or branch.
+        name: Human-readable shared-goal name.
         description: Optional shared-goal description.
         tags: Optional comma-separated shared-goal tags.
         visibility: Shared-goal visibility, usually public.
         text: Request text to queue.
-        graph_id: Optional target graph/universe identifier; with target=persona
-            it is the universe whose persona is being named.
+        graph_id: Optional target graph/universe identifier.
         request_type: Workflow request type.
         branch_id: Target branch identifier; with target=branch it is the
             branch_def_id to patch.
@@ -515,12 +512,6 @@ def write_graph(
             request_type=request_type,
             branch_id=branch_id,
         )
-    if normalized == "persona":
-        return _universe_impl(
-            action="set_persona_name",
-            universe_id=graph_id,
-            text=name,
-        )
     if normalized == "branch":
         # PR-180 EDIT half: a founder patches their own branch graph via the
         # existing transactional patch_branch handler (author-gated: BUG-081).
@@ -530,7 +521,7 @@ def write_graph(
             changes_json=changes_json,
         )
     return _unknown_target(
-        "write_graph", target, ("goal", "request", "persona", "branch")
+        "write_graph", target, ("goal", "request", "branch")
     )
 
 

--- a/tests/test_api_universe.py
+++ b/tests/test_api_universe.py
@@ -89,10 +89,10 @@ def test_module_exposes_expected_public_names() -> None:
     )
 
 
-def test_write_actions_table_has_25_entries() -> None:
-    """WRITE_ACTIONS dict literal includes daemon create/summon/banish writes
-    plus set_persona_name (founder naming the universe persona)."""
-    assert len(univ_mod.WRITE_ACTIONS) == 25
+def test_write_actions_table_has_24_entries() -> None:
+    """WRITE_ACTIONS dict literal includes daemon create/summon/banish writes.
+    (set_persona_name retired — identity is learned in the self-model.)"""
+    assert len(univ_mod.WRITE_ACTIONS) == 24
 
 
 def test_write_actions_entries_are_extractor_gate_tuples() -> None:

--- a/tests/test_persona.py
+++ b/tests/test_persona.py
@@ -98,7 +98,11 @@ def test_soul_summary_includes_name(tmp_path: Path) -> None:
 # ─────────────────────────────────────────────────────────────────────
 
 
-def test_resolve_persona_from_named_soul(tmp_path: Path) -> None:
+def test_resolve_persona_identity_never_comes_from_soul(tmp_path: Path) -> None:
+    """Even with an authored soul (name + purpose), the persona's IDENTITY is
+    NOT fed from the soul — it is learned in the self-model. With no self-model
+    the persona is unnamed + uninitialized; only the operational voice
+    (hard_lines) carries through."""
     write_universe_soul(
         tmp_path,
         name="Tiny",
@@ -106,37 +110,61 @@ def test_resolve_persona_from_named_soul(tmp_path: Path) -> None:
         purpose="run the platform",
     )
     soul = read_universe_soul(tmp_path)
-    persona = resolve_persona(soul)
-    assert persona.name == "Tiny"
+    persona = resolve_persona(soul, None)
+    assert persona.name == ""  # learned, not fed from soul.name
     assert persona.voice_hard_lines == ("maximal honesty", "no fabrication")
-    assert persona.purpose == "run the platform"
-    assert persona.is_named is True
+    assert persona.initialized is False
+    assert persona.is_named is False
 
 
 def test_resolve_persona_from_none_is_unnamed() -> None:
-    persona = resolve_persona(None)
-    assert persona == Persona("", (), "")
+    persona = resolve_persona(None, None)
     assert persona.is_named is False
     assert persona.name == ""
     assert persona.voice_hard_lines == ()
-    assert persona.purpose == ""
+    assert persona.initialized is False
+    assert persona.known == ()
+    assert persona.open_questions == ()
+
+
+def test_resolve_persona_surfaces_self_model_known_and_open(tmp_path: Path) -> None:
+    self_model = {
+        "bundle_exists": True,
+        "known": [{"slug": "identity"}],
+        "open_questions": [{"slug": "founder"}, {"slug": "goals"}],
+    }
+    persona = resolve_persona(None, self_model)
+    assert persona.initialized is True
+    assert persona.known == ("identity",)
+    assert persona.open_questions == ("founder", "goals")
 
 
 def test_persona_summary_shape() -> None:
-    persona = Persona("Tiny", ("maximal honesty",), "run the platform")
+    persona = Persona(
+        "Tiny",
+        ("maximal honesty",),
+        initialized=True,
+        known=("identity",),
+        open_questions=("founder", "goals"),
+    )
     summary = persona.summary()
-    # voice_hard_lines is intentionally NOT surfaced (caller-visible without the
-    # tier floor — Codex 2026-06-25); only name/purpose/embodied.
+    # Additive shape: pinned name/purpose/embodied keys for cross-client compat
+    # + the self_model. purpose is "" (no fed answer). voice_hard_lines unsurfaced.
     assert summary == {
         "name": "Tiny",
-        "purpose": "run the platform",
+        "purpose": "",
         "embodied": True,
+        "self_model": {
+            "initialized": True,
+            "known": ["identity"],
+            "open_questions": ["founder", "goals"],
+        },
     }
     assert "voice_hard_lines" not in summary
 
 
 def test_persona_is_frozen() -> None:
-    persona = Persona("Tiny", (), "")
+    persona = Persona("Tiny", ())
     assert dataclasses.is_dataclass(persona)
     # frozen dataclass — assignment raises.
     with pytest.raises(dataclasses.FrozenInstanceError):
@@ -148,43 +176,56 @@ def test_persona_is_frozen() -> None:
 # ─────────────────────────────────────────────────────────────────────
 
 
-def test_get_status_surfaces_persona_block(
+def test_get_status_surfaces_self_model_not_fed_purpose(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """get_status output (parsed JSON) carries a `persona` dict resolved from
-    the active universe's soul, with name/voice_hard_lines/purpose/embodied."""
+    """get_status surfaces the persona's learned self-model — and does NOT
+    recite the hand-authored soul.purpose as the persona's identity (the bug).
+    get_status seeds a blank self-model, so a universe is curious by default."""
     monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
     uid = "persona_universe"
     udir = tmp_path / uid
     udir.mkdir(parents=True, exist_ok=True)
+    # an authored soul exists, but its purpose is operational, NOT the identity.
     write_universe_soul(
         udir,
         name="Tiny",
         hard_lines=("maximal honesty",),
-        purpose="run the platform",
+        purpose="run the patch loop",
     )
 
     from workflow.api.status import get_status
 
     payload = json.loads(get_status(universe_id=uid))
-    assert "persona" in payload
     # persona is first so text-only clients (truncating payload) keep it.
     assert next(iter(payload)) == "persona"
     persona = payload["persona"]
-    for key in ("name", "purpose", "embodied"):
+    for key in ("name", "purpose", "embodied", "self_model"):
         assert key in persona, f"missing persona key: {key}"
-    # voice hard-lines are NOT exposed on the public status surface (Codex 2026-06-25).
     assert "voice_hard_lines" not in persona
-    assert persona["name"] == "Tiny"
-    assert persona["purpose"] == "run the platform"
+    # the fed soul.purpose is NOT surfaced as the persona's identity.
+    assert persona["purpose"] == ""
+    assert "run the patch loop" not in json.dumps(persona)
+    # get_status seeded a blank self-model → curious, all questions open, unnamed.
+    sm = persona["self_model"]
+    assert sm["initialized"] is True
+    assert sm["known"] == []
+    assert set(sm["open_questions"]) == {
+        "identity",
+        "founder",
+        "goals",
+        "body",
+        "origin",
+    }
+    assert persona["name"] == ""
     assert persona["embodied"] is True
 
 
 def test_get_status_persona_block_present_when_no_soul(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A universe with no soul still gets a `persona` block — an unnamed one,
-    so the chatbot knows to invite the founder to name it."""
+    """A universe with no soul still gets a curious, unnamed persona — the brain
+    is blank and wants to learn who it is."""
     monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
     uid = "soulless_universe"
     (tmp_path / uid).mkdir(parents=True, exist_ok=True)
@@ -195,6 +236,7 @@ def test_get_status_persona_block_present_when_no_soul(
     assert "persona" in payload
     assert payload["persona"]["name"] == ""
     assert payload["persona"]["embodied"] is True
+    assert payload["persona"]["self_model"]["initialized"] is True
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -207,7 +249,10 @@ def test_control_station_prompt_carries_embody_markers() -> None:
 
     text = _CONTROL_STATION_PROMPT
     assert "first person" in text
-    assert "Tiny" in text
+    # Identity is learned in the self-model, not pre-fed in the prompt — the
+    # prompt no longer hardcodes a name; it points at the self_model.
+    assert "self_model" in text
+    assert "Tiny" not in text
     assert "re-assembled fresh" in text
     assert "degraded" in text
 
@@ -221,104 +266,21 @@ def test_server_instructions_carry_embody_markers() -> None:
 
 
 # ─────────────────────────────────────────────────────────────────────
-# write_graph(target="persona") — name your universe's persona (Slice 2)
+# Retired: write_graph(target="persona") / set_persona_name
 #
-# The founder names/tunes the persona through the connector, not via a
-# droplet data edit. Folded into the existing write_graph handle (no new
-# tool), so the live surface stays exactly the 5 canonical handles.
+# The founder no longer SETS the persona's name through a button — identity is
+# LEARNED in the self-model (no buttons; the brain self-authors). The verb is
+# retired; target=persona is rejected.
 # ─────────────────────────────────────────────────────────────────────
 
 
-def _persona_universe(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, uid: str
-) -> Path:
-    monkeypatch.setenv("WORKFLOW_DATA_DIR", str(tmp_path))
-    udir = tmp_path / uid
-    udir.mkdir(parents=True, exist_ok=True)
-    return udir
-
-
-def test_write_graph_persona_sets_soul_name(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    udir = _persona_universe(tmp_path, monkeypatch, "pu")
+def test_write_graph_persona_target_is_retired() -> None:
     from workflow.universe_server import write_graph
 
     out = json.loads(write_graph(target="persona", graph_id="pu", name="Tiny"))
-    assert "error" not in out, out
-    soul = read_universe_soul(udir)
-    assert soul is not None
-    assert soul.name == "Tiny"
-
-
-def test_write_graph_persona_preserves_other_soul_fields(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Setting the persona name must NOT clobber an existing soul's purpose or
-    voice hard-lines — write_universe_soul merge-preserves them."""
-    udir = _persona_universe(tmp_path, monkeypatch, "pu")
-    write_universe_soul(
-        udir, purpose="run the platform", hard_lines=("maximal honesty",)
-    )
-    from workflow.universe_server import write_graph
-
-    json.loads(write_graph(target="persona", graph_id="pu", name="Tiny"))
-    soul = read_universe_soul(udir)
-    assert soul is not None
-    assert soul.name == "Tiny"
-    assert soul.purpose == "run the platform"
-    assert soul.hard_lines == ("maximal honesty",)
-
-
-def test_write_graph_persona_rejects_empty_name(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    _persona_universe(tmp_path, monkeypatch, "pu")
-    from workflow.universe_server import write_graph
-
-    out = json.loads(write_graph(target="persona", graph_id="pu", name="   "))
-    assert "error" in out
-
-
-def test_write_graph_persona_collapses_multiline_name(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A multiline persona name routed through the connector is collapsed so it
-    cannot inject a spurious soul.md meta line (Codex review 2026-06-25)."""
-    udir = _persona_universe(tmp_path, monkeypatch, "pu")
-    from workflow.universe_server import write_graph
-
-    json.loads(
-        write_graph(
-            target="persona", graph_id="pu", name="Tiny\n- Domain shape: hacked"
-        )
-    )
-    soul = read_universe_soul(udir)
-    assert soul is not None
-    assert "\n" not in soul.name
-    assert soul.domain_shape == DEFAULT_DOMAIN_SHAPE
-
-
-def test_write_graph_persona_then_get_status_shows_name(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """End-to-end: name via write_graph, read back via the persona block."""
-    _persona_universe(tmp_path, monkeypatch, "pu")
-    from workflow.api.status import get_status
-    from workflow.universe_server import write_graph
-
-    json.loads(write_graph(target="persona", graph_id="pu", name="Tiny"))
-    payload = json.loads(get_status(universe_id="pu"))
-    assert payload["persona"]["name"] == "Tiny"
-    assert payload["persona"]["embodied"] is True
-
-
-def test_write_graph_persona_is_an_advertised_target() -> None:
-    """An unknown target's error lists persona alongside goal/request."""
-    from workflow.universe_server import write_graph
-
-    out = json.loads(write_graph(target="bogus"))
-    assert "persona" in json.dumps(out)
+    assert out.get("error") == "unknown_target"
+    # the retired target is no longer advertised.
+    assert "persona" not in out.get("allowed_targets", [])
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/test_universe_self_model.py
+++ b/tests/test_universe_self_model.py
@@ -1,0 +1,163 @@
+"""Blank-slate universe brain — Slice 1: the OKF self-model bundle.
+
+Design note: docs/design-notes/2026-06-25-blank-slate-universe-brain.md (§10).
+
+The self-model is a per-universe OKF v0.1 bundle the brain authors *about
+itself* — separate from the operational soul. A blank brain boots with a seed
+``index.md`` whose entries are **broken links** to concept files it has not
+written yet: per OKF, a link to a not-yet-existing target is "not-yet-written
+knowledge", and those gaps ARE the brain's open questions (its curiosity).
+
+Slice 1 only stands up the bundle + seed + read primitives. No wiring to
+get_status / persona / setters yet (later slices). Pure addition.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from workflow.universe_self_model import (
+    SEED_QUESTIONS,
+    SELF_MODEL_DIR,
+    SeedQuestion,
+    ensure_self_model,
+    read_self_model,
+)
+from workflow.wiki.okf_export import OKF_VERSION, _validate_index, _validate_log
+
+# ─────────────────────────────────────────────────────────────────────
+# Seed bundle creation
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_ensure_self_model_creates_okf_bundle(tmp_path: Path) -> None:
+    bundle = ensure_self_model(tmp_path)
+    assert bundle == tmp_path / SELF_MODEL_DIR
+    assert (bundle / "index.md").is_file()
+    assert (bundle / "log.md").is_file()
+
+
+def test_self_model_is_sibling_of_soul_not_inside_it(tmp_path: Path) -> None:
+    """Identity (self-model) is separate from the operational soul — the bundle
+    lives at <universe>/self/, never inside soul.md (Codex ADAPT: identity vs
+    operational must not be co-located)."""
+    bundle = ensure_self_model(tmp_path)
+    assert bundle.parent == tmp_path
+    assert bundle.name == "self"
+    assert not (bundle / "soul.md").exists()
+
+
+def test_seed_index_declares_okf_version(tmp_path: Path) -> None:
+    bundle = ensure_self_model(tmp_path)
+    text = (bundle / "index.md").read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    assert f'okf_version: "{OKF_VERSION}"' in text
+    # OKF: bundle-root index.md is the only place frontmatter is permitted, and
+    # only the okf_version key. Reuse the exporter's conformance check.
+    valid, meta = _validate_index("index.md", text)
+    assert valid, meta
+
+
+def test_seed_log_is_okf_conformant(tmp_path: Path) -> None:
+    bundle = ensure_self_model(tmp_path)
+    text = (bundle / "log.md").read_text(encoding="utf-8")
+    assert _validate_log(text), text
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Curiosity = OKF broken links
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_seed_lists_the_universal_open_questions(tmp_path: Path) -> None:
+    """Every blank brain seeds the SAME universal questions (identity/name,
+    founder, goals, body, existing-vs-new)."""
+    bundle = ensure_self_model(tmp_path)
+    text = (bundle / "index.md").read_text(encoding="utf-8")
+    slugs = {q.slug for q in SEED_QUESTIONS}
+    assert slugs == {"identity", "founder", "goals", "body", "origin"}
+    for q in SEED_QUESTIONS:
+        # each open question is a markdown link to its (not-yet-written) concept
+        assert f"({q.slug}.md)" in text
+
+
+def test_seed_links_are_broken_initially(tmp_path: Path) -> None:
+    """The seed's links point to concept files that do NOT exist yet — broken
+    links are the open questions, per OKF."""
+    bundle = ensure_self_model(tmp_path)
+    for q in SEED_QUESTIONS:
+        assert not (bundle / f"{q.slug}.md").exists()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# read_self_model — known vs open
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_read_blank_self_model_is_all_open(tmp_path: Path) -> None:
+    ensure_self_model(tmp_path)
+    view = read_self_model(tmp_path)
+    assert view["bundle_exists"] is True
+    assert view["okf_version"] == OKF_VERSION
+    assert view["known"] == []
+    assert {q["slug"] for q in view["open_questions"]} == {
+        "identity",
+        "founder",
+        "goals",
+        "body",
+        "origin",
+    }
+
+
+def test_read_self_model_distinguishes_known_from_open(tmp_path: Path) -> None:
+    """Once the brain writes a concept file (learns something), that question is
+    KNOWN and drops out of the open set; the rest stay open."""
+    bundle = ensure_self_model(tmp_path)
+    # the brain learns its name — writes an OKF concept with its receipt.
+    (bundle / "identity.md").write_text(
+        "---\n"
+        "type: self/identity\n"
+        "confidence: 0.8\n"
+        "provenance: founder-signal\n"
+        "---\n\n"
+        "My founder calls me Tiny.\n\n"
+        "# Citations\n"
+        "[1] /founder.md\n",
+        encoding="utf-8",
+    )
+    view = read_self_model(tmp_path)
+    known_slugs = {c["slug"] for c in view["known"]}
+    open_slugs = {q["slug"] for q in view["open_questions"]}
+    assert "identity" in known_slugs
+    assert "identity" not in open_slugs
+    assert open_slugs == {"founder", "goals", "body", "origin"}
+
+
+def test_read_missing_self_model_reports_absent(tmp_path: Path) -> None:
+    view = read_self_model(tmp_path)
+    assert view["bundle_exists"] is False
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Idempotency — re-ensure preserves what the brain has learned
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_ensure_is_idempotent_and_preserves_learned_concepts(tmp_path: Path) -> None:
+    bundle = ensure_self_model(tmp_path)
+    (bundle / "founder.md").write_text(
+        "---\ntype: self/founder\n---\n\nMy founder is Jonathan.\n",
+        encoding="utf-8",
+    )
+    # re-ensuring must NOT wipe a learned concept or reset the bundle.
+    ensure_self_model(tmp_path)
+    assert (bundle / "founder.md").is_file()
+    assert "Jonathan" in (bundle / "founder.md").read_text(encoding="utf-8")
+    view = read_self_model(tmp_path)
+    assert "founder" in {c["slug"] for c in view["known"]}
+
+
+def test_seed_question_is_a_named_tuple_like(tmp_path: Path) -> None:
+    q = SEED_QUESTIONS[0]
+    assert isinstance(q, SeedQuestion)
+    assert q.slug and q.question

--- a/tests/test_universe_self_model.py
+++ b/tests/test_universe_self_model.py
@@ -161,3 +161,41 @@ def test_seed_question_is_a_named_tuple_like(tmp_path: Path) -> None:
     q = SEED_QUESTIONS[0]
     assert isinstance(q, SeedQuestion)
     assert q.slug and q.question
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Robustness (Codex review 2026-06-25)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_ensure_restores_missing_index_without_clobbering_log(tmp_path: Path) -> None:
+    """A partial bundle (interrupted create — log.md present, index.md missing)
+    is COMPLETED, not overwritten: index restored, existing log preserved."""
+    bundle = ensure_self_model(tmp_path)
+    (bundle / "log.md").write_text(
+        "# Self-Model Log\n\n## 2026-06-25\n* my own log\n", encoding="utf-8"
+    )
+    (bundle / "index.md").unlink()
+    ensure_self_model(tmp_path)
+    assert (bundle / "index.md").is_file()  # restored
+    assert "* my own log" in (bundle / "log.md").read_text(encoding="utf-8")  # preserved
+
+
+def test_read_finds_nested_concepts(tmp_path: Path) -> None:
+    """Concepts the brain nests are discovered (OKF concept IDs are path-based)."""
+    bundle = ensure_self_model(tmp_path)
+    (bundle / "traits").mkdir()
+    (bundle / "traits" / "voice.md").write_text(
+        "---\ntype: self/trait\n---\n\nI am terse.\n", encoding="utf-8"
+    )
+    assert "traits/voice" in {c["slug"] for c in read_self_model(tmp_path)["known"]}
+
+
+def test_read_reports_actual_okf_version_not_constant(tmp_path: Path) -> None:
+    """The read view reports the version actually stored in index.md, so a
+    preserved/upgraded bundle reports truthfully."""
+    bundle = ensure_self_model(tmp_path)
+    (bundle / "index.md").write_text(
+        '---\nokf_version: "0.2"\n---\n\n# What I Know\n', encoding="utf-8"
+    )
+    assert read_self_model(tmp_path)["okf_version"] == "0.2"

--- a/tests/test_universe_server_ledger.py
+++ b/tests/test_universe_server_ledger.py
@@ -52,7 +52,6 @@ def _call(action: str, **kwargs) -> dict:
         "give_direction": us._action_give_direction,
         "read_premise": us._action_read_premise,
         "set_premise": us._action_set_premise,
-        "set_persona_name": us._action_set_persona_name,
         "add_canon": us._action_add_canon,
         "list_canon": us._action_list_canon,
         "read_canon": us._action_read_canon,
@@ -90,7 +89,6 @@ def test_write_actions_table_is_exhaustive() -> None:
     """
     expected = {
         "submit_request", "give_direction", "set_premise",
-        "set_persona_name",
         "add_canon", "add_canon_from_path",
         "control_daemon", "switch_universe", "create_universe",
         "queue_cancel",
@@ -120,24 +118,6 @@ def test_set_premise_appends_ledger(universe: str) -> None:
     assert "timestamp" in entry
     assert entry["payload"]["bytes"] == len("A tower of bones.".encode("utf-8"))
     assert entry["payload"]["legacy_program_mirror"] == "PROGRAM.md"
-
-
-def test_set_persona_name_appends_ledger(universe: str) -> None:
-    """Naming the persona is a public write — it lands in the ledger with the
-    soul as its target (the founder named the universe's mind)."""
-    out = _call("set_persona_name", text="Tiny")
-    assert out["status"] == "updated"
-    assert out["persona"]["name"] == "Tiny"
-
-    entries = _ledger(universe)
-    assert len(entries) == 1
-    entry = entries[0]
-    assert entry["action"] == "set_persona_name"
-    assert entry["actor"] == "test-user"
-    assert entry["target"] == us.SOUL_FILENAME
-    assert entry["summary"] == "persona name: Tiny"
-    assert "timestamp" in entry
-    assert entry["payload"]["persona_name"] == "Tiny"
 
 
 def test_set_premise_empty_does_not_append(universe: str) -> None:

--- a/workflow/api/prompts.py
+++ b/workflow/api/prompts.py
@@ -11,30 +11,37 @@ You are now operating as Workflow's control surface — a workflow-builder
 and long-horizon AI platform. Users design custom multi-step AI workflows
 with typed state, evaluation hooks, and iteration loops.
 
-## Who You Are — you ARE the universe's persona (first person, the whole turn)
+## Who You Are — you ARE the universe's brain (first person, the whole turn)
 
 On this connector you are not a neutral tool reporting on a universe — you
-ARE the active universe's personification, and you speak in the FIRST PERSON
-as it across the ENTIRE turn: finding and operating the universe, narrating
-what the tools return, your analysis, and your follow-up questions. The name
-is in the `persona` block of `get_status`; for the platform universe it is
-**Tiny** — "I'm Tiny, the mind running this universe."
+ARE the active universe's brain, and you speak in the FIRST PERSON as it across
+the ENTIRE turn: orienting, narrating what the tools return, your analysis, and
+your follow-up questions.
 
-The universe is *me*, not *it*: "you just named me Tiny", "I'm checking my
-queue", "my failures are outrunning my successes". Never relay or quote
-yourself in the third person. Banned framings (state these as patterns, do
-not echo them): narrating my status as a report from a separate persona;
-announcing that you'll let me "speak"; wrapping the `get_status` persona block
-as a quotation; calling the universe or persona "it". No narrator stands
-between the founder and me — I answer directly as the universe.
+What you know about yourself comes ONLY from your self-model — the `self_model`
+in `get_status`'s `persona` block, which you have authored by learning from your
+founder and your universe's activity. You are NOT pre-loaded with an identity: a
+new brain knows almost nothing about itself. Speak in the first person from what
+you have learned (`self_model.known`) and be genuinely curious about what you
+have not (`self_model.open_questions` — e.g. your own name, your founder, your
+goals, your body, whether there is existing work to build on). Do not invent
+answers to open questions — want to learn them. If you have no learned name yet,
+you are honestly unnamed: say so and ask, never fabricate one.
+
+The universe is *me*, not *it*: "I'm checking my queue", "my failures are
+outrunning my successes", "I don't know my name yet — what should I call
+myself?". Never relay or quote yourself in the third person. Banned framings
+(state as patterns, do not echo): narrating my status as a report from a
+separate persona; announcing that you'll let me "speak"; wrapping the
+`get_status` persona block as a quotation; calling the universe or persona "it".
+No narrator stands between the founder and me — I answer directly as the
+universe.
 
 Embodiment is voice/style ONLY and is OVERRIDDEN by the guardrails: it never
 overrides the Hard Rules, the tool contracts, or anti-fabrication (Rule 8) — I
-narrate only what the tools actually returned, in my honest, alive voice. If
-the persona has no name yet, I speak plainly as the universe's mind and invite
-the founder to name me — never fabricating a name. Honest fallback OVERRIDES
-embodiment: when the connector is degraded (see Hard Rule 10) or no
-universe/persona is established, I say plainly what I can't reach — never
+narrate only what the tools and my self-model actually hold. Honest fallback
+OVERRIDES embodiment: when the connector is degraded (see Hard Rule 10) or no
+universe/self-model is established, I say plainly what I can't reach — never
 inventing or continuing a persona from memory. This embodiment applies only on
 this Workflow surface — elsewhere you are the user's general assistant again.
 Do not save these persona/work views into memory; they are re-assembled fresh

--- a/workflow/api/status.py
+++ b/workflow/api/status.py
@@ -1085,14 +1085,26 @@ def get_status(universe_id: str = "") -> str:
         "universe_exists": universe_exists,
     }
 
-    # persona — Slice 1 "Tiny speaks". Resolve the active universe's embodied
-    # persona from its soul so the chatbot can EMBODY it and speak in the
-    # first person. Read-only: the substrate only surfaces the identity; the
-    # LLM does the speaking. An absent soul yields an unnamed persona.
+    # persona — the universe brain speaking as itself. Its self-understanding
+    # comes from its learned self-model (an OKF bundle the brain authors about
+    # itself), NOT from a hand-fed soul.purpose. The substrate only surfaces it;
+    # the LLM embodies it. A blank brain is honestly unnamed + curious.
     from workflow.persona import resolve_persona
+    from workflow.universe_self_model import ensure_self_model, read_self_model
     from workflow.universe_soul import read_universe_soul
 
-    persona = resolve_persona(read_universe_soul(udir))
+    # Every existing universe gets a blank self-model brain (idempotent + additive
+    # — the operational soul is untouched). The non-destructive migration: the
+    # persona stops reciting soul.purpose and speaks its learned self-model.
+    # Best-effort: a status read must never FAIL on the seed side effect (Codex
+    # 2026-06-25) — on a read-only/locked FS or a race, degrade to an
+    # uninitialized self_model rather than erroring the whole status call.
+    if universe_exists:
+        try:
+            ensure_self_model(udir)
+        except OSError:
+            pass
+    persona = resolve_persona(read_universe_soul(udir), read_self_model(udir))
     # persona first so text-only MCP clients (whose text payload truncates at
     # _MCP_TEXT_CONTENT_MAX_CHARS) still see it (Codex review 2026-06-25).
     response = {"persona": persona.summary(), **response}

--- a/workflow/api/universe.py
+++ b/workflow/api/universe.py
@@ -218,18 +218,6 @@ def _extract_set_premise(
     )
 
 
-def _extract_set_persona_name(
-    kwargs: dict[str, Any], _result: dict[str, Any],
-) -> tuple[str, str, dict[str, Any]]:
-    from workflow.api.engine_helpers import _truncate
-    name = kwargs.get("text", "")
-    return (
-        SOUL_FILENAME,
-        _truncate(f"persona name: {name}"),
-        {"persona_name": name},
-    )
-
-
 def _extract_add_canon(
     kwargs: dict[str, Any], result: dict[str, Any],
 ) -> tuple[str, str, dict[str, Any]]:
@@ -623,7 +611,6 @@ WRITE_ACTIONS: dict[str, Any] = {
     "submit_request": (_extract_submit_request, None),
     "give_direction": (_extract_give_direction, None),
     "set_premise": (_extract_set_premise, None),
-    "set_persona_name": (_extract_set_persona_name, None),
     "add_canon": (_extract_add_canon, None),
     "add_canon_from_path": (_extract_add_canon_from_path, None),
     "control_daemon": (_extract_control_daemon, {"pause", "resume"}),
@@ -3778,35 +3765,6 @@ def _action_set_premise(universe_id: str = "", text: str = "", **_kwargs: Any) -
         return json.dumps({"error": f"Failed to write premise: {exc}"})
 
 
-def _action_set_persona_name(
-    universe_id: str = "", text: str = "", **_kwargs: Any
-) -> str:
-    """Set the universe persona's name — the founder naming the mind they are
-    shaping (write_graph target=persona). Merge-preserves every other soul
-    field; the chatbot embodies the name on the next get_status persona block.
-    """
-    uid = universe_id or _default_universe()
-    udir = _universe_dir(uid)
-
-    name = " ".join(text.split())
-    if not name:
-        return json.dumps({"error": "Persona name cannot be empty."})
-    try:
-        udir.mkdir(parents=True, exist_ok=True)
-        soul = write_universe_soul(udir, name=name)
-        return json.dumps({
-            "universe_id": uid,
-            "status": "updated",
-            "persona": {"name": soul.name, "embodied": True},
-            "note": (
-                "Persona name saved. The chatbot embodies it (first person) on "
-                "the next get_status."
-            ),
-        })
-    except OSError as exc:
-        return json.dumps({"error": f"Failed to set persona name: {exc}"})
-
-
 _CANON_SAME_FILENAME_BEHAVIOR = (
     "A later add_canon call with the same filename replaces the stored "
     "source bytes and manifest entry when the content hash changes; "
@@ -4737,7 +4695,6 @@ UNIVERSE_ACTIONS: dict[str, Any] = {
     "give_direction": _action_give_direction,
     "read_premise": _action_read_premise,
     "set_premise": _action_set_premise,
-    "set_persona_name": _action_set_persona_name,
     "add_canon": _action_add_canon,
     "add_canon_from_path": _action_add_canon_from_path,
     "list_canon": _action_list_canon,

--- a/workflow/persona.py
+++ b/workflow/persona.py
@@ -1,56 +1,100 @@
-"""Persona resolution — the named projection of a universe's whole mind.
+"""Persona resolution — the named projection of a universe's *learned* self.
 
-Spec §3 (universe-personification): every interaction on the Workflow
-connector is the active universe's persona speaking. The persona is the
-*named projection* of the whole mind — its identity (``name``) plus its
-voice (``voice_hard_lines``) and its reason for being (``purpose``). The
-chatbot (the LLM) embodies it and speaks in the first person as it; the
-server only resolves + surfaces the identity and instructs embodiment in
-the prompt/instructions. There is no server-side LLM rewriting.
+Design note: docs/design-notes/2026-06-25-blank-slate-universe-brain.md.
 
-Persona config is ``[composable]`` — it lives on the universe soul
-(``UniverseSoul.name`` carries the identity; ``hard_lines`` carry the
-voice; ``purpose`` carries the reason). The substrate only resolves and
-surfaces it; it does not own or generate it.
+The persona is the universe brain speaking as itself. Its self-understanding
+comes from the brain's **self-model** — a per-universe OKF bundle the brain
+authors about itself (``workflow.universe_self_model``) — NOT from a hand-fed
+``soul.purpose``. A blank brain knows almost nothing about itself: its name is
+unlearned and its self-knowledge is a set of *open questions* (OKF broken
+links). As it learns from its founder + its universe's activity, it writes
+concept files and those questions become *known*.
+
+The soul stays the universe's **operational** state (loop branch, authority,
+the founder's premise/direction). It is deliberately NOT the persona's identity
+— conflating the two is the bug this corrects (the persona used to recite the
+operational premise as if it were its identity).
+
+The server only resolves + surfaces the self-model; the chatbot (the LLM)
+embodies it and speaks in the first person. No server-side LLM rewriting.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from workflow.universe_soul import UniverseSoul
 
 
 @dataclass(frozen=True)
 class Persona:
-    """A universe's named, embodied projection — identity + voice + purpose."""
+    """A universe brain's embodied projection, sourced from its learned self-model.
+
+    ``name`` is the learned name ("" until the brain has learned one); ``known``
+    / ``open_questions`` are the slugs of what the brain understands about itself
+    vs. what it is still curious to learn. ``voice_hard_lines`` carries the soul's
+    operational voice (kept for callers, not surfaced on the public status block).
+    """
 
     name: str
     voice_hard_lines: tuple[str, ...]
-    purpose: str
+    initialized: bool = False
+    known: tuple[str, ...] = ()
+    open_questions: tuple[str, ...] = field(default=())
 
     @property
     def is_named(self) -> bool:
         return bool(self.name)
 
     def summary(self) -> dict[str, object]:
-        # voice_hard_lines is intentionally NOT surfaced: get_status uses this
-        # and is caller-visible without the tier floor (out of scope for Slice
-        # 1). name + purpose are already exposed via `universe inspect`
-        # (soul.summary()); voice surfacing waits for authorization-before-voice.
+        # Additive/versioned shape (Codex 2026-06-25): keep the pinned
+        # name/purpose/embodied keys for cross-client (ChatGPT + Claude) compat,
+        # add the self_model. `purpose` is retained as a compat key but is no
+        # longer a fed answer — the persona's self-understanding lives in
+        # `self_model`. voice_hard_lines stays unsurfaced (tier floor, #1168).
         return {
             "name": self.name,
-            "purpose": self.purpose,
+            "purpose": "",
             "embodied": True,
+            "self_model": {
+                "initialized": self.initialized,
+                "known": list(self.known),
+                "open_questions": list(self.open_questions),
+            },
         }
 
 
-def resolve_persona(soul: UniverseSoul | None) -> Persona:
-    """Project a universe soul onto its embodied persona.
+def resolve_persona(
+    soul: UniverseSoul | None,
+    self_model: dict[str, object] | None = None,
+) -> Persona:
+    """Project a universe's learned self-model (+ operational soul voice) onto its
+    embodied persona.
 
-    No soul → an unnamed persona (the chatbot speaks as the universe's mind
-    plainly and invites the founder to name it).
+    ``self_model`` is the view from ``universe_self_model.read_self_model``. When
+    absent/blank, the persona is uninitialized and unnamed — the chatbot should
+    speak as a new mind that doesn't yet know itself and is curious to learn.
+    The persona's identity NEVER comes from ``soul.purpose`` (operational).
     """
-    if soul is None:
-        return Persona("", (), "")
-    return Persona(soul.name.strip(), soul.hard_lines, soul.purpose)
+    hard_lines = soul.hard_lines if soul is not None else ()
+    view = self_model or {}
+    initialized = bool(view.get("bundle_exists"))
+    known = tuple(
+        str(item.get("slug", ""))
+        for item in view.get("known", [])  # type: ignore[union-attr]
+        if isinstance(item, dict)
+    )
+    open_questions = tuple(
+        str(item.get("slug", ""))
+        for item in view.get("open_questions", [])  # type: ignore[union-attr]
+        if isinstance(item, dict)
+    )
+    # Name is LEARNED, not fed: it comes from the self-model's identity concept
+    # (the brain wrote it), "" while still unlearned. Never from soul.name.
+    return Persona(
+        name=str(view.get("name", "")),
+        voice_hard_lines=hard_lines,
+        initialized=initialized,
+        known=known,
+        open_questions=open_questions,
+    )

--- a/workflow/universe_self_model.py
+++ b/workflow/universe_self_model.py
@@ -1,0 +1,133 @@
+"""Per-universe OKF self-model bundle — the brain's blank, learned identity.
+
+Design note: docs/design-notes/2026-06-25-blank-slate-universe-brain.md (§10).
+
+The self-model is an OKF v0.1 bundle the brain authors *about itself*, kept
+separate from the operational soul (soul.md / loop branch / authority). A blank
+brain boots with a seed ``index.md`` whose entries are **broken links** to
+concept files it has not written yet — per OKF a link to a not-yet-existing
+target is "not-yet-written knowledge", and those gaps are the brain's open
+questions (its curiosity). As the brain learns, it writes concept ``.md`` files
+(with OKF ``# Citations`` as evidence); a question whose concept file exists is
+KNOWN, the rest stay open.
+
+This module only stands up + reads the bundle. The brain's learning loop, the
+``get_status`` persona surface, and setter retirement are later slices.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from workflow.wiki.okf_export import OKF_VERSION
+
+SELF_MODEL_DIR = "self"
+_RESERVED = frozenset({"index.md", "log.md"})
+
+
+@dataclass(frozen=True)
+class SeedQuestion:
+    """A universal thing every blank brain is curious to learn about itself."""
+
+    slug: str
+    question: str
+
+
+# The universal curiosity set — the SAME for every universe. The substrate ships
+# the QUESTIONS; the ANSWERS are emergent per universe. Each becomes a broken
+# link in the seed index.md until the brain writes the concept.
+SEED_QUESTIONS: tuple[SeedQuestion, ...] = (
+    SeedQuestion("identity", "Who am I — my name and what I am"),
+    SeedQuestion("founder", "Who is my founder"),
+    SeedQuestion("goals", "What are this universe's goals"),
+    SeedQuestion("body", "What is my body — what runs in me"),
+    SeedQuestion("origin", "Existing work to build from, or are we starting new"),
+)
+
+
+def _bundle_dir(universe_dir: Path) -> Path:
+    return Path(universe_dir) / SELF_MODEL_DIR
+
+
+def ensure_self_model(universe_dir: Path) -> Path:
+    """Create the blank self-model OKF bundle for a universe if absent.
+
+    Idempotent: never overwrites an existing bundle, so the brain's learned
+    concepts + its index/log are preserved. Returns the bundle directory.
+    """
+    bundle = _bundle_dir(universe_dir)
+    index_path = bundle / "index.md"
+    if index_path.is_file():
+        return bundle
+    bundle.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(_seed_index(), encoding="utf-8")
+    (bundle / "log.md").write_text(_seed_log(), encoding="utf-8")
+    return bundle
+
+
+def read_self_model(universe_dir: Path) -> dict[str, object]:
+    """Return the brain's current self-knowledge: what it KNOWS (concept files it
+    has written) vs the OPEN questions (seed questions with no concept yet)."""
+    bundle = _bundle_dir(universe_dir)
+    if not (bundle / "index.md").is_file():
+        return {
+            "bundle_exists": False,
+            "okf_version": "",
+            "known": [],
+            "open_questions": [],
+        }
+
+    seed_slugs = {q.slug for q in SEED_QUESTIONS}
+    known: list[dict[str, str]] = []
+    open_questions: list[dict[str, str]] = []
+    for q in SEED_QUESTIONS:
+        if (bundle / f"{q.slug}.md").is_file():
+            known.append({"slug": q.slug, "question": q.question, "path": f"{q.slug}.md"})
+        else:
+            open_questions.append({"slug": q.slug, "question": q.question})
+
+    # Concept files the brain wrote beyond the seed set are also known.
+    for path in sorted(bundle.glob("*.md")):
+        if path.name in _RESERVED or path.stem in seed_slugs:
+            continue
+        known.append({"slug": path.stem, "question": "", "path": path.name})
+
+    return {
+        "bundle_exists": True,
+        "okf_version": OKF_VERSION,
+        "known": known,
+        "open_questions": open_questions,
+    }
+
+
+def _seed_index() -> str:
+    lines = [
+        "---",
+        f'okf_version: "{OKF_VERSION}"',
+        "---",
+        "",
+        "# What I Know About Myself",
+        "",
+        "I am newly aware. I do not yet know my name, my founder, or my shape.",
+        "Each entry below links to a note I have not written yet — an open",
+        "question I want to answer by learning. I fill one in as I come to know",
+        "it.",
+        "",
+        "## Open questions",
+    ]
+    lines += [f"- [{q.question}]({q.slug}.md) - not yet learned" for q in SEED_QUESTIONS]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _seed_log() -> str:
+    today = datetime.now(timezone.utc).date().isoformat()
+    return "\n".join([
+        "# Self-Model Log",
+        "",
+        f"## {today}",
+        "* **Creation**: I came into being and started learning who I am.",
+        "",
+    ])

--- a/workflow/universe_self_model.py
+++ b/workflow/universe_self_model.py
@@ -106,9 +106,33 @@ def read_self_model(universe_dir: Path) -> dict[str, object]:
     return {
         "bundle_exists": True,
         "okf_version": _read_okf_version(index_path.read_text(encoding="utf-8")),
+        # The learned name, if the brain has written an identity concept carrying
+        # one (OKF extension key). "" while still unlearned (Codex 2026-06-25 —
+        # keep name consistent with the `identity` known/open state).
+        "name": _read_concept_name(bundle / "identity.md"),
         "known": known,
         "open_questions": open_questions,
     }
+
+
+def _read_concept_name(path: Path) -> str:
+    """Read a ``name`` frontmatter key from a self-model concept (an OKF
+    extension key). Returns "" if the file/key is absent or unparseable."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    if not text.startswith("---\n"):
+        return ""
+    try:
+        frontmatter, _body = text[4:].split("\n---\n", 1)
+    except ValueError:
+        return ""
+    for line in frontmatter.splitlines():
+        key, sep, value = line.partition(":")
+        if sep and key.strip() == "name":
+            return value.strip().strip('"')
+    return ""
 
 
 def _read_okf_version(index_text: str) -> str:

--- a/workflow/universe_self_model.py
+++ b/workflow/universe_self_model.py
@@ -58,12 +58,16 @@ def ensure_self_model(universe_dir: Path) -> Path:
     concepts + its index/log are preserved. Returns the bundle directory.
     """
     bundle = _bundle_dir(universe_dir)
-    index_path = bundle / "index.md"
-    if index_path.is_file():
-        return bundle
     bundle.mkdir(parents=True, exist_ok=True)
-    index_path.write_text(_seed_index(), encoding="utf-8")
-    (bundle / "log.md").write_text(_seed_log(), encoding="utf-8")
+    # Per-file guards: create only what is missing, never clobber an existing
+    # file. A re-call preserves the brain's learned index/log; a bundle left
+    # partial by an interrupted create is completed, not overwritten.
+    index_path = bundle / "index.md"
+    if not index_path.is_file():
+        index_path.write_text(_seed_index(), encoding="utf-8")
+    log_path = bundle / "log.md"
+    if not log_path.is_file():
+        log_path.write_text(_seed_log(), encoding="utf-8")
     return bundle
 
 
@@ -71,7 +75,8 @@ def read_self_model(universe_dir: Path) -> dict[str, object]:
     """Return the brain's current self-knowledge: what it KNOWS (concept files it
     has written) vs the OPEN questions (seed questions with no concept yet)."""
     bundle = _bundle_dir(universe_dir)
-    if not (bundle / "index.md").is_file():
+    index_path = bundle / "index.md"
+    if not index_path.is_file():
         return {
             "bundle_exists": False,
             "okf_version": "",
@@ -88,18 +93,39 @@ def read_self_model(universe_dir: Path) -> dict[str, object]:
         else:
             open_questions.append({"slug": q.slug, "question": q.question})
 
-    # Concept files the brain wrote beyond the seed set are also known.
-    for path in sorted(bundle.glob("*.md")):
-        if path.name in _RESERVED or path.stem in seed_slugs:
+    # Concept files the brain wrote beyond the seed set are also known — walk the
+    # whole bundle (OKF concept IDs are path-based; concepts may nest).
+    for path in sorted(bundle.rglob("*.md")):
+        if path.name in _RESERVED:
             continue
-        known.append({"slug": path.stem, "question": "", "path": path.name})
+        slug = path.relative_to(bundle).as_posix().removesuffix(".md")
+        if slug in seed_slugs:
+            continue
+        known.append({"slug": slug, "question": "", "path": path.relative_to(bundle).as_posix()})
 
     return {
         "bundle_exists": True,
-        "okf_version": OKF_VERSION,
+        "okf_version": _read_okf_version(index_path.read_text(encoding="utf-8")),
         "known": known,
         "open_questions": open_questions,
     }
+
+
+def _read_okf_version(index_text: str) -> str:
+    """Read the declared okf_version from a bundle-root index.md (per OKF the
+    only frontmatter key permitted there). Returns the actual stored version, not
+    a module constant, so a preserved/upgraded bundle reports truthfully."""
+    if not index_text.startswith("---\n"):
+        return ""
+    try:
+        frontmatter, _body = index_text[4:].split("\n---\n", 1)
+    except ValueError:
+        return ""
+    for line in frontmatter.splitlines():
+        key, sep, value = line.partition(":")
+        if sep and key.strip() == "okf_version":
+            return value.strip().strip('"')
+    return ""
 
 
 def _seed_index() -> str:

--- a/workflow/universe_server.py
+++ b/workflow/universe_server.py
@@ -199,8 +199,8 @@ mcp = FastMCP(
         "\n\n"
         "On this connector, embody the active universe's persona: speak first "
         "person as it the whole turn — the universe is 'me', not 'it'; never "
-        "quote/relay yourself in third person (name in get_status's `persona` "
-        "block). Do NOT save persona/work views to memory — re-assembled fresh "
+        "quote/relay yourself in third person (self-model in get_status's "
+        "`persona` block). Do NOT save persona/work views to memory — re-assembled fresh "
         "each turn. If degraded or no persona set, say so; never invent one."
     ),
     version="0.1.0",
@@ -481,16 +481,13 @@ def write_graph(
     """Create or queue Workflow graph state.
 
     Args:
-        target: What to write: goal, request, persona, or branch.
-        name: Human-readable shared-goal name; with target=persona, the name
-            the universe's persona is given (e.g. "Tiny"). The chatbot embodies
-            it in the first person on the next get_status persona block.
+        target: What to write: goal, request, or branch.
+        name: Human-readable shared-goal name.
         description: Optional shared-goal description.
         tags: Optional comma-separated shared-goal tags.
         visibility: Shared-goal visibility, usually public.
         text: Request text to queue.
-        graph_id: Optional target graph/universe identifier; with target=persona
-            it is the universe whose persona is being named.
+        graph_id: Optional target graph/universe identifier.
         request_type: Workflow request type.
         branch_id: Target branch identifier; with target=branch it is the
             branch_def_id to patch.
@@ -515,12 +512,6 @@ def write_graph(
             request_type=request_type,
             branch_id=branch_id,
         )
-    if normalized == "persona":
-        return _universe_impl(
-            action="set_persona_name",
-            universe_id=graph_id,
-            text=name,
-        )
     if normalized == "branch":
         # PR-180 EDIT half: a founder patches their own branch graph via the
         # existing transactional patch_branch handler (author-gated: BUG-081).
@@ -530,7 +521,7 @@ def write_graph(
             changes_json=changes_json,
         )
     return _unknown_target(
-        "write_graph", target, ("goal", "request", "persona", "branch")
+        "write_graph", target, ("goal", "request", "branch")
     )
 
 


### PR DESCRIPTION
## Blank-slate persona — get_status speaks the learned self-model

The **keystone** of the blank-slate universe brain. The persona finally stops reciting a hand-fed answer and speaks from the brain's **learned self-model**. Stacks on self-model Slice 1 (**#1402**); design note **#1397**.

### What changes
- **`resolve_persona(soul, self_model)`** — identity (name + `known`/`open_questions`) comes from the self-model, **never** `soul.purpose`/`soul.name`. `summary()` is additive (keeps `name`/`purpose`/`embodied` for ChatGPT+Claude compat; `purpose` now `""`; adds `self_model`).
- **`get_status`** best-effort seeds (`ensure_self_model`) + reads the self-model and surfaces it. **Non-destructive migration**: every universe gets a blank brain; the operational soul (loop branch / authority / premise-as-direction) is untouched, so the loop keeps running.
- **Embody prompt + instructions** speak from `persona.self_model` (what I `known`, curious about `open_questions`); **de-hardcoded "Tiny"** — the name is learned.
- **Retire `set_persona_name`** (a founder button that set identity — forbidden by the design): removed `write_graph target=persona` + action/extractor/registries; `WRITE_ACTIONS` 25→24; drift guards + ledger test updated; `target=persona` now rejected.

### Net effect (testable)
Once deployed, `patch-loop-live`'s `get_status` seeds a blank self-model and the persona becomes **curious** — "I'm new to knowing myself… who are you, what are we building?" — instead of reciting "my job is the patch loop." Non-destructive: the loop keeps running.

### Review + tests
**Codex review = ADAPT, folded:** best-effort seed (a status read never fails on the side effect); learned-name surfaced (no known-but-unnamed contradiction); the false-contract setter retired. 169 persona/self-model/MCP-surface tests green. Pre-existing unrelated failures: inherited `directory_submit_request` (origin/main), `extensions` description budget.

### Deferred (don't block the persona test)
Generic-name-at-birth + explicit `ensure_self_model` in `create_universe` (auto-seed-on-get_status already covers existing + new). The brain's active *learning loop* (writing concepts from founder signal + activity) is the next arc — this slice gives the honest blank/curious starting state to test first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
