### PR TITLE
Hard-retire legacy Workflow deploy surfaces

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -205,11 +205,15 @@ jobs:
       # Also strip TINYASSETS_UNIVERSE: it is a stdio-shim override, and
       # leaving it in the cloud env can bind tinyassets-worker to a
       # different universe than the public MCP default.
+      # Hard rename cutover: /etc/tinyassets/env may have been bootstrapped
+      # from /etc/workflow/env on first deploy. Strip every legacy
+      # WORKFLOW_* override and workflow-named backup/log target so the
+      # container environment no longer exposes retired product surfaces.
       - name: Scrub stale cloud env overrides
         run: |
           ssh -i ~/.ssh/do_deploy -o BatchMode=yes \
               "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
-              'sudo bash -s -- delete TINYASSETS_WIKI_PATH TINYASSETS_UNIVERSE' \
+              "sudo bash -s -- delete TINYASSETS_WIKI_PATH TINYASSETS_UNIVERSE WORKFLOW_IMAGE WORKFLOW_DATA_DIR WORKFLOW_MCP_CANARY_URL WORKFLOW_ALLOW_API_KEY_PROVIDERS WORKFLOW_NODE_ENQUEUE_ENABLED WORKFLOW_SOUL_LOOP_DISPATCH WORKFLOW_BUG_INVESTIGATION_BACKFILL WORKFLOW_BUG_INVESTIGATION_BRANCH_DEF_ID WORKFLOW_BUG_INVESTIGATION_GOAL_ID WORKFLOW_CODEX_AUTH_JSON_B64 WORKFLOW_CLAUDE_CREDENTIALS_JSON_B64 WORKFLOW_GITHUB_PR_CAPABILITIES BACKUP_DEST BACKUP_GH_REPO LOG_DEST" \
               < deploy/install-tinyassets-env.sh
 
       - name: Sync runtime deploy files
@@ -329,6 +333,17 @@ jobs:
           CODEX_DIR="$VOLUME_DIR/.codex"
           CLAUDE_DIR="$VOLUME_DIR/.claude"
 
+          # OAuth registration state lives directly at /data/.auth.db.
+          # The volume root must be writable by the container's uid 1001;
+          # otherwise every public MCP initialize request fails in
+          # OptionalOAuthProvider with sqlite3 "unable to open database file".
+          chown "$TINYASSETS_UID:$TINYASSETS_GID" "$VOLUME_DIR"
+          chmod 755 "$VOLUME_DIR"
+          find "$VOLUME_DIR" -maxdepth 1 -type f \
+            \( -name '.auth.db' -o -name '.auth.db-*' \) \
+            -exec chown "$TINYASSETS_UID:$TINYASSETS_GID" {} + \
+            -exec chmod 600 {} + || true
+
           # Create the directory if missing. mkdir -p is itself a no-op
           # when the path already exists.
           if [ ! -d "$CODEX_DIR" ]; then
@@ -406,12 +421,27 @@ jobs:
               'sudo bash -s' <<'SH'
           set -euo pipefail
 
-          for unit in workflow-daemon.service workflow.service; do
+          legacy_units=(
+            workflow-daemon.service
+            workflow.service
+            workflow-watchdog.timer
+            workflow-watchdog.service
+            workflow-backup.timer
+            workflow-backup.service
+            workflow-disk-watch.timer
+            workflow-disk-watch.service
+            workflow-prune.timer
+            workflow-prune.service
+            workflow-ship-logs.timer
+            workflow-ship-logs.service
+          )
+
+          for unit in "${legacy_units[@]}"; do
             if systemctl list-unit-files "$unit" --no-legend 2>/dev/null | grep -q . \
               || systemctl list-units "$unit" --all --no-legend 2>/dev/null | grep -q .; then
               echo "retiring legacy unit ${unit}"
+              systemctl disable --now "$unit" || true
               systemctl stop "$unit" || true
-              systemctl disable "$unit" || true
             fi
           done
 
@@ -426,14 +456,31 @@ jobs:
             fi
           done
 
-          legacy_ids="$(docker ps -aq --filter 'name=^/workflow-' || true)"
+          legacy_ids="$(docker ps -aq --filter 'name=^/workflow' || true)"
           if [ -n "$legacy_ids" ]; then
             echo "removing legacy workflow containers: ${legacy_ids}"
             docker rm -f $legacy_ids || true
           fi
