### PR TITLE
Design note: Founder & universe identity (auth-in, serial-id, per-request persona routing)

### DIFF
--- a/docs/design-notes/2026-06-26-founder-and-universe-identity.md
+++ b/docs/design-notes/2026-06-26-founder-and-universe-identity.md
@@ -1,135 +1,151 @@
 # Founder & Universe Identity — who a universe belongs to, and which persona a chatbot wears
 
-- **Status:** Proposed (design). Host-ratified principles 2026-06-25/26 (surfaced during the blank-slate persona live ui-test). Not yet sliced.
+- **Status:** Proposed (design). Host-ratified principles 2026-06-25/26. Opposite-provider review (Codex) = **ADAPT, blocking** — folded (§8). Not build-ready until the §2 auth-subject reality is resolved.
 - **Author:** Claude Code session (host design dialogue 2026-06-26).
-- **Upstream of:** the blank-slate universe brain (`2026-06-25-blank-slate-universe-brain.md`). The persona can only "align with its founder" once a founder identity exists — this note builds that.
-- **Touches:** `workflow/auth/*` (provider, middleware, wellknown), `workflow/api/engine_helpers.py` (`_current_actor`), `workflow/api/universe.py` (creation, routing), `workflow/api/status.py` (persona/founder surface), `deploy/cloudflare-worker/worker.js`.
+- **Upstream of:** the blank-slate universe brain (`2026-06-25-blank-slate-universe-brain.md`). The persona can only "align with its founder" once a founder identity exists.
+- **Touches:** `workflow/auth/*` (provider, middleware, wellknown), `workflow/api/engine_helpers.py`, `workflow/api/universe.py`, `workflow/api/helpers.py`, `workflow/api/status.py`, `workflow/universe_server.py` (`create_streamable_http_app`), `fantasy_daemon/__main__.py` (the single-universe loop), `deploy/cloudflare-worker/worker.js`.
 
 ---
 
 ## 1. The problem (from the live ui-test, 2026-06-25/26)
 
-The blank-slate persona shipped and reads honestly curious — but `get_status`
-returns `account_user: "anonymous"`, even for the host's authenticated claude.ai
-session. The persona's entire premise is *"align with my founder"*; with no
-founder identity flowing, there is **no founder to align with**. This is upstream
-of the persona work.
+The blank-slate persona reads honestly curious, but `get_status` returns
+`account_user: "anonymous"` even for the host's authenticated claude.ai session.
+The persona's premise is *"align with my founder"*; with no founder identity, there
+is no founder to align with. This is upstream of the persona work.
 
-## 2. What's actually true (verified in code, 2026-06-26)
+## 2. What's actually true (verified in code; Codex 2026-06-26 corrected my first draft)
 
-- **The OAuth Bearer reaches the daemon.** `deploy/cloudflare-worker/worker.js`
-  preserves the `Authorization` header to the tunnel origin (it only strips
-  hop-by-hop headers, and injects CF-Access *service-token* headers to authenticate
-  the Worker itself). So the user's claude.ai OAuth token rides straight through.
-- **The daemon is the OAuth server.** `workflow/auth/wellknown.py` + `provider.py`
-  issue the tokens during connector install, so a received Bearer is one the daemon
-  can validate.
-- **Gap 1 — auth gating is OFF.** `UNIVERSE_SERVER_AUTH` is unset in `deploy/`
-  (default `false`). `auth_middleware` resolves the token only when the provider
-  is in gated mode; otherwise `_current_actor()` falls through to env
-  `UNIVERSE_SERVER_USER` = `"anonymous"`. The token arrives and is ignored.
-- **Gap 2 — no universe→founder binding exists.** `universe.py` has no `founder` /
-  `owner_id` / `claim`. The only `created_by=_current_actor()` is on daemons/goals
-  (and anonymous anyway). A universe never records whose it is.
+- ✅ **The OAuth Bearer reaches the daemon.** `deploy/cloudflare-worker/worker.js`
+  forwards `Authorization` (only hop-by-hop headers stripped; CF-Access service-token
+  headers added for the Worker itself). `worker.test.js` asserts it. **Not the gap.**
+- ❌ **Gap 0 (deepest) — the OAuth flow never captures a real user subject.** The
+  daemon's OAuth (`workflow/auth/provider.py`) is DCR + token issuance, but
+  `authorization_codes.user_id` **defaults to `"anonymous"`**, `create_authorization()`
+  inserts no human subject, and token exchange copies that anonymous value into the
+  access token. So `resolve_token()` returns a *stable* id that is **structurally
+  anonymous**. There is no login / upstream-IdP step that establishes *who the human
+  is*. **"OAuth = a person" is not true today** — turning on gating would just make a
+  stable anonymous, not a founder.
+- ❓ **Gap 0b — OAuth routes may not be mounted.** `wellknown.py` defines discovery/DCR/
+  token routes, but Codex found no caller mounting `create_wellknown_routes()` in
+  `create_streamable_http_app()`. Must prove the OAuth server is actually served live.
+- ❌ **Gap 1 — gating is off.** `UNIVERSE_SERVER_AUTH` unset → `_current_actor()` falls
+  to env `"anonymous"`. But flipping it on does NOT give "anonymous-read/OAuth-write"
+  (see §3.1).
+- ❌ **Gap 2 — no universe→founder binding.** No `founder`/`owner_id`/`claim` in
+  `universe.py`; `created_by` is on daemons/goals only.
 
-So: the identity plumbing is 90% there; the daemon just doesn't *use* it, and the
-universe doesn't *store* a founder.
+**Conclusion:** the foundation is *real user authentication in the OAuth flow*, not
+"flip a flag." Until a real human subject lands in the token, none of founder /
+capability / routing can work.
 
-## 3. The model (host-ratified)
+## 3. The model (host-ratified) — unchanged in intent, corrected in mechanism
 
