### PR TITLE
Rename prototype Workflow residues to TinyAssets

### DIFF
--- a/prototype/full-platform-v0/.env.example
+++ b/prototype/full-platform-v0/.env.example
@@ -3,7 +3,7 @@
 
 # --- Treasury wallet (testnet phase) -----------------------------------
 # Path to the base-sepolia-treasury-v0.txt seed file. Default (unset):
-# ~/.workflow-secrets/base-sepolia-treasury-v0.txt
+# ~/.tinyassets-secrets/base-sepolia-treasury-v0.txt
 #
 # Testnet-phase posture: file lives outside the project folder; no vault
 # needed this iteration. At real-currency phase, this flips to multisig +
@@ -12,6 +12,6 @@
 # TINYASSETS_TREASURY_KEY_PATH=/path/to/your/secrets/base-sepolia-treasury-v0.txt
 
 # --- Postgres DSN ------------------------------------------------------
-# Default (unset): postgresql://workflow:workflow_v0_dev@localhost:5433/workflow_v0
+# Default (unset): postgresql://tinyassets:tinyassets_v0_dev@localhost:5433/tinyassets_v0
 # Docker Compose overrides to the container hostname automatically.
-# TINYASSETS_V0_DSN=postgresql://workflow:workflow_v0_dev@localhost:5433/workflow_v0
+# TINYASSETS_V0_DSN=postgresql://tinyassets:tinyassets_v0_dev@localhost:5433/tinyassets_v0

--- a/prototype/full-platform-v0/Dockerfile
+++ b/prototype/full-platform-v0/Dockerfile
@@ -1,7 +1,7 @@
 # TinyAssets gateway (prototype v0) — FastMCP-over-HTTP on top of the
 # shared Postgres + pgvector migrations in this prototype.
 #
-# Build:   docker build -t workflow-v0-gateway .
+# Build:   docker build -t tinyassets-v0-gateway .
 # Run:     docker compose up -d  (picks this up via docker-compose.yml)
 #
 # Throwaway prototype container; real track-C build pulls from a proper
@@ -24,7 +24,7 @@ COPY gateway.py ./
 
 # Default DSN — compose overrides via env for container-to-container
 # routing (postgres hostname resolves inside the compose network).
-ENV TINYASSETS_V0_DSN="postgresql://workflow:workflow_v0_dev@postgres:5432/workflow_v0"
+ENV TINYASSETS_V0_DSN="postgresql://tinyassets:tinyassets_v0_dev@postgres:5432/tinyassets_v0"
 
 # FastMCP stdio is the default transport; for HTTP / streamable, real
 # track C uses `mcp.run(transport='streamable-http')`. v0 defaults to

--- a/prototype/full-platform-v0/README.md
+++ b/prototype/full-platform-v0/README.md
@@ -91,7 +91,7 @@ and if the daemon is running
 Scaffolding is complete + ruff-clean + ready to run. **When Docker Desktop is running**, the full 5-file test suite should exercise end-to-end:
 
 1. `docker compose up -d`
-2. `docker exec -i workflow_v0_postgres psql -U workflow -d workflow_v0 < migrations/001_core_tables.sql` (repeat for 002, 003)
+2. `docker exec -i tinyassets_v0_postgres psql -U tinyassets -d tinyassets_v0 < migrations/001_core_tables.sql` (repeat for 002, 003)
 3. `pytest tests/ -v`
 
 Tests expected green when DB is live: 10 tests across 5 files (schema×3, rls×3, discover×2, cas×2 — test_gateway has 2). Any failure = spec discrepancy worth flagging.

--- a/prototype/full-platform-v0/config.py
+++ b/prototype/full-platform-v0/config.py
@@ -20,7 +20,7 @@ def treasury_key_path() -> Path:
 
     Precedence:
         1. TINYASSETS_TREASURY_KEY_PATH env var (explicit override).
-        2. ~/.workflow-secrets/base-sepolia-treasury-v0.txt (default).
+        2. ~/.tinyassets-secrets/base-sepolia-treasury-v0.txt (default).
 
     The file itself is gitignored + lives outside the project folder.
     This function only returns the path; callers are responsible for
@@ -29,7 +29,7 @@ def treasury_key_path() -> Path:
     env = os.environ.get("TINYASSETS_TREASURY_KEY_PATH")
     if env:
         return Path(env).expanduser()
-    return Path.home() / ".workflow-secrets" / "base-sepolia-treasury-v0.txt"
+    return Path.home() / ".tinyassets-secrets" / "base-sepolia-treasury-v0.txt"
 
 
 def treasury_key_exists() -> bool:

--- a/prototype/full-platform-v0/docker-compose.yml
+++ b/prototype/full-platform-v0/docker-compose.yml
@@ -1,11 +1,11 @@
 services:
   postgres:
     image: pgvector/pgvector:pg15
