### PR TITLE
feat(loop): validate_patch syntax lint-guard — applies AND parses

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/validate_patch.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/validate_patch.py
@@ -52,7 +52,14 @@ def _syntax_error(path: str, content: str) -> str:
     """Return a syntax-error description for a known language, else ''. Pure
     (no import/exec): ``compile(..., 'exec')`` only PARSES, and json.loads only
     parses — catches a patch that applies cleanly but breaks the file (the SWE
-    "lint-guard"). Unknown extensions are skipped (no false positives)."""
+    "lint-guard"). Unknown extensions are skipped (no false positives).
+
+    Scope (Codex review of #1410): the Python check uses the DAEMON's grammar,
+    which is accurate when the target repo's Python <= the daemon's runtime
+    (the patch-loop targets Jonnyton/Workflow on the same 3.11+ runtime). A repo
+    using newer-than-daemon syntax could see a false INVALID on those constructs;
+    Python's strong back-compat keeps that surface tiny. JSON parsing is
+    version-independent."""
     lower = path.lower()
     if lower.endswith(".py") or lower.endswith(".pyi"):
         try:

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/validate_patch.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/effectors/validate_patch.py
@@ -48,6 +48,28 @@ def _invalid(detail: str) -> dict:
     return {"patch_validity": "INVALID", "patch_validity_detail": detail}
 
 
+def _syntax_error(path: str, content: str) -> str:
+    """Return a syntax-error description for a known language, else ''. Pure
+    (no import/exec): ``compile(..., 'exec')`` only PARSES, and json.loads only
+    parses — catches a patch that applies cleanly but breaks the file (the SWE
+    "lint-guard"). Unknown extensions are skipped (no false positives)."""
+    lower = path.lower()
+    if lower.endswith(".py") or lower.endswith(".pyi"):
+        try:
+            compile(content, path, "exec")
+        except SyntaxError as exc:
+            where = f" (line {exc.lineno})" if exc.lineno else ""
+            return f"Python SyntaxError: {exc.msg}{where}"
+        except (ValueError, TypeError) as exc:  # e.g. null bytes
+            return f"Python source not compilable: {exc}"
+    elif lower.endswith(".json"):
+        try:
+            json.loads(content)
+        except (ValueError, TypeError) as exc:
+            return f"invalid JSON: {exc}"
+    return ""
+
+
 def validate_patch(state: dict) -> dict:
     """Opaque-node body: a deterministic pre-flight. No LLM, no network. Never
     raises.
@@ -96,6 +118,12 @@ def validate_patch(state: dict) -> dict:
                 return _invalid(
                     f"changes_json[{pk!r}] must be a string (new contents) or null (delete)."
                 )
+            if isinstance(cv, str):
+                syn = _syntax_error(pk, cv)
+                if syn:
+                    return _invalid(
+                        f"new-file {pk!r} would not parse — {syn}. Fix the file content."
+                    )
             change_paths.add(pk)
 
     try:
@@ -123,11 +151,15 @@ def validate_patch(state: dict) -> dict:
                     "create a new file, or fix the path)"
                 )
                 continue
-            _new, err = _apply_edit_blocks(current, blocks)
+            new_content, err = _apply_edit_blocks(current, blocks)
             if err is not None:
                 errors[path] = err.get("detail") or err.get("error_kind") or "edit did not apply"
             else:
-                checked += 1
+                syn = _syntax_error(path, new_content or "")
+                if syn:
+                    errors[path] = f"edit applies but the patched file no longer parses — {syn}"
+                else:
+                    checked += 1
 
     if not edit_paths and not change_paths:
         return _invalid(

--- a/tests/test_validate_patch.py
+++ b/tests/test_validate_patch.py
@@ -108,8 +108,8 @@ def test_bad_changes_json_shape_is_invalid():
 
 def test_duplicate_path_in_edits_and_changes_is_invalid():
     packet = json.dumps({"sink": "github_pull_request", "payload": {
-        "edits_json": {"m.py": [{"search": "return a - b", "replace": "x"}]},
-        "changes_json": {"m.py": "whole new file\n"},
+        "edits_json": {"m.py": [{"search": "return a - b", "replace": "return b - a"}]},
+        "changes_json": {"m.py": "y = 2\n"},
     }})
     out = validate_patch(_state(packet, {"m.py": _FILE}))
     assert out["patch_validity"] == "INVALID"
@@ -126,4 +126,42 @@ def test_registered_as_opaque_domain_callable():
 
 def test_never_raises_on_empty_state():
     out = validate_patch({})
+    assert out["patch_validity"] == "INVALID"
+
+
+# ── Syntax lint-guard: an edit can APPLY yet break the file (SWE-agent pattern) ──
+
+def test_edit_that_breaks_python_syntax_is_invalid():
+    edits = {"m.py": [{"search": "return a + b", "replace": "return a +"}]}
+    out = validate_patch(_state(_packet(edits), {"m.py": _FILE}))
+    assert out["patch_validity"] == "INVALID"
+    detail = out["patch_validity_detail"].lower()
+    assert "pars" in detail or "syntax" in detail
+
+
+def test_valid_python_edit_passes_syntax_check():
+    edits = {"m.py": [{"search": "return a + b", "replace": "return (a + b)"}]}
+    out = validate_patch(_state(_packet(edits), {"m.py": _FILE}))
+    assert out["patch_validity"] == "VALID", out
+
+
+def test_new_python_file_with_bad_syntax_is_invalid():
+    packet = json.dumps({"sink": "github_pull_request",
+                         "payload": {"changes_json": {"n.py": "def f(:\n    pass\n"}}})
+    out = validate_patch(_state(packet, {}))
+    assert out["patch_validity"] == "INVALID"
+
+
+def test_non_python_file_edit_skips_syntax_check():
+    # A markdown edit applies; we must NOT false-INVALID on non-code prose.
+    md = "# Title\n\nsome text here\n"
+    edits = {"doc.md": [{"search": "some text here", "replace": "x {{ not python"}]}
+    out = validate_patch(_state(_packet(edits), {"doc.md": md}))
+    assert out["patch_validity"] == "VALID", out
+
+
+def test_new_json_file_invalid_json_is_invalid():
+    packet = json.dumps({"sink": "github_pull_request",
+                         "payload": {"changes_json": {"c.json": "{not valid json"}}})
+    out = validate_patch(_state(packet, {}))
     assert out["patch_validity"] == "INVALID"

--- a/workflow/effectors/validate_patch.py
+++ b/workflow/effectors/validate_patch.py
@@ -52,7 +52,14 @@ def _syntax_error(path: str, content: str) -> str:
     """Return a syntax-error description for a known language, else ''. Pure
     (no import/exec): ``compile(..., 'exec')`` only PARSES, and json.loads only
     parses — catches a patch that applies cleanly but breaks the file (the SWE
-    "lint-guard"). Unknown extensions are skipped (no false positives)."""
+    "lint-guard"). Unknown extensions are skipped (no false positives).
+
+    Scope (Codex review of #1410): the Python check uses the DAEMON's grammar,
+    which is accurate when the target repo's Python <= the daemon's runtime
+    (the patch-loop targets Jonnyton/Workflow on the same 3.11+ runtime). A repo
+    using newer-than-daemon syntax could see a false INVALID on those constructs;
+    Python's strong back-compat keeps that surface tiny. JSON parsing is
+    version-independent."""
     lower = path.lower()
     if lower.endswith(".py") or lower.endswith(".pyi"):
         try:

--- a/workflow/effectors/validate_patch.py
+++ b/workflow/effectors/validate_patch.py
@@ -48,6 +48,28 @@ def _invalid(detail: str) -> dict:
     return {"patch_validity": "INVALID", "patch_validity_detail": detail}
 
 
+def _syntax_error(path: str, content: str) -> str:
+    """Return a syntax-error description for a known language, else ''. Pure
+    (no import/exec): ``compile(..., 'exec')`` only PARSES, and json.loads only
+    parses — catches a patch that applies cleanly but breaks the file (the SWE
+    "lint-guard"). Unknown extensions are skipped (no false positives)."""
+    lower = path.lower()
+    if lower.endswith(".py") or lower.endswith(".pyi"):
+        try:
+            compile(content, path, "exec")
+        except SyntaxError as exc:
+            where = f" (line {exc.lineno})" if exc.lineno else ""
+            return f"Python SyntaxError: {exc.msg}{where}"
+        except (ValueError, TypeError) as exc:  # e.g. null bytes
+            return f"Python source not compilable: {exc}"
+    elif lower.endswith(".json"):
+        try:
+            json.loads(content)
+        except (ValueError, TypeError) as exc:
+            return f"invalid JSON: {exc}"
+    return ""
+
+
 def validate_patch(state: dict) -> dict:
     """Opaque-node body: a deterministic pre-flight. No LLM, no network. Never
     raises.
@@ -96,6 +118,12 @@ def validate_patch(state: dict) -> dict:
                 return _invalid(
                     f"changes_json[{pk!r}] must be a string (new contents) or null (delete)."
                 )
+            if isinstance(cv, str):
+                syn = _syntax_error(pk, cv)
+                if syn:
+                    return _invalid(
+                        f"new-file {pk!r} would not parse — {syn}. Fix the file content."
+                    )
             change_paths.add(pk)
 
     try:
@@ -123,11 +151,15 @@ def validate_patch(state: dict) -> dict:
                     "create a new file, or fix the path)"
                 )
                 continue
-            _new, err = _apply_edit_blocks(current, blocks)
+            new_content, err = _apply_edit_blocks(current, blocks)
             if err is not None:
                 errors[path] = err.get("detail") or err.get("error_kind") or "edit did not apply"
             else:
-                checked += 1
+                syn = _syntax_error(path, new_content or "")
+                if syn:
+                    errors[path] = f"edit applies but the patched file no longer parses — {syn}"
+                else:
+                    checked += 1
 
     if not edit_paths and not change_paths:
         return _invalid(


### PR DESCRIPTION
## What

Extends `validate_patch`: an edit can apply cleanly (search matches) yet introduce a `SyntaxError` that breaks the file — the "lint-guard" SWE-agent uses (reject an edit that introduces a syntax error). After `_apply_edit_blocks` yields the new content, deterministically **parse** it (Python via `compile(..., 'exec')` — parse only, no import/exec; JSON via `json.loads`); same for new-file `changes_json` content. **Unknown extensions are skipped** (no false positives on prose/markdown/yaml). INVALID carries the concrete syntax error for a propose retry.

Completes executable verification: a patch must now both **apply** and **parse** before `review_gate`/a PR. Pure (no network), still never raises.

## Tests

5 new (broken-py-edit / valid-py-edit / bad-new-py / non-py-skipped / bad-json). 18 validate_patch tests green; ruff clean. Additive only.

## Gate

- [ ] Codex review — focus: false-INVALID risk (compile() rejecting valid code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)