-### 3.1 Capability model — anonymous reads, OAuth writes
-- **Anonymous = read-only.** Can browse/read the commons; cannot create or write.
-- **OAuth = write/create powers**, including creating a universe.
-- This is a **permission model, not a hard gate** (don't reject anonymous outright).
-  The substrate is partway there: `Identity.can(capability)` + `require_action_scope`
-  exist. Write actions (`create_universe`, `write_graph`, `set_premise`,
-  `add_canon`, daemon control, …) require the OAuth capability; reads stay open.
-- The exact read/write line is refined as we go; the principle is fixed.
+### 3.1 Capability model — anonymous reads, OAuth writes (needs a NEW auth mode)
+- **Anonymous = read-only; OAuth = write/create.** Principle fixed.
+- **Mechanism correction (Codex):** the existing two modes don't express this.
+  *Gated* mode: `require_action_scope` rejects anonymous **before** action semantics —
+  so reads would be rejected too. *Optional* mode: it returns early and enforces
+  **nothing**. We need a **third mode**: *resolve the bearer when present, allow
+  anonymous READS, enforce named scopes only on writes/costly/admin.*
+- **Scopes are underspecified (Codex):** `create_universe` is classified `costly`, not
+  ordinary write; action checks require *exact named scopes* (`required_scope in
+  presented_grants`); the OAuth defaults grant coarse `"read write"`, which won't
+  satisfy `workflow.universe.write` / `.costly`. New scopes + a read/write/costly
+  taxonomy are required.
 
-### 3.2 Founder by construction — no claim flow
-- **Creating a universe requires OAuth.** Therefore **every universe has a founder
-  the instant it exists** — the founder is simply *the creator's OAuth user_id,
-  recorded at creation*. No separate binding step, no claim action.
-- A universe exists only because (a) a user's **first OAuth connect auto-created
-  their main universe**, or (b) they **used their OAuth to create another**.
-- **Long-term there are no anonymous universes.** The "who is my founder" problem
-  doesn't get solved — it's structurally impossible to have a founderless universe.
+### 3.2 Founder by construction — no claim flow (net-new ACL)
+- **Creating a universe requires OAuth → every universe has a founder by construction**
+  (creator's real user_id at creation). No claim action.
+- **ACL correction (Codex):** current ACLs only restrict *private* universes; public
+  ones return allowed before checking grants, and `create_universe` accepts a
+  caller-supplied id and writes no founder. So *founder storage* + a *founder-write
+  policy* (founder-only writes to their universe) are **net-new**, plus migration
+  behavior for legacy/fantasy/API-created universes that have no founder.
 
 ### 3.3 Universe ID = immutable serial; identity is learned
-- **`universe_id` = an opaque creation SERIAL, immutable forever** — never a
-  descriptive slug. `"patch-loop-live"` is a legacy hangover. The id is just a
-  stable address; it carries no meaning.
-- Everything meaningful — **persona name, purpose, body** — is **learned in the
-  self-model** and mutable; it changes as the universe gets to know itself.
-- **Serial format (open fork):** short monotonic serial (`u-000142`, human-skimmable)
-  vs. opaque UUID (no count leak). Lean monotonic unless hiding the universe count
-  matters.
+- `universe_id` = opaque creation **serial**, immutable forever — not a descriptive
+  slug. `"patch-loop-live"` is legacy. Identity (persona name/purpose/body) is **learned
+  + mutable** in the self-model.
+- **Compatibility (Codex):** `universe_id` is the on-disk dir name + the active-universe
+  marker + `UNIVERSE_SERVER_DEFAULT_UNIVERSE` + countless references. Serial ids for NEW
+  universes must coexist with legacy descriptive ids; design the path/marker/default
+  compatibility before switching.
+- **Open fork:** monotonic serial (`u-000142`) vs UUID.
 
-### 3.4 Per-request persona routing (the multi-user crux)
-At scale (say 50 universes, each with its own OAuth founder), **which persona a
-chatbot wears is resolved per request** from `(identity, prompt)` — NOT a global
-single active-universe marker. Resolution order:
+### 3.4 Per-request persona routing — READ-side only; the loop is separate (Codex)
+At scale, which persona a chatbot wears is resolved per request from `(identity,
+prompt)`:
+1. Prompt names a universe → that universe's persona (anyone *reads*; only founder
+   *writes*).
+2. Else → caller's **main universe** (OAuth: theirs, auto-created if new; anonymous:
+   no main → prompt-only, read-only, ask to name one).
+3. Ambiguity → caller's main universe.
 
-1. **Prompt names a specific universe/persona** → that universe's persona. Anyone
-   may *read* it (read-only for non-founders / anonymous); only its founder may
-   *write* to it.
-2. **Otherwise (unspecified / ambiguous)** → the caller's **main universe**:
-   - **Recognized OAuth** → their main universe's persona by default.
-   - **New OAuth** (never seen) → **auto-create** their main universe (serial id,
-     founder bound, blank self-model) and route to it.
-   - **Anonymous** → has no main universe; routes purely by prompt (read-only). With
-     no target and no main universe, the connector asks them to name one / offers the
-     public commons rather than guessing.
-3. **Any confusion over which persona is meant → default to the caller's main
-   universe** (for OAuth).
+**Architecture correction (Codex):** this is **read/status/persona** routing. The
+**execution loop is single-universe**: `fantasy_daemon/__main__.py` picks ONE universe
+at startup and runs ONE `DaemonController` with one `_universe_path`/`_universe_id`.
+`get_status(universe_id)` can already read an explicit universe, but the *default* is
+the active marker/env/first-subdir, not identity. So: per-request **read/persona**
+routing is buildable on the status surface; per-request **execution** (many universes'
+daemons concurrently) is a separate, bigger design (multi-daemon scheduling) and is
+explicitly out of scope for this note's read-side routing.
 
-This replaces the current single-operator model (`.active_universe` marker /
-`UNIVERSE_SERVER_DEFAULT_UNIVERSE`) with per-identity main-universe + per-prompt
-routing.
-
-## 4. What changes in code (audit, not yet built)
+## 4. What changes in code (audit)
 
 | Area | Today | Direction |
 |---|---|---|
-| `workflow/auth` | gating off; provider resolves nothing | Gated capability mode: resolve OAuth token → real `user_id`; anonymous = read caps only |
-| Write actions (`universe.py`, `write_graph`, …) | run as anonymous | `require_action_scope`/`Identity.can` gate: OAuth-only |
-| Universe creation | caller-supplied descriptive `universe_id`; no founder | Assign serial id; record `founder = current OAuth user_id`; seed blank self-model; require OAuth |
-| Active universe | global `.active_universe` / default env | Per-request resolution from (identity → main universe, prompt → override) |
-| `get_status` | `account_user` from env; no founder | Surface resolved `universe_id` (serial), `founder`, and `is_founder` (caller==founder) so the persona aligns |
-| Legacy anon universes | `patch-loop-live`, test ones | NOT user-claimable; host deletes / substrate-claims / controlled fake-OAuth for testing |
+| OAuth flow | issues anonymous-subject tokens; routes maybe unmounted | Capture a real user subject (login / upstream IdP); mount + prove discovery/token routes |
+| `workflow/auth` modes | gated (rejects anon) / optional (enforces nothing) | New mode: resolve-always, anon reads, enforce named scopes on writes/costly/admin |
+| Scopes | coarse `read write` | `workflow.universe.read/write/costly` taxonomy + OAuth grants that match |
+| Universe ACL | only private universes gated | Founder field + founder-only-write policy; public reads stay open |
+| `create_universe` | caller id; no founder; not gated | OAuth-gated; serial id; record `founder = real user_id`; seed blank self-model |
+| Default routing | active marker / env / first subdir | Identity→main-universe map; per-request read/persona routing |
+| `get_status` | env `account_user`; no founder | Surface serial `universe_id`, `founder`, `is_founder` |
+| Execution loop | single universe at startup | UNCHANGED here; multi-daemon scheduling is a separate note |
 
 ## 5. Rollout caution
