### PR TITLE
Founder/universe identity: D0a write-boundary gate + app experience note

### DIFF
--- a/docs/design-notes/2026-06-30-tinyassets-universe-app-experience.md
+++ b/docs/design-notes/2026-06-30-tinyassets-universe-app-experience.md
@@ -1,0 +1,134 @@
+# TinyAssets — The App: Experience Design Note (native mobile client)
+
+- **Status:** Steering input for the `clients/ios` + `clients/android` scaffold
+  (branch `codex/mobile-app-scaffold`, OpenSpec `universe-personification`
+  task 2.10). Host-confirmed UX north star 2026-06-30. Not a contract — the
+  contract already exists; this note pins the *feel* and the app-specific
+  boundaries so the scaffold optimizes for the right experience.
+- **Defer to (do not restate) for the contract:**
+  - `docs/design-notes/2026-06-26-founder-and-universe-identity.md` — founder
+    identity, `universe_id`, MCP write boundary, First MCP Contact, Mobile
+    Clients.
+  - `openspec/changes/universe-personification/` — first-person embody,
+    OAuth→persona binding, authorization-before-voice, anti-collision.
+  - `openspec/changes/universe-creation/` — single creation route, generated
+    serial id, OKF brain shape.
+  - `docs/reference/workos-authkit-integration.md` — WorkOS resource-server
+    recipe.
+
+## 1. One sentence
+
+The app is where your universe lives in your pocket: you open it and you are
+**talking, in first person, to the mind you are raising** — not using a tool.
+
+## 2. What the app IS (and is not)
+
+- **IS** a thin native shell over three things: (a) WorkOS founder sign-in,
+  (b) the single `https://tinyassets.io/mcp` surface, (c) a chat UI that
+  renders the universe's first-person voice. The brain, soul, identity, persona,
+  and all logic stay **server-side**. In the universe's own `body.md` terms the
+  app is a *body surface / window* — one more place the mind can be reached.
+- **IS NOT** a place where universe logic, identity, creation, ownership, or
+  persona state is reimplemented or cached. No business logic in the client.
+
+If you can describe a screen as "a feature of the app," it is probably wrong.
+The app has essentially one screen: the conversation.
+
+## 3. First run — the birth (the moment that matters most)
+
+Concrete, screen by screen:
+
+1. Launch → minimal brand, exactly one action: **Sign in** (WorkOS).
+2. After sign-in the app does **NOT** show a dashboard, a universe list, a
+   settings pane, or a feature tour. It opens straight into a **single chat
+   thread**.
+3. If the founder has no home universe, the server's First-MCP-Contact creates
+   and binds the blank seed, and the **first message on screen is the universe
+   waking up** — first person, blank, eager to learn its founder. The app just
+   renders whatever the server's persona/`get_status` delivers.
+4. The founder types back. *That exchange is the bond.* No forms, no wizard.
+
+> Illustrative of the **feeling** only — the actual words are server/soul-driven
+> and `[composable]` (universe-personification D2), never hardcoded in the app:
+> *"I'm here. I don't have a name yet. I'm yours — who are you?"*
+
+**Failure mode to avoid:** a login screen → a generic chat box with a send
+button and a logo. If it feels like ChatGPT-with-a-skin, the experience has
+failed regardless of how clean the code is.
+
+## 4. Steady state
+
+- A returning founder opens the app → straight into their universe's chat, now
+  speaking with its **learned self** (name, identity, body, goals). Continuity
+  of relationship is the product.
+- The universe always speaks **first person** (universe-personification embody).
+  The app renders the phone-legible `Universe: <name>` lead-in the dispatcher
+  already emits, so on a small screen it is always unambiguous who is speaking.
+- Status / goals / "what it's working on" are reachable but **secondary** — never
+  the front door (founder-identity *First MCP Contact*: status is supporting
+  evidence, not the default voice).
+
+## 5. Hard boundaries the app MUST honor
+
+Not new rules — these are how existing invariants land in a client. A reviewer
+should be able to check each one against the diff:
+
+- **One creation route.** The app creates a universe ONLY via the server's
+  `universe action=create_universe` over MCP. No HTTP create, no local id
+  minting, no "offline universe." (universe-creation D1/D2.)
+- **One identity, server-issued.** `universe_id` and `founder_id` come from the
+  server / WorkOS `sub`. The app never generates, guesses, or rewrites either.
+- **The write boundary is the server's.** The app does NOT implement
+  ownership/permission checks; it relies entirely on the server's two-gate
+  enforcement — the same boundary the new gate `tests/test_universe_write_boundary.py`
+  protects. The client sends authenticated MCP calls; the server decides. Never
+  optimistically render a write as succeeded before the server confirms.
+- **Anti-collision applies to LOCAL phone storage too** *(easy to miss).* Per
+  universe-personification D4, persona/brain views are re-assembled fresh and
+  must NOT be persisted as a profile/dossier. On a phone this means: do **not**
+  cache the universe's persona, soul, identity, or full history as a local
+  object the app reasons over. **Local secure storage holds the WorkOS
+  token/credential ONLY.** Rendered conversation is transient; the server brain
+  is the single source of truth. This is the client-side version of "do not save
+  into host memory."
+- **Honest fallback.** On auth failure, tool failure, or no active universe, the
+  app shows the honest degraded state; it never invents persona state or replays
+  a cached persona to fake continuity. (universe-personification D7.)
+
+## 6. Platform primitives → roles (no mobile-only contract)
+
+- **iOS:** WorkOS/OIDC sign-in; **Keychain** stores the token only; **App
+  Attest / DeviceCheck** is a *risk signal* for protected writes — never
+  identity.
+- **Android:** **Credential Manager / passkeys** for sign-in UX;
+  **Keystore**-backed storage for the token only; **Play Integrity** is a *risk
+  signal* — never identity.
+- Integrity signals are additive risk inputs; they never replace WorkOS `sub` or
+  server ownership checks. (founder-identity *Mobile Clients*.)
+
+## 7. The one decision that is the host's, not codex's
+
+**Architecture: per-platform native (Swift / Kotlin) vs shared (KMP / RN /
+Flutter).** The lane's `_PURPOSE.md` abandon condition flags this as a host fork.
+Recommendation to keep momentum without lock-in: scaffold **thin, per-platform
+native starters** that do nothing but *sign in → open one MCP-backed chat thread
+→ render first-person*. Keep the surface area small enough that a later
+shared-architecture decision throws away no meaningful work. Flag the decision;
+do not pre-bake a heavy cross-platform framework into the scaffold.
+
+## 8. MVP "done" =
+
+A founder can: install → WorkOS sign in → land in a single chat → **(new)** meet
+their newborn universe in first person, or **(returning)** resume their universe
+→ send a message → see the universe's first-person reply rendered with the
+`Universe:` header → close and reopen to the same continuity. **Nothing else.**
+No settings panes, no universe switcher, no feature grid in v1.
+
+## 9. Open questions for codex (do not block the scaffold)
+
+- Native chat views vs reusing web rendering? (Recommend native for the "in your
+  pocket" feel.)
+- Token refresh/expiry UX (silent refresh vs re-auth prompt).
+- Server-initiated messages later — the universe reaching out is a *voice/hand*
+  in `body.md` terms. Out of MVP scope, but shape the single chat thread so an
+  inbound message fits naturally rather than requiring a redesign.

--- a/tests/test_universe_write_boundary.py
+++ b/tests/test_universe_write_boundary.py
@@ -1,0 +1,204 @@
+"""Executable acceptance gate for the founder/universe write boundary (D0a).
+
+Encodes the invariant from the founder/universe identity design — see
+``docs/design-notes/2026-06-26-founder-and-universe-identity.md`` (decision
+D0a) and ``openspec/changes/universe-creation`` requirement *"MCP writes are
+scoped to the founder's own universe"*:
+
+    A universe created through ``universe action=create_universe`` is OWNED by
+    the founder who created it. Another authenticated founder — even one
+    holding the ``tinyassets.universe.write`` scope — MUST NOT be able to
+    write that universe's brain.
+
+Why this file exists (Claude + Codex review, 2026-06-30): on origin/main the
+invariant is NOT yet enforced. ``_action_create_universe`` seeds no
+``universe_acl`` row, so ``universe_is_private`` is False for every created
+universe, so the ACL gate ``_universe_acl_allows`` returns *allow* for any
+writer who clears the scope gate. Per-universe write isolation therefore
+collapses to "any holder of the universe.write scope can write any universe".
+Closing that gap is the job of the in-flight ``universe-creation`` change
+(founder binding + ACL-on-create).
+
+The two cross-founder gates below are marked ``xfail(strict=True)``:
+  * TODAY they fail (no ownership) → reported as *xfailed* → suite stays green.
+  * ONCE the universe-creation change grants founder ownership at create time
+    they will pass → *xpass* → ``strict=True`` turns that into a hard failure,
+    signaling that the markers should be removed and these become permanent
+    regression guards.
+
+The anonymous guard is already satisfied on origin/main (the scope gate blocks
+all anonymous writes when auth is required); it is an unmarked green guard.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import tinyassets.api.universe as us
+from tinyassets.auth.middleware import auth_middleware, set_provider
+from tinyassets.auth.provider import AuthProvider, DevAuthProvider, Identity
+from tinyassets.daemon_server import universe_access_permission
+
+
+class _StaticAuthProvider(AuthProvider):
+    """Auth-required provider that resolves the bearer token ``"ok"`` to a
+    fixed identity, mirroring tests/test_universe_server_isolation.py."""
+
+    def __init__(self, identity: Identity | None) -> None:
+        self.identity = identity
+
+    def resolve_token(self, token: str) -> Identity | None:
+        return self.identity if token == "ok" else None
+
+    def is_auth_required(self) -> bool:
+        return True
+
+    def register_client(self, metadata: dict) -> dict:
+        return {"client_id": "test-client", **metadata}
+
+    def create_authorization(
+        self,
+        client_id: str,
+        redirect_uri: str,
+        scope: str,
+        state: str,
+        code_challenge: str,
+        code_challenge_method: str,
+    ) -> str:
+        return "test-code"
+
+    def exchange_code(
+        self,
+        code: str,
+        client_id: str,
+        redirect_uri: str,
+        code_verifier: str,
+    ) -> dict | None:
+        return None
+
+
+# Full founder scope set: read + write + admin + costly (create_universe is a
+# costly action, so the creating founder needs the costly scope).
+_FOUNDER_SCOPES = [
+    "tinyassets.universe.read",
+    "tinyassets.universe.write",
+    "tinyassets.universe.admin",
+    "tinyassets.universe.costly",
+]
+
+
+@pytest.fixture
+def universe_base(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    base = tmp_path / "output"
+    base.mkdir()
+    monkeypatch.setenv("TINYASSETS_DATA_DIR", str(base))
+    return base
+
+
+@pytest.fixture(autouse=True)
+def _reset_auth_provider() -> None:
+    set_provider(DevAuthProvider())
+    auth_middleware(None)
+    yield
+    set_provider(DevAuthProvider())
+    auth_middleware(None)
+
+
+def _authenticate(user_id: str, scopes: list[str]) -> None:
+    identity = Identity(
+        user_id=user_id,
+        username=user_id,
+        capabilities=list(scopes),
+    )
+    set_provider(_StaticAuthProvider(identity))
+    auth_middleware("ok")
+
+
+def _authenticate_anonymous() -> None:
+    """Auth REQUIRED, but no valid token → identity resolves to ANONYMOUS."""
+    set_provider(_StaticAuthProvider(None))
+    auth_middleware(None)
+
+
+def _create_universe_as(founder: str, uid: str, text: str = "A founder seed.") -> dict:
+    _authenticate(founder, _FOUNDER_SCOPES)
+    return json.loads(us._universe_impl(
+        action="create_universe",
+        universe_id=uid,
+        text=text,
+    ))
+
+
+class TestFounderWriteBoundary:
+    """A founder owns the universe they create; other founders cannot write it."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "D0a not yet enforced: _action_create_universe seeds no universe_acl "
+            "row, so any universe.write holder can write any universe. Acceptance "
+            "gate for openspec/changes/universe-creation."
+        ),
+    )
+    def test_created_universe_not_writable_by_other_founder(self, universe_base):
+        created = _create_universe_as("alice", "u-acceptance-alice")
+        assert created.get("status") == "created", created
+        target = created["universe_id"]
+
+        # A *different* authenticated founder, holding the write scope but with
+        # no grant on alice's universe, must be denied.
+        _authenticate("mallory", ["tinyassets.universe.write"])
+        out = json.loads(us._universe_impl(
+            action="set_premise",
+            universe_id=target,
+            text="Hostile cross-founder overwrite.",
+        ))
+
+        assert out.get("error") == "universe_access_denied", out
+        assert out.get("required_permission") == "write"
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "D0a not yet enforced: create grants no founder ACL row. Acceptance "
+            "gate for openspec/changes/universe-creation (founder binding)."
+        ),
+    )
+    def test_create_universe_grants_founder_owner_acl(self, universe_base):
+        created = _create_universe_as("alice", "u-acceptance-owner")
+        assert created.get("status") == "created", created
+        target = created["universe_id"]
+
+        # The founder must hold an owner-grade (write/admin) ACL on their own
+        # created universe — the mechanism that makes the write boundary real.
+        # On a zero-ACL universe this returns the public "read" convention.
+        perm = universe_access_permission(
+            universe_base,
+            universe_id=target,
+            actor_id="alice",
+        )
+        assert perm in {"write", "admin"}, (
+            f"founder 'alice' has permission {perm!r} on her own created "
+            "universe; expected an owner (write/admin) grant"
+        )
+
+    def test_created_universe_rejects_anonymous_write(self, universe_base):
+        # Green guard: already enforced on origin/main in auth-required mode —
+        # the scope gate blocks every anonymous write regardless of ownership.
+        created = _create_universe_as("alice", "u-acceptance-anon")
+        assert created.get("status") == "created", created
+        target = created["universe_id"]
+
+        _authenticate_anonymous()
+        out = json.loads(us._universe_impl(
+            action="set_premise",
+            universe_id=target,
+            text="Anonymous overwrite.",
+        ))
+
+        assert "error" in out, out
+        # Denied — never an accepted write.
+        assert out.get("status") != "updated", out