-          for container in workflow-daemon workflow-tunnel workflow-logs workflow-worker; do
+          for container in \
+            workflow-daemon \
+            workflow-tunnel \
+            workflow-logs \
+            workflow-worker \
+            workflow-worker-codex-2 \
+            workflow-worker-claude-1 \
+            workflow-worker-claude-2; do
             docker rm -f "$container" >/dev/null 2>&1 || true
           done
+
+          for unit_file in /etc/systemd/system/workflow*.service /etc/systemd/system/workflow*.timer; do
+            if [ -e "$unit_file" ] || [ -L "$unit_file" ]; then
+              echo "removing legacy unit file ${unit_file}"
+              rm -f "$unit_file"
+            fi
+          done
+          systemctl daemon-reload
+          systemctl reset-failed "${legacy_units[@]}" || true
+          systemctl mask workflow-daemon.service workflow.service workflow-watchdog.timer || true
           SH
 
       - name: Deploy new image

--- a/.github/workflows/p0-outage-triage.yml
+++ b/.github/workflows/p0-outage-triage.yml
@@ -85,9 +85,11 @@ jobs:
               "${DO_SSH_USER}@${DO_DROPLET_HOST}" \
               "docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' 2>&1; \
                echo '---'; \
-               docker compose -f /opt/tinyassets/compose.yml ps 2>&1 | head -20; \
+               docker compose --env-file /etc/tinyassets/env -f /opt/tinyassets/compose.yml ps 2>&1 | head -30; \
                echo '--- journalctl tinyassets-daemon ---'; \
                journalctl -u tinyassets-daemon --no-pager -n 80 2>&1 || true; \
+               echo '--- tinyassets-daemon logs ---'; \
+               docker logs tinyassets-daemon --tail 120 2>&1 || true; \
                echo '--- df -h ---'; \
                df -h 2>&1 || true; \
                echo '--- systemctl status tinyassets-daemon ---'; \

--- a/deploy/tinyassets-daemon.service
+++ b/deploy/tinyassets-daemon.service
@@ -27,6 +27,8 @@ Documentation=https://github.com/Jonnyton/TinyAssets/blob/main/deploy/HETZNER-DE
 Requires=docker.service
 After=docker.service network-online.target
 Wants=network-online.target
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -54,8 +56,6 @@ ExecStop=/usr/bin/docker compose --env-file /etc/tinyassets/env -f /opt/tinyasse
 # (after which systemd refuses further restarts until manual reset).
 Restart=always
 RestartSec=10s
-StartLimitIntervalSec=300
-StartLimitBurst=5
 
 # TimeoutStopSec > the cloudflared + daemon graceful-shutdown budgets.
 TimeoutStopSec=60s

--- a/tests/test_deploy_prod_workflow.py
+++ b/tests/test_deploy_prod_workflow.py
@@ -330,6 +330,29 @@ def test_deploy_scrubs_stdio_only_workflow_universe_from_cloud_env():
     assert "delete TINYASSETS_WIKI_PATH TINYASSETS_UNIVERSE" in run_script
 
 