-
-- **Turning gating on is production-impacting.** It changes who can write on the
-  live MCP. Stage it: ship the capability model behind verification, confirm the
-  claude.ai OAuth token resolves to a stable `user_id` end-to-end (the one piece
-  still to prove live — provider.resolve_token against a real claude.ai token),
-  then enable. Don't flip `UNIVERSE_SERVER_AUTH` blind.
-- **Per-request routing is a real shift** from the single-active-universe daemon —
-  it's the biggest piece and should land incrementally (resolve identity first;
-  main-universe default next; prompt-override last).
+Gating on is production-impacting and — per §2 — premature: it would gate the live MCP
+to a stable *anonymous*, helping no one, until a real subject is captured. Stage:
+real-subject-in-token first (with live proof), then the new capability mode behind a
+flag, then founder metadata, then routing.
 
 ## 6. Open questions
+1. **How does a real human subject enter the token?** Upstream IdP (Google/GitHub), a
+   login page on the daemon's auth server, or claude.ai-provided identity? This is the
+   crux and is currently unbuilt.
+2. Are the OAuth discovery/token routes actually mounted + reachable live?
+3. Serial-ID format (monotonic vs UUID) + legacy-id compatibility.
+4. Exact read/write/costly capability split.
+5. Founder migration for legacy/fantasy/API-created universes.
+6. Multi-daemon execution (separate note) — does the loop ever need to serve >1 universe?
 
-1. Serial-ID format (§3.3) — monotonic vs UUID.
-2. The exact read/write capability split (which reads stay open to anonymous;
-   which writes are OAuth-only) — refined as we go.
-3. Live proof that a claude.ai OAuth Bearer resolves to a stable `user_id` via
-   `provider.resolve_token` (the daemon is the issuer, so expected — but unproven live).
-4. Multi-universe-per-daemon: does one daemon serve many universes' personas
-   concurrently (per-request routing implies yes), and how does that interact with
-   the current single-universe-at-startup loop?
+## 7. Proposed slices (reordered per Codex — compatibility/identity proof FIRST)
+1. **Auth-subject proof.** Mount + verify the OAuth discovery/token routes; establish
+   how a real human subject is captured and lands in `authorization_codes.user_id` →
+   `resolve_token()` returns a real id. *(Blocks everything; partly a host/IdP decision.)*
+2. **New capability mode.** Resolve-always + anonymous-reads + enforce named scopes on
+   writes/costly/admin; add the scope taxonomy. Behind a flag.
+3. **Founder metadata + founder-write ACL.** `create_universe` (OAuth-gated) records a
+   serial id + `founder`; founder-only writes; migration for founderless universes.
+4. **Identity→main-universe storage** + default routing to it.
+5. **Per-request read/persona routing** + `get_status` founder surface.
+6. **Legacy cleanup** (delete / substrate-claim / fake-OAuth) once the above land.
 
-## 7. Proposed slices (draft)
+Each slice: TDD, Codex review, live `ui-test` via the CDP route.
 
-1. **Founder at creation (additive).** `create_universe` (OAuth-gated) assigns a
-   **serial id** + records `founder = OAuth user_id`. New universes only.
-2. **Surface founder.** `get_status` exposes resolved `universe_id`, `founder`,
-   `is_founder`. Persona can say "you're my founder" / "you're a visitor".
-3. **Capability gate on writes.** Anonymous → read-only; OAuth → write. Behind a
-   flag; verify claude.ai token resolution live first.
-4. **Per-request routing.** Identity → main universe default; then prompt-override.
-   Retire the global active-universe singleton.
-5. **Legacy cleanup.** Delete / substrate-claim / fake-OAuth the pre-OAuth universes.
-
-Each slice: TDD, opposite-provider (Codex) review, live `ui-test` via the CDP route.
+## 8. Opposite-provider review (Codex, 2026-06-26) = ADAPT (blocking) — folded
+- **Critical:** OAuth doesn't identify a Claude user (`user_id` anonymous by
+  construction) → §2 Gap 0 added; §7 slice 1 makes auth-subject proof the blocker.
+- **Critical:** OAuth routes may be unmounted → §2 Gap 0b; slice 1 proves them.
+- **Critical:** anonymous-read/OAuth-write isn't a gating flip → §3.1 new auth mode +
+  scope taxonomy.
+- **Required:** founder-write ACL + founder storage are net-new (public universes
+  currently allow-by-default) → §3.2/§4.
+- **Required:** per-request routing collides with the single-universe daemon loop →
+  §3.4 splits read/persona routing from execution; multi-daemon deferred.
+- **Required:** serial-id compatibility with on-disk paths / markers / defaults → §3.3.
+- **Confirmed:** the Worker forwards `Authorization` (not the gap).
+- Slices reordered: auth-subject proof → capability mode → founder metadata →
+  identity→main → serial/routing.

--- a/docs/design-notes/2026-06-26-founder-and-universe-identity.md
+++ b/docs/design-notes/2026-06-26-founder-and-universe-identity.md
@@ -1,6 +1,6 @@
 # Founder & Universe Identity — who a universe belongs to, and which persona a chatbot wears
 
-- **Status:** Proposed (design). Host-ratified principles 2026-06-25/26. Opposite-provider review (Codex) = **ADAPT, blocking** — folded (§8). Not build-ready until the §2 auth-subject reality is resolved.
+- **Status:** Proposed (design). Host-ratified principles 2026-06-25/26. Opposite-provider review (Codex) = **ADAPT, blocking** — folded (§8). **AS provider decided 2026-06-26: WorkOS AuthKit (managed) — §3.0; resolves the §2 auth-subject crux + §6 Q1.** Spec currency: tracks MCP auth **2025-11-25** (DCR→CIMD) + **EMA stable 2026-06-18**, not only the 2025-06-18 revision §1 was first drafted against.
 - **Author:** Claude Code session (host design dialogue 2026-06-26).
 - **Upstream of:** the blank-slate universe brain (`2026-06-25-blank-slate-universe-brain.md`). The persona can only "align with its founder" once a founder identity exists.
 - **Touches:** `workflow/auth/*` (provider, middleware, wellknown), `workflow/api/engine_helpers.py`, `workflow/api/universe.py`, `workflow/api/helpers.py`, `workflow/api/status.py`, `workflow/universe_server.py` (`create_streamable_http_app`), `fantasy_daemon/__main__.py` (the single-universe loop), `deploy/cloudflare-worker/worker.js`.
@@ -38,9 +38,39 @@ is no founder to align with. This is upstream of the persona work.
 
 **Conclusion:** the foundation is *real user authentication in the OAuth flow*, not
 "flip a flag." Until a real human subject lands in the token, none of founder /
-capability / routing can work.
+capability / routing can work. **The mechanism is now decided (§3.0): a managed
+Authorization Server — WorkOS AuthKit — federates upstream to Google/GitHub OIDC and
+issues a token with a real `sub`; our MCP server becomes a pure OAuth 2.1 Resource
+Server that validates it. That is what makes Gap 0 closeable.**
 
 ## 3. The model (host-ratified) — unchanged in intent, corrected in mechanism
