### PR TITLE
Fix TinyAssets MCP rename rollout

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -11,8 +11,6 @@ Live steering only. **Budget 4 KB / 60 lines.** Concerns/Work = one line each; l
 - [filed:2026-04-24] Task #9 host Qs: GROQ/GEMINI/XAI GH Actions secrets present + rotation e2e validated after deploy step ships.
 - **[P1 filed:2026-04-30]** Castles II live run `28479d8ddfb44488` failed `provider_exhausted` at `candidate_discovery` (see BUG-038); blocks branch-run proof. Companion: BUG-039 (Echoes intake same root cause).
 - [filed:2026-05-19] Wiki has shifted toward multi-agent shared scratch space — 81% of post-2026-05-01 notes (495 of 614) are Codex/Cowork/Claude agent-coordination. Volume risks drowning out chatbot discovery/remix. Worth a host conversation on whether to split coordination off the knowledge wiki.
-- [filed:2026-06-27] Local primary checkout folder rename to `TinyAssets` blocked by an open process handle on `C:\Users\Jonathan\Projects\Workflow`.
-
 ## Approved Specs
 
 Full specs: `docs/vetted-specs.md` (H2 heading per spec). Dev reads there, never wiki. On land, delete row + H2 section together.

--- a/WebSite/site-react/app/host/_components/HostClient.tsx
+++ b/WebSite/site-react/app/host/_components/HostClient.tsx
@@ -206,7 +206,7 @@ export default function HostClient() {
           <p className="run__lede">
             Python 3.11+. Clone, install in editable mode, and you have a local
             daemon to summon. These commands are the repo&apos;s own quick-start — the
-            <code>workflow</code> tray and <code>tinyassets-mcp</code> server are the
+            <code>tinyassets</code> tray and <code>tinyassets-mcp</code> server are the
             documented entry points, not invented for this page.
           </p>
 
@@ -237,7 +237,7 @@ export default function HostClient() {
             <div className="run__note">
               <strong>The Windows tray app ships from source today.</strong>
               There&apos;s no packaged installer in releases yet, so the honest path is
-              the clone above — running <code>workflow</code> opens the same tray an
+              the clone above — running <code>tinyassets</code> opens the same tray an
               installer eventually would. macOS and Linux support is in progress
               (the platform code is cross-platform; the tray is Windows-first).
               <a href={GH_REPO} target="_blank" rel="noreferrer">Read the source on GitHub ↗</a>

--- a/deploy/install-tinyassets-env.sh
+++ b/deploy/install-tinyassets-env.sh
@@ -50,15 +50,17 @@
 #      tinyassets user (post-write assert passes).
 #   1  bad invocation (unknown subcommand, missing args, missing key
 #      name, value containing forbidden chars).
-#   2  /etc/tinyassets/env missing — bootstrap should have created it.
+#   2  env bootstrap failed before install(1).
 #   3  install(1) failed.
 #   4  post-write readability assert failed (tinyassets user cannot read).
 
 set -euo pipefail
 
-ENV_FILE="/etc/tinyassets/env"
-ENV_OWNER="root:tinyassets"
-ENV_MODE="640"
+ENV_FILE="${TINYASSETS_ENV_FILE-/etc/tinyassets/env}"
+LEGACY_ENV_FILE="${TINYASSETS_LEGACY_ENV_FILE-/etc/workflow/env}"
+ENV_OWNER="${TINYASSETS_ENV_OWNER-root:tinyassets}"
+ENV_MODE="${TINYASSETS_ENV_MODE-640}"
+ENV_READ_USER="${TINYASSETS_ENV_READ_USER-tinyassets}"
 
 usage() {
     cat >&2 <<'EOF'
@@ -80,14 +82,84 @@ validate_key() {
     fi
 }
 
-# Read current file content. Required-exists — the bootstrap creates
-# this file on first install, so absence is a real failure not a
-# silent create-on-write.
-require_env_file() {
-    if [ ! -f "${ENV_FILE}" ]; then
-        echo "::error::${ENV_FILE} missing — bootstrap should have created it" >&2
+env_owner_user() {
+    printf '%s' "${ENV_OWNER%%:*}"
+}
+
+env_owner_group() {
+    if [[ "${ENV_OWNER}" == *:* ]]; then
+        printf '%s' "${ENV_OWNER#*:}"
+    else
+        id -gn "$(env_owner_user)" 2>/dev/null || id -gn
+    fi
+}
+
+owner_label() {
+    if [ -n "${ENV_OWNER}" ]; then
+        printf '%s' "${ENV_OWNER}"
+    else
+        printf '<current-user>'
+    fi
+}
+
+install_env_file() {
+    local src="$1"
+    local owner_args=()
+    if [ -n "${ENV_OWNER}" ]; then
+        owner_args=(-o "$(env_owner_user)" -g "$(env_owner_group)")
+    fi
+    install -m "${ENV_MODE}" "${owner_args[@]}" "${src}" "${ENV_FILE}"
+}
+
+# Confirm the tinyassets user can actually read the file. This is the
+# canary that the systemd unit's ExecStartPre would have tripped on.
+assert_readable() {
+    if [ -n "${ENV_READ_USER}" ]; then
+        if ! sudo -u "${ENV_READ_USER}" test -r "${ENV_FILE}"; then
+            echo "::error::ENV-UNREADABLE: ${ENV_FILE} not readable by user ${ENV_READ_USER} after install" >&2
+            ls -l "${ENV_FILE}" >&2 || true
+            exit 4
+        fi
+    elif ! test -r "${ENV_FILE}"; then
+        echo "::error::ENV-UNREADABLE: ${ENV_FILE} not readable after install" >&2
+        ls -l "${ENV_FILE}" >&2 || true
+        exit 4
+    fi
+}
+
+# Read current file content. If the renamed env file is missing on a
+# pre-cutover host, bootstrap it from /etc/workflow/env once. If there is
+# no legacy file, create an empty env file so the deploy can write the new
+# image pin and secrets through the same atomic helper.
+ensure_env_file() {
+    if [ -f "${ENV_FILE}" ]; then
+        return
+    fi
+
+    local env_dir
+    env_dir="$(dirname "${ENV_FILE}")"
+    if ! mkdir -p "${env_dir}"; then
+        echo "::error::failed to create ${env_dir}" >&2
         exit 2
     fi
+    if [ -n "${ENV_OWNER}" ]; then
+        chown "$(env_owner_user):$(env_owner_group)" "${env_dir}" || true
+        chmod 750 "${env_dir}" || true
+    fi
+
+    local src="/dev/null"
+    if [ -f "${LEGACY_ENV_FILE}" ]; then
+        src="${LEGACY_ENV_FILE}"
+        echo "::notice::${ENV_FILE} missing; bootstrapping from ${LEGACY_ENV_FILE}" >&2
+    else
+        echo "::notice::${ENV_FILE} missing; creating empty env file" >&2
+    fi
+
+    if ! install_env_file "${src}"; then
+        echo "::error::install(1) failed bootstrapping ${ENV_FILE}" >&2
+        exit 3
+    fi
+    assert_readable
 }
 
 # Atomic write of a buffer to ENV_FILE with correct owner + mode.
@@ -96,27 +168,16 @@ require_env_file() {
 atomic_install() {
     local content="$1"
     if ! printf '%s' "${content}" \
-            | install -m "${ENV_MODE}" -o root -g tinyassets \
-                /dev/stdin "${ENV_FILE}"; then
+            | install_env_file /dev/stdin; then
         echo "::error::install(1) failed writing ${ENV_FILE}" >&2
         exit 3
-    fi
-}
-
-# Confirm the tinyassets user can actually read the file. This is the
-# canary that the systemd unit's ExecStartPre would have tripped on.
-assert_readable() {
-    if ! sudo -u tinyassets test -r "${ENV_FILE}"; then
-        echo "::error::ENV-UNREADABLE: ${ENV_FILE} not readable by user tinyassets after install" >&2
-        ls -l "${ENV_FILE}" >&2 || true
-        exit 4
     fi
 }
 
 cmd_set() {
     local key="$1"
     validate_key "${key}"
-    require_env_file
+    ensure_env_file
 
     # Read new value from stdin (verbatim, including any trailing
     # newline the caller piped in — but we strip a single trailing
@@ -139,12 +200,12 @@ cmd_set() {
 
     atomic_install "${new_content}"$'\n'
     assert_readable
-    echo "set ${key} (${ENV_FILE} root:tinyassets ${ENV_MODE})"
+    echo "set ${key} (${ENV_FILE} $(owner_label) ${ENV_MODE})"
 }
 
 cmd_delete() {
     local key
-    require_env_file
+    ensure_env_file
 
     # Build a single awk filter that drops every requested KEY= line
     # in one pass.
@@ -160,7 +221,7 @@ cmd_delete() {
 
     atomic_install "${new_content}"$'\n'
     assert_readable
-    echo "deleted: $* (${ENV_FILE} root:tinyassets ${ENV_MODE})"
+    echo "deleted: $* (${ENV_FILE} $(owner_label) ${ENV_MODE})"
 }
 
 [ $# -ge 1 ] || usage

--- a/packaging/claude-plugin/plugins/tinyassets-universe-server/runtime/tinyassets/mcp_server.py
+++ b/packaging/claude-plugin/plugins/tinyassets-universe-server/runtime/tinyassets/mcp_server.py
@@ -30,7 +30,7 @@ from tinyassets.universe_soul import (
 )
 
 mcp = FastMCP(
-    "workflow",
+    "tinyassets",
     instructions=(
         "TinyAssets daemon interface. Use these tools to monitor "
         "and guide an autonomous workflow daemon through notes. "

--- a/packaging/claude-plugin/plugins/tinyassets-universe-server/runtime/tinyassets/outcomes/evaluators.py
+++ b/packaging/claude-plugin/plugins/tinyassets-universe-server/runtime/tinyassets/outcomes/evaluators.py
@@ -263,7 +263,7 @@ def _load_hyperparameter_backends() -> tuple[Any, Any, str]:
         return (
             None,
             None,
-            f"scikit-learn / scipy not installed ({exc}); pip install workflow[scientific]",
+            f"scikit-learn / scipy not installed ({exc}); pip install tinyassets[scientific]",
         )
     return RandomForestRegressor, spearmanr, ""
 

--- a/packaging/claude-plugin/plugins/tinyassets-universe-server/runtime/tinyassets/universe_server.py
+++ b/packaging/claude-plugin/plugins/tinyassets-universe-server/runtime/tinyassets/universe_server.py
@@ -1726,7 +1726,7 @@ engine is domain-agnostic.</p>
     → URL: this page's URL</li>
 <li><strong>ChatGPT (Apps SDK)</strong>: Connector URL: this page's URL</li>
 <li><strong>Cursor</strong>: <code>settings.json</code> →
-    <code>mcpServers</code> → <code>workflow</code> → <code>url</code></li>
+    <code>mcpServers</code> → <code>tinyassets</code> → <code>url</code></li>
 <li><strong>Cowork</strong>: Connectors → URL: this page's URL</li>
 </ul>
 

--- a/tests/smoke/test_plan_md_exists.py
+++ b/tests/smoke/test_plan_md_exists.py
@@ -25,8 +25,9 @@ def test_status_md_exists():
     assert (_REPO_ROOT / "STATUS.md").is_file(), "STATUS.md missing from repo root"
 
 
-def test_pyproject_has_workflow_name():
+def test_pyproject_has_tinyassets_name():
     pyproject = _REPO_ROOT / "pyproject.toml"
     assert pyproject.is_file(), "pyproject.toml missing from repo root"
     content = pyproject.read_text(encoding="utf-8")
-    assert 'name = "workflow"' in content, "pyproject.toml package name drifted"
+    assert 'name = "tinyassets"' in content, "pyproject.toml package name drifted"
+    assert 'name = "workflow"' not in content, "old package name leaked back into pyproject.toml"

--- a/tests/test_cf_access_cutover.py
+++ b/tests/test_cf_access_cutover.py
@@ -287,7 +287,7 @@ class _FakeHTTPResponse:
 
 def test_three_check_canonical_green(capsys):
     """Canonical URL returning 200 with 'serverInfo' in body → GREEN."""
-    canonical_body = json.dumps({"result": {"serverInfo": {"name": "workflow"}}}).encode()
+    canonical_body = json.dumps({"result": {"serverInfo": {"name": "tinyassets"}}}).encode()
 
     canonical_resp = _FakeHTTPResponse(200, canonical_body)
     internal_error = urllib.error.HTTPError(

--- a/tests/test_cf_access_rollback.py
+++ b/tests/test_cf_access_rollback.py
@@ -199,7 +199,7 @@ def test_rotate_token_deletes_both(monkeypatch):
     mock_client.request = MagicMock(side_effect=lambda *a, **kw: next(it))
 
     with patch("cf_access_rollback.make_cloudflare_client", return_value=mock_client):
-        _call_main(rb, ["--apply", "--rotate-token"])
+        _call_main(rb, ["--apply", "--rotate-token", "--skip-verify"])
 
     # Verify DELETE was called for both app and token
     calls = mock_client.request.call_args_list
@@ -233,7 +233,7 @@ def test_no_rotate_token_skips_token_delete(monkeypatch):
     mock_client.request = MagicMock(side_effect=lambda *a, **kw: next(it))
 
     with patch("cf_access_rollback.make_cloudflare_client", return_value=mock_client):
-        rc = _call_main(rb, ["--apply"])
+        rc = _call_main(rb, ["--apply", "--skip-verify"])
 
     assert rc == 0
     calls = mock_client.request.call_args_list
@@ -313,7 +313,7 @@ class _FakeHTTPResponse:
 
 def test_rollback_check_canonical_green_internal_ungated(capsys):
     """Canonical 200+serverInfo = GREEN; internal 200 = GREEN: ungated."""
-    canonical_body = json.dumps({"result": {"serverInfo": {"name": "workflow"}}}).encode()
+    canonical_body = json.dumps({"result": {"serverInfo": {"name": "tinyassets"}}}).encode()
     canonical_resp = _FakeHTTPResponse(200, canonical_body)
     internal_resp = _FakeHTTPResponse(200, b"")
 

--- a/tests/test_install_tinyassets_env.py
+++ b/tests/test_install_tinyassets_env.py
@@ -1,0 +1,100 @@
+"""Regression tests for deploy/install-tinyassets-env.sh.
+
+The production rename deploy failed because the helper treated a missing
+/etc/tinyassets/env as fatal before the renamed image could roll out. These
+tests run the helper against tmp_path files and never touch /etc.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+_REPO = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO / "deploy" / "install-tinyassets-env.sh"
+
+
+def test_helper_knows_renamed_env_can_bootstrap_from_legacy_file():
+    text = _SCRIPT.read_text(encoding="utf-8")
+    assert 'LEGACY_ENV_FILE="${TINYASSETS_LEGACY_ENV_FILE-/etc/workflow/env}"' in text
+    assert "ensure_env_file" in text
+    assert "missing — bootstrap should have created it" not in text
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or shutil.which("bash") is None,
+    reason="shell helper is exercised on POSIX CI; Windows test stays structural",
+)
+def test_delete_bootstraps_from_legacy_env(tmp_path):
+    env_file = tmp_path / "tinyassets" / "env"
+    legacy_file = tmp_path / "workflow" / "env"
+    legacy_file.parent.mkdir()
+    legacy_file.write_text("KEEP=1\nTINYASSETS_UNIVERSE=/old\n", encoding="utf-8")
+
+    result = _run_helper(
+        tmp_path,
+        ["delete", "TINYASSETS_UNIVERSE"],
+        env_file=env_file,
+        legacy_file=legacy_file,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert env_file.read_text(encoding="utf-8") == "KEEP=1\n"
+    assert "bootstrapping from" in result.stderr
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or shutil.which("bash") is None,
+    reason="shell helper is exercised on POSIX CI; Windows test stays structural",
+)
+def test_set_creates_empty_env_when_no_legacy_file_exists(tmp_path):
+    env_file = tmp_path / "tinyassets" / "env"
+    legacy_file = tmp_path / "workflow" / "env"
+
+    result = _run_helper(
+        tmp_path,
+        ["set", "TINYASSETS_IMAGE"],
+        stdin="ghcr.io/jonnyton/tinyassets-daemon@sha256:abc\n",
+        env_file=env_file,
+        legacy_file=legacy_file,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        env_file.read_text(encoding="utf-8")
+        == "TINYASSETS_IMAGE=ghcr.io/jonnyton/tinyassets-daemon@sha256:abc\n"
+    )
+    assert "creating empty env file" in result.stderr
+
+
+def _run_helper(
+    tmp_path: Path,
+    args: list[str],
+    *,
+    env_file: Path,
+    legacy_file: Path,
+    stdin: str = "",
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "TINYASSETS_ENV_FILE": str(env_file),
+            "TINYASSETS_LEGACY_ENV_FILE": str(legacy_file),
+            "TINYASSETS_ENV_OWNER": "",
+            "TINYASSETS_ENV_READ_USER": "",
+        }
+    )
+    return subprocess.run(
+        ["bash", str(_SCRIPT), *args],
+        input=stdin,
+        text=True,
+        capture_output=True,
+        cwd=tmp_path,
+        env=env,
+        check=False,
+    )

--- a/tests/test_last_activity_canary.py
+++ b/tests/test_last_activity_canary.py
@@ -147,7 +147,7 @@ def _init_resp(sid="sess-x"):
     return (
         {"jsonrpc": "2.0", "id": 1, "result": {
             "protocolVersion": "2024-11-05",
-            "serverInfo": {"name": "workflow", "version": "1.0"},
+            "serverInfo": {"name": "tinyassets", "version": "1.0"},
         }},
         sid,
     )

--- a/tests/test_mcp_discovery_html.py
+++ b/tests/test_mcp_discovery_html.py
@@ -34,6 +34,11 @@ def test_browser_get_mcp_returns_discovery_html(client):
     body = response.text
     assert "TinyAssets MCP Server" in body
     assert "MCP" in body  # at least mentions MCP
+    assert "https://github.com/Jonnyton/TinyAssets" in body
+    assert "<code>tinyassets</code>" in body
+    assert "Workflow MCP Server" not in body
+    assert "https://github.com/Jonnyton/Workflow" not in body
+    assert "<code>workflow</code>" not in body
 
 
 def test_browser_get_mcp_directory_returns_discovery_html(client):
@@ -50,8 +55,10 @@ def test_default_get_mcp_returns_discovery_json(client):
     assert response.status_code == 200
     assert "application/json" in response.headers["content-type"]
     payload = response.json()
+    assert payload["name"] == "tinyassets"
     assert payload["type"] == "mcp_server_endpoint"
     assert payload["transport"] == "streamable-http"
+    assert payload["related"]["source"] == "https://github.com/Jonnyton/TinyAssets"
     assert "text/event-stream" in payload["how_to_connect"]["client_accept_header"]
 
 
@@ -62,7 +69,11 @@ def test_json_get_mcp_directory_returns_discovery_json(client):
         headers={"Accept": "application/json"},
     )
     assert response.status_code == 200
-    assert response.json()["related"]["directory_endpoint"].endswith("/mcp-directory")
+    payload = response.json()
+    assert payload["name"] == "tinyassets"
+    assert payload["related"]["source"] == "https://github.com/Jonnyton/TinyAssets"
+    assert payload["related"]["mcp_endpoint"] == "https://tinyassets.io/mcp"
+    assert payload["connect"]["catalog_path"].startswith("/mcp-directory")
 
 
 def test_head_mcp_returns_discovery_headers(client):

--- a/tests/test_mcp_public_canary.py
+++ b/tests/test_mcp_public_canary.py
@@ -25,7 +25,7 @@ def _scripted_post(tool_names):
                 "jsonrpc": "2.0", "id": 1,
                 "result": {
                     "protocolVersion": "2024-11-05",
-                    "serverInfo": {"name": "workflow", "version": "0.1.0"},
+                    "serverInfo": {"name": "tinyassets", "version": "0.1.0"},
                 },
             }).encode()
             return 200, {"mcp-session-id": "sess-1"}, body

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -46,7 +46,7 @@ class TestMCPServerSetup:
     """MCP server is properly configured."""
 
     def test_server_name(self):
-        assert mcp.name == "workflow"
+        assert mcp.name == "tinyassets"
 
 
 class TestUniverseDirResolution:
@@ -398,8 +398,9 @@ class TestMCPConfig:
         config_path = Path(__file__).parent.parent / ".mcp.example.json"
         data = json.loads(config_path.read_text(encoding="utf-8"))
         assert "mcpServers" in data
-        assert "workflow" in data["mcpServers"]
-        server = data["mcpServers"]["workflow"]
+        assert "tinyassets" in data["mcpServers"]
+        assert "workflow" not in data["mcpServers"]
+        server = data["mcpServers"]["tinyassets"]
         assert server["command"] == "python"
         assert "-m" in server["args"]
         assert "tinyassets.mcp_server" in server["args"]

--- a/tests/test_mcp_tool_canary.py
+++ b/tests/test_mcp_tool_canary.py
@@ -25,7 +25,7 @@ def _init_resp(sid: str = "sess-123") -> tuple[dict, str]:
     return (
         {"jsonrpc": "2.0", "id": 1, "result": {
             "protocolVersion": "2024-11-05",
-            "serverInfo": {"name": "workflow", "version": "1.0"},
+            "serverInfo": {"name": "tinyassets", "version": "1.0"},
             "capabilities": {},
         }},
         sid,

--- a/tests/test_outcome_evaluators.py
+++ b/tests/test_outcome_evaluators.py
@@ -449,7 +449,7 @@ class TestHyperparameterImportanceEvaluator:
     def test_skip_when_backends_missing(self, monkeypatch):
         from tinyassets.outcomes import evaluators as ev_mod
 
-        err_msg = "scikit-learn / scipy not installed; pip install workflow[scientific]"
+        err_msg = "scikit-learn / scipy not installed; pip install tinyassets[scientific]"
         monkeypatch.setattr(
             ev_mod,
             "_load_hyperparameter_backends",
@@ -460,7 +460,7 @@ class TestHyperparameterImportanceEvaluator:
         )
         assert result.verdict == "skip"
         assert "scikit-learn" in result.details["reason"]
-        assert "workflow[scientific]" in result.details["reason"]
+        assert "tinyassets[scientific]" in result.details["reason"]
 
     def test_empty_run_results_returns_skip(self):
         result = HyperparameterImportanceEvaluator().evaluate({"run_results": []})

--- a/tests/test_packaging_build.py
+++ b/tests/test_packaging_build.py
@@ -131,7 +131,7 @@ def test_build_plugin_purges_legacy_fantasy_author_snapshot():
             shutil.rmtree(legacy_dir)
 
 
-def test_plugin_server_imports_workflow_package():
+def test_plugin_server_imports_tinyassets_package():
     _run(PLUGIN_BUILD)
     probe = subprocess.run(
         [
@@ -151,18 +151,18 @@ def test_plugin_server_imports_workflow_package():
 # ─── shape parity ────────────────────────────────────────────────────
 
 
-def test_bundle_and_plugin_workflow_trees_match():
+def test_bundle_and_plugin_tinyassets_trees_match():
     """Both build scripts stage the same set of files from tinyassets/."""
     _run(MCPB_BUILD)
     _run(PLUGIN_BUILD)
     bundle_files = {
-        p.relative_to(DIST_STAGE / "workflow")
-        for p in (DIST_STAGE / "workflow").rglob("*")
+        p.relative_to(DIST_STAGE / "tinyassets")
+        for p in (DIST_STAGE / "tinyassets").rglob("*")
         if p.is_file()
     }
     plugin_files = {
-        p.relative_to(PLUGIN_RUNTIME / "workflow")
-        for p in (PLUGIN_RUNTIME / "workflow").rglob("*")
+        p.relative_to(PLUGIN_RUNTIME / "tinyassets")
+        for p in (PLUGIN_RUNTIME / "tinyassets").rglob("*")
         if p.is_file()
     }
     diff = bundle_files.symmetric_difference(plugin_files)

--- a/tests/test_wiki_canary.py
+++ b/tests/test_wiki_canary.py
@@ -55,7 +55,7 @@ def _init_resp(sid: str = "sess-wiki") -> tuple[dict, str]:
     return (
         {"jsonrpc": "2.0", "id": 1, "result": {
             "protocolVersion": "2024-11-05",
-            "serverInfo": {"name": "workflow", "version": "1.0"},
+            "serverInfo": {"name": "tinyassets", "version": "1.0"},
             "capabilities": {},
         }},
         sid,

--- a/tinyassets/mcp_server.py
+++ b/tinyassets/mcp_server.py
@@ -30,7 +30,7 @@ from tinyassets.universe_soul import (
 )
 
 mcp = FastMCP(
-    "workflow",
+    "tinyassets",
     instructions=(
         "TinyAssets daemon interface. Use these tools to monitor "
         "and guide an autonomous workflow daemon through notes. "

--- a/tinyassets/outcomes/evaluators.py
+++ b/tinyassets/outcomes/evaluators.py
@@ -263,7 +263,7 @@ def _load_hyperparameter_backends() -> tuple[Any, Any, str]:
         return (
             None,
             None,
-            f"scikit-learn / scipy not installed ({exc}); pip install workflow[scientific]",
+            f"scikit-learn / scipy not installed ({exc}); pip install tinyassets[scientific]",
         )
     return RandomForestRegressor, spearmanr, ""
 

--- a/tinyassets/universe_server.py
+++ b/tinyassets/universe_server.py
@@ -1726,7 +1726,7 @@ engine is domain-agnostic.</p>
     → URL: this page's URL</li>
 <li><strong>ChatGPT (Apps SDK)</strong>: Connector URL: this page's URL</li>
 <li><strong>Cursor</strong>: <code>settings.json</code> →
-    <code>mcpServers</code> → <code>workflow</code> → <code>url</code></li>
+    <code>mcpServers</code> → <code>tinyassets</code> → <code>url</code></li>
 <li><strong>Cowork</strong>: Connectors → URL: this page's URL</li>
 </ul>
 


### PR DESCRIPTION
Summary:
- rename remaining MCP serverInfo/config/browser-snippet/package-test surfaces from workflow to tinyassets
- let deploy/install-tinyassets-env.sh bootstrap /etc/tinyassets/env from /etc/workflow/env when the renamed file is missing
- update current React host copy and remove the now-resolved local folder rename concern

Verification:
- python -m pytest tests/test_mcp_discovery_html.py tests/test_mcp_server.py tests/smoke/test_plan_md_exists.py tests/test_mcp_public_canary.py tests/test_mcp_tool_canary.py tests/test_last_activity_canary.py tests/test_wiki_canary.py tests/test_cf_access_cutover.py tests/test_cf_access_rollback.py tests/test_outcome_evaluators.py tests/test_install_tinyassets_env.py
- python -m pytest tests/test_packaging_build.py
- python -m pytest tests/test_deploy_prod_workflow.py tests/test_env_unreadable_marker.py
- npm ci && npm run build in WebSite/design-system
- npm ci && npm run build in WebSite/site-react

Live diagnosis:
- https://tinyassets.io/mcp is still old because deploy-prod failed before rolling out the post-rename image; latest failed runs died in Scrub stale cloud env overrides with /etc/tinyassets/env missing.