### PR TITLE
Codex-dispatch reflex: trigger layer for proactive cross-family use

### DIFF
--- a/.claude/hooks/codex_dispatch_nudge.py
+++ b/.claude/hooks/codex_dispatch_nudge.py
@@ -112,8 +112,12 @@ def render(label: str, instruction: str) -> str:
 
 def main() -> int:
     try:
-        payload: dict[str, Any] = json.load(sys.stdin)
+        payload: Any = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError):
+        return 0
+
+    # Valid JSON that isn't an object (e.g. `[]`) would crash payload.get.
+    if not isinstance(payload, dict):
         return 0
 
     if str(payload.get("hook_event_name") or "") != "UserPromptSubmit":

--- a/.claude/hooks/codex_dispatch_nudge.py
+++ b/.claude/hooks/codex_dispatch_nudge.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Claude Code hook: push the Codex cross-family dispatch reflex.
+
+Claude sessions *have* the `mcp__codex__codex` capability and the CLAUDE.md
+§"Calling Codex via MCP" instructions in context, but the behavior is passive
+knowledge — without a trigger at the decision moment the default-to-self bias
+wins and the opposite-provider gate silently doesn't fire (the failure the host
+reported: Claude finishes a review and presents a verdict without ever
+cross-checking with Codex, then only dispatches once told to).
+
+This is the trigger layer. On UserPromptSubmit, classify the prompt against the
+qualifying surface (review / finding / risky-ship / decision / stuck /
+second-opinion) and inject an imperative reminder with the exact dispatch shape.
+Mirrors provider_context_feed_hook.py: non-blocking, additionalContext only.
+
+Calibrated aggressive per host directive 2026-06-30 (default-to-dispatch), but
+deliberately NOT firing on every build/edit/lookup — a nudge on every turn is
+noise that gets tuned out, which defeats the purpose. It fires where an
+independent model genuinely adds confidence.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from typing import Any
+
+# Ordered most-actionable-first; the first match wins so the nudge is specific.
+TRIGGERS: tuple[tuple[str, str, re.Pattern[str]], ...] = (
+    (
+        "stuck-loop",
+        "Fresh eyes: hand Codex the error + what you've already tried for a "
+        "different-model angle (don't grind a 4th time on the same approach).",
+        re.compile(
+            r"\b(stuck|blocked|can'?t (figure|get|work)|keep(s)? failing|"
+            r"still (failing|broken)|same error|going in circles|"
+            r"tried everything|3\+? ?(times|iterations|attempts))\b",
+            re.I,
+        ),
+    ),
+    (
+        "review/finding",
+        "Dispatch the opposite-provider review gate: have Codex re-check the "
+        "sources + the actual code and return approve/adapt/reject BEFORE you "
+        "present a verdict, finding, or 'looks correct' claim.",
+        re.compile(
+            r"\b(review|verif\w+|audit|conformance|finding|findings|verdict|"
+            r"is this (right|correct|sound)|double[- ]?check|sanity[- ]?check|"
+            r"security review|re-?check)\b",
+            re.I,
+        ),
+    ),
+    (
+        "risky/ship",
+        "Get an adversarial second opinion before acting: ask Codex to *refute* "
+        "the change/plan/result — independent skeptic pass before it ships.",
+        re.compile(
+            r"\b(ship|push|deploy|merge|release|roll[- ]?out|rollout|land|"
+            r"production|risky|breaking change|data ?loss|migration)\b",
+            re.I,
+        ),
+    ),
+    (
+        "decision/recommend",
+        "Get a diverse-perspective judge: have Codex independently weigh the "
+        "options before you present a recommendation (different model than the "
+        "writer).",
+        re.compile(
+            r"\b(recommend\w*|which (one|approach|option|way)|should (i|we)|"
+            r"compare|trade[- ]?offs?|decide|decision|best approach|judge)\b",
+            re.I,
+        ),
+    ),
+    (
+        "second-opinion",
+        "Ask Codex to *refute* it — an independent skeptic pass before you rely "
+        "on this result.",
+        re.compile(
+            r"\b(second opinion|refute|are you sure|surprising|unexpected|"
+            r"skeptic\w*|sceptic\w*|challenge this|does this (look|seem) (right|ok))\b",
+            re.I,
+        ),
+    ),
+)
+
+
+def classify(prompt: str) -> tuple[str, str] | None:
+    for label, instruction, pattern in TRIGGERS:
+        if pattern.search(prompt):
+            return label, instruction
+    return None
+
+
+def render(label: str, instruction: str) -> str:
+    return "\n".join(
+        (
+            f"Codex cross-family reflex — qualifying signal: {label}.",
+            "You have Codex (a second model family) wired into the harness. Per",
+            'CLAUDE.md §"Calling Codex via MCP", dispatch PROACTIVELY now — do not',
+            "wait to be told:",
+            f"  → {instruction}",
+            "  Call mcp__codex__codex (sandbox: read-only, approval-policy: never;",
+            "  workspace-write only if Codex must edit, in its own branch). Log the",
+            "  verdict like any review.",
+            "This dispatch is a standing reflex, not an option. If you deliberately",
+            "skip it, say so in one line and why — don't just default to doing it",
+            "yourself.",
+        )
+    )
+
+
+def main() -> int:
+    try:
+        payload: dict[str, Any] = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    if str(payload.get("hook_event_name") or "") != "UserPromptSubmit":
+        return 0
+
+    prompt = payload.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return 0
+
+    match = classify(prompt)
+    if match is None:
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": render(*match),
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -92,6 +92,12 @@
             "command": "python \"$env:CLAUDE_PROJECT_DIR/.claude/hooks/provider_context_feed_hook.py\"",
             "shell": "powershell",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python \"$env:CLAUDE_PROJECT_DIR/.claude/hooks/codex_dispatch_nudge.py\"",
