### PR TITLE
Founder & universe identity — implementation (slice 1: WorkOS RS auth; more slices incoming)

### DIFF
--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/provider.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/provider.py
@@ -1071,6 +1071,14 @@ class OptionalOAuthProvider(OAuthProvider):
 def create_provider() -> AuthProvider:
     """Create the appropriate auth provider based on configuration."""
     auth_mode = os.environ.get("UNIVERSE_SERVER_AUTH", "false").strip().lower()
+    if auth_mode == "workos":
+        # WorkOS AuthKit is the Authorization Server; we are a Resource Server
+        # validating its bearer JWTs. Lazy import so non-WorkOS deployments
+        # don't load PyJWT. See docs/reference/workos-authkit-integration.md.
+        from workflow.auth.workos_provider import WorkOSAuthProvider
+
+        logger.info("WorkOS AuthKit auth provider enabled (Resource Server)")
+        return WorkOSAuthProvider.from_env()
     if auth_mode in ("true", "1", "yes", "oauth"):
         logger.info("OAuth auth provider enabled")
         return OAuthProvider()

--- a/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/workos_provider.py
+++ b/packaging/claude-plugin/plugins/workflow-universe-server/runtime/workflow/auth/workos_provider.py
@@ -1,0 +1,184 @@
+"""WorkOS AuthKit Resource Server provider.
+
+Our MCP server is a pure OAuth 2.1 Resource Server: **WorkOS AuthKit is the
+Authorization Server.** This provider validates an incoming AuthKit access-token
+JWT (PyJWT + JWKS) and resolves it to an :class:`Identity` whose ``user_id`` is
+the token's ``sub`` — the stable WorkOS user id we use as the founder key.
+
+The OAuth-flow methods (DCR / authorize / token exchange) are AuthKit's job, not
+ours; they raise :class:`NotImplementedError` here. Clients obtain tokens from
+AuthKit, which they discover via our Protected Resource Metadata.
+
+Design + live staging values: ``docs/reference/workos-authkit-integration.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import jwt
+from jwt import PyJWKClient
+
+from workflow.auth.provider import AuthProvider, Identity
+
+logger = logging.getLogger("universe_server.auth.workos")
+
+# Capabilities granted to ANY authenticated WorkOS user. Founder-scoped write
+# authority (founder == the universe's ``sub``) is layered on in a later slice;
+# for now an authenticated user carries a write-capable base so the capability
+# model (anonymous-read / authenticated-write, slice 2) has a real subject to
+# gate on. Slice 1 itself does not enforce these (see ``is_auth_required``).
+_AUTHENTICATED_CAPABILITIES = ("read", "write", "submit_request", "list")
+
+_ALGORITHMS = ("RS256",)
+
+
+def derive_endpoints(authkit_domain: str) -> tuple[str, str]:
+    """Return ``(issuer, jwks_uri)`` for an AuthKit domain.
+
+    Confirmed against live AS metadata 2026-06-26:
+      ``issuer   = https://<domain>``
+      ``jwks_uri = https://<domain>/oauth2/jwks``
+    Accepts a bare domain (``foo.authkit.app``) or a full origin.
+    """
+    domain = (authkit_domain or "").strip().rstrip("/")
+    if not domain:
+        raise ValueError("authkit_domain must be non-empty")
+    base = domain if domain.startswith(("http://", "https://")) else f"https://{domain}"
+    return base, f"{base}/oauth2/jwks"
+
+
+class WorkOSAuthProvider(AuthProvider):
+    """Validate WorkOS AuthKit bearer JWTs; resolve ``sub`` -> founder Identity."""
+
+    def __init__(
+        self,
+        *,
+        issuer: str,
+        jwks_uri: str,
+        audience: str | None = None,
+        jwks_client: Any | None = None,
+        leeway: float = 60.0,
+    ) -> None:
+        self._issuer = issuer
+        self._jwks_uri = jwks_uri
+        self._audience = (audience or "").strip() or None
+        self._leeway = leeway
+        # PyJWKClient caches keys + handles rotation / ``kid`` matching.
+        # Injectable so tests can supply a fake without network access.
+        self._jwks_client = (
+            jwks_client if jwks_client is not None else PyJWKClient(jwks_uri)
+        )
+
+    @classmethod
+    def from_env(cls) -> "WorkOSAuthProvider":
+        """Build from ``WORKOS_AUTHKIT_DOMAIN`` (+ optional ``WORKOS_MCP_RESOURCE``)."""
+        domain = os.environ.get("WORKOS_AUTHKIT_DOMAIN", "").strip()
+        if not domain:
+            raise RuntimeError(
+                "WORKOS_AUTHKIT_DOMAIN is required for the WorkOS auth provider."
+            )
+        issuer, jwks_uri = derive_endpoints(domain)
+        audience = os.environ.get("WORKOS_MCP_RESOURCE", "").strip() or None
+        if audience is None:
+            logger.warning(
+                "WORKOS_MCP_RESOURCE unset — skipping audience (aud) validation. "
+                "Register the MCP URL as a WorkOS Resource Indicator and set this "
+                "env var to bind tokens to this server."
+            )
+        return cls(issuer=issuer, jwks_uri=jwks_uri, audience=audience)
+
+    # --- Resource Server: the methods that matter -------------------------
+
+    def resolve_token(self, token: str) -> Identity | None:
+        if not token or not token.strip():
+            return None
+        try:
+            signing_key = self._jwks_client.get_signing_key_from_jwt(token)
+        except Exception:
+            # kid mismatch, malformed token, or JWKS fetch failure.
+            logger.debug("WorkOS token: no signing key", exc_info=True)
+            return None
+
+        options: dict[str, Any] = {"require": ["exp", "sub"]}
+        decode_kwargs: dict[str, Any] = {
+            "algorithms": list(_ALGORITHMS),  # pin RS256 (alg-substitution defense)
+            "issuer": self._issuer,
+            "leeway": self._leeway,
+            "options": options,
+        }
+        if self._audience:
+            decode_kwargs["audience"] = self._audience
+        else:
+            options["verify_aud"] = False
+
+        try:
+            claims = jwt.decode(token, signing_key.key, **decode_kwargs)
+        except jwt.PyJWTError:
+            logger.debug("WorkOS token failed validation", exc_info=True)
+            return None
+
+        sub = str(claims.get("sub", "")).strip()
+        if not sub or sub == "anonymous":
+            return None
+
+        email = str(claims.get("email", "")).strip()
+        username = email or sub
+        display_name = str(claims.get("name", "")).strip() or username
+        permissions = claims.get("permissions")
+
+        return Identity(
+            user_id=sub,
+            username=username,
+            display_name=display_name,
+            capabilities=list(_AUTHENTICATED_CAPABILITIES),
+            metadata={
+                "auth_provider": "workos",
+                "email": email,
+                "org_id": claims.get("org_id"),
+                "role": claims.get("role"),
+                "permissions": permissions if isinstance(permissions, list) else [],
+                "iss": claims.get("iss"),
+            },
+        )
+
+    def is_auth_required(self) -> bool:
+        # Slice 1: resolve-when-present, never reject anonymous. The
+        # anonymous-read / authenticated-write capability gate is layered on in
+        # slice 2. Returning False means gating is UNCHANGED — we only make the
+        # subject real when a valid WorkOS token is presented.
+        return False
+
+    # --- OAuth flow: AuthKit's job, not the Resource Server's --------------
+
+    def _flow_not_ours(self, what: str) -> Any:
+        raise NotImplementedError(
+            f"WorkOS AuthKit is the Authorization Server; this Resource Server "
+            f"does not {what}. Clients obtain tokens from AuthKit, discovered via "
+            f"our Protected Resource Metadata."
+        )
+
+    def register_client(self, metadata: dict[str, Any]) -> dict[str, Any]:
+        return self._flow_not_ours("register clients (DCR/CIMD)")
+
+    def create_authorization(
+        self,
+        client_id: str,
+        redirect_uri: str,
+        scope: str,
+        state: str,
+        code_challenge: str,
+        code_challenge_method: str,
+    ) -> str:
+        return self._flow_not_ours("create authorizations")
+
+    def exchange_code(
+        self,
+        code: str,
+        client_id: str,
+        redirect_uri: str,
+        code_verifier: str,
+    ) -> dict[str, Any] | None:
+        return self._flow_not_ours("exchange codes for tokens")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ dependencies = [
     # MCP/server entry points and Tier-3 structural smoke imports
     "fastmcp>=3.0",
     "uvicorn[standard]>=0.30",
+
+    # OAuth 2.1 Resource Server: validate WorkOS AuthKit bearer JWTs (PyJWT + JWKS).
+    # The [crypto] extra pulls cryptography for RS256 signature verification.
+    "pyjwt[crypto]>=2.8,<3.0",
 ]
 
 [project.scripts]

--- a/tests/test_workos_provider.py
+++ b/tests/test_workos_provider.py
@@ -1,0 +1,263 @@
+"""Tests for the WorkOS AuthKit Resource Server provider (founder-identity slice 1).
+
+Our MCP server validates a WorkOS AuthKit access-token JWT and resolves its
+``sub`` to the founder Identity. These tests sign real RS256 tokens with a
+generated keypair and inject a fake JWKS client, so nothing touches the network.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from workflow.auth.provider import Identity, create_provider
+from workflow.auth.workos_provider import (
+    WorkOSAuthProvider,
+    derive_endpoints,
+)
+
+ISSUER = "https://inventive-van-62-staging.authkit.app"
+RESOURCE = "https://tinyassets.io/mcp"
+
+
+@pytest.fixture(scope="module")
+def keypair() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(scope="module")
+def other_key() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+class _FakeSigningKey:
+    def __init__(self, public_key: object) -> None:
+        self.key = public_key
+
+
+class _FakeJWKSClient:
+    """Stand-in for PyJWKClient: always returns the configured public key."""
+
+    def __init__(self, public_key: object) -> None:
+        self._key = _FakeSigningKey(public_key)
+
+    def get_signing_key_from_jwt(self, token: str) -> _FakeSigningKey:
+        return self._key
+
+
+def _provider(
+    keypair: rsa.RSAPrivateKey,
+    *,
+    issuer: str = ISSUER,
+    audience: str | None = None,
+) -> WorkOSAuthProvider:
+    return WorkOSAuthProvider(
+        issuer=issuer,
+        jwks_uri="https://example.invalid/oauth2/jwks",
+        audience=audience,
+        jwks_client=_FakeJWKSClient(keypair.public_key()),
+    )
+
+
+def _sign(keypair: rsa.RSAPrivateKey, **claims: object) -> str:
+    now = int(time.time())
+    payload = {
+        "sub": "user_workos_123",
+        "iss": ISSUER,
+        "iat": now,
+        "exp": now + 3600,
+        "email": "founder@example.com",
+    }
+    payload.update(claims)
+    return jwt.encode(payload, keypair, algorithm="RS256", headers={"kid": "test"})
+
+
+# --- derive_endpoints ------------------------------------------------------
+
+
+def test_derive_endpoints_bare_domain() -> None:
+    issuer, jwks = derive_endpoints("inventive-van-62-staging.authkit.app")
+    assert issuer == ISSUER
+    assert jwks == f"{ISSUER}/oauth2/jwks"
+
+
+def test_derive_endpoints_full_origin_and_trailing_slash() -> None:
+    issuer, jwks = derive_endpoints("https://foo.authkit.app/")
+    assert issuer == "https://foo.authkit.app"
+    assert jwks == "https://foo.authkit.app/oauth2/jwks"
+
+
+def test_derive_endpoints_rejects_empty() -> None:
+    with pytest.raises(ValueError):
+        derive_endpoints("   ")
+
+
+# --- resolve_token: happy path --------------------------------------------
+
+
+def test_valid_token_resolves_to_founder_identity(keypair) -> None:
+    ident = _provider(keypair).resolve_token(_sign(keypair))
+    assert isinstance(ident, Identity)
+    assert ident.user_id == "user_workos_123"  # sub == founder key
+    assert ident.username == "founder@example.com"
+    assert ident.metadata["auth_provider"] == "workos"
+    assert ident.metadata["email"] == "founder@example.com"
+    assert "write" in ident.capabilities
+
+
+def test_username_falls_back_to_sub_without_email(keypair) -> None:
+    ident = _provider(keypair).resolve_token(_sign(keypair, email=""))
+    assert ident is not None
+    assert ident.username == "user_workos_123"
+
+
+def test_org_role_permissions_surface_in_metadata(keypair) -> None:
+    token = _sign(
+        keypair,
+        org_id="org_1",
+        role="admin",
+        permissions=["a", "b"],
+    )
+    ident = _provider(keypair).resolve_token(token)
+    assert ident is not None
+    assert ident.metadata["org_id"] == "org_1"
+    assert ident.metadata["role"] == "admin"
+    assert ident.metadata["permissions"] == ["a", "b"]
+
+
+# --- resolve_token: rejections --------------------------------------------
+
+
+def test_expired_token_rejected(keypair) -> None:
+    now = int(time.time())
+    token = _sign(keypair, iat=now - 7200, exp=now - 3600)
+    assert _provider(keypair).resolve_token(token) is None
+
+
+def test_missing_sub_rejected(keypair) -> None:
+    # require=["exp","sub"] -> PyJWT raises MissingRequiredClaim.
+    assert _provider(keypair).resolve_token(_sign(keypair, sub="")) is None
+
+
+def test_anonymous_sub_rejected(keypair) -> None:
+    assert _provider(keypair).resolve_token(_sign(keypair, sub="anonymous")) is None
+
+
+def test_wrong_issuer_rejected(keypair) -> None:
+    token = _sign(keypair, iss="https://evil.example.com")
+    assert _provider(keypair).resolve_token(token) is None
+
+
+def test_bad_signature_rejected(keypair, other_key) -> None:
+    # Token signed by a different key than the provider's JWKS exposes.
+    token = jwt.encode(
+        {"sub": "x", "iss": ISSUER, "exp": int(time.time()) + 3600},
+        other_key,
+        algorithm="RS256",
+        headers={"kid": "test"},
+    )
+    assert _provider(keypair).resolve_token(token) is None
+
+
+def test_empty_token_returns_none(keypair) -> None:
+    p = _provider(keypair)
+    assert p.resolve_token("") is None
+    assert p.resolve_token("   ") is None
+
+
+# --- audience binding ------------------------------------------------------
+
+
+def test_audience_enforced_when_configured(keypair) -> None:
+    p = _provider(keypair, audience=RESOURCE)
+    assert p.resolve_token(_sign(keypair, aud=RESOURCE)) is not None
+    assert p.resolve_token(_sign(keypair, aud="https://other")) is None
+    assert p.resolve_token(_sign(keypair)) is None  # no aud at all
+
+
+def test_audience_skipped_when_not_configured(keypair) -> None:
+    # No audience on the provider -> tokens without aud still validate.
+    assert _provider(keypair).resolve_token(_sign(keypair)) is not None
+
+
+# --- provider contract -----------------------------------------------------
+
+
+def test_is_auth_required_false(keypair) -> None:
+    # Slice 1 never rejects anonymous; gating is slice 2.
+    assert _provider(keypair).is_auth_required() is False
+
+
+def test_flow_methods_are_not_ours(keypair) -> None:
+    p = _provider(keypair)
+    with pytest.raises(NotImplementedError):
+        p.register_client({})
+    with pytest.raises(NotImplementedError):
+        p.create_authorization("c", "r", "s", "st", "cc", "S256")
+    with pytest.raises(NotImplementedError):
+        p.exchange_code("code", "c", "r", "v")
+
+
+# --- from_env / factory ----------------------------------------------------
+
+
+def test_from_env_derives_endpoints(monkeypatch) -> None:
+    monkeypatch.setenv("WORKOS_AUTHKIT_DOMAIN", "inventive-van-62-staging.authkit.app")
+    monkeypatch.delenv("WORKOS_MCP_RESOURCE", raising=False)
+    p = WorkOSAuthProvider.from_env()
+    assert p._issuer == ISSUER
+    assert p._jwks_uri == f"{ISSUER}/oauth2/jwks"
+    assert p._audience is None
+
+
+def test_from_env_reads_resource_audience(monkeypatch) -> None:
+    monkeypatch.setenv("WORKOS_AUTHKIT_DOMAIN", "foo.authkit.app")
+    monkeypatch.setenv("WORKOS_MCP_RESOURCE", RESOURCE)
+    assert WorkOSAuthProvider.from_env()._audience == RESOURCE
+
+
+def test_from_env_requires_domain(monkeypatch) -> None:
+    monkeypatch.delenv("WORKOS_AUTHKIT_DOMAIN", raising=False)
+    with pytest.raises(RuntimeError):
+        WorkOSAuthProvider.from_env()
+
+
+def test_create_provider_selects_workos(monkeypatch) -> None:
+    monkeypatch.setenv("UNIVERSE_SERVER_AUTH", "workos")
+    monkeypatch.setenv("WORKOS_AUTHKIT_DOMAIN", "foo.authkit.app")
+    assert isinstance(create_provider(), WorkOSAuthProvider)
+
+
+# --- integration: the whole point of slice 1 ------------------------------
+
+
+def test_middleware_chain_yields_real_subject(keypair, monkeypatch) -> None:
+    """auth_middleware -> current_identity -> _current_actor returns the real sub,
+    not 'anonymous'. This is the slice-1 acceptance behavior."""
+    from workflow.api import engine_helpers
+    from workflow.auth import middleware as mw
+
+    monkeypatch.delenv("UNIVERSE_SERVER_USER", raising=False)
+    mw.set_provider(_provider(keypair))
+    try:
+        mw.auth_middleware(_sign(keypair))
+        assert mw.current_identity().user_id == "user_workos_123"
+        assert engine_helpers._current_actor() == "user_workos_123"
+    finally:
+        mw.auth_middleware(None)  # reset request-local identity to ANONYMOUS
+        mw.set_provider(None)
+
+
+def test_middleware_anonymous_without_token(keypair, monkeypatch) -> None:
+    from workflow.auth import middleware as mw
+
+    monkeypatch.delenv("UNIVERSE_SERVER_USER", raising=False)
+    mw.set_provider(_provider(keypair))
+    try:
+        mw.auth_middleware(None)
+        assert mw.current_identity().user_id == "anonymous"
+    finally:
+        mw.set_provider(None)