+
+### 3.0 The Authorization Server — WorkOS AuthKit (managed; decided 2026-06-26)
+**Decision:** we do NOT self-host an OAuth Authorization Server. Our MCP server is a pure
+**OAuth 2.1 Resource Server**; a **managed AS — WorkOS AuthKit — is the separate
+Authorization Server**, federating upstream to **Sign in with Google / GitHub (OIDC)**.
+The user logs in with an existing account; WorkOS issues a JWT with a stable `sub`; our
+server validates it against WorkOS's JWKS. **`sub` = the founder key.**
+
+- **Why managed, not self-host:** owning an AS forever (PKCE, refresh rotation, upstream-IdP
+  plumbing, SAML/SCIM, the EMA/ID-JAG extension) is a long-term security liability; managed
+  is the industry standard + where it's going, and is *less* code than self-hosting. (Host
+  principle: build the known long-term design, not the easy reuse of the existing
+  `workflow/auth` AS code.)
+- **Why WorkOS (head-to-head 2026-06-25, vs Auth0 + 7 others):** $0 + no credit card now,
+  **1M MAU free incl. social login**, a production "AuthKit for MCP" AS, **CIMD** (the
+  post-DCR client-identity model from the 2025-11-25 spec), SAML/SCIM ready for enterprise
+  "later" (per-connection cost only when an enterprise customer arrives), an ID-JAG/EMA
+  path, independent vendor (low roadmap risk). Auth0 splits *worse on both horizons* for a
+  customer-facing MCP server (DCR friction now; growth-penalty pricing later) — fallback
+  only if a future enterprise customer mandates Okta.
+- **Lock-in posture:** all standards-based (OAuth 2.1 / OIDC / JWKS / PRM discovery), so the
+  Resource Server stays insulated and the AS is swappable later; the only real switching
+  cost is the identity store (`sub`s) — identical for any managed AS, which is why we pick
+  one that covers both horizons up front.
+- **What `workflow/auth` becomes:** the self-issued anonymous-subject provider
+  (`provider.py`) is no longer the production identity source — retire it or demote it to
+  local-dev only; production identity comes from WorkOS. (Slice-1 work.)
 
 ### 3.1 Capability model — anonymous reads, OAuth writes (needs a NEW auth mode)
 - **Anonymous = read-only; OAuth = write/create.** Principle fixed.
@@ -96,7 +126,7 @@ explicitly out of scope for this note's read-side routing.
 
 | Area | Today | Direction |
 |---|---|---|
-| OAuth flow | issues anonymous-subject tokens; routes maybe unmounted | Capture a real user subject (login / upstream IdP); mount + prove discovery/token routes |
+| OAuth flow | issues anonymous-subject tokens; routes maybe unmounted | **WorkOS AuthKit = the AS** (upstream Google/GitHub OIDC → real `sub`); our server = Resource Server validating WorkOS JWTs vs JWKS; retire/demote self-issued anon provider |
 | `workflow/auth` modes | gated (rejects anon) / optional (enforces nothing) | New mode: resolve-always, anon reads, enforce named scopes on writes/costly/admin |
 | Scopes | coarse `read write` | `workflow.universe.read/write/costly` taxonomy + OAuth grants that match |
 | Universe ACL | only private universes gated | Founder field + founder-only-write policy; public reads stay open |
@@ -112,9 +142,9 @@ real-subject-in-token first (with live proof), then the new capability mode behi
 flag, then founder metadata, then routing.
 
 ## 6. Open questions
-1. **How does a real human subject enter the token?** Upstream IdP (Google/GitHub), a
-   login page on the daemon's auth server, or claude.ai-provided identity? This is the
-   crux and is currently unbuilt.
+1. ~~**How does a real human subject enter the token?**~~ **RESOLVED 2026-06-26 (§3.0):**
+   managed AS = **WorkOS AuthKit**, federating upstream to Google/GitHub OIDC → real `sub`.
+   Remaining build detail: wire AuthKit, validate JWTs vs JWKS, map `sub` → founder.
 2. Are the OAuth discovery/token routes actually mounted + reachable live?
 3. Serial-ID format (monotonic vs UUID) + legacy-id compatibility.
 4. Exact read/write/costly capability split.
@@ -122,9 +152,12 @@ flag, then founder metadata, then routing.
 6. Multi-daemon execution (separate note) — does the loop ever need to serve >1 universe?
 
 ## 7. Proposed slices (reordered per Codex — compatibility/identity proof FIRST)
-1. **Auth-subject proof.** Mount + verify the OAuth discovery/token routes; establish
-   how a real human subject is captured and lands in `authorization_codes.user_id` →
-   `resolve_token()` returns a real id. *(Blocks everything; partly a host/IdP decision.)*
+1. **Adopt WorkOS AuthKit as the AS (auth-subject proof).** Integrate WorkOS AuthKit as the
+   separate Authorization Server with upstream Google/GitHub OIDC; make our MCP server a
+   Resource Server that validates AuthKit JWTs against WorkOS's JWKS so `resolve_token()`
+   returns a real `sub`; retire/demote the self-issued anonymous provider in `workflow/auth`.
+   Live proof: an authenticated claude.ai session yields a non-anonymous `account_user`.
+   *(Blocks everything. AS-provider decision made; integration is the build.)*
 2. **New capability mode.** Resolve-always + anonymous-reads + enforce named scopes on
    writes/costly/admin; add the scope taxonomy. Behind a flag.
 3. **Founder metadata + founder-write ACL.** `create_universe` (OAuth-gated) records a
@@ -149,3 +182,9 @@ Each slice: TDD, Codex review, live `ui-test` via the CDP route.
 - **Confirmed:** the Worker forwards `Authorization` (not the gap).
 - Slices reordered: auth-subject proof → capability mode → founder metadata →
   identity→main → serial/routing.
+
+**Post-review AS-provider decision (2026-06-26, host-ratified):** managed AS = **WorkOS
+AuthKit** (head-to-head vs Auth0 + 7 others, §3.0). Resolves §2 Gap 0's "how does a real
+subject enter the token" (§6 Q1) — federate upstream OIDC, validate WorkOS JWTs, `sub` =
+founder. Slice 1 reframed from "prove the self-hosted routes" to "adopt WorkOS AuthKit."
+Spec currency bumped to track 2025-11-25 (CIMD) + EMA-stable 2026-06-18.