+            "shell": "powershell",
+            "timeout": 10
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,19 +34,32 @@ judge with a different model than the writer" applied directly (basis:
 codebase already routes its prose-loop editorial judge to Codex, so the pattern
 has precedent.
 
-Reach for it whenever a different model or an independent perspective raises
-confidence:
-- **Opposite-provider review gate.** AGENTS.md §"Project Skills" requires
-  research-derived findings to get opposite-provider review before build / push
-  / live rollout. When Claude makes the finding, dispatch the review to Codex
-  via MCP and log the verdict (`approve` / `adapt` / `reject`) — don't wait for a
-  human to open a Codex session.
-- **Adversarial / second opinion** on a risky change, a surprising result, or a
-  finding you're about to act on — ask Codex to *refute* it.
-- **Diverse-perspective judging** (LLM-as-judge with a different model than the
-  writer); cross-checking before an evidence-before-completion claim.
-- **Fresh eyes when stuck** 3+ iterations on the same error (the stuck-loop
-  reflection rule in AGENTS.md).
+**Standing reflex — dispatch to Codex proactively; do not wait to be told.**
+You have a second model family in the harness; default to using it like you'd
+use a subagent or a teammate. At each checkpoint below the dispatch is a MUST,
+not an option. If you deliberately skip one, say so in one line and why — don't
+silently default to doing it yourself (that default-to-self bias is exactly what
+makes this reflex fail).
+
+- **Before presenting any review verdict, finding, or "looks correct" claim** —
+  dispatch the opposite-provider review gate to Codex (it re-checks sources +
+  actual code), log the verdict (`approve` / `adapt` / `reject`). AGENTS.md
+  §"Project Skills" already requires this for research-derived findings before
+  build / push / live rollout; do it without a human opening a Codex session.
+- **Before acting on a risky change, a surprising result, or a finding you're
+  about to ship** — get an adversarial second opinion: ask Codex to *refute* it.
+- **Before an evidence-before-completion / "done" claim on non-trivial work, or
+  before presenting a recommendation between options** — cross-check with a
+  diverse-perspective judge (different model than the writer).
+- **When stuck 3+ iterations on the same error** — hand it to Codex for fresh
+  eyes (the stuck-loop reflection rule in AGENTS.md).
+
+**Default to dispatch.** The bar is "would an independent model add
+confidence?", not "is it worth the cost?". When in doubt, dispatch — reserve
+self-only for trivial mechanical edits and pure lookups. The
+`codex_dispatch_nudge` hook fires this reflex at qualifying prompts, but the
+obligation stands whether or not the hook fires; treat a missing nudge as
+silence, not permission to skip.
 
 Discipline:
 - Reviews must be substantive — Codex re-checks sources + actual code, never
@@ -59,8 +72,10 @@ Discipline:
 - Calling Codex is an *additional* independent path — it does NOT bypass
   host/navigator gates or the live user-sim proof, and the result is logged like
   any other review (STATUS row / design note / activity log).
-- Mind cost: a Codex session is a real agent run. Use it where independence
-  matters, not for routine lookups.
+- Cost is real but secondary: a Codex session is a real agent run, so batch a
+  meaningful review scope into one dispatch rather than many tiny ones — but do
+  not let cost talk you out of a qualifying dispatch. Independence is the goal;
+  the spend is the price of it.
 
 ### Skills [Claude Code only]
 


### PR DESCRIPTION
## Problem
`mcp__codex__codex` was wired into Claude Code so sessions could use Codex like a subagent (cross-family review, second opinions, load-balancing), but sessions had the capability + CLAUDE.md docs in context yet never *acted* without being explicitly told. Root cause: no trigger layer (every other reliable recurring behavior in this repo is hook-backed; this one wasn't) + permission-toned prose ("reach for it whenever…", "mind cost… not for routine lookups").

## Change (Claude Code only — no public surface touched)
1. **`.claude/hooks/codex_dispatch_nudge.py`** — UserPromptSubmit hook. Classifies the prompt (stuck-loop / review-finding / risky-ship / decision / second-opinion) and injects an imperative dispatch reminder. Silent on greetings, trivial edits, wrong event, and non-object/malformed JSON.
2. **`.claude/settings.json`** — registers the hook so the trigger is actually live (not dormant).
3. **CLAUDE.md §"Calling Codex via MCP"** — permission-tone → obligation: concrete MUST-checkpoints + "default to dispatch" (bar is *would an independent model add confidence*, not *cost*); replaced the cost-aversion line with batch-the-scope guidance.

## Cross-family review (the gate this change itself encodes)
Dispatched to **Codex via MCP (read-only)** before push. Verdict: **ADAPT**. Both findings fixed in `898b8bb5`:
- Register the hook in settings.json (else origin/main ships a dormant trigger).
- Guard non-object JSON (`[]` would crash `payload.get`).

## Verification
- `ruff` clean.
- Hook: `[]` / bare-string / malformed stdin → silent exit 0; review/ship/decision/stuck prompts fire with correct category; greeting + trivial edit stay silent (7+ cases).
- settings.json valid JSON; both UserPromptSubmit hooks present.
- Rule #12 N/A: no DNS/tunnel/Worker/MCP-tool-catalog change → no public canary / chatbot ui-test required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)