-    container_name: workflow_v0_postgres
+    container_name: tinyassets_v0_postgres
     environment:
-      POSTGRES_USER: workflow
-      POSTGRES_PASSWORD: workflow_v0_dev
-      POSTGRES_DB: workflow_v0
+      POSTGRES_USER: tinyassets
+      POSTGRES_PASSWORD: tinyassets_v0_dev
+      POSTGRES_DB: tinyassets_v0
     ports:
       - "5433:5432"
     volumes:
@@ -15,7 +15,7 @@ services:
       # if pgdata volume is empty — subsequent restarts preserve state.
       - ./migrations:/docker-entrypoint-initdb.d:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U workflow -d workflow_v0"]
+      test: ["CMD-SHELL", "pg_isready -U tinyassets -d tinyassets_v0"]
       interval: 2s
       timeout: 2s
       retries: 15
@@ -24,12 +24,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: workflow_v0_gateway
+    container_name: tinyassets_v0_gateway
     depends_on:
       postgres:
         condition: service_healthy
     environment:
-      TINYASSETS_V0_DSN: "postgresql://workflow:workflow_v0_dev@postgres:5432/workflow_v0"
+      TINYASSETS_V0_DSN: "postgresql://tinyassets:tinyassets_v0_dev@postgres:5432/tinyassets_v0"
     # Run gateway in HTTP transport mode for in-container debugging.
     command: >
       python -c "from gateway import mcp; mcp.run(transport='streamable-http', host='0.0.0.0', port=8002)"