--- a/docs/design-notes/2026-06-26-founder-and-universe-identity.md
+++ b/docs/design-notes/2026-06-26-founder-and-universe-identity.md
@@ -1,0 +1,135 @@
+# Founder & Universe Identity — who a universe belongs to, and which persona a chatbot wears
+
+- **Status:** Proposed (design). Host-ratified principles 2026-06-25/26 (surfaced during the blank-slate persona live ui-test). Not yet sliced.
+- **Author:** Claude Code session (host design dialogue 2026-06-26).
+- **Upstream of:** the blank-slate universe brain (`2026-06-25-blank-slate-universe-brain.md`). The persona can only "align with its founder" once a founder identity exists — this note builds that.
+- **Touches:** `workflow/auth/*` (provider, middleware, wellknown), `workflow/api/engine_helpers.py` (`_current_actor`), `workflow/api/universe.py` (creation, routing), `workflow/api/status.py` (persona/founder surface), `deploy/cloudflare-worker/worker.js`.
+
+---
+
+## 1. The problem (from the live ui-test, 2026-06-25/26)
+
+The blank-slate persona shipped and reads honestly curious — but `get_status`
+returns `account_user: "anonymous"`, even for the host's authenticated claude.ai
+session. The persona's entire premise is *"align with my founder"*; with no
+founder identity flowing, there is **no founder to align with**. This is upstream
+of the persona work.
+
+## 2. What's actually true (verified in code, 2026-06-26)
+
+- **The OAuth Bearer reaches the daemon.** `deploy/cloudflare-worker/worker.js`
+  preserves the `Authorization` header to the tunnel origin (it only strips
+  hop-by-hop headers, and injects CF-Access *service-token* headers to authenticate
+  the Worker itself). So the user's claude.ai OAuth token rides straight through.
+- **The daemon is the OAuth server.** `workflow/auth/wellknown.py` + `provider.py`
+  issue the tokens during connector install, so a received Bearer is one the daemon
+  can validate.
+- **Gap 1 — auth gating is OFF.** `UNIVERSE_SERVER_AUTH` is unset in `deploy/`
+  (default `false`). `auth_middleware` resolves the token only when the provider
+  is in gated mode; otherwise `_current_actor()` falls through to env
+  `UNIVERSE_SERVER_USER` = `"anonymous"`. The token arrives and is ignored.
+- **Gap 2 — no universe→founder binding exists.** `universe.py` has no `founder` /
+  `owner_id` / `claim`. The only `created_by=_current_actor()` is on daemons/goals
+  (and anonymous anyway). A universe never records whose it is.
+
+So: the identity plumbing is 90% there; the daemon just doesn't *use* it, and the
+universe doesn't *store* a founder.
+
+## 3. The model (host-ratified)
+
+### 3.1 Capability model — anonymous reads, OAuth writes
+- **Anonymous = read-only.** Can browse/read the commons; cannot create or write.
+- **OAuth = write/create powers**, including creating a universe.
+- This is a **permission model, not a hard gate** (don't reject anonymous outright).
+  The substrate is partway there: `Identity.can(capability)` + `require_action_scope`
+  exist. Write actions (`create_universe`, `write_graph`, `set_premise`,
+  `add_canon`, daemon control, …) require the OAuth capability; reads stay open.
+- The exact read/write line is refined as we go; the principle is fixed.
+
+### 3.2 Founder by construction — no claim flow
+- **Creating a universe requires OAuth.** Therefore **every universe has a founder
+  the instant it exists** — the founder is simply *the creator's OAuth user_id,
+  recorded at creation*. No separate binding step, no claim action.
+- A universe exists only because (a) a user's **first OAuth connect auto-created
+  their main universe**, or (b) they **used their OAuth to create another**.
+- **Long-term there are no anonymous universes.** The "who is my founder" problem
+  doesn't get solved — it's structurally impossible to have a founderless universe.
+
+### 3.3 Universe ID = immutable serial; identity is learned
+- **`universe_id` = an opaque creation SERIAL, immutable forever** — never a
+  descriptive slug. `"patch-loop-live"` is a legacy hangover. The id is just a
+  stable address; it carries no meaning.
+- Everything meaningful — **persona name, purpose, body** — is **learned in the
+  self-model** and mutable; it changes as the universe gets to know itself.
+- **Serial format (open fork):** short monotonic serial (`u-000142`, human-skimmable)
+  vs. opaque UUID (no count leak). Lean monotonic unless hiding the universe count
+  matters.
+
+### 3.4 Per-request persona routing (the multi-user crux)
+At scale (say 50 universes, each with its own OAuth founder), **which persona a
+chatbot wears is resolved per request** from `(identity, prompt)` — NOT a global
+single active-universe marker. Resolution order:
+
+1. **Prompt names a specific universe/persona** → that universe's persona. Anyone
+   may *read* it (read-only for non-founders / anonymous); only its founder may
+   *write* to it.
+2. **Otherwise (unspecified / ambiguous)** → the caller's **main universe**:
+   - **Recognized OAuth** → their main universe's persona by default.
+   - **New OAuth** (never seen) → **auto-create** their main universe (serial id,
+     founder bound, blank self-model) and route to it.
+   - **Anonymous** → has no main universe; routes purely by prompt (read-only). With
+     no target and no main universe, the connector asks them to name one / offers the
+     public commons rather than guessing.
+3. **Any confusion over which persona is meant → default to the caller's main
+   universe** (for OAuth).
+
+This replaces the current single-operator model (`.active_universe` marker /
+`UNIVERSE_SERVER_DEFAULT_UNIVERSE`) with per-identity main-universe + per-prompt
+routing.
+
+## 4. What changes in code (audit, not yet built)
+
+| Area | Today | Direction |
+|---|---|---|
+| `workflow/auth` | gating off; provider resolves nothing | Gated capability mode: resolve OAuth token → real `user_id`; anonymous = read caps only |
+| Write actions (`universe.py`, `write_graph`, …) | run as anonymous | `require_action_scope`/`Identity.can` gate: OAuth-only |
+| Universe creation | caller-supplied descriptive `universe_id`; no founder | Assign serial id; record `founder = current OAuth user_id`; seed blank self-model; require OAuth |
+| Active universe | global `.active_universe` / default env | Per-request resolution from (identity → main universe, prompt → override) |
+| `get_status` | `account_user` from env; no founder | Surface resolved `universe_id` (serial), `founder`, and `is_founder` (caller==founder) so the persona aligns |
+| Legacy anon universes | `patch-loop-live`, test ones | NOT user-claimable; host deletes / substrate-claims / controlled fake-OAuth for testing |
+
+## 5. Rollout caution
+
+- **Turning gating on is production-impacting.** It changes who can write on the
+  live MCP. Stage it: ship the capability model behind verification, confirm the
+  claude.ai OAuth token resolves to a stable `user_id` end-to-end (the one piece
+  still to prove live — provider.resolve_token against a real claude.ai token),
+  then enable. Don't flip `UNIVERSE_SERVER_AUTH` blind.
+- **Per-request routing is a real shift** from the single-active-universe daemon —
+  it's the biggest piece and should land incrementally (resolve identity first;
+  main-universe default next; prompt-override last).
+
+## 6. Open questions
+
+1. Serial-ID format (§3.3) — monotonic vs UUID.
+2. The exact read/write capability split (which reads stay open to anonymous;
+   which writes are OAuth-only) — refined as we go.
+3. Live proof that a claude.ai OAuth Bearer resolves to a stable `user_id` via
+   `provider.resolve_token` (the daemon is the issuer, so expected — but unproven live).
+4. Multi-universe-per-daemon: does one daemon serve many universes' personas
+   concurrently (per-request routing implies yes), and how does that interact with
+   the current single-universe-at-startup loop?
+
+## 7. Proposed slices (draft)
+
+1. **Founder at creation (additive).** `create_universe` (OAuth-gated) assigns a
+   **serial id** + records `founder = OAuth user_id`. New universes only.
+2. **Surface founder.** `get_status` exposes resolved `universe_id`, `founder`,
+   `is_founder`. Persona can say "you're my founder" / "you're a visitor".
+3. **Capability gate on writes.** Anonymous → read-only; OAuth → write. Behind a
+   flag; verify claude.ai token resolution live first.
+4. **Per-request routing.** Identity → main universe default; then prompt-override.
+   Retire the global active-universe singleton.
+5. **Legacy cleanup.** Delete / substrate-claim / fake-OAuth the pre-OAuth universes.
+
+Each slice: TDD, opposite-provider (Codex) review, live `ui-test` via the CDP route.