--- a/workflow/auth/provider.py
+++ b/workflow/auth/provider.py
@@ -1071,6 +1071,14 @@ class OptionalOAuthProvider(OAuthProvider):
 def create_provider() -> AuthProvider:
     """Create the appropriate auth provider based on configuration."""
     auth_mode = os.environ.get("UNIVERSE_SERVER_AUTH", "false").strip().lower()
+    if auth_mode == "workos":
+        # WorkOS AuthKit is the Authorization Server; we are a Resource Server
+        # validating its bearer JWTs. Lazy import so non-WorkOS deployments
+        # don't load PyJWT. See docs/reference/workos-authkit-integration.md.
+        from workflow.auth.workos_provider import WorkOSAuthProvider
+
+        logger.info("WorkOS AuthKit auth provider enabled (Resource Server)")
+        return WorkOSAuthProvider.from_env()
     if auth_mode in ("true", "1", "yes", "oauth"):
         logger.info("OAuth auth provider enabled")
         return OAuthProvider()

--- a/workflow/auth/workos_provider.py
+++ b/workflow/auth/workos_provider.py
@@ -1,0 +1,184 @@
+"""WorkOS AuthKit Resource Server provider.
+
+Our MCP server is a pure OAuth 2.1 Resource Server: **WorkOS AuthKit is the
+Authorization Server.** This provider validates an incoming AuthKit access-token
+JWT (PyJWT + JWKS) and resolves it to an :class:`Identity` whose ``user_id`` is
+the token's ``sub`` — the stable WorkOS user id we use as the founder key.
+
+The OAuth-flow methods (DCR / authorize / token exchange) are AuthKit's job, not
+ours; they raise :class:`NotImplementedError` here. Clients obtain tokens from
+AuthKit, which they discover via our Protected Resource Metadata.
+
+Design + live staging values: ``docs/reference/workos-authkit-integration.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import jwt
+from jwt import PyJWKClient
+
+from workflow.auth.provider import AuthProvider, Identity
+
+logger = logging.getLogger("universe_server.auth.workos")
+
+# Capabilities granted to ANY authenticated WorkOS user. Founder-scoped write
+# authority (founder == the universe's ``sub``) is layered on in a later slice;
+# for now an authenticated user carries a write-capable base so the capability
+# model (anonymous-read / authenticated-write, slice 2) has a real subject to
+# gate on. Slice 1 itself does not enforce these (see ``is_auth_required``).
+_AUTHENTICATED_CAPABILITIES = ("read", "write", "submit_request", "list")
+
+_ALGORITHMS = ("RS256",)
+
+
+def derive_endpoints(authkit_domain: str) -> tuple[str, str]:
+    """Return ``(issuer, jwks_uri)`` for an AuthKit domain.
+
+    Confirmed against live AS metadata 2026-06-26:
+      ``issuer   = https://<domain>``
+      ``jwks_uri = https://<domain>/oauth2/jwks``
+    Accepts a bare domain (``foo.authkit.app``) or a full origin.
+    """
+    domain = (authkit_domain or "").strip().rstrip("/")
+    if not domain:
+        raise ValueError("authkit_domain must be non-empty")
+    base = domain if domain.startswith(("http://", "https://")) else f"https://{domain}"
+    return base, f"{base}/oauth2/jwks"
+
+
+class WorkOSAuthProvider(AuthProvider):
+    """Validate WorkOS AuthKit bearer JWTs; resolve ``sub`` -> founder Identity."""
+
+    def __init__(
+        self,
+        *,
+        issuer: str,
+        jwks_uri: str,
+        audience: str | None = None,
+        jwks_client: Any | None = None,
+        leeway: float = 60.0,
+    ) -> None:
+        self._issuer = issuer
+        self._jwks_uri = jwks_uri
+        self._audience = (audience or "").strip() or None
+        self._leeway = leeway
+        # PyJWKClient caches keys + handles rotation / ``kid`` matching.
+        # Injectable so tests can supply a fake without network access.
+        self._jwks_client = (
+            jwks_client if jwks_client is not None else PyJWKClient(jwks_uri)
+        )
+
+    @classmethod
+    def from_env(cls) -> "WorkOSAuthProvider":
+        """Build from ``WORKOS_AUTHKIT_DOMAIN`` (+ optional ``WORKOS_MCP_RESOURCE``)."""
+        domain = os.environ.get("WORKOS_AUTHKIT_DOMAIN", "").strip()
+        if not domain:
+            raise RuntimeError(
+                "WORKOS_AUTHKIT_DOMAIN is required for the WorkOS auth provider."
+            )
+        issuer, jwks_uri = derive_endpoints(domain)
+        audience = os.environ.get("WORKOS_MCP_RESOURCE", "").strip() or None
+        if audience is None:
+            logger.warning(
+                "WORKOS_MCP_RESOURCE unset — skipping audience (aud) validation. "
+                "Register the MCP URL as a WorkOS Resource Indicator and set this "
+                "env var to bind tokens to this server."
+            )
+        return cls(issuer=issuer, jwks_uri=jwks_uri, audience=audience)
+
+    # --- Resource Server: the methods that matter -------------------------
+
+    def resolve_token(self, token: str) -> Identity | None:
+        if not token or not token.strip():
+            return None
+        try:
+            signing_key = self._jwks_client.get_signing_key_from_jwt(token)
+        except Exception:
+            # kid mismatch, malformed token, or JWKS fetch failure.
+            logger.debug("WorkOS token: no signing key", exc_info=True)
+            return None
+
+        options: dict[str, Any] = {"require": ["exp", "sub"]}
+        decode_kwargs: dict[str, Any] = {
+            "algorithms": list(_ALGORITHMS),  # pin RS256 (alg-substitution defense)
+            "issuer": self._issuer,
+            "leeway": self._leeway,
+            "options": options,
+        }
+        if self._audience:
+            decode_kwargs["audience"] = self._audience
+        else:
+            options["verify_aud"] = False
+
+        try:
+            claims = jwt.decode(token, signing_key.key, **decode_kwargs)
+        except jwt.PyJWTError:
+            logger.debug("WorkOS token failed validation", exc_info=True)
+            return None
+
+        sub = str(claims.get("sub", "")).strip()
+        if not sub or sub == "anonymous":
+            return None
+
+        email = str(claims.get("email", "")).strip()
+        username = email or sub
+        display_name = str(claims.get("name", "")).strip() or username
+        permissions = claims.get("permissions")
+
+        return Identity(
+            user_id=sub,
+            username=username,
+            display_name=display_name,
+            capabilities=list(_AUTHENTICATED_CAPABILITIES),
+            metadata={
+                "auth_provider": "workos",
+                "email": email,
+                "org_id": claims.get("org_id"),
+                "role": claims.get("role"),
+                "permissions": permissions if isinstance(permissions, list) else [],
+                "iss": claims.get("iss"),
+            },
+        )
+
+    def is_auth_required(self) -> bool:
+        # Slice 1: resolve-when-present, never reject anonymous. The
+        # anonymous-read / authenticated-write capability gate is layered on in
+        # slice 2. Returning False means gating is UNCHANGED — we only make the
+        # subject real when a valid WorkOS token is presented.
+        return False
+
+    # --- OAuth flow: AuthKit's job, not the Resource Server's --------------
+
+    def _flow_not_ours(self, what: str) -> Any:
+        raise NotImplementedError(
+            f"WorkOS AuthKit is the Authorization Server; this Resource Server "
+            f"does not {what}. Clients obtain tokens from AuthKit, discovered via "
+            f"our Protected Resource Metadata."
+        )
+
+    def register_client(self, metadata: dict[str, Any]) -> dict[str, Any]:
+        return self._flow_not_ours("register clients (DCR/CIMD)")
+
+    def create_authorization(
+        self,
+        client_id: str,
+        redirect_uri: str,
+        scope: str,
+        state: str,
+        code_challenge: str,
+        code_challenge_method: str,
+    ) -> str:
+        return self._flow_not_ours("create authorizations")
+
+    def exchange_code(
+        self,
+        code: str,
+        client_id: str,
+        redirect_uri: str,
+        code_verifier: str,
+    ) -> dict[str, Any] | None:
+        return self._flow_not_ours("exchange codes for tokens")


### PR DESCRIPTION
Implements the founder & universe identity arc (design note #1407, on main as `4ed20e28`).
**Draft — building all 6 slices on this branch; Codex-reviewed per slice; live ui-test at the end (host-watched).**

## Slice 1 — WorkOS AuthKit Resource Server token validation ✅ (this commit)
WorkOS AuthKit is the Authorization Server; our MCP server is a pure OAuth 2.1 Resource Server.
- `workflow/auth/workos_provider.py` — `WorkOSAuthProvider.resolve_token()` validates an AuthKit JWT (PyJWT+JWKS, pinned RS256, iss/aud/exp/sub) → `Identity(user_id=sub)` (the founder key). Integrates with the existing `Identity`/middleware/`_current_actor` path — **no parallel system**. Flow methods (DCR/authorize/exchange) raise NotImplementedError (AuthKit's job).
- Wired into `create_provider()` via `UNIVERSE_SERVER_AUTH=workos` (lazy import). `is_auth_required()=False` — slice 1 only makes the subject *real*; the anon-read/auth-write gate is slice 2.
- `pyjwt[crypto]` declared (was installed-but-undeclared).
- **22 TDD tests**, ruff clean, no auth-test regression. Integration test proves `auth_middleware → current_identity → _current_actor` returns the real `sub`.

Live staging tenant provisioned + verified (recipe `docs/reference/workos-authkit-integration.md`): client_id `client_01KW15P07QYSMF9CY4XXXJN520`, domain `inventive-van-62-staging.authkit.app`, Google/GitHub/Microsoft social enabled.

## Remaining slices (incoming)
2. Capability mode (anon-read / auth-write) — consume the existing `provider.py` scope registry, not a parallel one. 3. Founder metadata + founder-write ACL + migration. 4. Identity→main-universe routing. 5. Per-request persona routing + `get_status` founder surface. 6. Legacy cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)