### PR TITLE
Retire legacy Workflow deploy stack

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -399,6 +399,43 @@ jobs:
           ls -la "$CLAUDE_DIR" || true
           SH
 
+      - name: Retire legacy Workflow service
+        run: |
+          ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
+              "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
+              'sudo bash -s' <<'SH'
+          set -euo pipefail
+
+          for unit in workflow-daemon.service workflow.service; do
+            if systemctl list-unit-files "$unit" --no-legend 2>/dev/null | grep -q . \
+              || systemctl list-units "$unit" --all --no-legend 2>/dev/null | grep -q .; then
+              echo "retiring legacy unit ${unit}"
+              systemctl stop "$unit" || true
+              systemctl disable "$unit" || true
+            fi
+          done
+
+          for compose_file in /opt/workflow/compose.yml /opt/workflow/deploy/compose.yml; do
+            if [ -f "$compose_file" ]; then
+              echo "bringing down legacy compose stack from ${compose_file}"
+              if [ -f /etc/workflow/env ]; then
+                docker compose --env-file /etc/workflow/env -f "$compose_file" down --timeout 30 || true
+              else
+                docker compose -f "$compose_file" down --timeout 30 || true
+              fi
+            fi
+          done
+
+          legacy_ids="$(docker ps -aq --filter 'name=^/workflow-' || true)"
+          if [ -n "$legacy_ids" ]; then
+            echo "removing legacy workflow containers: ${legacy_ids}"
+            docker rm -f $legacy_ids || true
+          fi
+          for container in workflow-daemon workflow-tunnel workflow-logs workflow-worker; do
+            docker rm -f "$container" >/dev/null 2>&1 || true
+          done
+          SH
+
       - name: Deploy new image
         id: deploy
         env:
@@ -617,7 +654,7 @@ jobs:
               echo "::error::${container} is not running after deploy; node execution fleet is not 24/7."
               ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
                   "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
-                  "sudo docker compose -f /opt/tinyassets/compose.yml ps; sudo docker logs --tail 120 ${container} 2>&1 || true"
+                  "sudo docker compose --env-file /etc/tinyassets/env -f /opt/tinyassets/compose.yml ps; sudo docker ps -a --filter name=${container}; sudo docker logs --tail 120 ${container} 2>&1 || true"
               exit 1
             fi
             if ssh -i ~/.ssh/do_deploy -o BatchMode=yes \

--- a/deploy/tinyassets-daemon.service
+++ b/deploy/tinyassets-daemon.service
@@ -46,8 +46,8 @@ ExecStartPre=/bin/sh -c 'test -r /etc/tinyassets/env || { echo "ENV-UNREADABLE: 
 
 # docker compose up runs in foreground; systemd watches the PID.
 # The image's own tini PID-1 handles SIGTERM cleanly (Row A Dockerfile).
-ExecStart=/usr/bin/docker compose -f /opt/tinyassets/compose.yml up
-ExecStop=/usr/bin/docker compose -f /opt/tinyassets/compose.yml down --timeout 30
+ExecStart=/usr/bin/docker compose --env-file /etc/tinyassets/env -f /opt/tinyassets/compose.yml up
+ExecStop=/usr/bin/docker compose --env-file /etc/tinyassets/env -f /opt/tinyassets/compose.yml down --timeout 30
 
 # Restart posture. 10s delay avoids hot-loop on persistent failure;
 # StartLimitInterval/Burst caps cascading restarts to 5 in 5 min

--- a/tests/test_deploy_prod_workflow.py
+++ b/tests/test_deploy_prod_workflow.py
@@ -349,7 +349,36 @@ def test_deploy_verifies_cloud_worker_running():
     assert "State.Running" in run_script
     assert "for i in $(seq 1 30)" in run_script
     assert "sleep 2" in run_script
+    assert "docker compose --env-file /etc/tinyassets/env" in run_script
     assert "exit 1" in run_script
+
+
+def test_deploy_retires_legacy_workflow_service_before_restart():
+    wf = _load()
+    steps = _steps(wf)
+    retire_idx = next(
+        (
+            i
+            for i, s in enumerate(steps)
+            if s.get("name") == "Retire legacy Workflow service"
+        ),
+        None,
+    )
+    deploy_idx = next(
+        (i for i, s in enumerate(steps) if s.get("name") == "Deploy new image"),
+        None,
+    )
+    assert retire_idx is not None
+    assert deploy_idx is not None
+    assert retire_idx < deploy_idx
+
+    run_script = steps[retire_idx].get("run", "") or ""
+    assert "workflow-daemon.service" in run_script
+    assert "workflow.service" in run_script
+    assert "/opt/workflow/compose.yml" in run_script
+    assert "/etc/workflow/env" in run_script
+    assert "workflow-tunnel" in run_script
+    assert "docker rm -f" in run_script
 
 
 def test_deploy_rejects_cloud_worker_workflow_universe_override():

--- a/tests/test_env_unreadable_marker.py
+++ b/tests/test_env_unreadable_marker.py
@@ -226,6 +226,12 @@ def test_systemd_unit_execstartpre_emits_canonical_marker():
     )
 
 
+def test_systemd_unit_compose_loads_tinyassets_env_for_interpolation():
+    text = _SYSTEMD_UNIT.read_text(encoding="utf-8")
+    assert "ExecStart=/usr/bin/docker compose --env-file /etc/tinyassets/env" in text
+    assert "ExecStop=/usr/bin/docker compose --env-file /etc/tinyassets/env" in text
+
+
 def test_deploy_prod_yaml_sed_sites_emit_canonical_marker():
     """Helper-mediated invariant: every env-mutation site in the YAML
     invokes ``deploy/install-tinyassets-env.sh``, and the helper itself


### PR DESCRIPTION
Summary:
- stop and disable legacy workflow systemd units before starting tinyassets-daemon
- bring down /opt/workflow compose stacks and remove workflow-* containers during deploy
- pass --env-file /etc/tinyassets/env to systemd docker compose start/stop and deploy diagnostics

Why:
- After PR #1424, deploy created /etc/tinyassets/env and started the new image, but live https://tinyassets.io/mcp still served the old Workflow page. The old Workflow stack is still behind the tunnel/port, so the hard rename needs an explicit legacy-stack retirement.

Verification:
- python -m pytest tests/test_deploy_prod_workflow.py tests/test_env_unreadable_marker.py