+def test_deploy_scrubs_legacy_workflow_env_from_cloud_env():
+    wf = _load()
+    scrub_step = next(
+        (s for s in _steps(wf) if s.get("name") == "Scrub stale cloud env overrides"),
+        None,
+    )
+    assert scrub_step is not None
+    run_script = scrub_step.get("run", "") or ""
+
+    for key in (
+        "WORKFLOW_IMAGE",
+        "WORKFLOW_DATA_DIR",
+        "WORKFLOW_MCP_CANARY_URL",
+        "WORKFLOW_CODEX_AUTH_JSON_B64",
+        "WORKFLOW_CLAUDE_CREDENTIALS_JSON_B64",
+        "WORKFLOW_GITHUB_PR_CAPABILITIES",
+        "BACKUP_DEST",
+        "BACKUP_GH_REPO",
+        "LOG_DEST",
+    ):
+        assert key in run_script
+
+
 def test_deploy_verifies_cloud_worker_running():
     wf = _load()
     worker_step = next(
@@ -375,10 +398,19 @@ def test_deploy_retires_legacy_workflow_service_before_restart():
     run_script = steps[retire_idx].get("run", "") or ""
     assert "workflow-daemon.service" in run_script
     assert "workflow.service" in run_script
+    assert "workflow-watchdog.timer" in run_script
+    assert "workflow-backup.timer" in run_script
+    assert "workflow-ship-logs.timer" in run_script
+    assert "systemctl disable --now" in run_script
     assert "/opt/workflow/compose.yml" in run_script
     assert "/etc/workflow/env" in run_script
     assert "workflow-tunnel" in run_script
+    assert "workflow-worker-codex-2" in run_script
+    assert "workflow-worker-claude-1" in run_script
+    assert "workflow-worker-claude-2" in run_script
     assert "docker rm -f" in run_script
+    assert "rm -f \"$unit_file\"" in run_script
+    assert "systemctl mask workflow-daemon.service" in run_script
 
 
 def test_deploy_rejects_cloud_worker_workflow_universe_override():
@@ -601,6 +633,17 @@ def test_codex_volume_step_creates_dir_idempotently():
         "dir-create branch must be guarded by an existence check so the "
         "create-log line is skipped when the dir already exists"
     )
+
+
+def test_codex_volume_step_repairs_volume_root_for_auth_db():
+    wf = _load()
+    step = _codex_volume_step(wf)
+    run_script = step.get("run", "") or ""
+
+    assert 'chown "$TINYASSETS_UID:$TINYASSETS_GID" "$VOLUME_DIR"' in run_script
+    assert 'chmod 755 "$VOLUME_DIR"' in run_script
+    assert ".auth.db" in run_script
+    assert "unable to open database file" in run_script
 
 
 def test_codex_volume_step_migrates_from_running_container_once():

--- a/tests/test_env_unreadable_marker.py
+++ b/tests/test_env_unreadable_marker.py
@@ -232,6 +232,17 @@ def test_systemd_unit_compose_loads_tinyassets_env_for_interpolation():
     assert "ExecStop=/usr/bin/docker compose --env-file /etc/tinyassets/env" in text
 
 
+def test_systemd_start_limit_is_in_unit_section_not_service_section():
+    text = _SYSTEMD_UNIT.read_text(encoding="utf-8")
+    unit_section = text.split("[Service]", 1)[0]
+    service_section = text.split("[Service]", 1)[1].split("[Install]", 1)[0]
+
+    assert "StartLimitIntervalSec=300" in unit_section
+    assert "StartLimitBurst=5" in unit_section
+    assert "StartLimitIntervalSec" not in service_section
+    assert "StartLimitBurst" not in service_section
+
+
 def test_deploy_prod_yaml_sed_sites_emit_canonical_marker():
     """Helper-mediated invariant: every env-mutation site in the YAML
     invokes ``deploy/install-tinyassets-env.sh``, and the helper itself

--- a/tests/test_p0_triage_workflow.py
+++ b/tests/test_p0_triage_workflow.py
@@ -132,6 +132,12 @@ def test_restart_uses_env_file():
     assert "--env-file /etc/tinyassets/env" in _text()
 
 
+def test_p0_diag_uses_env_file_and_daemon_logs():
+    text = _text()
+    assert "docker compose --env-file /etc/tinyassets/env" in text
+    assert "docker logs tinyassets-daemon --tail 120" in text
+
+
 def test_triage_uses_live_systemd_compose_file():
     text = _text()
     assert "/opt/tinyassets/compose.yml" in text


### PR DESCRIPTION
## Summary
- hard-retire legacy Workflow systemd timers/services and all workflow-* containers during prod deploy
- scrub legacy WORKFLOW_* and workflow-named backup/log env keys from /etc/tinyassets/env after bootstrap
- repair tinyassets-data volume root ownership so /data/.auth.db is writable by the container uid
- add P0 diagnostics for tinyassets-daemon logs and move systemd start-limit settings into [Unit]

## Validation
- python -m pytest tests/test_deploy_prod_workflow.py tests/test_p0_triage_workflow.py tests/test_env_unreadable_marker.py
- python scripts/mcp_public_canary.py --url https://tinyassets.io/mcp --timeout 15 --verbose
- live host: tinyassets-daemon and all tinyassets workers healthy; no running workflow-* containers; no WORKFLOW_* env keys in tinyassets-daemon