### PR TITLE
Remove legacy Workflow framing from TinyAssets site

### DIFF
--- a/WebSite/site-react/app/_components/HomeClient.tsx
+++ b/WebSite/site-react/app/_components/HomeClient.tsx
@@ -212,8 +212,8 @@ export default function HomeClient() {
               you'd paste into your chatbot.
             </p>
             <p className="cover__naming">
-              Formally: <strong>Tiny</strong> is the public face of{" "}
-              <strong>TinyAssets</strong>, an open-source engine.
+              Formally: <strong>TinyAssets</strong> is the platform.{" "}
+              <strong>Tiny</strong> is the personified intelligence users and builders meet through it.
             </p>
             <div className="cover__actions">
               <a className="btn btn--primary" href="/start">Put me to work →</a>

--- a/WebSite/site-react/app/host/_components/HostClient.tsx
+++ b/WebSite/site-react/app/host/_components/HostClient.tsx
@@ -149,9 +149,8 @@ export default function HostClient() {
             <a className="btn btn--ghost" href="#run-it">Run it yourself ↓</a>
           </div>
           <p className="cover__naming">
-            <strong>Tiny</strong> is the public face of <strong>TinyAssets</strong>,
-            an open-source engine. Same code whether it runs on the public box or on
-            yours.
+            <strong>TinyAssets</strong> is the platform. <strong>Tiny</strong> is the
+            acting intelligence on the public box; the same code can run on yours.
           </p>
         </div>
       </section>

--- a/WebSite/site-react/app/layout.tsx
+++ b/WebSite/site-react/app/layout.tsx
@@ -10,13 +10,13 @@ import TinyBot from "../components/TinyBot";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://tinyassets.io"),
-  title: "Tiny — a small living engine that turns chat into finished work",
+  title: "TinyAssets — meet Tiny, the engine that turns chat into finished work",
   description:
-    "Tiny is the public face of TinyAssets — an open-source engine you connect to your chatbot over MCP. Name a goal and it runs real multi-step work, with evidence-gated outcomes and a loop that patches the engine itself.",
+    "TinyAssets is the open-source platform you connect to your chatbot over MCP. Tiny is the acting intelligence inside it: name a goal and he runs real multi-step work, with evidence-gated outcomes and a loop that patches the engine itself.",
   openGraph: {
-    siteName: "Tiny",
+    siteName: "TinyAssets",
     type: "website",
-    title: "Tiny — a small living engine that turns chat into finished work",
+    title: "TinyAssets — meet Tiny, the engine that turns chat into finished work",
     description:
       "Connect your chatbot to one URL. Name a goal. Tiny runs the real, multi-step work — and shows you live, verifiable evidence instead of marketing claims.",
     images: ["/og-image.png"],
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Tiny — the engine that shows its work",
+    title: "TinyAssets — the engine that shows its work",
     description:
       "Live, verifiable state on every page: the same MCP endpoint you paste into your chatbot renders this site's numbers.",
     images: ["/og-image.png"],
@@ -47,10 +47,10 @@ const jsonLd = {
       "@type": "WebSite",
       "@id": "https://tinyassets.io/#site",
       url: "https://tinyassets.io/",
-      name: "Tiny",
-      alternateName: "TinyAssets",
+      name: "TinyAssets",
+      alternateName: "Tiny",
       description:
-        "Tiny is the public face of TinyAssets — an open-source engine you connect to your chatbot over MCP.",
+        "TinyAssets is the open-source platform behind Tiny, the personified intelligence users meet through MCP.",
       publisher: { "@id": "https://tinyassets.io/#org" },
     },
   ],

--- a/WebSite/site-react/app/page.tsx
+++ b/WebSite/site-react/app/page.tsx
@@ -5,9 +5,9 @@ import type { Metadata } from "next";
 import HomeClient from "./_components/HomeClient";
 
 export const metadata: Metadata = {
-  title: "Tiny — a small living engine that turns chat into finished work",
+  title: "TinyAssets — meet Tiny, the engine that turns chat into finished work",
   description:
-    "Tiny is the public face of TinyAssets, an open-source engine. Connect your chatbot to one URL, name a goal, and it runs real multi-step work — with live vital signs, evidence-gated outcome ladders, and a self-patching loop you can watch.",
+    "TinyAssets is the open-source platform behind Tiny, the personified intelligence users meet through MCP. Connect your chatbot to one URL, name a goal, and Tiny runs real multi-step work — with live vital signs, evidence-gated outcome ladders, and a self-patching loop you can watch.",
 };
 
 export default function Page() {

--- a/WebSite/site-react/app/start/_components/StartClient.tsx
+++ b/WebSite/site-react/app/start/_components/StartClient.tsx
@@ -297,8 +297,8 @@ export default function StartClient() {
           <p className="eyebrow">entry four · other ways in</p>
           <h2 id="oss-title">Or run the engine yourself.</h2>
           <p className="oss__lede">
-            Tiny is the public face of <strong>TinyAssets</strong>, an open-source
-            engine. You don&apos;t need to host anything to use the connector above — but
+            <strong>TinyAssets</strong> is the open-source platform behind Tiny.
+            You don&apos;t need to host anything to use the connector above — but
             if you&apos;d rather run it locally or read the code, both paths are real.
           </p>
           <div className="oss">

--- a/WebSite/site-react/components/Footer.tsx
+++ b/WebSite/site-react/components/Footer.tsx
@@ -13,9 +13,9 @@ export function Footer() {
         <div className={styles.brand}>
           <TinyAssetsMark size={22} />
           <p className={styles.namingText}>
-            <strong>Tiny</strong> is the public face of <strong>TinyAssets</strong> — an open-source
-            engine that runs real multi-step work for any goal. He lives at{" "}
-            <span className="ev">tinyassets.io</span>; his code lives on{" "}
+            <strong>TinyAssets</strong> is the platform. <strong>Tiny</strong> is the
+            acting intelligence users and builders meet through it. He lives at{" "}
+            <span className="ev">tinyassets.io</span>; the code lives on{" "}
             <a href="https://github.com/Jonnyton/TinyAssets" target="_blank" rel="noreferrer">GitHub</a>.
           </p>
         </div>

--- a/tests/test_website_rename_surfaces.py
+++ b/tests/test_website_rename_surfaces.py
@@ -1,0 +1,71 @@
+"""Guards for public website TinyAssets/Tiny rename surfaces."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PUBLIC_SITE_PATHS = [
+    ROOT / "WebSite" / "site-react" / "app",
+    ROOT / "WebSite" / "site-react" / "components",
+    ROOT / "WebSite" / "site-react" / "lib",
+    ROOT / "WebSite" / "site-react" / "public",
+    ROOT / "WebSite" / "site" / "src",
+    ROOT / "WebSite" / "site" / "static",
+]
+
+TEXT_SUFFIXES = {
+    ".css",
+    ".html",
+    ".js",
+    ".json",
+    ".md",
+    ".mjs",
+    ".svelte",
+    ".svg",
+    ".ts",
+    ".tsx",
+    ".txt",
+}
+
+RETIRED_PUBLIC_STRINGS = {
+    "https://github.com/Jonnyton/Workflow": "legacy GitHub repository URL",
+    "github.com/Jonnyton/Workflow": "legacy GitHub repository path",
+    "Jonnyton/Workflow": "legacy GitHub repository slug",
+    "Workflow on GitHub": "legacy GitHub link label",
+    "public face of Workflow": "legacy two-name positioning",
+    "public face of TinyAssets": "two-name transitional positioning",
+    "Tiny is the public face of": "two-name transitional positioning",
+    "one body, two names": "two-name transitional positioning",
+    "Same thing, one body": "two-name transitional positioning",
+    "/workflow-mark.png": "legacy public asset URL",
+    "workflow-mark": "legacy public asset/class name",
+    '"name":"Workflow"': "legacy JSON-LD site/org name",
+    '"alternateName":"Workflow"': "legacy JSON-LD alternate name",
+    'name: "Workflow"': "legacy site/org name",
+    'alternateName: "Workflow"': "legacy alternate name",
+}
+
+
+def _site_text_files() -> list[Path]:
+    files: list[Path] = []
+    for base in PUBLIC_SITE_PATHS:
+        for path in base.rglob("*"):
+            if path.is_file() and path.suffix.lower() in TEXT_SUFFIXES:
+                files.append(path)
+    return files
+
+
+def test_public_website_has_no_retired_workflow_branding():
+    failures: list[str] = []
+
+    for path in _site_text_files():
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        rel = path.relative_to(ROOT)
+        for needle, reason in RETIRED_PUBLIC_STRINGS.items():
+            if needle in text:
+                failures.append(f"{rel}: {reason}: {needle!r}")
+
+    assert not failures, "Retired Workflow public branding found:\n" + "\n".join(failures)


### PR DESCRIPTION
## Summary
- remove the remaining Tiny-as-public-face transitional framing from the active React site
- make TinyAssets the site/platform/GitHub identity and Tiny the acting/personified intelligence users meet
- add a website-source guard that fails on old Workflow repo links, old asset names, and two-name transitional copy

## Validation
- python -m pytest tests\test_website_rename_surfaces.py tests\test_mcp_discovery_html.py
- npm run build (WebSite/design-system)
- npm run build (WebSite/site-react)