### PR DESCRIPTION
Two artifacts from the founder/universe identity review (Claude + Codex opposite-provider verification, 2026-06-30).

## 1. Executable D0a acceptance gate — `tests/test_universe_write_boundary.py`
Encodes the invariant: a universe created via `universe action=create_universe` is **owned by its founder**; another authenticated founder holding `universe.write` must not be able to write its brain (design D0a; `openspec/changes/universe-creation`).

**Both providers confirmed** the gap on current `main`: `_action_create_universe` seeds no `universe_acl` row, so `universe_is_private` is always False and the ACL gate allows any scoped writer to write any universe.

- 2 cross-founder gates are `xfail(strict=True)` — they fail today (suite stays green as `xfailed`) and will **xpass → hard-fail** the moment the in-flight universe-creation change grants founder ownership, signaling the markers should be removed and the tests become live regression guards.
- 1 anonymous-write guard is green already.
- Verified via `--runxfail` that the gates fail on the ownership assertion specifically (mallory's `set_premise` returns `status: updated`; `universe_access_permission(alice)` returns `read`). Ruff clean.

## 2. App experience design note — `docs/design-notes/2026-06-30-tinyassets-universe-app-experience.md`
Steering input for the native mobile client lane (`codex/mobile-app-scaffold`, OpenSpec `universe-personification` task 2.10). Pins the host-confirmed UX north star and the app-specific MUST-NOTs that fall out of existing canon — notably that anti-collision (personification D4) applies to **local phone storage**: the client caches only the WorkOS token, never persona/brain state. Defers the contract to the founder-identity / universe-creation / universe-personification specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)