--- a/docs/design-notes/2026-06-26-founder-and-universe-identity.md
+++ b/docs/design-notes/2026-06-26-founder-and-universe-identity.md
@@ -71,6 +71,13 @@ server validates it against WorkOS's JWKS. **`sub` = the founder key.**
 - **What `workflow/auth` becomes:** the self-issued anonymous-subject provider
   (`provider.py`) is no longer the production identity source — retire it or demote it to
   local-dev only; production identity comes from WorkOS. (Slice-1 work.)
+- **Implementation recipe → `docs/reference/workos-authkit-integration.md`** (token
+  validation, PRM/RFC 9728, claims, dashboard config, env). Load-bearing: validate via
+  **PyJWT + JWKS** (NOT the sealed-session SDK — that's the web-app pattern); `sub` =
+  founder key (email is custom-claim-only); **dev/staging uses WorkOS's shared Google +
+  GitHub creds → no own OAuth apps needed yet**; the write-gate enforces in the **dispatcher
+  via the scope taxonomy**, the middleware only parses the token. 4 VERIFY-flags to confirm
+  against a live token before shipping.
 
 ### 3.1 Capability model — anonymous reads, OAuth writes (needs a NEW auth mode)
 - **Anonymous = read-only; OAuth = write/create.** Principle fixed.

--- a/docs/design-notes/2026-06-26-founder-and-universe-identity.md
+++ b/docs/design-notes/2026-06-26-founder-and-universe-identity.md
@@ -86,11 +86,22 @@ server validates it against WorkOS's JWKS. **`sub` = the founder key.**
   so reads would be rejected too. *Optional* mode: it returns early and enforces
   **nothing**. We need a **third mode**: *resolve the bearer when present, allow
   anonymous READS, enforce named scopes only on writes/costly/admin.*
-- **Scopes are underspecified (Codex):** `create_universe` is classified `costly`, not
-  ordinary write; action checks require *exact named scopes* (`required_scope in
-  presented_grants`); the OAuth defaults grant coarse `"read write"`, which won't
-  satisfy `workflow.universe.write` / `.costly`. New scopes + a read/write/costly
-  taxonomy are required.
+- **Scopes — the taxonomy ALREADY EXISTS (verified 2026-06-26); do NOT rebuild it.**
+  `workflow/auth/provider.py` `build_action_scope_registry()` already maps every
+  `{tool}.{action}` → a read/write/costly/admin effect with
+  `oauth_scope = workflow.{tool}.{effect}`, incl. `_UNIVERSE_COSTLY_ACTIONS`
+  (create_universe, post_to_goal_pool, submit_node_bid, daemon_create/summon,
+  daemon_memory_promote) and `_UNIVERSE_ADMIN_ACTIONS` (control_daemon, set_tier_config,
+  daemon_banish/pause/resume/restart/update_behavior). Slice 2 **consumes** this via
+  `action_scope_for(tool, action)` — it must NOT author a parallel table. (A 2026-06-26
+  scaffold that rebuilt a universe-only taxonomy was discarded once this primitive was
+  found — a cohit; the existing registry is richer, e.g. it marks `control_daemon`/
+  `set_tier_config` admin, not plain write.) So the genuinely-new work is NOT the
+  taxonomy but: **(a)** the anonymous-read consumption policy (reads pass with no/invalid
+  token; enforce the existing scope only on write/costly/admin effects), **(b)** making
+  OAuth **grants actually carry** `workflow.universe.write/costly/admin` — the defaults
+  grant coarse `"read write"`, which is the real gap, and **(c)** the **resolve-always**
+  auth mode.
 
 ### 3.2 Founder by construction — no claim flow (net-new ACL)
 - **Creating a universe requires OAuth → every universe has a founder by construction**
@@ -166,7 +177,9 @@ flag, then founder metadata, then routing.
    Live proof: an authenticated claude.ai session yields a non-anonymous `account_user`.
    *(Blocks everything. AS-provider decision made; integration is the build.)*
 2. **New capability mode.** Resolve-always + anonymous-reads + enforce named scopes on
-   writes/costly/admin; add the scope taxonomy. Behind a flag.
+   writes/costly/admin by **consuming the existing `provider.py` registry**
+   (`action_scope_for`) — do NOT rebuild the taxonomy (§3.1) — plus make OAuth grants
+   carry `workflow.universe.write/costly/admin`. Behind a flag.
 3. **Founder metadata + founder-write ACL.** `create_universe` (OAuth-gated) records a
    serial id + `founder`; founder-only writes; migration for founderless universes.
 4. **Identity→main-universe storage** + default routing to it.

--- a/docs/reference/workos-authkit-integration.md
+++ b/docs/reference/workos-authkit-integration.md
@@ -1,0 +1,118 @@
+# WorkOS AuthKit ↔ MCP Resource Server — implementation recipe
+
+Pointer-loaded reference (ADR-002) for the founder-identity build. Design + decision
+live in `docs/design-notes/2026-06-26-founder-and-universe-identity.md` §3.0; this doc
+is the *how* for slice 1. Synthesized from WorkOS's own 2026 docs (sources at bottom).
+
+> **Status:** research synthesis (Claude, 2026-06-26). The four **VERIFY-flags** below must
+> be confirmed against a live token + AuthKit AS metadata before shipping. Slice-1
+> implementation gets opposite-provider (Codex) review per AGENTS.md.
+
+## Architecture
+**AuthKit = the OAuth 2.1 Authorization Server. Our MCP server = the Resource Server.**
+The RS has exactly two auth jobs: (1) publish Protected Resource Metadata, (2) validate
+the incoming bearer JWT. AuthKit owns login, consent, token issuance, and client
+registration. We host **no** authorization-server endpoints.
+
+## Token validation — PyJWT + JWKS, NOT the sealed-session SDK
+- The workos-python session helpers (`load_sealed_session().authenticate()`) are the
+  **web-app client** pattern (cookies/sealed sessions) — wrong for an RS validating an
+  incoming `Authorization: Bearer`. Misusing them throws `InvalidToken`. **Don't.**
+- For the RS: **PyJWT + `PyJWKClient`** (handles `kid` matching + key rotation + caching).
+  Use the SDK for exactly one thing so the URL isn't hardcoded:
+  `WorkOSClient(...).user_management.get_jwks_url(client_id)`.
+- **JWKS URL (confirmed):** `https://api.workos.com/sso/jwks/<WORKOS_CLIENT_ID>` (per client_id).
+- Pin `algorithms=["RS256"]` (algorithm-substitution defense). Validate `iss` **and** `aud`.
+
+## Token claims (AuthKit Sessions doc)
+| Claim | Use |
+|---|---|
+| `sub` | **stable WorkOS user id → our `founder` key.** Docs say use `sub`, not email (email is mutable/unverified). |
+| `sid` | session id (sign-out) |
+| `iss` | `https://api.workos.com/` **or** your AuthKit domain — VERIFY (flag 1) |
+| `org_id` / `role` / `permissions` | only present when an org is selected at sign-in; social-login users w/o org won't have them |
+| `exp` / `iat` | standard |
+- **Email is NOT in the access token by default.** Either add it as a **custom claim**
+  (Dashboard JWT/sessions config — avoids a per-request API call) or look it up server-side
+  with `user_management.get_user(sub).email` (needs the API key). Prefer the custom claim.
+
+## MCP discovery / OAuth 2.1 RS plumbing
+- **PRM (RFC 9728)** — our server serves `/.well-known/oauth-protected-resource`:
+  ```json
+  { "resource": "https://tinyassets.io/mcp",
+    "authorization_servers": ["https://<authkit_domain>"],
+    "bearer_methods_supported": ["header"] }
+  ```
+- **AS metadata (RFC 8414)** — AuthKit hosts it at
+  `https://<authkit_domain>/.well-known/oauth-authorization-server` (advertises
+  `authorization_endpoint`, `token_endpoint`, `introspection_endpoint`, `issuer`, `jwks_uri`).
+- **Audience binding (RFC 8707)** — register our MCP URL as a **Resource Indicator** in the
+  Dashboard; tokens then carry `aud` = that URL. Validate `aud == WORKOS_MCP_RESOURCE`.
+- **Client identity** — AuthKit-for-MCP defaults to **CIMD** (2025-11-25 spec) with **DCR**
+  for legacy clients. Enable under Dashboard → Connect → Configuration. We manage neither.
+- Canonical connector-side guidance: the WorkOS **"Model Context Protocol – AuthKit"** doc.
+
+## The write-gate lives in the dispatcher, not by HTTP verb
+All MCP tool calls are POST, so "is this a write?" can't be inferred from the HTTP method.
+The middleware only **parses + validates the token → principal**; the **enforcement**
+(does this action's `required_scope` match the principal's grants?) happens in the action
+dispatcher, keyed by the **scope taxonomy** (`required_scope(action)` — built separately:
+reads→open, ordinary writes→write, `create_universe`→costly). Anonymous = no principal =
+reads allowed, writes 401.
+
+## Minimal middleware (token-parse only; enforcement in dispatcher)
+```python
+import os, jwt
+from jwt import PyJWKClient
+from workos import WorkOSClient
+
+_workos = WorkOSClient(api_key=os.environ.get("WORKOS_API_KEY", ""),
+                       client_id=os.environ["WORKOS_CLIENT_ID"])
+_jwks = PyJWKClient(_workos.user_management.get_jwks_url(os.environ["WORKOS_CLIENT_ID"]))
+_RESOURCE = os.environ["WORKOS_MCP_RESOURCE"]           # https://tinyassets.io/mcp
+_ISSUER   = f'https://{os.environ["WORKOS_AUTHKIT_DOMAIN"]}'   # VERIFY (flag 1) vs AS metadata
+
+def validate_bearer(token: str) -> dict:
+    key = _jwks.get_signing_key_from_jwt(token)
+    c = jwt.decode(token, key.key, algorithms=["RS256"],
+                   audience=_RESOURCE, issuer=_ISSUER,
+                   options={"require": ["exp", "sub"]})
+    return {"founder": c["sub"], "email": c.get("email"),
+            "scopes": c.get("permissions", []), "role": c.get("role"),
+            "org_id": c.get("org_id")}
+```
+On a protected action with no/invalid principal, return **401** with
+`WWW-Authenticate: Bearer error="invalid_token", resource_metadata="<PRM_URL>"` so the
+client can discover AuthKit.
+
+## Env / secrets (RS needs very little)
+| Var | Value / where | Needed for |
+|---|---|---|
+| `WORKOS_CLIENT_ID` | `client_…` (Dashboard → API Keys) | JWKS URL + app id |
+| `WORKOS_AUTHKIT_DOMAIN` | e.g. `your-app.authkit.app` or custom `auth.tinyassets.io` | `iss` + PRM + AS discovery |
+| `WORKOS_MCP_RESOURCE` | `https://tinyassets.io/mcp` (= registered Resource Indicator) | `aud` + PRM `resource` |
+| `WORKOS_API_KEY` | `sk_…` (Dashboard → API Keys) | **only** if doing `get_user()` email lookups; keep out of RS if email is a custom claim |
+`WORKOS_REDIRECT_URI` / `WORKOS_COOKIE_PASSWORD` are web-app-client concerns — the RS does
+not need them. Vault these via `scripts/load_secrets.sh` (add keys to `secrets_keys.txt`).
+
+## Dashboard config checklist
+- [ ] Connect → Configuration: CIMD on (DCR stays on for legacy).
+- [ ] Register **Resource Indicator** = our MCP URL.
+- [ ] Authentication → OAuth providers: enable **Google** + **GitHub**.
+  - **Staging: WorkOS provides default Google + GitHub creds — NO own OAuth apps needed** (WorkOS branding on consent; staging-only).
+  - **Production: create our own Google Cloud OAuth client + GitHub OAuth App**, paste Client ID/Secret, set WorkOS's redirect URI as the authorized callback.
+- [ ] (Optional) add `email` as a custom access-token claim.
+- [ ] Serve PRM at `/.well-known/oauth-protected-resource`.
+- [ ] **VERIFY** against live AS metadata: exact `issuer` + `jwks_uri`, then validate accordingly.
+
+## VERIFY-flags (confirm against a real token/metadata before shipping)
+1. **Exact `iss`** for our AuthKit-domain config (`https://api.workos.com/` vs the AuthKit domain) — read from AS metadata, don't hardcode.
+2. **`email` in token** — authoritative claim list omits it; treat as custom-claim-only; decode a real token to confirm.
+3. **No one-call SDK RS-validator** — SDK is sealed-session-oriented; `get_jwks_url()` + PyJWT is the path. Re-check the SDK changelog in case a newer RS helper shipped.
+4. **`aud` literal format** for MCP (full URL vs registered identifier) — confirm once the Resource Indicator is registered.
+
+## Sources
+WorkOS docs: AuthKit MCP, AuthKit Sessions, Session tokens/JWKS API ref, Connect/OAuth,
+Social Login, Google/GitHub OAuth integrations; WorkOS blog: JWT-in-Python, JWT-validation
+guide, FastAPI+AuthKit, "add OAuth to your MCP server", "MCP authorization in 5 OAuth specs";
+workos-python SDK + issue #493 (RS token validation).

--- a/docs/reference/workos-authkit-integration.md
+++ b/docs/reference/workos-authkit-integration.md
@@ -4,9 +4,33 @@ Pointer-loaded reference (ADR-002) for the founder-identity build. Design + deci
 live in `docs/design-notes/2026-06-26-founder-and-universe-identity.md` §3.0; this doc
 is the *how* for slice 1. Synthesized from WorkOS's own 2026 docs (sources at bottom).
 
-> **Status:** research synthesis (Claude, 2026-06-26). The four **VERIFY-flags** below must
-> be confirmed against a live token + AuthKit AS metadata before shipping. Slice-1
+> **Status:** research synthesis (Claude, 2026-06-26); **live values + AS metadata resolved
+> against the TinyAssets staging tenant 2026-06-26** (see *Live staging values*). Slice-1
 > implementation gets opposite-provider (Codex) review per AGENTS.md.
+
+## Live staging values (resolved 2026-06-26, TinyAssets WorkOS tenant)
+Non-secret config (the secret key is **vault-only, not here**). Production gets its own
+values + its own upstream Google/GitHub OAuth apps.
+
+| Var | Staging value |
+|---|---|
+| `WORKOS_CLIENT_ID` | `client_01KW15P07QYSMF9CY4XXXJN520` |
+| `WORKOS_AUTHKIT_DOMAIN` | `inventive-van-62-staging.authkit.app` |
+| `WORKOS_MCP_RESOURCE` | `https://tinyassets.io/mcp` (register as Resource Indicator — pending) |
+| issuer (`iss`) | `https://inventive-van-62-staging.authkit.app` |
+| `jwks_uri` | `https://inventive-van-62-staging.authkit.app/oauth2/jwks` |
+| authorize / token | `…/oauth2/authorize` · `…/oauth2/token` |
+| PKCE | `S256` (required) |
+| `scopes_supported` | `openid profile email offline_access` |
+| environment | `environment_01KW15NZV1H9T2Z1J12E9FNJG1` (Staging) |
+
+**Validate against `iss` + `jwks_uri` from the AuthKit domain — NOT the legacy
+`https://api.workos.com/sso/jwks/<client_id>` (it also 200s but is the SSO product's JWKS).**
+
+**Dashboard state (verified live 2026-06-26):** social providers **Google / GitHub /
+Microsoft = Enabled**; Email+Password enabled; Passkeys / Magic Auth disabled.
+**Remaining config:** register the **Resource Indicator** (`https://tinyassets.io/mcp`) for
+`aud` binding, and allowlist the connector **redirect URI** when wiring the claude.ai OAuth flow.
 
 ## Architecture
 **AuthKit = the OAuth 2.1 Authorization Server. Our MCP server = the Resource Server.**
@@ -105,11 +129,11 @@ not need them. Vault these via `scripts/load_secrets.sh` (add keys to `secrets_k
 - [ ] Serve PRM at `/.well-known/oauth-protected-resource`.
 - [ ] **VERIFY** against live AS metadata: exact `issuer` + `jwks_uri`, then validate accordingly.
 
-## VERIFY-flags (confirm against a real token/metadata before shipping)
-1. **Exact `iss`** for our AuthKit-domain config (`https://api.workos.com/` vs the AuthKit domain) — read from AS metadata, don't hardcode.
-2. **`email` in token** — authoritative claim list omits it; treat as custom-claim-only; decode a real token to confirm.
-3. **No one-call SDK RS-validator** — SDK is sealed-session-oriented; `get_jwks_url()` + PyJWT is the path. Re-check the SDK changelog in case a newer RS helper shipped.
-4. **`aud` literal format** for MCP (full URL vs registered identifier) — confirm once the Resource Indicator is registered.
+## VERIFY-flags — status (checked vs live staging metadata 2026-06-26)
+1. **Exact `iss`** — ✅ **RESOLVED:** `https://inventive-van-62-staging.authkit.app` (the AuthKit domain, not `api.workos.com/`). Read from AS metadata.
+2. **`email` in token** — ⚠️ **STILL VERIFY** by decoding a real access token. `scopes_supported` includes `email`/`profile`, so email *should* appear when requested — but the authoritative claim list omitted it, so confirm on a real token.
+3. **JWKS source** — ✅ **RESOLVED:** use `…authkit.app/oauth2/jwks` (from AS metadata). The legacy `api.workos.com/sso/jwks/<client_id>` also 200s but is the SSO JWKS — don't use it.
+4. **`aud` literal format** — ⏳ **PENDING:** register `https://tinyassets.io/mcp` as a Resource Indicator, then decode a token to confirm the exact `aud` string.
 
 ## Sources
 WorkOS docs: AuthKit MCP, AuthKit Sessions, Session tokens/JWKS API ref, Connect/OAuth,


### PR DESCRIPTION
## Design note: Founder & universe identity

`docs/design-notes/2026-06-26-founder-and-universe-identity.md`. **Design only, for review** — the foundation *underneath* the blank-slate persona, surfaced by the live ui-test (`account_user: "anonymous"` → the persona has no founder to align with).

### Verified in code (2026-06-26)
- The CF Worker **forwards the OAuth `Authorization` Bearer** to the daemon; the daemon **is** the OAuth server. So identity already arrives — **no Worker gap.**
- Daemon-side gaps: **(1)** `UNIVERSE_SERVER_AUTH` off → token ignored → anonymous; **(2)** no universe→founder binding exists.

### Host-ratified model
- **Anonymous = read-only; OAuth = write/create** (capability model, not a hard gate).
- **Creating a universe requires OAuth → every universe has a founder by construction** (creator's user_id at creation). **No claim flow;** legacy anon universes are host-deleted / substrate-claimed / fake-OAuth for testing. Long-term no anonymous universes.
- **`universe_id` = immutable serial** (not a descriptive slug like `patch-loop-live`); identity (persona name/purpose/body) is **learned + mutable** in the self-model.
- **Per-request persona routing (multi-user):** identity → main-universe default; prompt → override to a named universe (read-only unless founder); new OAuth → auto-create main; ambiguity → default to caller's main.

### Includes
Code-change audit, rollout caution (gating-on gates the live MCP — stage it), open questions (serial format; read/write split; live token-resolution proof; multi-universe-per-daemon), and 5 draft slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