--- a/prototype/full-platform-v0/gateway.py
+++ b/prototype/full-platform-v0/gateway.py
@@ -23,11 +23,11 @@ from pgvector.psycopg import register_vector
 
 DSN = os.environ.get(
     "TINYASSETS_V0_DSN",
-    "postgresql://workflow:workflow_v0_dev@localhost:5433/workflow_v0",
+    "postgresql://tinyassets:tinyassets_v0_dev@localhost:5433/tinyassets_v0",
 )
 
 mcp = FastMCP(
-    "workflow-v0",
+    "tinyassets-v0",
     instructions=(
         "Prototype FastMCP gateway proving #25 schema + #27 gateway compose. "
         "Not for production. Bearer token is the user_id uuid directly; "

--- a/prototype/full-platform-v0/migrations/001_core_tables.sql
+++ b/prototype/full-platform-v0/migrations/001_core_tables.sql
@@ -157,7 +157,7 @@ CREATE TABLE IF NOT EXISTS public.ledger (
   entry_kind       text NOT NULL CHECK (entry_kind IN (
                      'reserve','release','debit','credit','refund','bonus','adjustment')),
   amount           numeric(18,6) NOT NULL,
-  currency         text NOT NULL DEFAULT 'workflow_credit',
+  currency         text NOT NULL DEFAULT 'tinyassets_credit',
   settlement_mode  text NOT NULL DEFAULT 'immediate'
                      CHECK (settlement_mode IN ('immediate','batched')),
   related_request  uuid NULL REFERENCES public.requests(request_id),
@@ -180,7 +180,7 @@ CREATE TABLE IF NOT EXISTS public.settlements (
   gross_amount     numeric(18,6) NOT NULL,
   platform_fee     numeric(18,6) NOT NULL DEFAULT 0,
   net_amount       numeric(18,6) NOT NULL,
-  currency         text NOT NULL DEFAULT 'workflow_credit',
+  currency         text NOT NULL DEFAULT 'tinyassets_credit',
   mode             text NOT NULL CHECK (mode IN ('immediate','batched')),
   debit_entry_id   bigint NOT NULL REFERENCES public.ledger(entry_id),
   credit_entry_id  bigint NOT NULL REFERENCES public.ledger(entry_id),

--- a/prototype/full-platform-v0/tests/conftest.py
+++ b/prototype/full-platform-v0/tests/conftest.py
@@ -29,7 +29,7 @@ except ImportError:  # live-Postgres deps optional — tests skip if absent
 
 DSN = os.environ.get(
     "TINYASSETS_V0_DSN",
-    "postgresql://workflow:workflow_v0_dev@localhost:5433/workflow_v0",
+    "postgresql://tinyassets:tinyassets_v0_dev@localhost:5433/tinyassets_v0",
 )
 
 

--- a/prototype/full-platform-v0/tests/test_track_a.py
+++ b/prototype/full-platform-v0/tests/test_track_a.py
@@ -37,7 +37,7 @@ except ImportError:
 
 DSN = os.environ.get(
     "TINYASSETS_V0_DSN",
-    "postgresql://workflow:workflow_v0_dev@localhost:5433/workflow_v0",
+    "postgresql://tinyassets:tinyassets_v0_dev@localhost:5433/tinyassets_v0",
 )
 
 

--- a/prototype/full-platform-v0/treasury_config.toml
+++ b/prototype/full-platform-v0/treasury_config.toml
@@ -17,12 +17,12 @@ network_type             = "testnet"
 fee_bps                  = 100       # 1% (per project_monetization_crypto_1pct memory)
 settlement_threshold_usd = 1.00      # Per-bid on-chain above, batched below (per project_q10_q11_q12_resolutions Q4-follow-up)
 batch_cadence_hours      = 168       # Weekly
-label                    = "workflow-testnet-treasury-v0"
+label                    = "tinyassets-testnet-treasury-v0"
 created                  = "2026-04-19"
 is_active                = true
 
 # Seed storage location (references only — never values):
-#   Default: ~/.workflow-secrets/base-sepolia-treasury-v0.txt (outside
+#   Default: ~/.tinyassets-secrets/base-sepolia-treasury-v0.txt (outside
 #            the project folder; gitignored by `.secrets/` + `*.seed`
 #            patterns, but stored at a home-dir path to avoid accidental
 #            project-folder backup / rm-rf loss).

--- a/tests/test_hard_rename_surfaces.py
+++ b/tests/test_hard_rename_surfaces.py
@@ -1,0 +1,98 @@
+"""Hard-rename guards for active source/config surfaces.
+
+Historical docs and tests can mention the retired name as evidence or denylist
+fixtures. Active code, config, packaging, and website sources should not.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+SKIP_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".next",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "dist",
+    "docs",
+    "node_modules",
+    "out",
+    "tests",
+    "venv",
+}
+
+TEXT_SUFFIXES = {
+    "",
+    ".cfg",
+    ".css",
+    ".env",
+    ".example",
+    ".html",
+    ".ini",
+    ".js",
+    ".json",
+    ".md",
+    ".mjs",
+    ".py",
+    ".sql",
+    ".svelte",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".yml",
+    ".yaml",
+}
+
+RETIRED_STRINGS = {
+    "https://github.com/Jonnyton/Workflow": "legacy GitHub repository URL",
+    "github.com/Jonnyton/Workflow": "legacy GitHub repository path",
+    "Jonnyton/Workflow": "legacy GitHub repository slug",
+    "Workflow MCP Server": "legacy MCP server label",
+    "Workflow on GitHub": "legacy GitHub link label",
+    "public face of Workflow": "legacy two-name positioning",
+    "public face of TinyAssets": "two-name transitional positioning",
+    "Tiny is the public face of": "two-name transitional positioning",
+    "workflow-mark": "legacy public asset/class name",
+    "workflow_v0": "legacy prototype resource name",
+    "workflow-v0": "legacy prototype resource name",
+    "workflow_credit": "legacy prototype currency label",
+    "workflow-testnet": "legacy prototype treasury label",
+    "postgresql://workflow": "legacy prototype DSN",
+    ".workflow-secrets": "legacy local secret path",
+    '"name":"workflow"': "legacy JSON server name",
+    'name = "workflow"': "legacy config server name",
+    'name: "workflow"': "legacy config server name",
+}
+
+
+def _active_text_files() -> list[Path]:
+    files: list[Path] = []
+    for path in ROOT.rglob("*"):
+        if any(part in SKIP_DIRS for part in path.relative_to(ROOT).parts):
+            continue
+        if path.is_file() and path.suffix.lower() in TEXT_SUFFIXES:
+            files.append(path)
+    return files
+
+
+def test_active_surfaces_have_no_high_confidence_retired_workflow_names():
+    failures: list[str] = []
+
+    for path in _active_text_files():
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        rel = path.relative_to(ROOT)
+        for needle, reason in RETIRED_STRINGS.items():
+            if needle in text:
+                failures.append(f"{rel}: {reason}: {needle!r}")
+
+    assert not failures, (
+        "Retired Workflow names found in active source/config surfaces:\n"
+        + "\n".join(failures)
+    )


### PR DESCRIPTION
## Summary
- rename full-platform prototype resources from Workflow/workflow_v0 to TinyAssets/tinyassets_v0
- update prototype DSNs, Docker container names, FastMCP server label, treasury secret path, and prototype currency default
- add a repo-wide active-surface guard for high-confidence retired Workflow strings outside docs/tests

## Validation
- python -m pytest tests\test_hard_rename_surfaces.py tests\test_website_rename_surfaces.py tests\test_mcp_discovery_html.py
- python -m py_compile prototype\full-platform-v0\config.py prototype\full-platform-v0\gateway.py
- targeted rg sweep for retired high-confidence strings outside docs/tests

## Note
- The full prototype test suite requires its pinned prototype dependency set and a live Docker/Postgres instance; this pass verified syntax plus the rename guards without changing global dependencies.