### PR TITLE
feat(loop): validate_patch — deterministic patch-apply verification (frontier correctness gap)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/__init__.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/__init__.py
@@ -40,6 +40,10 @@ from workflow.effectors.twitter_post import (
     EXTERNAL_WRITE_SINK_TWITTER_POST,
     run_twitter_post_effector,
 )
+from workflow.effectors.validate_patch import (
+    register_validate_patch,
+    validate_patch,
+)
 from workflow.effectors.wiki_write_back import (
     EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
     run_wiki_write_back_effector,
@@ -53,6 +57,7 @@ from workflow.effectors.windows_desktop import (
 # them resolves a body at compile time (read + search side of the loop).
 register_read_repo_files()
 register_search_repo_files()
+register_validate_patch()
 
 
 def _branch_without_github_merge(branch):
@@ -126,6 +131,8 @@ __all__ = [
     "register_read_repo_files",
     "search_repo_files",
     "register_search_repo_files",
+    "validate_patch",
+    "register_validate_patch",
     "run_github_merge_effector",
     "run_github_pr_effector",
     "run_twitter_post_effector",

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/validate_patch.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/validate_patch.py
@@ -1,0 +1,144 @@
+"""validate_patch: a platform-trusted opaque node that deterministically
+verifies a proposed patch packet APPLIES to the fetched current contents —
+before a real PR is attempted and before an LLM review burns a guess.
+
+The frontier gap it closes: every SOTA issue→PR system (Agentless, AutoCodeRover,
+SWE-agent) validates patches with executable ground truth; our loop had none —
+``review_gate`` only *guessed* (via an LLM) whether each search string matched.
+The dominant patch-failure mode is a ``search`` string that does not occur
+verbatim-and-unique in the live file, so the PR fails to apply. That is checkable
+deterministically, in code, with NO LLM and NO network: the loop already fetched
+the real file contents into ``current_contents_json`` (read_repo_files), and the
+github_pull_request effector's ``_apply_edit_blocks`` is a pure exact-match apply.
+
+Contract (opaque callable — ``fn(state) -> dict`` of state updates; never raises):
+
+  reads from state:
+    - ``pr_packet_draft`` (str|dict): the external_write_packet from
+      propose_changes. We validate ``payload.edits_json`` ({path: [blocks]}).
+    - ``current_contents_json`` (str): {path: contents|null} fetched by
+      read_repo_files — the ground truth each edit must anchor on.
+  writes to state:
+    - ``patch_validity`` (str): exactly ``VALID`` or ``INVALID`` — a branch
+      conditional-edges on this (``INVALID`` -> propose_changes for a retry,
+      ``VALID`` -> review_gate).
+    - ``patch_validity_detail`` (str): concrete, per-file reasons a propose
+      retry can act on (which search text was not found / not unique).
+
+Wiring (the user composes it via patch_branch): insert a ``validate_patch`` node
+between propose_changes and review_gate, declare output_keys
+[patch_validity, patch_validity_detail], and add a conditional edge from it.
+
+Design parallels read_repo_files (opaque domain callable; user references it but
+cannot supply its body) — see workflow/effectors/github_read.py.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DOMAIN_ID = "workflow"
+NODE_ID = "validate_patch"
+
+
+def _coerce_packet(raw: Any) -> tuple[dict | None, str]:
+    """Return (packet_dict, error). Accepts a dict or a JSON string."""
+    if isinstance(raw, dict):
+        return raw, ""
+    text = str(raw or "").strip()
+    if not text:
+        return None, "pr_packet_draft is empty; nothing to validate."
+    # Tolerate a stray code fence the model may have added.
+    if text.startswith("```"):
+        text = text.strip("`")
+        nl = text.find("\n")
+        if nl != -1:
+            text = text[nl + 1:]
+    try:
+        parsed = json.loads(text)
+    except (TypeError, ValueError) as exc:
+        return None, f"pr_packet_draft is not valid JSON ({exc}); cannot verify the patch."
+    if not isinstance(parsed, dict):
+        return None, "pr_packet_draft did not decode to a JSON object."
+    return parsed, ""
+
+
+def validate_patch(state: dict) -> dict:
+    """Opaque-node body: deterministically check the packet's edits apply to the
+    fetched current contents. No LLM, no network. Never raises."""
+    # _apply_edit_blocks is a pure (search must occur exactly once) apply; reuse
+    # the SAME logic the effector uses so validation matches real apply behavior.
+    from workflow.effectors.github_pr import _apply_edit_blocks
+
+    packet, perr = _coerce_packet(state.get("pr_packet_draft"))
+    if packet is None:
+        return {"patch_validity": "INVALID", "patch_validity_detail": perr}
+
+    try:
+        contents = json.loads(state.get("current_contents_json") or "{}")
+        if not isinstance(contents, dict):
+            contents = {}
+    except (TypeError, ValueError):
+        contents = {}
+
+    payload = packet.get("payload")
+    if not isinstance(payload, dict):
+        payload = packet
+    edits = payload.get("edits_json")
+
+    errors: dict[str, str] = {}
+    checked = 0
+    if isinstance(edits, dict):
+        for path, blocks in edits.items():
+            current = contents.get(path)
+            if not isinstance(current, str):
+                errors[path] = (
+                    "target file was not fetched present in current_contents "
+                    "(an in-place edit needs the real file; use changes_json to "
+                    "create a new file, or fix the path)"
+                )
+                continue
+            _new, err = _apply_edit_blocks(current, blocks)
+            if err is not None:
+                errors[path] = err.get("detail") or err.get("error_kind") or "edit did not apply"
+            else:
+                checked += 1
+
+    # changes_json (string=new-file create, null=deletion) carries no search
+    # anchors, so there is nothing deterministic to verify here — left to review.
+
+    if errors:
+        detail = "; ".join(f"{p}: {e}" for p, e in sorted(errors.items()))
+        return {
+            "patch_validity": "INVALID",
+            "patch_validity_detail": (
+                "Patch does NOT apply to the current file contents — fix these and "
+                f"re-propose: {detail}"
+            ),
+        }
+    return {
+        "patch_validity": "VALID",
+        "patch_validity_detail": (
+            f"All {checked} in-place-edited file(s) apply cleanly to current contents."
+            if checked else
+            "No in-place edits to verify (new-file/deletion packet); deferred to review."
+        ),
+    }
+
+
+def register_validate_patch() -> None:
+    """Register the validate_patch opaque callable for the workflow domain.
+
+    Idempotent. Called from workflow/effectors/__init__.py at import and lazily
+    from the compiler's opaque-resolution path.
+    """
+    from workflow.domain_registry import register_domain_callable
+
+    register_domain_callable(DOMAIN_ID, NODE_ID, validate_patch)
+
+
+__all__ = ["validate_patch", "register_validate_patch", "DOMAIN_ID", "NODE_ID"]

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/validate_patch.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/validate_patch.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -45,38 +44,59 @@ DOMAIN_ID = "workflow"
 NODE_ID = "validate_patch"
 
 
-def _coerce_packet(raw: Any) -> tuple[dict | None, str]:
-    """Return (packet_dict, error). Accepts a dict or a JSON string."""
-    if isinstance(raw, dict):
-        return raw, ""
-    text = str(raw or "").strip()
-    if not text:
-        return None, "pr_packet_draft is empty; nothing to validate."
-    # Tolerate a stray code fence the model may have added.
-    if text.startswith("```"):
-        text = text.strip("`")
-        nl = text.find("\n")
-        if nl != -1:
-            text = text[nl + 1:]
-    try:
-        parsed = json.loads(text)
-    except (TypeError, ValueError) as exc:
-        return None, f"pr_packet_draft is not valid JSON ({exc}); cannot verify the patch."
-    if not isinstance(parsed, dict):
-        return None, "pr_packet_draft did not decode to a JSON object."
-    return parsed, ""
+def _invalid(detail: str) -> dict:
+    return {"patch_validity": "INVALID", "patch_validity_detail": detail}
 
 
 def validate_patch(state: dict) -> dict:
-    """Opaque-node body: deterministically check the packet's edits apply to the
-    fetched current contents. No LLM, no network. Never raises."""
-    # _apply_edit_blocks is a pure (search must occur exactly once) apply; reuse
-    # the SAME logic the effector uses so validation matches real apply behavior.
-    from workflow.effectors.github_pr import _apply_edit_blocks
+    """Opaque-node body: a deterministic pre-flight. No LLM, no network. Never
+    raises.
 
-    packet, perr = _coerce_packet(state.get("pr_packet_draft"))
+    Scope (honest — Codex review of #1409): this verifies the packet is a
+    well-formed external_write_packet (reusing github_pr._parse_packet, the SAME
+    shape gate the effector uses) and that its ``edits_json`` applies to the
+    ALREADY-FETCHED ``current_contents_json`` — the same basis propose_changes
+    edited against. It is NOT a full effector simulation: the github_pull_request
+    effector re-fetches each path at ``payload.base_branch`` before applying, so
+    base_branch divergence (and deletion-target presence) remain the effector's
+    authority. What this reliably catches early is the dominant failure: a search
+    string that isn't verbatim-and-unique in the fetched file, plus malformed
+    packets / empty or conflicting change sets — feeding a concrete reason back
+    for a propose retry instead of burning a review + a failed PR attempt.
+    """
+    if not isinstance(state, dict):
+        return _invalid("no run state to validate.")
+    # Reuse the effector's own pure helpers so verdicts match real behavior.
+    from workflow.effectors.github_pr import _apply_edit_blocks, _parse_packet
+
+    packet = _parse_packet(state.get("pr_packet_draft"))
     if packet is None:
-        return {"patch_validity": "INVALID", "patch_validity_detail": perr}
+        return _invalid(
+            "pr_packet_draft is not a valid external_write_packet — it must be a "
+            "JSON object starting with '{', carrying a 'sink', with no code fences "
+            "or prose. Re-emit ONLY the raw JSON object."
+        )
+    payload = packet.get("payload")
+    if not isinstance(payload, dict):
+        return _invalid("packet.payload is missing or not a JSON object.")
+
+    edits = payload.get("edits_json")
+    changes = payload.get("changes_json")
+    edit_paths: set[str] = set()
+    change_paths: set[str] = set()
+
+    # changes_json shape — mirror github_pr._materialize_branch's offline checks.
+    if changes is not None:
+        if not isinstance(changes, dict):
+            return _invalid("packet.payload.changes_json must be an object or omitted.")
+        for pk, cv in changes.items():
+            if not isinstance(pk, str) or not pk.strip():
+                return _invalid("changes_json keys must be non-empty repo-relative path strings.")
+            if cv is not None and not isinstance(cv, str):
+                return _invalid(
+                    f"changes_json[{pk!r}] must be a string (new contents) or null (delete)."
+                )
+            change_paths.add(pk)
 
     try:
         contents = json.loads(state.get("current_contents_json") or "{}")
@@ -85,15 +105,16 @@ def validate_patch(state: dict) -> dict:
     except (TypeError, ValueError):
         contents = {}
 
-    payload = packet.get("payload")
-    if not isinstance(payload, dict):
-        payload = packet
-    edits = payload.get("edits_json")
-
     errors: dict[str, str] = {}
     checked = 0
-    if isinstance(edits, dict):
+    if edits is not None:
+        if not isinstance(edits, dict) or not edits:
+            return _invalid(
+                "packet.payload.edits_json must be a non-empty object of "
+                "{path: [search/replace blocks]} (or omitted)."
+            )
         for path, blocks in edits.items():
+            edit_paths.add(path)
             current = contents.get(path)
             if not isinstance(current, str):
                 errors[path] = (
@@ -108,24 +129,29 @@ def validate_patch(state: dict) -> dict:
             else:
                 checked += 1
 
-    # changes_json (string=new-file create, null=deletion) carries no search
-    # anchors, so there is nothing deterministic to verify here — left to review.
+    if not edit_paths and not change_paths:
+        return _invalid(
+            "packet has no effective change set (no edits_json or changes_json entries)."
+        )
+    overlap = edit_paths & change_paths
+    if overlap:
+        return _invalid(
+            "a path appears in BOTH edits_json and changes_json (use exactly one "
+            f"per path): {', '.join(sorted(overlap))}."
+        )
 
     if errors:
         detail = "; ".join(f"{p}: {e}" for p, e in sorted(errors.items()))
-        return {
-            "patch_validity": "INVALID",
-            "patch_validity_detail": (
-                "Patch does NOT apply to the current file contents — fix these and "
-                f"re-propose: {detail}"
-            ),
-        }
+        return _invalid(
+            "Patch does NOT apply to the fetched current contents — fix these and "
+            f"re-propose: {detail}"
+        )
     return {
         "patch_validity": "VALID",
         "patch_validity_detail": (
-            f"All {checked} in-place-edited file(s) apply cleanly to current contents."
+            f"All {checked} in-place-edited file(s) apply to the fetched current contents."
             if checked else
-            "No in-place edits to verify (new-file/deletion packet); deferred to review."
+            "Change set is new-file/deletion only; apply deferred to the effector."
         ),
     }
 

--- a/tests/test_validate_patch.py
+++ b/tests/test_validate_patch.py
@@ -1,0 +1,96 @@
+"""validate_patch opaque node — deterministic patch-apply verification.
+
+The loop's first EXECUTABLE check: does the proposed packet's edits_json apply
+to the fetched current contents? No LLM, no network. Catches the dominant
+patch-failure mode (a search string that isn't verbatim-unique) before
+review_gate/open_pr, and emits a concrete reason for a retry.
+"""
+from __future__ import annotations
+
+import json
+
+from workflow.effectors.validate_patch import (
+    DOMAIN_ID,
+    NODE_ID,
+    register_validate_patch,
+    validate_patch,
+)
+
+_FILE = "def add(a, b):\n    return a + b\n\n\ndef sub(a, b):\n    return a - b\n"
+
+
+def _packet(edits):
+    return json.dumps({
+        "sink": "github_pull_request",
+        "destination": "Owner/Repo",
+        "payload": {"title": "t", "edits_json": edits},
+    })
+
+
+def _state(packet, contents):
+    return {
+        "pr_packet_draft": packet,
+        "current_contents_json": json.dumps(contents),
+    }
+
+
+def test_valid_patch_applies_cleanly():
+    edits = {"m.py": [{"search": "return a - b", "replace": "return a - b  # fixed"}]}
+    out = validate_patch(_state(_packet(edits), {"m.py": _FILE}))
+    assert out["patch_validity"] == "VALID", out
+    assert "apply cleanly" in out["patch_validity_detail"]
+
+
+def test_invalid_search_not_found():
+    edits = {"m.py": [{"search": "return a * b", "replace": "x"}]}
+    out = validate_patch(_state(_packet(edits), {"m.py": _FILE}))
+    assert out["patch_validity"] == "INVALID"
+    assert "m.py" in out["patch_validity_detail"]
+
+
+def test_invalid_search_not_unique():
+    # "a, b" occurs in both function signatures -> not unique.
+    edits = {"m.py": [{"search": "a, b", "replace": "a, b, c"}]}
+    out = validate_patch(_state(_packet(edits), {"m.py": _FILE}))
+    assert out["patch_validity"] == "INVALID"
+    assert "unique" in out["patch_validity_detail"].lower()
+
+
+def test_invalid_unfetched_target_path():
+    edits = {"missing.py": [{"search": "x", "replace": "y"}]}
+    out = validate_patch(_state(_packet(edits), {"m.py": _FILE}))
+    assert out["patch_validity"] == "INVALID"
+    assert "missing.py" in out["patch_validity_detail"]
+
+
+def test_malformed_packet_is_invalid_not_crash():
+    out = validate_patch({"pr_packet_draft": "not json {{{", "current_contents_json": "{}"})
+    assert out["patch_validity"] == "INVALID"
+    assert "json" in out["patch_validity_detail"].lower()
+
+
+def test_new_file_only_packet_defers_to_review():
+    # changes_json with a string = new file; no edits_json to verify deterministically.
+    packet = json.dumps({"payload": {"changes_json": {"new.py": "print('hi')\n"}}})
+    out = validate_patch(_state(packet, {}))
+    assert out["patch_validity"] == "VALID"
+
+
+def test_code_fence_wrapped_packet_tolerated():
+    edits = {"m.py": [{"search": "return a - b", "replace": "return b - a"}]}
+    fenced = "```json\n" + _packet(edits) + "\n```"
+    out = validate_patch(_state(fenced, {"m.py": _FILE}))
+    assert out["patch_validity"] == "VALID", out
+
+
+def test_registered_as_opaque_domain_callable():
+    register_validate_patch()
+    from workflow.domain_registry import resolve_domain_callable
+
+    fn = resolve_domain_callable(DOMAIN_ID, NODE_ID)
+    assert fn is validate_patch
+
+
+def test_never_raises_on_empty_state():
+    out = validate_patch({})
+    assert out["patch_validity"] == "INVALID"

--- a/tests/test_validate_patch.py
+++ b/tests/test_validate_patch.py
@@ -38,7 +38,7 @@ def test_valid_patch_applies_cleanly():
     edits = {"m.py": [{"search": "return a - b", "replace": "return a - b  # fixed"}]}
     out = validate_patch(_state(_packet(edits), {"m.py": _FILE}))
     assert out["patch_validity"] == "VALID", out
-    assert "apply cleanly" in out["patch_validity_detail"]
+    assert "apply to the fetched" in out["patch_validity_detail"]
 
 
 def test_invalid_search_not_found():
@@ -69,18 +69,51 @@ def test_malformed_packet_is_invalid_not_crash():
     assert "json" in out["patch_validity_detail"].lower()
 
 
-def test_new_file_only_packet_defers_to_review():
-    # changes_json with a string = new file; no edits_json to verify deterministically.
-    packet = json.dumps({"payload": {"changes_json": {"new.py": "print('hi')\n"}}})
+def test_no_sink_packet_is_invalid():
+    # The effector's _parse_packet requires a sink; mirror it (no false VALID).
+    packet = json.dumps({"payload": {"changes_json": {"new.py": "x\n"}}})
     out = validate_patch(_state(packet, {}))
-    assert out["patch_validity"] == "VALID"
+    assert out["patch_validity"] == "INVALID"
 
 
-def test_code_fence_wrapped_packet_tolerated():
+def test_new_file_only_packet_defers_to_review():
+    # changes_json string = new file; no edits to verify, but packet is well-formed.
+    packet = json.dumps({"sink": "github_pull_request",
+                         "payload": {"changes_json": {"new.py": "print('hi')\n"}}})
+    out = validate_patch(_state(packet, {}))
+    assert out["patch_validity"] == "VALID", out
+
+
+def test_code_fence_wrapped_packet_is_invalid():
+    # The effector rejects non-'{'-leading strings; we must too (else false VALID).
     edits = {"m.py": [{"search": "return a - b", "replace": "return b - a"}]}
     fenced = "```json\n" + _packet(edits) + "\n```"
     out = validate_patch(_state(fenced, {"m.py": _FILE}))
-    assert out["patch_validity"] == "VALID", out
+    assert out["patch_validity"] == "INVALID", out
+
+
+def test_empty_change_set_is_invalid():
+    packet = json.dumps({"sink": "github_pull_request", "payload": {"title": "t"}})
+    out = validate_patch(_state(packet, {}))
+    assert out["patch_validity"] == "INVALID"
+    assert "no effective change set" in out["patch_validity_detail"]
+
+
+def test_bad_changes_json_shape_is_invalid():
+    packet = json.dumps({"sink": "github_pull_request",
+                         "payload": {"changes_json": {"p.py": 123}}})
+    out = validate_patch(_state(packet, {}))
+    assert out["patch_validity"] == "INVALID"
+
+
+def test_duplicate_path_in_edits_and_changes_is_invalid():
+    packet = json.dumps({"sink": "github_pull_request", "payload": {
+        "edits_json": {"m.py": [{"search": "return a - b", "replace": "x"}]},
+        "changes_json": {"m.py": "whole new file\n"},
+    }})
+    out = validate_patch(_state(packet, {"m.py": _FILE}))
+    assert out["patch_validity"] == "INVALID"
+    assert "both" in out["patch_validity_detail"].lower()
 
 
 def test_registered_as_opaque_domain_callable():

--- a/workflow/effectors/__init__.py
+++ b/workflow/effectors/__init__.py
@@ -40,6 +40,10 @@ from workflow.effectors.twitter_post import (
     EXTERNAL_WRITE_SINK_TWITTER_POST,
     run_twitter_post_effector,
 )
+from workflow.effectors.validate_patch import (
+    register_validate_patch,
+    validate_patch,
+)
 from workflow.effectors.wiki_write_back import (
     EXTERNAL_WRITE_SINK_WIKI_WRITE_BACK,
     run_wiki_write_back_effector,
@@ -53,6 +57,7 @@ from workflow.effectors.windows_desktop import (
 # them resolves a body at compile time (read + search side of the loop).
 register_read_repo_files()
 register_search_repo_files()
+register_validate_patch()
 
 
 def _branch_without_github_merge(branch):
@@ -126,6 +131,8 @@ __all__ = [
     "register_read_repo_files",
     "search_repo_files",
     "register_search_repo_files",
+    "validate_patch",
+    "register_validate_patch",
     "run_github_merge_effector",
     "run_github_pr_effector",
     "run_twitter_post_effector",

--- a/workflow/effectors/validate_patch.py
+++ b/workflow/effectors/validate_patch.py
@@ -1,0 +1,144 @@
+"""validate_patch: a platform-trusted opaque node that deterministically
+verifies a proposed patch packet APPLIES to the fetched current contents —
+before a real PR is attempted and before an LLM review burns a guess.
+
+The frontier gap it closes: every SOTA issue→PR system (Agentless, AutoCodeRover,
+SWE-agent) validates patches with executable ground truth; our loop had none —
+``review_gate`` only *guessed* (via an LLM) whether each search string matched.
+The dominant patch-failure mode is a ``search`` string that does not occur
+verbatim-and-unique in the live file, so the PR fails to apply. That is checkable
+deterministically, in code, with NO LLM and NO network: the loop already fetched
+the real file contents into ``current_contents_json`` (read_repo_files), and the
+github_pull_request effector's ``_apply_edit_blocks`` is a pure exact-match apply.
+
+Contract (opaque callable — ``fn(state) -> dict`` of state updates; never raises):
+
+  reads from state:
+    - ``pr_packet_draft`` (str|dict): the external_write_packet from
+      propose_changes. We validate ``payload.edits_json`` ({path: [blocks]}).
+    - ``current_contents_json`` (str): {path: contents|null} fetched by
+      read_repo_files — the ground truth each edit must anchor on.
+  writes to state:
+    - ``patch_validity`` (str): exactly ``VALID`` or ``INVALID`` — a branch
+      conditional-edges on this (``INVALID`` -> propose_changes for a retry,
+      ``VALID`` -> review_gate).
+    - ``patch_validity_detail`` (str): concrete, per-file reasons a propose
+      retry can act on (which search text was not found / not unique).
+
+Wiring (the user composes it via patch_branch): insert a ``validate_patch`` node
+between propose_changes and review_gate, declare output_keys
+[patch_validity, patch_validity_detail], and add a conditional edge from it.
+
+Design parallels read_repo_files (opaque domain callable; user references it but
+cannot supply its body) — see workflow/effectors/github_read.py.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DOMAIN_ID = "workflow"
+NODE_ID = "validate_patch"
+
+
+def _coerce_packet(raw: Any) -> tuple[dict | None, str]:
+    """Return (packet_dict, error). Accepts a dict or a JSON string."""
+    if isinstance(raw, dict):
+        return raw, ""
+    text = str(raw or "").strip()
+    if not text:
+        return None, "pr_packet_draft is empty; nothing to validate."
+    # Tolerate a stray code fence the model may have added.
+    if text.startswith("```"):
+        text = text.strip("`")
+        nl = text.find("\n")
+        if nl != -1:
+            text = text[nl + 1:]
+    try:
+        parsed = json.loads(text)
+    except (TypeError, ValueError) as exc:
+        return None, f"pr_packet_draft is not valid JSON ({exc}); cannot verify the patch."
+    if not isinstance(parsed, dict):
+        return None, "pr_packet_draft did not decode to a JSON object."
+    return parsed, ""
+
+
+def validate_patch(state: dict) -> dict:
+    """Opaque-node body: deterministically check the packet's edits apply to the
+    fetched current contents. No LLM, no network. Never raises."""
+    # _apply_edit_blocks is a pure (search must occur exactly once) apply; reuse
+    # the SAME logic the effector uses so validation matches real apply behavior.
+    from workflow.effectors.github_pr import _apply_edit_blocks
+
+    packet, perr = _coerce_packet(state.get("pr_packet_draft"))
+    if packet is None:
+        return {"patch_validity": "INVALID", "patch_validity_detail": perr}
+
+    try:
+        contents = json.loads(state.get("current_contents_json") or "{}")
+        if not isinstance(contents, dict):
+            contents = {}
+    except (TypeError, ValueError):
+        contents = {}
+
+    payload = packet.get("payload")
+    if not isinstance(payload, dict):
+        payload = packet
+    edits = payload.get("edits_json")
+
+    errors: dict[str, str] = {}
+    checked = 0
+    if isinstance(edits, dict):
+        for path, blocks in edits.items():
+            current = contents.get(path)
+            if not isinstance(current, str):
+                errors[path] = (
+                    "target file was not fetched present in current_contents "
+                    "(an in-place edit needs the real file; use changes_json to "
+                    "create a new file, or fix the path)"
+                )
+                continue
+            _new, err = _apply_edit_blocks(current, blocks)
+            if err is not None:
+                errors[path] = err.get("detail") or err.get("error_kind") or "edit did not apply"
+            else:
+                checked += 1
+
+    # changes_json (string=new-file create, null=deletion) carries no search
+    # anchors, so there is nothing deterministic to verify here — left to review.
+
+    if errors:
+        detail = "; ".join(f"{p}: {e}" for p, e in sorted(errors.items()))
+        return {
+            "patch_validity": "INVALID",
+            "patch_validity_detail": (
+                "Patch does NOT apply to the current file contents — fix these and "
+                f"re-propose: {detail}"
+            ),
+        }
+    return {
+        "patch_validity": "VALID",
+        "patch_validity_detail": (
+            f"All {checked} in-place-edited file(s) apply cleanly to current contents."
+            if checked else
+            "No in-place edits to verify (new-file/deletion packet); deferred to review."
+        ),
+    }
+
+
+def register_validate_patch() -> None:
+    """Register the validate_patch opaque callable for the workflow domain.
+
+    Idempotent. Called from workflow/effectors/__init__.py at import and lazily
+    from the compiler's opaque-resolution path.
+    """
+    from workflow.domain_registry import register_domain_callable
+
+    register_domain_callable(DOMAIN_ID, NODE_ID, validate_patch)
+
+
+__all__ = ["validate_patch", "register_validate_patch", "DOMAIN_ID", "NODE_ID"]

--- a/workflow/effectors/validate_patch.py
+++ b/workflow/effectors/validate_patch.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -45,38 +44,59 @@ DOMAIN_ID = "workflow"
 NODE_ID = "validate_patch"
 
 
-def _coerce_packet(raw: Any) -> tuple[dict | None, str]:
-    """Return (packet_dict, error). Accepts a dict or a JSON string."""
-    if isinstance(raw, dict):
-        return raw, ""
-    text = str(raw or "").strip()
-    if not text:
-        return None, "pr_packet_draft is empty; nothing to validate."
-    # Tolerate a stray code fence the model may have added.
-    if text.startswith("```"):
-        text = text.strip("`")
-        nl = text.find("\n")
-        if nl != -1:
-            text = text[nl + 1:]
-    try:
-        parsed = json.loads(text)
-    except (TypeError, ValueError) as exc:
-        return None, f"pr_packet_draft is not valid JSON ({exc}); cannot verify the patch."
-    if not isinstance(parsed, dict):
-        return None, "pr_packet_draft did not decode to a JSON object."
-    return parsed, ""
+def _invalid(detail: str) -> dict:
+    return {"patch_validity": "INVALID", "patch_validity_detail": detail}
 
 
 def validate_patch(state: dict) -> dict:
-    """Opaque-node body: deterministically check the packet's edits apply to the
-    fetched current contents. No LLM, no network. Never raises."""
-    # _apply_edit_blocks is a pure (search must occur exactly once) apply; reuse
-    # the SAME logic the effector uses so validation matches real apply behavior.
-    from workflow.effectors.github_pr import _apply_edit_blocks
+    """Opaque-node body: a deterministic pre-flight. No LLM, no network. Never
+    raises.
 
-    packet, perr = _coerce_packet(state.get("pr_packet_draft"))
+    Scope (honest — Codex review of #1409): this verifies the packet is a
+    well-formed external_write_packet (reusing github_pr._parse_packet, the SAME
+    shape gate the effector uses) and that its ``edits_json`` applies to the
+    ALREADY-FETCHED ``current_contents_json`` — the same basis propose_changes
+    edited against. It is NOT a full effector simulation: the github_pull_request
+    effector re-fetches each path at ``payload.base_branch`` before applying, so
+    base_branch divergence (and deletion-target presence) remain the effector's
+    authority. What this reliably catches early is the dominant failure: a search
+    string that isn't verbatim-and-unique in the fetched file, plus malformed
+    packets / empty or conflicting change sets — feeding a concrete reason back
+    for a propose retry instead of burning a review + a failed PR attempt.
+    """
+    if not isinstance(state, dict):
+        return _invalid("no run state to validate.")
+    # Reuse the effector's own pure helpers so verdicts match real behavior.
+    from workflow.effectors.github_pr import _apply_edit_blocks, _parse_packet
+
+    packet = _parse_packet(state.get("pr_packet_draft"))
     if packet is None:
-        return {"patch_validity": "INVALID", "patch_validity_detail": perr}
+        return _invalid(
+            "pr_packet_draft is not a valid external_write_packet — it must be a "
+            "JSON object starting with '{', carrying a 'sink', with no code fences "
+            "or prose. Re-emit ONLY the raw JSON object."
+        )
+    payload = packet.get("payload")
+    if not isinstance(payload, dict):
+        return _invalid("packet.payload is missing or not a JSON object.")
+
+    edits = payload.get("edits_json")
+    changes = payload.get("changes_json")
+    edit_paths: set[str] = set()
+    change_paths: set[str] = set()
+
+    # changes_json shape — mirror github_pr._materialize_branch's offline checks.
+    if changes is not None:
+        if not isinstance(changes, dict):
+            return _invalid("packet.payload.changes_json must be an object or omitted.")
+        for pk, cv in changes.items():
+            if not isinstance(pk, str) or not pk.strip():
+                return _invalid("changes_json keys must be non-empty repo-relative path strings.")
+            if cv is not None and not isinstance(cv, str):
+                return _invalid(
+                    f"changes_json[{pk!r}] must be a string (new contents) or null (delete)."
+                )
+            change_paths.add(pk)
 
     try:
         contents = json.loads(state.get("current_contents_json") or "{}")
@@ -85,15 +105,16 @@ def validate_patch(state: dict) -> dict:
     except (TypeError, ValueError):
         contents = {}
 
-    payload = packet.get("payload")
-    if not isinstance(payload, dict):
-        payload = packet
-    edits = payload.get("edits_json")
-
     errors: dict[str, str] = {}
     checked = 0
-    if isinstance(edits, dict):
+    if edits is not None:
+        if not isinstance(edits, dict) or not edits:
+            return _invalid(
+                "packet.payload.edits_json must be a non-empty object of "
+                "{path: [search/replace blocks]} (or omitted)."
+            )
         for path, blocks in edits.items():
+            edit_paths.add(path)
             current = contents.get(path)
             if not isinstance(current, str):
                 errors[path] = (
@@ -108,24 +129,29 @@ def validate_patch(state: dict) -> dict:
             else:
                 checked += 1
 
-    # changes_json (string=new-file create, null=deletion) carries no search
-    # anchors, so there is nothing deterministic to verify here — left to review.
+    if not edit_paths and not change_paths:
+        return _invalid(
+            "packet has no effective change set (no edits_json or changes_json entries)."
+        )
+    overlap = edit_paths & change_paths
+    if overlap:
+        return _invalid(
+            "a path appears in BOTH edits_json and changes_json (use exactly one "
+            f"per path): {', '.join(sorted(overlap))}."
+        )
 
     if errors:
         detail = "; ".join(f"{p}: {e}" for p, e in sorted(errors.items()))
-        return {
-            "patch_validity": "INVALID",
-            "patch_validity_detail": (
-                "Patch does NOT apply to the current file contents — fix these and "
-                f"re-propose: {detail}"
-            ),
-        }
+        return _invalid(
+            "Patch does NOT apply to the fetched current contents — fix these and "
+            f"re-propose: {detail}"
+        )
     return {
         "patch_validity": "VALID",
         "patch_validity_detail": (
-            f"All {checked} in-place-edited file(s) apply cleanly to current contents."
+            f"All {checked} in-place-edited file(s) apply to the fetched current contents."
             if checked else
-            "No in-place edits to verify (new-file/deletion packet); deferred to review."
+            "Change set is new-file/deletion only; apply deferred to the effector."
         ),
     }
 


### PR DESCRIPTION
## The frontier gap

Research was unanimous (Agentless / AutoCodeRover / SWE-agent — captured in `project_loop_design_research_2026_06_26`): every SOTA issue→PR system validates patches with **executable ground truth**; our loop had **none**. `review_gate` only *guessed* via an LLM whether each `search` string matched the live file. The dominant patch-failure mode — a `search` string that isn't verbatim-and-unique, so the PR fails to apply — is checkable **deterministically, in code, with no LLM and no network**: the loop already fetches real contents into `current_contents_json` (read_repo_files), and `github_pr._apply_edit_blocks` is a pure exact-match apply.

## What

`validate_patch` — a platform-trusted **opaque domain callable** (same mechanism as `read_repo_files`/`search_repo_files`; user references it, can't supply its body). Reads `pr_packet_draft.payload.edits_json` + `current_contents_json`, runs the **same** `_apply_edit_blocks` the effector uses per file, writes:
- `patch_validity`: `VALID` / `INVALID`
- `patch_validity_detail`: concrete per-file reasons (which search wasn't found / wasn't unique / path unfetched)

**No new node kind, no compiler dispatch change, no source-code approval friction** — registered at effectors import. Never raises, no network (despite living in effectors).

## How a user composes it (follow-up branch edit, not this PR)

Insert a `validate_patch` node between `propose_changes` and `review_gate`, declare `output_keys=[patch_validity, patch_validity_detail]`, conditional-edge `INVALID → propose_changes` (reusing the reflection `attempt_log`) / `VALID → review_gate`. Catches bad patches **before** a PR is attempted and before an LLM review burns a guess — pairs with the reflection retry loop already live on the branch.

## Tests

9 (`tests/test_validate_patch.py`): valid-applies / search-not-found / not-unique / unfetched-path / malformed-packet / new-file-defers / code-fence-tolerated / registration / never-raises-empty. 113 effector+opaque suite green. Pure addition.

## Gates

- [ ] Codex opposite-provider review. Dispatched.
- [ ] Post-merge: wire it into `0ca6e9c97f65` and validate that INVALID patches now retry deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)